### PR TITLE
fix: release activeSyncsMutex after marking mirror sync active

### DIFF
--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -426,7 +426,6 @@ func (h *MirrorHandler) DeleteMirrorConfig(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}  "Invalid mirror ID"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Mirror configuration not found"
-// @Failure      409  {object}  map[string]interface{}  "Sync already in progress"
 // @Failure      503  {object}  map[string]interface{}  "Sync job not configured"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/mirrors/{id}/sync [post]
@@ -463,7 +462,7 @@ func (h *MirrorHandler) TriggerSync(c *gin.Context) {
 		log.Printf("API: Triggering manual sync for mirror %s (ID: %s)", config.Name, id) // #nosec G706 -- logged value is application-internal (config string, integer, or application-constructed path); not raw user-controlled request input
 		if err := h.syncJob.TriggerManualSync(c.Request.Context(), id); err != nil {
 			if err.Error() == "sync already in progress for this mirror" {
-				c.JSON(http.StatusConflict, gin.H{"error": "A sync is already in progress for this mirror"})
+				c.JSON(http.StatusAccepted, gin.H{"message": "Sync already in progress"})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to trigger sync: " + err.Error()})

--- a/backend/internal/api/admin/mirror_test.go
+++ b/backend/internal/api/admin/mirror_test.go
@@ -446,8 +446,8 @@ func TestMirrorTriggerSync_AlreadyInProgress(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors/"+knownUUID+"/sync", nil))
 
-	if w.Code != http.StatusConflict {
-		t.Errorf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202: body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -1018,6 +1018,7 @@ func (j *MirrorSyncJob) TriggerManualSync(ctx context.Context, mirrorID uuid.UUI
 	}
 	// Mark as active immediately to prevent race conditions
 	j.activeSyncs[mirrorID] = true
+	j.activeSyncsMutex.Unlock()
 
 	// Get mirror config using the request context
 	config, err := j.mirrorRepo.GetByID(ctx, mirrorID)


### PR DESCRIPTION
Closes #1

## Summary

- `TriggerManualSync` acquired `activeSyncsMutex`, set `activeSyncs[mirrorID] = true`, but never called `Unlock()` on the success path. This permanently locked the mutex, causing every subsequent call to `TriggerManualSync` or `runScheduledSyncs` to block forever — reproducing the 504/hang observed in production.
- The handler now returns `202 Accepted` with `{"message": "Sync already in progress"}` instead of `409 Conflict` when a concurrent sync is detected, so the UI receives an immediate non-error response regardless of sync state.
- Updated `TestMirrorTriggerSync_AlreadyInProgress` to assert `202` instead of `409`.

## Changelog
- fix: release activeSyncsMutex after marking mirror sync active to prevent indefinite blocking on concurrent sync requests