### PR TITLE
fix: rebase swagger auto-commit before pushing to avoid push rejection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
             # Push back to the source branch (works for both PRs and direct pushes).
             # GITHUB_HEAD_REF is set for pull_request events; GITHUB_REF_NAME is used otherwise.
             TARGET_BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+            # Fetch and rebase before pushing so concurrent commits to the same branch
+            # (e.g. two PR squash-merges landing seconds apart) don't cause a rejected push.
+            git fetch origin "${TARGET_BRANCH}"
+            git rebase "origin/${TARGET_BRANCH}"
             git push origin "HEAD:refs/heads/${TARGET_BRANCH}"
           else
             echo "swagger.json is up-to-date — nothing to commit"


### PR DESCRIPTION
Closes #5

## Summary

When two squash-merges land on `development` within seconds of each other, both CI runs detect a stale `swagger.json`, regenerate it, and try to push a `chore: regenerate swagger.json [skip ci]` commit. The second push is rejected because the branch moved ahead between checkout and push, causing the CI job to fail.

The fix adds `git fetch origin "${TARGET_BRANCH}" && git rebase "origin/${TARGET_BRANCH}"` before the push in the swagger auto-commit step. The swagger commit is always rebased onto the current remote HEAD before pushing, so it is always a fast-forward and the push succeeds regardless of concurrent activity.

## Changelog
- fix: rebase swagger auto-commit before pushing to avoid push rejection on concurrent CI runs