### PR TITLE
fix: count distinct versions in terraform mirror status response

### DIFF
--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -201,7 +201,7 @@ func (h *TerraformMirrorHandler) GetStatus(c *gin.Context) {
 		return
 	}
 
-	total, synced, pending, statsErr := h.repo.CountVersionStats(c.Request.Context(), id)
+	versionCount, platformCount, pendingCount, statsErr := h.repo.CountVersionStats(c.Request.Context(), id)
 	if statsErr != nil {
 		log.Printf("[terraform-mirror] failed to count stats for %s: %v", id, statsErr)
 	}
@@ -214,9 +214,9 @@ func (h *TerraformMirrorHandler) GetStatus(c *gin.Context) {
 
 	c.JSON(http.StatusOK, models.TerraformMirrorStatusResponse{
 		Config:        cfg,
-		VersionCount:  synced,
-		PlatformCount: total,
-		PendingCount:  pending,
+		VersionCount:  versionCount,
+		PlatformCount: platformCount,
+		PendingCount:  pendingCount,
 		LatestVersion: latestStr,
 	})
 }

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -573,7 +573,7 @@ func TestTMGetStatus_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE id").
 		WillReturnRows(sampleTMCRow())
 	mock.ExpectQuery("SELECT.*COUNT.*FROM terraform_version_platforms").
-		WillReturnRows(sqlmock.NewRows([]string{"total", "synced", "pending"}).AddRow(10, 8, 2))
+		WillReturnRows(sqlmock.NewRows([]string{"version_count", "platform_count", "pending_count"}).AddRow(10, 8, 2))
 	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*is_latest").
 		WillReturnRows(sqlmock.NewRows(tfvCols))
 
@@ -872,7 +872,7 @@ func TestTMGetStatus_WithLatestVersion(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE id").
 		WillReturnRows(sampleTMCRow())
 	mock.ExpectQuery("SELECT.*COUNT.*FROM terraform_version_platforms").
-		WillReturnRows(sqlmock.NewRows([]string{"total", "synced", "pending"}).AddRow(5, 3, 2))
+		WillReturnRows(sqlmock.NewRows([]string{"version_count", "platform_count", "pending_count"}).AddRow(5, 3, 2))
 	// GetLatestVersion returns a real version row
 	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*is_latest").
 		WillReturnRows(sampleTFVRow())

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -612,23 +612,23 @@ func (r *TerraformMirrorRepository) UpdateGPGVerifiedForVersion(ctx context.Cont
 	return nil
 }
 
-// CountVersionStats returns total, synced, and pending platform counts for a config.
-func (r *TerraformMirrorRepository) CountVersionStats(ctx context.Context, configID uuid.UUID) (total, synced, pending int, err error) {
+// CountVersionStats returns distinct version count, total platform count, and pending platform count for a config.
+func (r *TerraformMirrorRepository) CountVersionStats(ctx context.Context, configID uuid.UUID) (versionCount, platformCount, pendingCount int, err error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT
-			COUNT(*) AS total,
-			COUNT(*) FILTER (WHERE p.sync_status = 'synced') AS synced,
-			COUNT(*) FILTER (WHERE p.sync_status IN ('pending','failed')) AS pending
+			COUNT(DISTINCT v.id) AS version_count,
+			COUNT(*) AS platform_count,
+			COUNT(*) FILTER (WHERE p.sync_status IN ('pending','failed')) AS pending_count
 		FROM terraform_version_platforms p
 		JOIN terraform_versions v ON v.id = p.version_id
 		WHERE v.config_id = $1
 	`, configID)
 
-	if scanErr := row.Scan(&total, &synced, &pending); scanErr != nil {
+	if scanErr := row.Scan(&versionCount, &platformCount, &pendingCount); scanErr != nil {
 		return 0, 0, 0, fmt.Errorf("failed to count terraform platform stats: %w", scanErr)
 	}
 
-	return total, synced, pending, nil
+	return versionCount, platformCount, pendingCount, nil
 }
 
 // ---- Sync History ----------------------------------------------------------


### PR DESCRIPTION
Closes #2

## Summary

- `CountVersionStats` was querying `COUNT(*)` against `terraform_version_platforms`, which produces one row per version-platform pair. This caused `version_count` and `platform_count` to be identical when all platforms were synced.
- Replaced the inner count with `COUNT(DISTINCT v.id)` so `version_count` correctly reflects the number of unique Terraform versions, while `platform_count` retains the total number of version-platform records.
- Updated mock column names in `TestTMGetStatus_Success` and `TestTMGetStatus_WithLatestVersion` to reflect the new query semantics.

## Changelog
- fix: count distinct versions in terraform mirror status response so version_count and platform_count are no longer equal