### PR TITLE
fix: harden Kubernetes and Helm deployment configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [ main, development ]
+    branches: [main, development]
   pull_request:
-    branches: [ main, development ]
+    branches: [main, development]
   workflow_dispatch: {}
-  workflow_call: {}   # allows release.yml to call this as a prerequisite
+  workflow_call: {} # allows release.yml to call this as a prerequisite
 
 jobs:
   backend-test:
     name: Backend Tests & Quality
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # needed to push auto-generated swagger.json back to the branch
+      contents: write # needed to push auto-generated swagger.json back to the branch
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache-dependency-path: backend/go.sum
 
       - name: Check go mod tidy
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: "1.24"
           cache-dependency-path: backend/go.sum
 
       - name: Install gosec
@@ -273,7 +273,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: 'latest'
+          version: "latest"
 
       - name: Helm lint
         run: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -70,7 +70,7 @@ EXPOSE 8080 9090
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider --no-check-certificate https://localhost:8080/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
 
 # Set entrypoint
 ENTRYPOINT ["/app/terraform-registry"]

--- a/deployments/helm/templates/clusterissuer.yaml
+++ b/deployments/helm/templates/clusterissuer.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.gatewayAPI.enabled -}}
+{{- if not .Values.gatewayAPI.email }}
+{{- fail "gatewayAPI.email is required when gatewayAPI.enabled=true for Let's Encrypt ClusterIssuer registration." }}
+{{- end }}
+# ── Let's Encrypt Staging (untrusted, no rate limits — use for testing) ────────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ .Values.gatewayAPI.email | quote }}
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ include "terraform-registry.fullname" . }}-gateway
+                namespace: {{ .Release.Namespace }}
+                kind: Gateway
+---
+# ── Let's Encrypt Production (trusted, rate-limited — use for production) ──────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: {{ .Values.gatewayAPI.email | quote }}
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: {{ include "terraform-registry.fullname" . }}-gateway
+                namespace: {{ .Release.Namespace }}
+                kind: Gateway
+---
+# ── TLS Certificate (issued by the configured ClusterIssuer) ───────────────────
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-tls
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.gatewayAPI.tlsSecretName }}
+  issuerRef:
+    name: {{ .Values.gatewayAPI.certManagerIssuer }}
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    - {{ .Values.gatewayAPI.hostname | quote }}
+{{- end }}

--- a/deployments/helm/templates/configmap-frontend-nginx.yaml
+++ b/deployments/helm/templates/configmap-frontend-nginx.yaml
@@ -15,6 +15,12 @@ data:
 
         client_max_body_size 500m;
 
+        # Security headers
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
         location / {
             try_files $uri $uri/ /index.html;
         }

--- a/deployments/helm/templates/deployment-frontend.yaml
+++ b/deployments/helm/templates/deployment-frontend.yaml
@@ -20,10 +20,21 @@ spec:
       annotations:
         checksum/nginx-config: {{ include (print $.Template.BasePath "/configmap-frontend-nginx.yaml") . | sha256sum }}
     spec:
+      serviceAccountName: {{ include "terraform-registry.serviceAccountName" . }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
           image: {{ include "terraform-registry.frontendImage" . }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
           ports:
             - name: http
               containerPort: 80

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         {{- include "terraform-registry.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
+        # Azure Workload Identity: label is required on the pod for the
+        # mutating webhook to inject the OIDC federated token volume.
+        # Safe to include on non-AKS clusters (label is ignored without the webhook).
+        azure.workload.identity/use: "true"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
@@ -57,33 +61,48 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /health
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             {{- if eq .Values.storage.backend "local" }}
             - name: storage
               mountPath: {{ .Values.storage.local.basePath }}
+            {{- end }}
+            {{- if .Values.keyVault.enabled }}
+            # CSI volume mount triggers the Secrets Store CSI Driver to fetch
+            # secrets from Azure Key Vault and sync them into the k8s Secret.
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
             {{- end }}
             {{- with .Values.backend.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         {{- if eq .Values.storage.backend "local" }}
         - name: storage
           {{- if .Values.storage.persistence.enabled }}
@@ -92,6 +111,14 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if .Values.keyVault.enabled }}
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "terraform-registry.fullname" . }}-secrets
         {{- end }}
         {{- with .Values.backend.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/deployments/helm/templates/gateway.yaml
+++ b/deployments/helm/templates/gateway.yaml
@@ -1,0 +1,65 @@
+---
+{{- if .Values.gatewayAPI.enabled -}}
+{{- if not .Values.gatewayAPI.email }}
+{{- fail "gatewayAPI.email is required when gatewayAPI.enabled=true. Set it to your ops email for Let's Encrypt certificate notifications." }}
+{{- end }}
+{{- if not .Values.gatewayAPI.hostname }}
+{{- fail "gatewayAPI.hostname is required when gatewayAPI.enabled=true." }}
+{{- end }}
+
+{{- /* GatewayClass — only created when createGatewayClass=true (not needed for GKE) */ -}}
+{{- if .Values.gatewayAPI.createGatewayClass }}
+# ── GatewayClass ─────────────────────────────────────────────────────────────
+# Cluster-scoped resource. Tells Gateway API which controller handles Gateways
+# that reference this class.
+# AKS/AGfC:  controllerName: alb.networking.azure.io/alb-controller
+# EKS/ALB:   controllerName: gateway.k8s.aws/alb
+# GKE:       set createGatewayClass=false (GKE pre-provisions GatewayClasses)
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: {{ .Values.gatewayAPI.gatewayClassName }}
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  controllerName: {{ required "gatewayAPI.controllerName is required when createGatewayClass=true" .Values.gatewayAPI.controllerName | quote }}
+---
+{{- end }}
+# ── Gateway — HTTP and HTTPS listeners ────────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-gateway
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+  annotations:
+    {{- /* AKS/AGfC: albId annotation associates Gateway with the AGfC ARM resource */ -}}
+    {{- if .Values.gatewayAPI.albId }}
+    alb.networking.azure.io/alb-id: {{ .Values.gatewayAPI.albId | quote }}
+    {{- end }}
+    cert-manager.io/cluster-issuer: {{ .Values.gatewayAPI.certManagerIssuer | quote }}
+    {{- with .Values.gatewayAPI.gatewayAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gatewayAPI.gatewayClassName }}
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: {{ .Values.gatewayAPI.hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: {{ .Values.gatewayAPI.tlsSecretName }}
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: Same
+{{- end }}

--- a/deployments/helm/templates/httproute.yaml
+++ b/deployments/helm/templates/httproute.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.gatewayAPI.enabled -}}
+# ── HTTP → HTTPS redirect ──────────────────────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-http-redirect
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "terraform-registry.fullname" . }}-gateway
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+# ── Backend API and protocol paths (HTTPS) ────────────────────────────────────
+# Routes API, Terraform registry protocol, and auxiliary paths directly to the
+# backend service. Bypasses the frontend nginx proxy for these paths.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-backend-routes
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "terraform-registry.fullname" . }}-gateway
+      sectionName: https
+  hostnames:
+    - {{ .Values.gatewayAPI.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /terraform/
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks/
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: Exact
+            value: /health
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: Exact
+            value: /ready
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+    - matches:
+        - path:
+            type: Exact
+            value: /swagger.json
+      backendRefs:
+        - name: {{ include "terraform-registry.backendServiceName" . }}
+          port: {{ .Values.service.backend.port }}
+{{- if .Values.frontend.enabled }}
+---
+# ── Frontend SPA — catch-all (HTTPS) ──────────────────────────────────────────
+# Lower priority than backend-routes above (Gateway API: shorter prefix / matches last).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-frontend-route
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "terraform-registry.fullname" . }}-gateway
+      sectionName: https
+  hostnames:
+    - {{ .Values.gatewayAPI.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "terraform-registry.fullname" . }}-frontend
+          port: {{ .Values.service.frontend.port }}
+{{- end }}
+{{- end }}

--- a/deployments/helm/templates/networkpolicy.yaml
+++ b/deployments/helm/templates/networkpolicy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.networkPolicy.enabled -}}
+# ── Default: deny all ingress in this namespace ────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-default-deny-ingress
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# ── Frontend: allow HTTP from anywhere (external Gateway / load balancer) ──────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-allow-frontend-ingress
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.service.frontend.port }}
+          protocol: TCP
+---
+# ── Backend: allow HTTP from frontend pods and external Gateway/LB ───────────
+# Gateway API HTTPRoute sends /api/*, /v1/*, /.well-known/* etc. directly to
+# backend pods. Traffic from cloud load balancers originates outside the pod
+# network, so we allow all sources on the backend HTTP port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-allow-backend-ingress
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.service.backend.port }}
+          protocol: TCP
+---
+# ── Backend metrics: allow Prometheus scrape ──────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-allow-backend-metrics
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.prometheusNamespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: {{ .Values.telemetry.metrics.prometheusPort }}
+          protocol: TCP
+{{- end }}

--- a/deployments/helm/templates/secretproviderclass.yaml
+++ b/deployments/helm/templates/secretproviderclass.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.keyVault.enabled -}}
+{{- if not .Values.keyVault.name }}
+{{- fail "keyVault.name is required when keyVault.enabled=true." }}
+{{- end }}
+{{- if not .Values.keyVault.tenantId }}
+{{- fail "keyVault.tenantId is required when keyVault.enabled=true." }}
+{{- end }}
+{{- if not .Values.keyVault.clientId }}
+{{- fail "keyVault.clientId is required when keyVault.enabled=true." }}
+{{- end }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-secrets
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "false"
+    clientID: {{ .Values.keyVault.clientId | quote }}
+    keyvaultName: {{ .Values.keyVault.name | quote }}
+    cloudName: ""
+    objects: |
+      array:
+        - |
+          objectName: jwt-secret
+          objectType: secret
+          objectAlias: TFR_JWT_SECRET
+        - |
+          objectName: encryption-key
+          objectType: secret
+          objectAlias: ENCRYPTION_KEY
+        - |
+          objectName: database-password
+          objectType: secret
+          objectAlias: TFR_DATABASE_PASSWORD
+        {{- if eq .Values.storage.backend "azure" }}
+        - |
+          objectName: azure-blob-account-key
+          objectType: secret
+          objectAlias: TFR_STORAGE_AZURE_ACCOUNT_KEY
+        {{- end }}
+    tenantId: {{ .Values.keyVault.tenantId | quote }}
+  secretObjects:
+    - secretName: {{ include "terraform-registry.secretName" . }}
+      type: Opaque
+      data:
+        - objectName: TFR_JWT_SECRET
+          key: TFR_JWT_SECRET
+        - objectName: ENCRYPTION_KEY
+          key: ENCRYPTION_KEY
+        - objectName: TFR_DATABASE_PASSWORD
+          key: TFR_DATABASE_PASSWORD
+        {{- if eq .Values.storage.backend "azure" }}
+        - objectName: TFR_STORAGE_AZURE_ACCOUNT_KEY
+          key: TFR_STORAGE_AZURE_ACCOUNT_KEY
+        {{- end }}
+{{- end }}

--- a/deployments/helm/templates/serviceaccount.yaml
+++ b/deployments/helm/templates/serviceaccount.yaml
@@ -5,8 +5,13 @@ metadata:
   name: {{ include "terraform-registry.serviceAccountName" . }}
   labels:
     {{- include "terraform-registry.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    {{- if .Values.workloadIdentity.enabled }}
+    # Azure Workload Identity: instructs the mutating webhook to inject the
+    # federated OIDC token into pods that have azure.workload.identity/use: "true".
+    azure.workload.identity/client-id: {{ .Values.workloadIdentity.clientId | quote }}
+    {{- end }}
 {{- end }}

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -1,0 +1,155 @@
+# ============================================================
+# values-aks.yaml — AKS Deployment Values
+# ============================================================
+# Copy this file and fill in ALL <PLACEHOLDER> values before deploying.
+# Do NOT commit a filled-in copy that contains real secrets or IDs.
+#
+# Deploy with:
+#   helm upgrade --install terraform-registry ./deployments/helm \
+#     --namespace terraform-registry --create-namespace \
+#     -f deployments/helm/values-aks.yaml
+#
+# Or override specific values at deploy time:
+#   helm upgrade ... -f values-aks.yaml \
+#     --set externalDatabase.host=<PG_FQDN> \
+#     --set gatewayAPI.albId=<AGfC_RESOURCE_ID>
+#
+# See docs/deployment/aks-new-cluster.md for complete setup instructions.
+# See docs/deployment/aks-prerequisites.md for required Azure resources.
+# ============================================================
+
+# ── Images: replace with your ACR FQDN and pinned tags ────────────────────────
+backend:
+  image:
+    # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
+    repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
+    # Pin to a specific semver tag. Never use 'latest' in production.
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  # Production resource sizing — adjust to match your workload
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+frontend:
+  enabled: true
+  image:
+    repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+
+# ── Server ─────────────────────────────────────────────────────────────────────
+server:
+  # Must match gatewayAPI.hostname below
+  baseUrl: "https://<HOSTNAME>"
+
+# ── Database: Azure Database for PostgreSQL Flexible Server ────────────────────
+externalDatabase:
+  # Flexible Server FQDN: <server-name>.postgres.database.azure.com
+  host: "<AZURE_POSTGRES_SERVER>.postgres.database.azure.com"
+  port: 5432
+  name: "terraform_registry"
+  user: "registry"
+  sslMode: "require"
+  # Leave password blank — it is pulled from Azure Key Vault via the CSI driver.
+  # Set existingSecret if you want to reference a pre-existing k8s Secret instead.
+  password: ""
+  existingSecret: ""
+
+# ── Storage: Azure Blob Storage ────────────────────────────────────────────────
+# Azure Blob is recommended for AKS multi-replica deployments.
+# The PVC is created but unused when backend=azure.
+storage:
+  backend: "azure"
+  azure:
+    # Azure Storage Account name
+    accountName: "<AZURE_STORAGE_ACCOUNT_NAME>"
+    # Name of the blob container (will be created if it doesn't exist on first upload)
+    containerName: "terraform-registry"
+    # accountKey pulled from Key Vault via CSI driver — leave blank here.
+    accountKey: ""
+  # Disable local PVC since we're using Azure Blob
+  persistence:
+    enabled: false
+
+# ── Security: secrets from Azure Key Vault (keyVault.enabled below) ────────────
+# Leave jwtSecret and encryptionKey blank — they are fetched from Key Vault.
+security:
+  jwtSecret: ""
+  encryptionKey: ""
+  existingSecret: ""
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+logging:
+  level: "warn"
+  format: "json"
+
+# ── ServiceAccount + Azure Workload Identity ──────────────────────────────────
+serviceAccount:
+  create: true
+  annotations: {}
+
+workloadIdentity:
+  enabled: true
+  # Client ID of the User-Assigned Managed Identity.
+  # This identity must have:
+  #   - Key Vault Secret User role on the Key Vault
+  #   - Storage Blob Data Contributor role on the Storage Account
+  #   - A federated credential pointing to this ServiceAccount
+  clientId: "<MANAGED_IDENTITY_CLIENT_ID>"
+
+# ── Azure Key Vault CSI Driver ─────────────────────────────────────────────────
+keyVault:
+  enabled: true
+  # Key Vault resource name (not the full URI)
+  name: "<KEY_VAULT_NAME>"
+  # Azure AD Tenant ID (UUID)
+  tenantId: "<TENANT_ID>"
+  # Client ID of the Managed Identity (must match workloadIdentity.clientId)
+  clientId: "<MANAGED_IDENTITY_CLIENT_ID>"
+
+# ── Gateway API: Application Gateway for Containers ───────────────────────────
+gatewayAPI:
+  enabled: true
+  gatewayClassName: azure-alb-external
+  # Full ARM resource ID of the Application Gateway for Containers resource.
+  # Get it with: az network alb show -g <RG> -n <AGFC_NAME> --query id -o tsv
+  albId: >-
+    /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.ServiceNetworking/trafficControllers/<AGFC_NAME>
+  # Public hostname (DNS A record must point to the AGfC frontend IP before cert issuance)
+  hostname: "<HOSTNAME>"
+  # Use letsencrypt-staging during initial testing (untrusted cert, no rate limits)
+  # Switch to letsencrypt-prod once ACME challenge succeeds
+  certManagerIssuer: "letsencrypt-staging"
+  tlsSecretName: "terraform-registry-tls"
+  # Email for Let's Encrypt expiry notifications (required by ACME)
+  email: "<OPS_EMAIL>"
+
+# ── Disable legacy nginx Ingress (replaced by Gateway API above) ───────────────
+ingress:
+  enabled: false
+
+# ── NetworkPolicy ──────────────────────────────────────────────────────────────
+# Requires AKS with Azure CNI + Azure Network Policy Manager or Calico.
+networkPolicy:
+  enabled: true
+  prometheusNamespace: "monitoring"
+
+# ── Horizontal Pod Autoscaler ──────────────────────────────────────────────────
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# ── PodDisruptionBudget ────────────────────────────────────────────────────────
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -1,0 +1,167 @@
+# ============================================================
+# values-eks.yaml — AWS Elastic Kubernetes Service Deployment Values
+# ============================================================
+# Copy this file and fill in ALL <PLACEHOLDER> values before deploying.
+# Do NOT commit a filled-in copy that contains real IDs or secrets.
+#
+# Prerequisites: See docs/deployment/eks-prerequisites.md
+#
+# Deploy with:
+#   helm upgrade --install terraform-registry ./deployments/helm \
+#     --namespace terraform-registry --create-namespace \
+#     -f deployments/helm/values-eks.yaml
+#
+# For secrets management (AWS Secrets Manager via CSI driver), the
+# SecretProviderClass must be applied separately — see overlays/eks/ for
+# the Kustomize-based approach, or apply secretproviderclass.yaml manually.
+# The extraVolumes/extraVolumeMounts below hook into the CSI driver once the
+# SecretProviderClass exists in the cluster.
+# ============================================================
+
+# ── Images: Amazon ECR ────────────────────────────────────────────────────────
+backend:
+  image:
+    # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
+    repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # Mount the CSI secret volume so AWS ASCP syncs Secrets Manager values
+  # into the terraform-registry-secrets k8s Secret at pod startup.
+  # Apply overlays/eks/secretproviderclass.yaml before deploying this chart.
+  extraVolumes:
+    - name: secrets-store
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: terraform-registry-secrets
+  extraVolumeMounts:
+    - name: secrets-store
+      mountPath: /mnt/secrets-store
+      readOnly: true
+
+frontend:
+  enabled: true
+  image:
+    repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+
+# ── Server ─────────────────────────────────────────────────────────────────────
+server:
+  baseUrl: "https://<HOSTNAME>"
+
+# ── Database: Amazon RDS for PostgreSQL ───────────────────────────────────────
+externalDatabase:
+  # RDS endpoint: <db-instance-id>.xxxxxxxxxxxx.<region>.rds.amazonaws.com
+  host: "<RDS_ENDPOINT>"
+  port: 5432
+  name: "terraform_registry"
+  user: "registry"
+  sslMode: "require"
+  # Leave blank — DB password comes from AWS Secrets Manager via CSI driver.
+  password: ""
+  existingSecret: ""
+
+# ── Storage: AWS S3 ────────────────────────────────────────────────────────────
+storage:
+  backend: "s3"
+  s3:
+    region: "<AWS_REGION>"
+    bucket: "<S3_BUCKET_NAME>"
+    # Use IRSA (IAM Roles for Service Accounts) — no static credentials needed.
+    # The pod's ServiceAccount role must have s3:GetObject, s3:PutObject, etc.
+    authMethod: "irsa"
+    accessKeyId: ""
+    secretAccessKey: ""
+  persistence:
+    enabled: false
+
+# ── Security: secrets from AWS Secrets Manager ────────────────────────────────
+# Leave blank — secrets come from AWS Secrets Manager via the CSI driver.
+# The SecretProviderClass in overlays/eks/ syncs them into the k8s Secret.
+security:
+  jwtSecret: ""
+  encryptionKey: ""
+  existingSecret: ""
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+logging:
+  level: "warn"
+  format: "json"
+
+# ── ServiceAccount: AWS IRSA ───────────────────────────────────────────────────
+# The role-arn must reference an IAM Role with trust policy allowing the
+# service account (system:serviceaccount:terraform-registry:terraform-registry)
+# to assume the role via OIDC. The role needs:
+#   - s3:GetObject, s3:PutObject, s3:DeleteObject, s3:ListBucket on the S3 bucket
+#   - secretsmanager:GetSecretValue on the registry secrets (for CSI driver)
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<IRSA_ROLE_NAME>"
+
+# ── Gateway API: AWS Load Balancer Controller ─────────────────────────────────
+# Requires AWS LBC v2.6+ installed in the cluster with Gateway API support.
+# Install LBC: https://kubernetes-sigs.github.io/aws-load-balancer-controller/
+#   helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+#     -n kube-system --set clusterName=<CLUSTER_NAME> \
+#     --set serviceAccount.create=false \
+#     --set serviceAccount.name=aws-load-balancer-controller
+gatewayAPI:
+  enabled: true
+  createGatewayClass: true
+  # Name is user-defined. The controller will reconcile all Gateways referencing it.
+  gatewayClassName: aws-alb-external
+  controllerName: "gateway.k8s.aws/alb"
+  # albId blank for EKS — no ARM resource ID needed.
+  albId: ""
+  # Additional Gateway annotations for AWS LBC.
+  # service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+  # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+  gatewayAnnotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+  hostname: "<HOSTNAME>"
+  # Use letsencrypt-staging during initial testing
+  certManagerIssuer: "letsencrypt-staging"
+  tlsSecretName: "terraform-registry-tls"
+  email: "<OPS_EMAIL>"
+
+# ── Disable legacy nginx Ingress ───────────────────────────────────────────────
+ingress:
+  enabled: false
+
+# ── Azure-specific features: disabled for EKS ─────────────────────────────────
+keyVault:
+  enabled: false
+workloadIdentity:
+  enabled: false
+
+# ── NetworkPolicy ──────────────────────────────────────────────────────────────
+# Requires EKS with Amazon VPC CNI + Calico or native VPC network policies.
+# Check: https://docs.aws.amazon.com/eks/latest/userguide/network-policy.html
+networkPolicy:
+  enabled: true
+  prometheusNamespace: "monitoring"
+
+# ── Autoscaling ────────────────────────────────────────────────────────────────
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -1,0 +1,168 @@
+# ============================================================
+# values-gke.yaml — Google Kubernetes Engine Deployment Values
+# ============================================================
+# Copy this file and fill in ALL <PLACEHOLDER> values before deploying.
+# Do NOT commit a filled-in copy that contains real IDs or secrets.
+#
+# Prerequisites: See docs/deployment/gke-prerequisites.md
+#
+# Deploy with:
+#   helm upgrade --install terraform-registry ./deployments/helm \
+#     --namespace terraform-registry --create-namespace \
+#     -f deployments/helm/values-gke.yaml
+#
+# For secrets management (GCP Secret Manager via CSI driver), the
+# SecretProviderClass must be applied separately — see overlays/gke/ for
+# the Kustomize-based approach, or apply secretproviderclass.yaml manually.
+# ============================================================
+
+# ── Images: Google Artifact Registry ─────────────────────────────────────────
+backend:
+  image:
+    # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
+    repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # Mount the CSI secret volume so GCP Secrets Manager provider syncs secrets
+  # into the terraform-registry-secrets k8s Secret at pod startup.
+  # Apply overlays/gke/secretproviderclass.yaml before deploying this chart.
+  extraVolumes:
+    - name: secrets-store
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: terraform-registry-secrets
+  extraVolumeMounts:
+    - name: secrets-store
+      mountPath: /mnt/secrets-store
+      readOnly: true
+
+frontend:
+  enabled: true
+  image:
+    repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
+    tag: "v1.0.0"
+    pullPolicy: IfNotPresent
+  replicaCount: 2
+
+# ── Server ─────────────────────────────────────────────────────────────────────
+server:
+  baseUrl: "https://<HOSTNAME>"
+
+# ── Database: Cloud SQL for PostgreSQL ────────────────────────────────────────
+# Option A: Use the Cloud SQL Auth Proxy as a sidecar (recommended).
+#   host: 127.0.0.1, port: 5432, sslMode: disable (proxy handles TLS).
+#   See: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+# Option B: Connect via Private IP directly (requires private services access).
+#   host: <CLOUD_SQL_PRIVATE_IP>, sslMode: require
+externalDatabase:
+  host: "127.0.0.1" # Cloud SQL Auth Proxy sidecar address
+  port: 5432
+  name: "terraform_registry"
+  user: "registry"
+  sslMode: "disable" # Proxy handles TLS when using Auth Proxy
+  password: ""
+  existingSecret: ""
+
+# ── Storage: Google Cloud Storage ─────────────────────────────────────────────
+storage:
+  backend: "gcs"
+  gcs:
+    bucket: "<GCS_BUCKET_NAME>"
+    projectId: "<PROJECT_ID>"
+    # Workload Identity provides credentials — no key file needed.
+    authMethod: "workload-identity"
+    credentialsFile: ""
+  persistence:
+    enabled: false
+
+# ── Security: secrets from GCP Secret Manager ─────────────────────────────────
+security:
+  jwtSecret: ""
+  encryptionKey: ""
+  existingSecret: ""
+
+# ── Logging ────────────────────────────────────────────────────────────────────
+logging:
+  level: "warn"
+  format: "json"
+
+# ── ServiceAccount: GKE Workload Identity ─────────────────────────────────────
+# Links this Kubernetes ServiceAccount to a Google Service Account (GSA).
+# The GSA must have:
+#   - roles/storage.objectAdmin on the GCS bucket
+#   - roles/cloudsql.client (if using Cloud SQL Auth Proxy)
+#   - roles/secretmanager.secretAccessor on the registry secrets
+# Bind the KSA to the GSA:
+#   gcloud iam service-accounts add-iam-policy-binding \
+#     <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com \
+#     --role roles/iam.workloadIdentityUser \
+#     --member "serviceAccount:<PROJECT_ID>.svc.id.goog[terraform-registry/terraform-registry]"
+serviceAccount:
+  create: true
+  annotations:
+    iam.gke.io/gcp-service-account: "<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com"
+
+# ── Gateway API: GKE built-in Controller ──────────────────────────────────────
+# GKE provides GatewayClasses automatically — no GatewayClass resource needed.
+# Available GatewayClasses:
+#   gke-l7-global-external-managed   — Global External Application Load Balancer
+#   gke-l7-regional-external-managed — Regional External Application Load Balancer
+#   gke-l7-rilb                      — Internal Application Load Balancer
+#
+# Enable the Gateway API in GKE:
+#   gcloud container clusters update <CLUSTER> --gateway-api=standard --region <REGION>
+#
+# cert-manager with GKE Gateway: requires cert-manager >= 1.14 with
+#   --set "featureGates=ExperimentalGatewayAPISupport=true"
+gatewayAPI:
+  enabled: true
+  # GKE pre-provisions GatewayClasses — do NOT create one.
+  createGatewayClass: false
+  gatewayClassName: gke-l7-global-external-managed
+  controllerName: "" # not used when createGatewayClass: false
+  albId: "" # not applicable for GKE
+  gatewayAnnotations: {}
+  hostname: "<HOSTNAME>"
+  certManagerIssuer: "letsencrypt-staging"
+  tlsSecretName: "terraform-registry-tls"
+  email: "<OPS_EMAIL>"
+
+# ── Disable legacy nginx Ingress ───────────────────────────────────────────────
+ingress:
+  enabled: false
+
+# ── Azure-specific features: disabled for GKE ─────────────────────────────────
+keyVault:
+  enabled: false
+workloadIdentity:
+  enabled: false
+
+# ── NetworkPolicy ──────────────────────────────────────────────────────────────
+# GKE supports NetworkPolicy with Calico or Dataplane V2 (Cilium-based).
+# Enable with: gcloud container clusters create ... --enable-network-policy
+# Or for Dataplane V2: --enable-dataplane-v2
+networkPolicy:
+  enabled: true
+  prometheusNamespace: "monitoring"
+
+# ── Autoscaling ────────────────────────────────────────────────────────────────
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -31,7 +31,7 @@ backend:
     runAsNonRoot: true
   # -- Container security context
   securityContext:
-    readOnlyRootFilesystem: false
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []
@@ -146,20 +146,33 @@ multiTenancy:
   defaultOrganization: "default"
 
 # -- Security
+# IMPORTANT: For production deployments, use existingSecret (or Key Vault CSI /
+# External Secrets Operator) instead of setting jwtSecret / encryptionKey here.
+# Values passed via --set or in a values file are stored in plain text inside
+# the Helm release Secret (sh.helm.release.v1.*), readable by anyone with
+# get-secrets RBAC in the namespace.
 security:
   # -- JWT secret (required, min 32 chars). Ignored if existingSecret is set.
   jwtSecret: ""
   # -- Encryption key for sensitive data (32 bytes). Ignored if existingSecret is set.
   encryptionKey: ""
-  # -- Use an existing secret containing TFR_JWT_SECRET and ENCRYPTION_KEY keys
+  # -- Use an existing secret containing TFR_JWT_SECRET and ENCRYPTION_KEY keys.
+  # This is the recommended approach for production — it avoids storing secrets
+  # in Helm release history. Create the Secret before installing the chart:
+  #   kubectl create secret generic my-registry-secrets \
+  #     --from-literal=TFR_JWT_SECRET="$(openssl rand -hex 32)" \
+  #     --from-literal=ENCRYPTION_KEY="$(openssl rand -hex 16)" \
+  #     -n terraform-registry
   existingSecret: ""
   rateLimiting:
     enabled: true
     requestsPerMinute: 60
     burst: 10
   cors:
-    allowedOrigins:
-      - "*"
+    # -- Allowed CORS origins. Set to your registry's public URL in production.
+    # Defaults to empty (no cross-origin requests allowed). Example:
+    #   allowedOrigins: ["https://registry.example.com"]
+    allowedOrigins: []
 
 # -- Logging
 logging:
@@ -222,3 +235,93 @@ serviceMonitor:
   enabled: false
   interval: 30s
   labels: {}
+
+# -- Kubernetes Gateway API
+# Supports AKS (Application Gateway for Containers), AWS EKS (ALB Controller),
+# GKE (built-in Gateway), and any other Gateway API-compliant implementation.
+# When gatewayAPI.enabled=true, set ingress.enabled=false to avoid deploying
+# the legacy nginx Ingress resource alongside Gateway API resources.
+gatewayAPI:
+  # -- Enable Gateway API resources (GatewayClass, Gateway, HTTPRoute, ClusterIssuers, Certificate)
+  enabled: false
+  # -- Create a GatewayClass resource. Set false for GKE, which pre-provisions
+  # GatewayClasses (gke-l7-global-external-managed, etc.) — no user GatewayClass needed.
+  # Set true for AKS (AGfC) and EKS (AWS LBC) which require a user-created GatewayClass.
+  createGatewayClass: true
+  # -- GatewayClass name.
+  # AKS/AGfC:     azure-alb-external (or azure-alb-internal for private)
+  # EKS/AWS LBC:  aws-alb-external   (or any name you choose)
+  # GKE:          gke-l7-global-external-managed (pre-provisioned, no createGatewayClass needed)
+  gatewayClassName: azure-alb-external
+  # -- GatewayClass controller name. Only used when createGatewayClass: true.
+  # AKS/AGfC:  alb.networking.azure.io/alb-controller
+  # EKS/AWS:   gateway.k8s.aws/alb
+  # GKE:       (not needed — set createGatewayClass: false)
+  controllerName: "alb.networking.azure.io/alb-controller"
+  # -- AKS/AGfC only: ARM resource ID of the Application Gateway for Containers resource.
+  # Format: /subscriptions/<SUB>/resourceGroups/<RG>/providers/
+  #         Microsoft.ServiceNetworking/trafficControllers/<AGFC_NAME>
+  # Leave empty for EKS and GKE.
+  albId: ""
+  # -- Additional annotations to merge onto the Gateway resource.
+  # Use for provider-specific annotations not covered by albId above.
+  # Example for EKS:  service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+  # Example for GKE:  networking.gke.io/certmap: my-cert-map  (optional)
+  gatewayAnnotations: {}
+  # -- Public hostname for the registry (must match your DNS record and TLS certificate)
+  hostname: "registry.example.com"
+  # -- cert-manager ClusterIssuer name for automatic TLS provisioning.
+  # Use letsencrypt-staging during testing; switch to letsencrypt-prod for production.
+  certManagerIssuer: "letsencrypt-staging"
+  # -- Name of the TLS Secret created by cert-manager.
+  # Must match the Gateway listener's certificateRefs[].name.
+  tlsSecretName: "terraform-registry-tls"
+  # -- Email address for Let's Encrypt certificate expiry notifications (required)
+  email: ""
+
+# -- Azure Key Vault + Secrets Store CSI Driver (AKS-specific)
+# When enabled, creates a SecretProviderClass that syncs secrets from Azure Key
+# Vault into the terraform-registry-secrets Kubernetes Secret at pod startup.
+# The backend Deployment gets a CSI volume and mount injected automatically.
+# Requires: AKS Secrets Store CSI Driver add-on + Azure Workload Identity.
+#
+# For AWS EKS or GCP GKE: use backend.extraVolumes + backend.extraVolumeMounts
+# to mount a cloud-specific SecretProviderClass applied separately (or via the
+# Kustomize overlays in overlays/eks/ or overlays/gke/).
+keyVault:
+  # -- Enable Azure Key Vault CSI Driver integration
+  enabled: false
+  # -- Azure Key Vault resource name (not full URI — just the vault name)
+  name: ""
+  # -- Azure AD Tenant ID (UUID)
+  tenantId: ""
+  # -- Client ID of the User-Assigned Managed Identity used for Key Vault access.
+  # Must match workloadIdentity.clientId if workloadIdentity is also enabled.
+  clientId: ""
+
+# -- Azure Workload Identity (AKS-specific)
+# When enabled, adds the azure.workload.identity/client-id annotation to the
+# ServiceAccount so the Workload Identity webhook injects OIDC tokens into pods.
+# A federated credential must be configured on the managed identity pointing to
+# this ServiceAccount (see docs/deployment/aks-prerequisites.md).
+#
+# For AWS EKS:  use serviceAccount.annotations with eks.amazonaws.com/role-arn
+# For GCP GKE:  use serviceAccount.annotations with iam.gke.io/gcp-service-account
+workloadIdentity:
+  # -- Enable Azure Workload Identity annotation on ServiceAccount
+  enabled: false
+  # -- Client ID of the User-Assigned Managed Identity (UUID)
+  clientId: ""
+
+# -- Kubernetes NetworkPolicy
+# When enabled, creates a default-deny-ingress policy for the namespace with
+# explicit allow rules for frontend HTTP, backend API, and Prometheus metrics.
+# Requires a CNI that supports NetworkPolicy: Azure CNI, Calico, Cilium, etc.
+# Kubenet clusters do NOT enforce NetworkPolicy — the resources are accepted but
+# ignored. Set enabled: false if your cluster uses kubenet.
+networkPolicy:
+  # -- Enable NetworkPolicy resources (recommended for production)
+  enabled: true
+  # -- Namespace label value where Prometheus / metrics scraper runs.
+  # Used to allow scraping backend port 9090. Set to match your monitoring namespace.
+  prometheusNamespace: "monitoring"

--- a/deployments/kubernetes/base/configmap-frontend-nginx.yaml
+++ b/deployments/kubernetes/base/configmap-frontend-nginx.yaml
@@ -1,74 +1,93 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: frontend-nginx-config
+    name: frontend-nginx-config
 data:
-  default.conf: |
-    server {
-        listen 80;
-        server_name _;
-        root /usr/share/nginx/html;
-        index index.html;
+    default.conf: |
+        server {
+            listen 80;
+            server_name _;
+            root /usr/share/nginx/html;
+            index index.html;
 
-        client_max_body_size 500m;
+            client_max_body_size 500m;
 
-        location / {
-            try_files $uri $uri/ /index.html;
+            # Security headers
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+
+            location / {
+                try_files $uri $uri/ /index.html;
+            }
+
+            # API — includes large file uploads (modules up to 100MB, providers up to 500MB)
+            location /api/ {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_read_timeout 600s;
+                proxy_send_timeout 600s;
+                proxy_connect_timeout 60s;
+            }
+
+            location = /swagger.json {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            # Terraform Module/Provider Registry protocol
+            location /v1/ {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_read_timeout 600s;
+                proxy_send_timeout 600s;
+                proxy_connect_timeout 60s;
+            }
+
+            # OIDC / Terraform service discovery
+            location /.well-known/ {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location /webhooks/ {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            # Network Mirror protocol — can involve long-running sync operations
+            location /terraform/ {
+                proxy_pass http://backend:8080;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_read_timeout 600s;
+                proxy_send_timeout 600s;
+                proxy_connect_timeout 60s;
+            }
+
+            location /health {
+                proxy_pass http://backend:8080;
+            }
+
+            location /ready {
+                proxy_pass http://backend:8080;
+            }
         }
-
-        location /api/ {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location = /swagger.json {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /v1/ {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /.well-known/ {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /webhooks/ {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /terraform/ {
-            proxy_pass http://backend:8080;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        location /health {
-            proxy_pass http://backend:8080;
-        }
-
-        location /ready {
-            proxy_pass http://backend:8080;
-        }
-    }

--- a/deployments/kubernetes/base/configmap.yaml
+++ b/deployments/kubernetes/base/configmap.yaml
@@ -6,19 +6,38 @@ data:
   # Server
   TFR_SERVER_HOST: "0.0.0.0"
   TFR_SERVER_PORT: "8080"
+  # REQUIRED: Override TFR_SERVER_BASE_URL in your overlay to match your public hostname.
   TFR_SERVER_BASE_URL: "https://registry.example.com"
 
   # Database (password in Secret)
-  TFR_DATABASE_HOST: "postgres.terraform-registry.svc.cluster.local"
+  # REQUIRED: Override TFR_DATABASE_HOST in your overlay.
+  # For Azure Database for PostgreSQL Flexible Server the host looks like:
+  #   <server-name>.postgres.database.azure.com
+  # For an in-cluster PostgreSQL (e.g. Bitnami chart) use the service FQDN:
+  #   <release>-postgresql.<namespace>.svc.cluster.local
+  TFR_DATABASE_HOST: ""
   TFR_DATABASE_PORT: "5432"
   TFR_DATABASE_NAME: "terraform_registry"
   TFR_DATABASE_USER: "registry"
   TFR_DATABASE_SSL_MODE: "require"
 
-  # Storage
+  # Storage backend — override in your overlay.
+  # Options: local | s3 | azure | gcs
+  #
+  # "local" uses a PersistentVolumeClaim mounted at TFR_STORAGE_LOCAL_BASE_PATH.
+  #   ReadWriteOnce (default) only supports a single node. For multiple replicas
+  #   across nodes use storageClass: azurefile-csi (ReadWriteMany) or switch to
+  #   a cloud storage backend.
+  #
+  # "azure" uses Azure Blob Storage — recommended for AKS multi-replica deployments.
+  #   Set TFR_STORAGE_AZURE_ACCOUNT_NAME and TFR_STORAGE_AZURE_CONTAINER_NAME here.
+  #   Store TFR_STORAGE_AZURE_ACCOUNT_KEY in the Secret (or Key Vault).
   TFR_STORAGE_DEFAULT_BACKEND: "local"
   TFR_STORAGE_LOCAL_BASE_PATH: "/app/storage"
   TFR_STORAGE_LOCAL_SERVE_DIRECTLY: "true"
+  # Azure Blob Storage (used when TFR_STORAGE_DEFAULT_BACKEND=azure)
+  TFR_STORAGE_AZURE_ACCOUNT_NAME: ""
+  TFR_STORAGE_AZURE_CONTAINER_NAME: ""
 
   # Auth
   TFR_AUTH_API_KEYS_ENABLED: "true"
@@ -29,7 +48,7 @@ data:
   TFR_MULTI_TENANCY_ENABLED: "false"
   TFR_MULTI_TENANCY_DEFAULT_ORGANIZATION: "default"
 
-  # Security (TLS terminated at Ingress)
+  # Security (TLS terminated at Gateway/Ingress)
   TFR_SECURITY_TLS_ENABLED: "false"
   TFR_SECURITY_RATE_LIMITING_ENABLED: "true"
 

--- a/deployments/kubernetes/base/deployment-backend.yaml
+++ b/deployments/kubernetes/base/deployment-backend.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: backend
+        # Required by Azure Workload Identity to inject OIDC token.
+        # Safe to leave on non-AKS clusters (label is ignored if the
+        # azure-workload-identity mutating webhook is not installed).
+        azure.workload.identity/use: "true"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
@@ -26,7 +30,16 @@ spec:
         runAsNonRoot: true
       containers:
         - name: backend
+          # Image and tag are overridden by each overlay's kustomization.yaml
+          # via the images transformer. Do not apply the base directly in production.
           image: terraform-registry-backend:latest
+          imagePullPolicy: Always
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: 8080
@@ -39,19 +52,23 @@ spec:
                 name: terraform-registry-config
             - secretRef:
                 name: terraform-registry-secrets
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /health
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -65,7 +82,11 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: /app/storage
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: storage
           persistentVolumeClaim:
             claimName: terraform-registry-storage
+        - name: tmp
+          emptyDir: {}

--- a/deployments/kubernetes/base/deployment-frontend.yaml
+++ b/deployments/kubernetes/base/deployment-frontend.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         app.kubernetes.io/component: frontend
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: frontend
           image: terraform-registry-frontend:latest
@@ -21,6 +24,13 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
           livenessProbe:
             httpGet:
               path: /

--- a/deployments/kubernetes/base/ingress.yaml
+++ b/deployments/kubernetes/base/ingress.yaml
@@ -1,3 +1,21 @@
+# ============================================================
+# Ingress — legacy nginx Ingress Controller
+# ============================================================
+# NOTE: This manifest uses ingressClassName: nginx (OSS ingress-nginx).
+# The upstream ingress-nginx project ended maintenance in March 2026.
+#
+# FOR AKS DEPLOYMENTS: Do not apply this resource. Use the AKS overlay
+# (overlays/aks/) instead, which provides a GatewayClass + Gateway +
+# HTTPRoute using Application Gateway for Containers (AGfC) with the
+# Kubernetes Gateway API. See docs/deployment/aks-new-cluster.md.
+#
+# This manifest remains for:
+#   - Non-AKS clusters with a self-managed nginx Ingress Controller
+#   - Migration reference
+#
+# Before applying, replace registry.example.com with your hostname and
+# create the terraform-registry-tls Secret (or use cert-manager).
+# ============================================================
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -5,6 +23,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "500m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    # Uncomment to use cert-manager for automatic TLS provisioning:
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: nginx
   tls:

--- a/deployments/kubernetes/base/kustomization.yaml
+++ b/deployments/kubernetes/base/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - service-frontend.yaml
   - ingress.yaml
   - pdb.yaml
+  - networkpolicy.yaml
 
 labels:
   - pairs:

--- a/deployments/kubernetes/base/networkpolicy.yaml
+++ b/deployments/kubernetes/base/networkpolicy.yaml
@@ -1,0 +1,133 @@
+# NetworkPolicy resources for the terraform-registry namespace.
+#
+# IMPORTANT: NetworkPolicy enforcement requires a CNI plugin that supports it.
+# On AKS use Azure CNI (or Azure CNI Overlay) with either:
+#   - Azure Network Policy Manager: --network-policy azure
+#   - Calico:                       --network-policy calico
+# Kubenet does NOT support NetworkPolicy.
+#
+# These policies implement a default-deny-ingress pattern with explicit allow
+# rules for required traffic flows:
+#
+#   [External/Gateway] ──(80)──▶ frontend ──(8080)──▶ backend
+#   [External/Gateway] ──(8080)─────────────────────▶ backend  (direct API/Terraform routes)
+#                                                         ▲
+#                                   Prometheus ──(9090)───┘
+#
+# Egress is unrestricted by default. The backend must reach PostgreSQL,
+# cloud storage endpoints (Azure Blob, S3, GCS), OIDC providers, and the
+# container registry. To restrict egress, uncomment the policy below and
+# customise the CIDR / port rules for your environment.
+#
+# To add egress restriction, create a separate file (e.g. networkpolicy-egress.yaml)
+# and add it to your overlay's resources list:
+#
+# ---
+# # Default deny egress, then allow only required destinations
+# apiVersion: networking.k8s.io/v1
+# kind: NetworkPolicy
+# metadata:
+#   name: backend-restrict-egress
+# spec:
+#   podSelector:
+#     matchLabels:
+#       app.kubernetes.io/component: backend
+#   policyTypes:
+#     - Egress
+#   egress:
+#     # DNS
+#     - ports:
+#         - port: 53
+#           protocol: UDP
+#         - port: 53
+#           protocol: TCP
+#     # PostgreSQL
+#     - ports:
+#         - port: 5432
+#           protocol: TCP
+#     # HTTPS (cloud storage, OIDC, container registry)
+#     - ports:
+#         - port: 443
+#           protocol: TCP
+
+# ── 1. Default: deny all ingress in this namespace ────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# ── 2. Frontend: allow HTTP from anywhere ─────────────────────────────────────
+# Traffic arrives from external sources (Application Gateway for Containers,
+# cloud load balancers, or the nginx Ingress Controller). AGfC routes packets
+# directly to pod IPs (Azure CNI), so the source is the AGfC subnet—not a
+# cluster-namespaced pod. Allow all sources on port 80.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 80
+          protocol: TCP
+---
+# ── 3. Backend: allow HTTP from frontend pods and external Gateway/LB ─────────
+# The Gateway API HTTPRoute (used in AKS/EKS/GKE overlays) routes /api/*,
+# /v1/*, /.well-known/*, /terraform/*, /webhooks/* directly to the backend
+# service—not through the frontend nginx proxy. This traffic originates from
+# the cloud load balancer (AGfC, ALB, GKE LB), which is outside the cluster
+# pod network. We must allow all sources on port 8080 in addition to
+# frontend-only access, because the LB source IP is not a labelled pod.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+---
+# ── 4. Backend metrics: allow Prometheus scrape from the monitoring namespace ──
+# The namespace label kubernetes.io/metadata.name is automatically applied by
+# Kubernetes 1.21+. If using an older cluster or a custom namespace label,
+# adjust the namespaceSelector below.
+#
+# For AKS with Azure Managed Prometheus / Azure Monitor, traffic arrives from
+# the kube-system or azuremonitor-metrics namespace. Add additional from entries
+# as needed.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 9090
+          protocol: TCP

--- a/deployments/kubernetes/base/pdb.yaml
+++ b/deployments/kubernetes/base/pdb.yaml
@@ -7,3 +7,13 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: backend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: frontend

--- a/deployments/kubernetes/base/pvc.yaml
+++ b/deployments/kubernetes/base/pvc.yaml
@@ -1,7 +1,26 @@
-# PVC for local storage backend.
-# Not needed if using cloud storage (S3, Azure Blob, GCS).
-# Note: ReadWriteOnce limits to single-node. For multi-replica with local
-# storage, use ReadWriteMany with NFS/EFS, or switch to cloud storage.
+# PVC for the local storage backend.
+# Not needed (and should be disabled) when using cloud storage:
+#   Azure Blob (TFR_STORAGE_DEFAULT_BACKEND=azure) — recommended for AKS
+#   AWS S3    (TFR_STORAGE_DEFAULT_BACKEND=s3)
+#   GCS       (TFR_STORAGE_DEFAULT_BACKEND=gcs)
+#
+# ReadWriteOnce (RWO) vs ReadWriteMany (RWX)
+# ------------------------------------------
+# ReadWriteOnce (default): only one node may mount the volume at a time.
+#   Use when replicas=1, or when all backend pods are on the same node.
+#   AKS default StorageClass: managed-csi (Azure Disk, RWO).
+#
+# ReadWriteMany: multiple nodes may mount simultaneously.
+#   Required when replicas>1 and pods may land on different nodes.
+#   AKS StorageClass for RWX: azurefile-csi (Azure Files, NFS or SMB).
+#   Override storageClassName in your overlay:
+#     storageClassName: azurefile-csi
+#     accessModes: [ReadWriteMany]
+#
+# NOTE: If you switch to Azure Blob storage (recommended for AKS), set
+#   TFR_STORAGE_DEFAULT_BACKEND=azure in the ConfigMap and disable
+#   this PVC by removing pvc.yaml from your overlay's resources list,
+#   or setting storage.persistence.enabled=false in Helm values.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -9,6 +28,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  # storageClassName: ""  # Leave blank to use cluster default.
+  #                       # AKS Azure Disk (RWO): managed-csi
+  #                       # AKS Azure Files (RWX): azurefile-csi
   resources:
     requests:
       storage: 10Gi

--- a/deployments/kubernetes/base/secret.yaml
+++ b/deployments/kubernetes/base/secret.yaml
@@ -1,12 +1,54 @@
-# IMPORTANT: Replace placeholder values before applying.
-# For production, use sealed-secrets, external-secrets-operator,
-# or inject via CI/CD pipeline.
+# ============================================================
+# Secret — terraform-registry-secrets
+# ============================================================
+# This file contains placeholder values. DO NOT commit real secrets.
+#
+# Supported patterns for populating this Secret:
+#
+# 1. Azure Key Vault + Secrets Store CSI Driver (recommended for AKS)
+#    -------------------------------------------------------------------
+#    Enable the AKS overlay (overlays/aks/) which includes a
+#    SecretProviderClass that pulls secrets from Key Vault and syncs
+#    them into this Secret automatically at pod start-up.
+#    The backend pod must mount the CSI volume (handled by the overlay
+#    patch in overlays/aks/patches/backend-workload-identity.yaml).
+#
+# 2. External Secrets Operator
+#    -------------------------------------------------------------------
+#    Install ESO (https://external-secrets.io) and replace this manifest
+#    with an ExternalSecret resource referencing your Key Vault / Vault /
+#    Parameter Store.
+#
+# 3. CI/CD pipeline substitution
+#    -------------------------------------------------------------------
+#    kubectl create secret generic terraform-registry-secrets \
+#      --from-literal=TFR_DATABASE_PASSWORD="$DB_PASS" \
+#      --from-literal=TFR_JWT_SECRET="$JWT_SECRET" \
+#      --from-literal=ENCRYPTION_KEY="$ENC_KEY" \
+#      --namespace terraform-registry \
+#      --dry-run=client -o yaml | kubectl apply -f -
+#
+#    Or use kustomize secretGenerator with an envFile pointing at a
+#    CI/CD-injected .env file (add the .env to .gitignore).
+#
+# 4. Sealed Secrets (GitOps-friendly)
+#    -------------------------------------------------------------------
+#    Install kubeseal, encrypt the values, and commit the SealedSecret
+#    manifest instead of this file.
+# ============================================================
 apiVersion: v1
 kind: Secret
 metadata:
   name: terraform-registry-secrets
 type: Opaque
 stringData:
-  TFR_DATABASE_PASSWORD: "CHANGEME"
-  TFR_JWT_SECRET: "CHANGEME-must-be-at-least-32-characters-long"
-  ENCRYPTION_KEY: "CHANGEME-32-bytes-for-aes256!!"
+  # Generate with: openssl rand -hex 32
+  TFR_JWT_SECRET: "<REPLACE_VIA_SEALED_SECRETS_OR_CI>"
+  # Must be exactly 32 bytes for AES-256. Generate with: openssl rand -hex 16
+  ENCRYPTION_KEY: "<REPLACE_VIA_SEALED_SECRETS_OR_CI>"
+  # Database password (also accepted via externalDatabase.existingSecret in Helm)
+  TFR_DATABASE_PASSWORD: "<REPLACE_VIA_SEALED_SECRETS_OR_CI>"
+  # Azure Blob Storage account key — only when storage backend=azure
+  # and NOT using Workload Identity / managed identity for storage access.
+  # Remove this entry if using Workload Identity (preferred for AKS).
+  # TFR_STORAGE_AZURE_ACCOUNT_KEY: "<REPLACE_VIA_SEALED_SECRETS_OR_CI>"

--- a/deployments/kubernetes/base/service-backend.yaml
+++ b/deployments/kubernetes/base/service-backend.yaml
@@ -11,6 +11,11 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
+    # Prometheus metrics port. The metrics endpoint is unauthenticated.
+    # The NetworkPolicy restricts scraping to monitoring/kube-system namespaces,
+    # but this only works when your CNI enforces NetworkPolicy. On clusters
+    # without NetworkPolicy enforcement (e.g. kubenet), the metrics endpoint
+    # is accessible from any pod in the cluster.
     - name: metrics
       port: 9090
       targetPort: metrics

--- a/deployments/kubernetes/base/serviceaccount.yaml
+++ b/deployments/kubernetes/base/serviceaccount.yaml
@@ -4,11 +4,18 @@ metadata:
   name: terraform-registry
   labels:
     app.kubernetes.io/component: backend
-  # Add annotations for cloud provider IAM integration:
-  # AWS IRSA:
-  #   eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/terraform-registry
-  # GCP Workload Identity:
-  #   iam.gke.io/gcp-service-account: terraform-registry@PROJECT.iam.gserviceaccount.com
-  # Azure Workload Identity:
-  #   azure.workload.identity/client-id: <client-id>
-  annotations: {}
+  annotations:
+    # --- Azure Workload Identity (AKS) ---
+    # Uncomment and set this annotation when deploying to AKS with Workload Identity.
+    # The client-id is the Client ID of the User-Assigned Managed Identity (UAMI).
+    # A federated credential must be created on the UAMI pointing to this
+    # ServiceAccount (namespace: terraform-registry, name: terraform-registry).
+    # See docs/deployment/aks-prerequisites.md for the full setup procedure.
+    #
+    # azure.workload.identity/client-id: "<AZURE_CLIENT_ID>"
+    #
+    # --- AWS IRSA ---
+    # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/terraform-registry
+    #
+    # --- GCP Workload Identity ---
+    # iam.gke.io/gcp-service-account: terraform-registry@PROJECT.iam.gserviceaccount.com

--- a/deployments/kubernetes/overlays/aks/certificate.yaml
+++ b/deployments/kubernetes/overlays/aks/certificate.yaml
@@ -1,0 +1,37 @@
+# ============================================================
+# Certificate — cert-manager TLS Certificate
+# ============================================================
+# Requests a TLS certificate from Let's Encrypt and stores it in
+# the terraform-registry-tls Secret. The Gateway (gateway.yaml)
+# references this Secret for HTTPS termination.
+#
+# Start with letsencrypt-staging issuer (no rate limits, untrusted CA)
+# to verify the full ACME flow, then change issuerRef.name to
+# letsencrypt-prod for production.
+#
+# Replace <HOSTNAME> with your public DNS name.
+# Ensure the DNS record already points to the Gateway's public IP
+# before creating this Certificate — the ACME HTTP-01 challenge
+# requires that /.well-known/acme-challenge/ on port 80 is reachable.
+# ============================================================
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: terraform-registry-tls
+  namespace: terraform-registry
+spec:
+  # Name of the Secret that will be created/updated by cert-manager.
+  # Must match the certificateRefs[].name in the Gateway listener.
+  secretName: terraform-registry-tls
+  issuerRef:
+    # Start with letsencrypt-staging for initial testing.
+    # Change to letsencrypt-prod once staging certificate issues successfully.
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    # Replace <HOSTNAME> with your public hostname (e.g. registry.company.com)
+    - "<HOSTNAME>"
+  # Optional: specify duration and renewBefore (defaults: 90d, 30d before expiry)
+  # duration: 2160h    # 90 days
+  # renewBefore: 720h  # 30 days before expiry

--- a/deployments/kubernetes/overlays/aks/clusterissuer.yaml
+++ b/deployments/kubernetes/overlays/aks/clusterissuer.yaml
@@ -1,0 +1,65 @@
+# ============================================================
+# cert-manager ClusterIssuers — Let's Encrypt ACME
+# ============================================================
+# Two issuers are provided:
+#
+#   letsencrypt-staging — Use during sandbox/testing (untrusted CA, no rate limits)
+#   letsencrypt-prod    — Use for production (trusted CA, rate limits apply)
+#
+# Workflow:
+#   1. Start with letsencrypt-staging to verify the ACME HTTP-01 challenge works.
+#   2. Check certificate is issued: kubectl get certificate -n terraform-registry
+#   3. Once verified, update certificate.yaml issuerRef to letsencrypt-prod
+#      and delete+recreate the Certificate (or patch the issuerRef).
+#
+# HTTP-01 challenge via Gateway API:
+#   cert-manager creates a temporary HTTPRoute in the terraform-registry namespace
+#   to serve the ACME challenge token. This requires:
+#     - cert-manager >= 1.14 installed with --set featureGates="ExperimentalGatewayAPISupport=true"
+#     - The Gateway's http listener must be accessible from the internet on port 80
+#     - The DNS record for <HOSTNAME> must already point to the Gateway's public IP
+#       before the certificate request is created
+#
+# Replace <EMAIL> with your ops/admin email for certificate expiry notifications.
+# ============================================================
+
+# ── Staging (untrusted, for testing) ──────────────────────────────────────────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Replace with your email for expiry warnings and account notifications.
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          # Use a Gateway API HTTPRoute for the ACME challenge (requires cert-manager >= 1.14
+          # with ExperimentalGatewayAPISupport=true feature gate).
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway
+---
+# ── Production (trusted, rate-limited) ────────────────────────────────────────
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway

--- a/deployments/kubernetes/overlays/aks/gateway.yaml
+++ b/deployments/kubernetes/overlays/aks/gateway.yaml
@@ -1,0 +1,74 @@
+# ============================================================
+# Gateway API Resources — Application Gateway for Containers (AGfC)
+# ============================================================
+# GatewayClass + Gateway for AGfC with Kubernetes Gateway API v1.
+#
+# Replace ALL <PLACEHOLDER> values before applying.
+#
+# The GatewayClass is cluster-scoped; it is shared across namespaces.
+# The Gateway is namespace-scoped (terraform-registry).
+#
+# TLS is terminated at the Gateway using a cert-manager-issued Let's Encrypt
+# certificate stored in the terraform-registry-tls Secret.
+# HTTP traffic (port 80) is redirected to HTTPS via an HTTPRoute in httproute.yaml.
+#
+# Documentation: docs/deployment/aks-new-cluster.md
+# ============================================================
+
+# ── GatewayClass — references the AGfC ALB Controller ─────────────────────────
+# The ALB Controller (deployed in the azure-alb-system namespace) reconciles
+# all Gateway resources that reference this GatewayClass.
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: azure-alb-external
+spec:
+  controllerName: alb.networking.azure.io/alb-controller
+---
+# ── Gateway — defines traffic entry points ────────────────────────────────────
+# The alb.networking.azure.io/alb-id annotation associates this Gateway with
+# your pre-provisioned Application Gateway for Containers ARM resource.
+#
+# The cert-manager.io/cluster-issuer annotation instructs cert-manager to create
+# an HTTPRoute for the ACME HTTP-01 challenge on the http listener.
+# Use letsencrypt-staging until the full flow is validated, then switch to
+# letsencrypt-prod (or edit the certificate.yaml to change the issuerRef).
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: terraform-registry-gateway
+  namespace: terraform-registry
+  annotations:
+    # Full ARM resource ID of the Application Gateway for Containers resource.
+    # Format: /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/
+    #         providers/Microsoft.ServiceNetworking/trafficControllers/<AGFC_NAME>
+    alb.networking.azure.io/alb-id: >-
+      /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>/providers/Microsoft.ServiceNetworking/trafficControllers/<AGFC_NAME>
+    # cert-manager annotation: creates ACME HTTP-01 challenge HTTPRoute automatically.
+    # Change to letsencrypt-prod after verifying sandbox certificate issuance.
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+spec:
+  gatewayClassName: azure-alb-external
+  listeners:
+    # HTTP listener — used only for ACME HTTP-01 challenge and redirect to HTTPS
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    # HTTPS listener — all application traffic
+    # Replace <HOSTNAME> with your public DNS name (must match the Certificate dnsName)
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "<HOSTNAME>"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          # Secret created by cert-manager (see certificate.yaml)
+          - name: terraform-registry-tls
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/deployments/kubernetes/overlays/aks/httproute.yaml
+++ b/deployments/kubernetes/overlays/aks/httproute.yaml
@@ -1,0 +1,138 @@
+# ============================================================
+# HTTPRoute Resources — Kubernetes Gateway API v1
+# ============================================================
+# Three HTTPRoute resources:
+#
+#   1. http-redirect    — HTTP (port 80) → HTTPS redirect (301)
+#   2. backend-routes   — HTTPS: API/protocol paths → backend Service:8080
+#   3. frontend-route   — HTTPS: catch-all (/) → frontend Service:80
+#
+# Note on path priority (Gateway API spec):
+#   - Exact matches take priority over Prefix matches
+#   - Longer prefix matches take priority over shorter ones
+#   - /api/ and /v1/ (backend-routes) are matched before / (frontend-route)
+#
+# With AGfC routing API traffic directly to the backend pod, the frontend
+# nginx's proxy_pass directives for /api/, /v1/, etc. are NOT invoked for
+# those paths. Only SPA requests (HTML/JS/CSS) go to the frontend pod.
+#
+# Replace <HOSTNAME> with your domain (must match Gateway listener hostname).
+# ============================================================
+
+# ── 1. HTTP → HTTPS redirect ──────────────────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-redirect
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+# ── 2. Backend API and protocol paths (HTTPS) ─────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-routes
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "<HOSTNAME>"
+  rules:
+    # REST API — all admin, auth, provider, module, and mirror management endpoints
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: backend
+          port: 8080
+    # Terraform Module/Provider Registry protocol (RFC)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/
+      backendRefs:
+        - name: backend
+          port: 8080
+    # OIDC discovery and Terraform service discovery (.well-known endpoints)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+      backendRefs:
+        - name: backend
+          port: 8080
+    # Network Mirror protocol endpoints
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /terraform/
+      backendRefs:
+        - name: backend
+          port: 8080
+    # Webhook endpoints
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks/
+      backendRefs:
+        - name: backend
+          port: 8080
+    # Health and readiness probes (useful for external uptime monitoring)
+    - matches:
+        - path:
+            type: Exact
+            value: /health
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /ready
+      backendRefs:
+        - name: backend
+          port: 8080
+    # OpenAPI spec
+    - matches:
+        - path:
+            type: Exact
+            value: /swagger.json
+      backendRefs:
+        - name: backend
+          port: 8080
+---
+# ── 3. Frontend SPA — catch-all (HTTPS) ───────────────────────────────────────
+# Matches any path not matched by backend-routes above.
+# The frontend nginx serves the React SPA and handles client-side routing
+# via the try_files $uri $uri/ /index.html fallback.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend-route
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "<HOSTNAME>"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80

--- a/deployments/kubernetes/overlays/aks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/aks/kustomization.yaml
@@ -1,0 +1,85 @@
+# ============================================================
+# AKS Overlay — Kustomize overlay for Azure Kubernetes Service
+# ============================================================
+# Prerequisites before applying:
+#   1. AKS cluster with OIDC Issuer + Workload Identity + Secrets Store CSI Driver enabled
+#   2. cert-manager installed with ExperimentalGatewayAPISupport=true
+#   3. ALB Controller installed (Azure Application Gateway for Containers)
+#   4. Azure Application Gateway for Containers resource and Frontend provisioned
+#   5. Azure Key Vault with secrets: jwt-secret, encryption-key, database-password
+#   6. User-Assigned Managed Identity with federated credential on this ServiceAccount
+#
+# REQUIRED: Before applying, replace ALL occurrences of angle-bracket placeholders:
+#   <ACR_NAME>               Azure Container Registry name (e.g. mycompanyacr)
+#   <IMAGE_TAG>              Image tag to deploy (e.g. v1.0.0)
+#   <SUBSCRIPTION_ID>        Azure Subscription ID (UUID)
+#   <RESOURCE_GROUP>         Resource group containing the AGfC resource
+#   <AGFC_NAME>              Application Gateway for Containers resource name
+#   <AZURE_POSTGRES_SERVER>  PostgreSQL Flexible Server name (without .postgres.database.azure.com)
+#   <AZURE_STORAGE_ACCOUNT>  Azure Blob Storage account name
+#   <STORAGE_CONTAINER>      Azure Blob container name (default: terraform-registry)
+#   <KEY_VAULT_NAME>         Azure Key Vault name
+#   <TENANT_ID>              Azure AD Tenant ID (UUID)
+#   <AZURE_CLIENT_ID>        User-Assigned Managed Identity Client ID (UUID)
+#   <HOSTNAME>               Your public DNS hostname (e.g. registry.company.com)
+#   <EMAIL>                  Email address for Let's Encrypt certificate notifications
+#
+# Apply with:
+#   kubectl apply -k deployments/kubernetes/overlays/aks/
+#
+# See docs/deployment/aks-new-cluster.md for complete setup instructions.
+# ============================================================
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: terraform-registry
+
+resources:
+  - ../../base
+  - gateway.yaml
+  - httproute.yaml
+  - secretproviderclass.yaml
+  - clusterissuer.yaml
+  - certificate.yaml
+
+patches:
+  # 1. Add Azure Workload Identity client-id annotation to ServiceAccount
+  - path: patches/serviceaccount-workload-identity.yaml
+    target:
+      kind: ServiceAccount
+      name: terraform-registry
+
+  # 2. Add CSI secrets volume + mount to backend pod; add topology spread constraints
+  - path: patches/backend-workload-identity.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # 3. Override ConfigMap with AKS-specific values (DB host, Azure Blob storage)
+  - path: patches/configmap-aks.yaml
+    target:
+      kind: ConfigMap
+      name: terraform-registry-config
+
+  # 4. Remove the legacy nginx Ingress resource — all traffic is handled by
+  #    Gateway API (gateway.yaml + httproute.yaml) on AKS.
+  - target:
+      kind: Ingress
+      name: terraform-registry-ingress
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: terraform-registry-ingress
+
+images:
+  # Replace <ACR_NAME> with your Azure Container Registry name (without .azurecr.io)
+  # Replace <IMAGE_TAG> with the semver version to deploy (e.g. v1.0.0)
+  # In CI/CD: kustomize edit set image terraform-registry-backend=<repo>:<tag>
+  - name: terraform-registry-backend
+    newName: <ACR_NAME>.azurecr.io/terraform-registry-backend
+    newTag: <IMAGE_TAG>
+  - name: terraform-registry-frontend
+    newName: <ACR_NAME>.azurecr.io/terraform-registry-frontend
+    newTag: <IMAGE_TAG>

--- a/deployments/kubernetes/overlays/aks/patches/backend-csi-and-topology.yaml
+++ b/deployments/kubernetes/overlays/aks/patches/backend-csi-and-topology.yaml
@@ -1,0 +1,42 @@
+# Strategic merge patch: add CSI secret volume + zone topology spread to backend.
+#
+# CSI volume mount:
+#   The Secrets Store CSI Driver requires a volume mount to trigger secret sync.
+#   When the pod starts, the CSI driver fetches secrets from Key Vault and
+#   materialises them in the terraform-registry-secrets Kubernetes Secret (via
+#   secretObjects in SecretProviderClass). The pod reads those secrets via envFrom.
+#   The /mnt/secrets-store directory is empty — its only purpose is to trigger sync.
+#
+# Topology spread:
+#   Ensures backend pods are spread across AKS availability zones. Requires the
+#   cluster to span multiple zones (--zones 1 2 3 in az aks create).
+#   whenUnsatisfiable: DoNotSchedule — prevents scheduling if spread cannot be
+#   maintained (prefer ScheduleAnyway for clusters with fewer than 3 zones).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      containers:
+        - name: backend
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: terraform-registry-secrets

--- a/deployments/kubernetes/overlays/aks/patches/backend-workload-identity.yaml
+++ b/deployments/kubernetes/overlays/aks/patches/backend-workload-identity.yaml
@@ -1,0 +1,52 @@
+# Strategic merge patch: adds CSI Secrets Store volume, volumeMount, and
+# topology spread constraints to the backend Deployment for AKS.
+#
+# CSI volume:
+#   Mounting the SecretProviderClass as a CSI volume triggers the Secrets Store
+#   CSI Driver to fetch secrets from Azure Key Vault and sync them into the
+#   terraform-registry-secrets Kubernetes Secret at pod start-up.
+#   The mount directory itself (/mnt/secrets-store) is a side-effect mechanism;
+#   the pod reads env vars via envFrom (secretRef) not the mounted files.
+#
+# Topology spread constraints:
+#   - hostname: hard spread (DoNotSchedule) ensures no two backend pods share a node.
+#   - zone: soft spread (ScheduleAnyway) distributes pods across availability zones.
+#   Adjust maxSkew and whenUnsatisfiable to match your cluster's node pool topology.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          volumeMounts:
+            # CSI volume mount triggers Key Vault secret sync.
+            # The path /mnt/secrets-store will contain individual secret files,
+            # but the backend reads secrets via envFrom (secretRef), not these files.
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: terraform-registry-secrets
+      # Spread backend pods across nodes and zones.
+      # Requires at least 2 nodes in the node pool for DoNotSchedule to be satisfiable.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend

--- a/deployments/kubernetes/overlays/aks/patches/configmap-aks.yaml
+++ b/deployments/kubernetes/overlays/aks/patches/configmap-aks.yaml
@@ -1,0 +1,33 @@
+# JSON 6902 patch: AKS-specific ConfigMap overrides.
+#
+# Replaces the placeholder database host (left empty in base) and
+# configures Azure Blob Storage as the artifact storage backend.
+#
+# Replace ALL <PLACEHOLDER> values before applying:
+#   <AZURE_POSTGRES_SERVER>  PostgreSQL Flexible Server resource name
+#                            (hostname will be <name>.postgres.database.azure.com)
+#   <AZURE_STORAGE_ACCOUNT>  Azure Storage Account name (lowercase, no hyphens in name)
+#   <STORAGE_CONTAINER>      Blob container name (e.g. terraform-registry)
+#   <HOSTNAME>               Public hostname (e.g. registry.company.com)
+#
+# When TFR_STORAGE_DEFAULT_BACKEND=azure is set:
+#   - The PVC (pvc.yaml from base) is created but unused by the backend.
+#   - The backend uses Azure Blob Storage for all module/provider artifacts.
+#   - TFR_STORAGE_AZURE_ACCOUNT_KEY must be in the Secret (via Key Vault CSI).
+#     Alternatively, set up the managed identity with Blob Data Contributor role
+#     and configure the backend to use managed identity authentication.
+- op: replace
+  path: /data/TFR_DATABASE_HOST
+  value: "<AZURE_POSTGRES_SERVER>.postgres.database.azure.com"
+- op: replace
+  path: /data/TFR_STORAGE_DEFAULT_BACKEND
+  value: "azure"
+- op: replace
+  path: /data/TFR_STORAGE_AZURE_ACCOUNT_NAME
+  value: "<AZURE_STORAGE_ACCOUNT>"
+- op: replace
+  path: /data/TFR_STORAGE_AZURE_CONTAINER_NAME
+  value: "<STORAGE_CONTAINER>"
+- op: replace
+  path: /data/TFR_SERVER_BASE_URL
+  value: "https://<HOSTNAME>"

--- a/deployments/kubernetes/overlays/aks/patches/serviceaccount-workload-identity.yaml
+++ b/deployments/kubernetes/overlays/aks/patches/serviceaccount-workload-identity.yaml
@@ -1,0 +1,14 @@
+# Strategic merge patch: adds Azure Workload Identity client-id annotation
+# to the terraform-registry ServiceAccount.
+#
+# Replace <AZURE_CLIENT_ID> with the Client ID of the User-Assigned Managed
+# Identity that has the Key Vault Secret User and Storage Blob Data Contributor
+# roles, and has a federated credential pointing to this ServiceAccount.
+#
+# The annotation value must match the clientID field in secretproviderclass.yaml.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-registry
+  annotations:
+    azure.workload.identity/client-id: "<AZURE_CLIENT_ID>"

--- a/deployments/kubernetes/overlays/aks/secretproviderclass.yaml
+++ b/deployments/kubernetes/overlays/aks/secretproviderclass.yaml
@@ -1,0 +1,71 @@
+# ============================================================
+# SecretProviderClass — Azure Key Vault CSI Driver
+# ============================================================
+# Pulls secrets from Azure Key Vault and syncs them into the
+# terraform-registry-secrets Kubernetes Secret at pod start-up.
+#
+# Prerequisites:
+#   - AKS Secrets Store CSI Driver add-on enabled:
+#       az aks enable-addons --addons azure-keyvault-secrets-provider
+#   - Azure Workload Identity configured on the ServiceAccount
+#   - Key Vault secrets provisioned (see docs/deployment/aks-prerequisites.md):
+#       Secret name          → Environment variable
+#       ──────────────────────────────────────────────
+#       jwt-secret           → TFR_JWT_SECRET
+#       encryption-key       → ENCRYPTION_KEY
+#       database-password    → TFR_DATABASE_PASSWORD
+#
+# The backend Deployment must mount this SecretProviderClass as a CSI volume
+# (see patches/backend-workload-identity.yaml). The mount triggers the CSI
+# driver to sync secrets from Key Vault into the terraform-registry-secrets
+# k8s Secret. The backend pod then reads env vars from that Secret via envFrom.
+#
+# Replace ALL <PLACEHOLDER> values before applying.
+# ============================================================
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: terraform-registry-secrets
+  namespace: terraform-registry
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "false"
+    # Client ID of the User-Assigned Managed Identity (UAMI) used for Workload Identity.
+    # Must match the annotation on the ServiceAccount and the federated credential subject.
+    clientID: "<AZURE_CLIENT_ID>"
+    # Name (not URI) of the Azure Key Vault containing the secrets.
+    keyvaultName: "<KEY_VAULT_NAME>"
+    cloudName: ""   # AzurePublicCloud (default). Use AzureUSGovernmentCloud etc. if needed.
+    # Secret objects to fetch from Key Vault.
+    # objectName: the name of the secret in Key Vault
+    # objectAlias: the filename used in the CSI volume mount (also used as k8s Secret key)
+    objects: |
+      array:
+        - |
+          objectName: jwt-secret
+          objectType: secret
+          objectAlias: TFR_JWT_SECRET
+        - |
+          objectName: encryption-key
+          objectType: secret
+          objectAlias: ENCRYPTION_KEY
+        - |
+          objectName: database-password
+          objectType: secret
+          objectAlias: TFR_DATABASE_PASSWORD
+    # Azure AD Tenant ID where the Key Vault resides.
+    tenantId: "<TENANT_ID>"
+  # Sync fetched secrets into a Kubernetes Secret so they can be used via envFrom.
+  # The Secret is created/updated each time the CSI volume is mounted (pod start/restart).
+  secretObjects:
+    - secretName: terraform-registry-secrets
+      type: Opaque
+      data:
+        - objectName: TFR_JWT_SECRET
+          key: TFR_JWT_SECRET
+        - objectName: ENCRYPTION_KEY
+          key: ENCRYPTION_KEY
+        - objectName: TFR_DATABASE_PASSWORD
+          key: TFR_DATABASE_PASSWORD

--- a/deployments/kubernetes/overlays/dev/kustomization.yaml
+++ b/deployments/kubernetes/overlays/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: terraform-registry-dev
+namespace: dev-terraform-registry
 
 resources:
   - ../../base

--- a/deployments/kubernetes/overlays/eks/certificate.yaml
+++ b/deployments/kubernetes/overlays/eks/certificate.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: terraform-registry-tls
+  namespace: terraform-registry
+spec:
+  secretName: terraform-registry-tls
+  issuerRef:
+    # Use letsencrypt-staging for initial sandbox testing.
+    # Change to letsencrypt-prod once ACME challenge succeeds.
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    # Replace with your actual public hostname (must match Route53 DNS record)
+    - "registry.yourdomain.com"

--- a/deployments/kubernetes/overlays/eks/clusterissuer.yaml
+++ b/deployments/kubernetes/overlays/eks/clusterissuer.yaml
@@ -1,0 +1,44 @@
+# ============================================================
+# cert-manager ClusterIssuers — Let's Encrypt (EKS)
+# ============================================================
+# Identical to the AKS overlay ClusterIssuers: uses HTTP-01 challenge
+# via a temporary HTTPRoute on the Gateway's http listener.
+#
+# Replace <EMAIL> with your ops email for expiry notifications.
+# ============================================================
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway

--- a/deployments/kubernetes/overlays/eks/gateway.yaml
+++ b/deployments/kubernetes/overlays/eks/gateway.yaml
@@ -1,0 +1,71 @@
+# ============================================================
+# Gateway API Resources — AWS Load Balancer Controller (ALB)
+# ============================================================
+# GatewayClass + Gateway for AWS Application Load Balancer (ALB) via
+# the AWS Load Balancer Controller (LBC) v2.6+ Gateway API support.
+#
+# Prerequisites:
+#   - AWS LBC v2.6+ installed:
+#       helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+#         -n kube-system \
+#         --set clusterName=<CLUSTER_NAME> \
+#         --set serviceAccount.create=true \
+#         --set serviceAccount.name=aws-load-balancer-controller \
+#         --set "serviceAccount.annotations.eks\.amazonaws\.com/role-arn=<LBC_ROLE_ARN>"
+#   - Gateway API CRDs installed:
+#       kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+#   - cert-manager installed with ExperimentalGatewayAPISupport=true
+#   - Public subnet tags: kubernetes.io/role/elb=1
+#   - Subnet auto-discovery or explicit subnet annotation on Gateway
+#
+# Before applying, replace:
+#   <HOSTED_ZONE_ID>   — Route53 Hosted Zone ID for DNS (optional, for ALB annotations)
+#   registry.yourdomain.com — Your public DNS hostname
+# ============================================================
+
+# ── GatewayClass — references the AWS LBC controller ─────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: aws-alb-external
+spec:
+  controllerName: gateway.k8s.aws/alb
+---
+# ── Gateway — ALB with HTTP redirect and HTTPS termination ────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: terraform-registry-gateway
+  namespace: terraform-registry
+  annotations:
+    # cert-manager creates a temporary HTTPRoute for the ACME HTTP-01 challenge.
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    # Route traffic via internet-facing ALB (external load balancer).
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    # Use IP mode for target registration (recommended for EKS with VPC CNI).
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    # Optional: specify subnets explicitly if auto-discovery is not configured
+    # service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-xxx,subnet-yyy"
+spec:
+  gatewayClassName: aws-alb-external
+  listeners:
+    # HTTP listener — ACME challenge + redirect to HTTPS
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    # HTTPS listener — ALB terminates TLS using the cert-manager-issued Secret
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "registry.yourdomain.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: terraform-registry-tls
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/deployments/kubernetes/overlays/eks/httproute.yaml
+++ b/deployments/kubernetes/overlays/eks/httproute.yaml
@@ -1,0 +1,119 @@
+# ============================================================
+# HTTPRoute Resources — AWS ALB via Gateway API
+# ============================================================
+# Identical routing logic to the AKS overlay:
+#   1. http-redirect   — HTTP → HTTPS (301)
+#   2. backend-routes  — HTTPS API/protocol paths → backend:8080
+#   3. frontend-route  — HTTPS catch-all → frontend:80
+#
+# Replace registry.yourdomain.com with your actual hostname.
+# Must match the Gateway hostname and Route53/DNS record.
+# ============================================================
+
+# ── 1. HTTP → HTTPS redirect ───────────────────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-redirect
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+# ── 2. Backend API and Terraform protocol paths (HTTPS) ──────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-routes
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "registry.yourdomain.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /terraform/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /health
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /ready
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /swagger.json
+      backendRefs:
+        - name: backend
+          port: 8080
+---
+# ── 3. Frontend SPA — catch-all (HTTPS) ───────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend-route
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "registry.yourdomain.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -1,0 +1,75 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ============================================================
+# EKS overlay — AWS Elastic Kubernetes Service
+# ============================================================
+# Uses:
+#   - AWS Load Balancer Controller (LBC) v2.6+ + Gateway API for ingress
+#   - cert-manager + Let's Encrypt for TLS
+#   - AWS Secrets and Configuration Provider (ASCP) + Secrets Store CSI Driver
+#   - IRSA (IAM Roles for Service Accounts) for pod-level AWS IAM access
+#   - Amazon S3 for module/provider artifact storage
+#   - Amazon RDS for PostgreSQL for the database
+#
+# Prerequisites: See docs/deployment/eks-prerequisites.md
+# Deployment:   See docs/deployment/eks-deployment.md
+#
+# REQUIRED: Replace ALL <PLACEHOLDER> values in this overlay and its patches
+# before applying.
+#
+# Apply with:
+#   kubectl apply -k deployments/kubernetes/overlays/eks/
+# ============================================================
+
+namespace: terraform-registry
+
+resources:
+  - ../../base
+  - gateway.yaml
+  - httproute.yaml
+  - secretproviderclass.yaml
+  - clusterissuer.yaml
+  - certificate.yaml
+
+patches:
+  # 1. Add IRSA annotation to ServiceAccount
+  - path: patches/serviceaccount-irsa.yaml
+    target:
+      kind: ServiceAccount
+      name: terraform-registry
+
+  # 2. Add CSI secret volume + zone topology spread to backend Deployment
+  - path: patches/backend-csi-and-topology.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # 3. Override ConfigMap with EKS-specific values (RDS host, S3 storage)
+  - path: patches/configmap-eks.yaml
+    target:
+      kind: ConfigMap
+      name: terraform-registry-config
+
+  # 4. Remove the legacy nginx Ingress resource — all traffic is handled by
+  #    Gateway API (gateway.yaml + httproute.yaml) on EKS.
+  - target:
+      kind: Ingress
+      name: terraform-registry-ingress
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: terraform-registry-ingress
+
+# Pin image tags for EKS deployment.
+# Replace <ACCOUNT_ID> and <REGION> with your AWS account and region.
+# Replace <IMAGE_TAG> with the version to deploy.
+images:
+  - name: terraform-registry-backend
+    newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
+    newTag: v1.0.0
+  - name: terraform-registry-frontend
+    newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
+    newTag: v1.0.0

--- a/deployments/kubernetes/overlays/eks/patches/backend-csi-and-topology.yaml
+++ b/deployments/kubernetes/overlays/eks/patches/backend-csi-and-topology.yaml
@@ -1,0 +1,43 @@
+# Strategic merge patch: add CSI secret volume + zone topology spread to backend.
+#
+# The CSI volume mount triggers the AWS Secrets Store CSI Driver (ASCP provider)
+# to fetch secrets from AWS Secrets Manager and sync them into the
+# terraform-registry-secrets Kubernetes Secret at pod start-up.
+# The backend pod reads env vars from the Secret via envFrom.
+#
+# Topology spread distributes backend pods across EKS availability zones.
+# Adjust whenUnsatisfiable if your node group spans fewer than 3 zones.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      containers:
+        - name: backend
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: terraform-registry-secrets

--- a/deployments/kubernetes/overlays/eks/patches/configmap-eks.yaml
+++ b/deployments/kubernetes/overlays/eks/patches/configmap-eks.yaml
@@ -1,0 +1,25 @@
+# JSON 6902 patch: EKS-specific ConfigMap overrides.
+#
+# Replace ALL <PLACEHOLDER> values before applying:
+#   <RDS_ENDPOINT>   RDS endpoint (e.g. mydb.xxxxxxxx.us-east-1.rds.amazonaws.com)
+#   <S3_BUCKET_NAME> S3 bucket name for module/provider artifact storage
+#   <AWS_REGION>     AWS Region (e.g. us-east-1)
+#   <HOSTNAME>       Public hostname (e.g. registry.company.com)
+- op: replace
+  path: /data/TFR_DATABASE_HOST
+  value: "<RDS_ENDPOINT>"
+- op: replace
+  path: /data/TFR_STORAGE_DEFAULT_BACKEND
+  value: "s3"
+- op: add
+  path: /data/TFR_STORAGE_S3_BUCKET
+  value: "<S3_BUCKET_NAME>"
+- op: add
+  path: /data/TFR_STORAGE_S3_REGION
+  value: "<AWS_REGION>"
+- op: replace
+  path: /data/TFR_SERVER_BASE_URL
+  value: "https://<HOSTNAME>"
+- op: replace
+  path: /data/TFR_LOGGING_LEVEL
+  value: "warn"

--- a/deployments/kubernetes/overlays/eks/patches/serviceaccount-irsa.yaml
+++ b/deployments/kubernetes/overlays/eks/patches/serviceaccount-irsa.yaml
@@ -1,0 +1,31 @@
+# Strategic merge patch: add AWS IRSA annotation to ServiceAccount.
+#
+# IRSA (IAM Roles for Service Accounts) allows pods to assume an AWS IAM Role
+# via OIDC token exchange without long-lived credentials.
+#
+# Creating the IRSA role and binding:
+#   OIDC_ID=$(aws eks describe-cluster --name <CLUSTER> \
+#     --query "cluster.identity.oidc.issuer" --output text | cut -d'/' -f5)
+#   # Associate OIDC provider if not already done:
+#   eksctl utils associate-iam-oidc-provider --cluster <CLUSTER> --approve
+#   # Create role with trust policy:
+#   eksctl create iamserviceaccount \
+#     --namespace terraform-registry \
+#     --name terraform-registry \
+#     --cluster <CLUSTER> \
+#     --role-name terraform-registry-irsa \
+#     --attach-policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/TerraformRegistryPolicy \
+#     --approve
+#
+# The policy should allow:
+#   - s3:GetObject, s3:PutObject, s3:DeleteObject, s3:ListBucket on S3 bucket
+#   - secretsmanager:GetSecretValue on terraform-registry/* secrets
+#
+# Replace <ACCOUNT_ID> and <ROLE_NAME> before applying.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-registry
+  namespace: terraform-registry
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT_ID>:role/<IRSA_ROLE_NAME>"

--- a/deployments/kubernetes/overlays/eks/secretproviderclass.yaml
+++ b/deployments/kubernetes/overlays/eks/secretproviderclass.yaml
@@ -1,0 +1,61 @@
+# ============================================================
+# SecretProviderClass — AWS Secrets Manager + Secrets Store CSI Driver
+# ============================================================
+# Uses the AWS Secrets and Configuration Provider (ASCP) to fetch secrets
+# from AWS Secrets Manager and sync them into the terraform-registry-secrets
+# Kubernetes Secret at pod start-up.
+#
+# Prerequisites:
+#   - Secrets Store CSI Driver installed in the cluster:
+#       helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver \
+#         --namespace kube-system \
+#         --set syncSecret.enabled=true \
+#         --set enableSecretRotation=true
+#   - AWS Secrets and Configuration Provider (ASCP) installed:
+#       kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
+#   - IRSA role with secretsmanager:GetSecretValue on the secrets below
+#   - Secrets created in AWS Secrets Manager (replace <REGION> and <ACCOUNT_ID>):
+#       aws secretsmanager create-secret \
+#         --name "terraform-registry/jwt-secret" \
+#         --secret-string "$(openssl rand -hex 32)"
+#       aws secretsmanager create-secret \
+#         --name "terraform-registry/encryption-key" \
+#         --secret-string "$(openssl rand -hex 16)"
+#       aws secretsmanager create-secret \
+#         --name "terraform-registry/database-password" \
+#         --secret-string "<YOUR_DB_PASSWORD>"
+#
+# Before applying, replace:
+#   <AWS_REGION>    — AWS Region (e.g. us-east-1)
+#   <ACCOUNT_ID>    — AWS Account ID (12-digit number)
+# ============================================================
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: terraform-registry-secrets
+  namespace: terraform-registry
+spec:
+  provider: aws
+  parameters:
+    region: "<AWS_REGION>"
+    objects: |
+      - objectName: "arn:aws:secretsmanager:<AWS_REGION>:<ACCOUNT_ID>:secret:terraform-registry/jwt-secret"
+        objectType: "secretsmanager"
+        objectAlias: "TFR_JWT_SECRET"
+      - objectName: "arn:aws:secretsmanager:<AWS_REGION>:<ACCOUNT_ID>:secret:terraform-registry/encryption-key"
+        objectType: "secretsmanager"
+        objectAlias: "ENCRYPTION_KEY"
+      - objectName: "arn:aws:secretsmanager:<AWS_REGION>:<ACCOUNT_ID>:secret:terraform-registry/database-password"
+        objectType: "secretsmanager"
+        objectAlias: "TFR_DATABASE_PASSWORD"
+  # Sync Secrets Manager values into a Kubernetes Secret for use via envFrom.
+  secretObjects:
+    - secretName: terraform-registry-secrets
+      type: Opaque
+      data:
+        - objectName: TFR_JWT_SECRET
+          key: TFR_JWT_SECRET
+        - objectName: ENCRYPTION_KEY
+          key: ENCRYPTION_KEY
+        - objectName: TFR_DATABASE_PASSWORD
+          key: TFR_DATABASE_PASSWORD

--- a/deployments/kubernetes/overlays/gke/certificate.yaml
+++ b/deployments/kubernetes/overlays/gke/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: terraform-registry-tls
+  namespace: terraform-registry
+spec:
+  secretName: terraform-registry-tls
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+    # Replace with your actual public hostname (must match Cloud DNS record)
+    - "registry.yourdomain.com"

--- a/deployments/kubernetes/overlays/gke/clusterissuer.yaml
+++ b/deployments/kubernetes/overlays/gke/clusterissuer.yaml
@@ -1,0 +1,45 @@
+# ============================================================
+# cert-manager ClusterIssuers — Let's Encrypt (GKE)
+# ============================================================
+# GKE alternative: instead of cert-manager you can use Google-managed
+# certificates via networking.gke.io/managed-certificates annotation.
+# This overlay uses cert-manager for consistency with AKS and EKS.
+#
+# Replace <EMAIL> with your ops email for expiry notifications.
+# ============================================================
+
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: <EMAIL>
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          gatewayHTTPRoute:
+            parentRefs:
+              - name: terraform-registry-gateway
+                namespace: terraform-registry
+                kind: Gateway

--- a/deployments/kubernetes/overlays/gke/gateway.yaml
+++ b/deployments/kubernetes/overlays/gke/gateway.yaml
@@ -1,0 +1,65 @@
+# ============================================================
+# Gateway API Resources — GKE built-in Gateway controller
+# ============================================================
+# GKE pre-provisions GatewayClasses — NO GatewayClass resource is needed here.
+# Available pre-provisioned GatewayClasses:
+#   gke-l7-global-external-managed   — Global External Application Load Balancer
+#   gke-l7-regional-external-managed — Regional External Application Load Balancer
+#   gke-l7-rilb                       — Internal Application Load Balancer
+#   gke-l7-gxlb                       — Classic HTTP(S) Load Balancer (legacy)
+#
+# This overlay uses the global external managed class (recommended for new workloads).
+#
+# Prerequisites:
+#   - GKE cluster with Gateway API enabled:
+#       gcloud container clusters update <CLUSTER> \
+#         --gateway-api=standard --region <REGION>
+#   - Static IP reserved (recommended for stable DNS):
+#       gcloud compute addresses create terraform-registry-ip --global
+#   - cert-manager installed with ExperimentalGatewayAPISupport=true
+#   - DNS record for <HOSTNAME> pointing to the reserved static IP BEFORE
+#     creating the Certificate (required for HTTP-01 ACME challenge)
+#
+# Before applying, replace:
+#   <STATIC_IP_NAME>          — Name of the reserved static IP (optional)
+#   registry.yourdomain.com   — Your public DNS hostname
+# ============================================================
+
+# ── Gateway — GKE-managed Global External Application Load Balancer ───────────
+# Note: No GatewayClass resource is created here. The gke-l7-global-external-managed
+# GatewayClass is pre-provisioned by GKE. The Gateway references it by name.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: terraform-registry-gateway
+  namespace: terraform-registry
+  annotations:
+    # cert-manager creates a temporary HTTPRoute for the ACME HTTP-01 challenge.
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    # Optional: bind to a pre-reserved static external IP.
+    # Ensures DNS record can be configured before the cluster is created.
+    # networking.gke.io/certmap: ""   # Alternative: use GCP Certificate Manager
+    # networking.gke.io/stable-ip-address: "true"
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+    # HTTP listener — ACME challenge + redirect to HTTPS
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    # HTTPS listener — Google-managed ALB terminates TLS
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "registry.yourdomain.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: terraform-registry-tls
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/deployments/kubernetes/overlays/gke/httproute.yaml
+++ b/deployments/kubernetes/overlays/gke/httproute.yaml
@@ -1,0 +1,114 @@
+# ============================================================
+# HTTPRoute Resources — GKE Gateway API
+# ============================================================
+# Identical routing logic to AKS and EKS overlays.
+# Replace registry.yourdomain.com with your actual hostname.
+# ============================================================
+
+# ── 1. HTTP → HTTPS redirect ───────────────────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-redirect
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: http
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+# ── 2. Backend API and Terraform protocol paths (HTTPS) ──────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-routes
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "registry.yourdomain.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /.well-known/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /terraform/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhooks/
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /health
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /ready
+      backendRefs:
+        - name: backend
+          port: 8080
+    - matches:
+        - path:
+            type: Exact
+            value: /swagger.json
+      backendRefs:
+        - name: backend
+          port: 8080
+---
+# ── 3. Frontend SPA — catch-all (HTTPS) ───────────────────────────────────────
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: frontend-route
+  namespace: terraform-registry
+spec:
+  parentRefs:
+    - name: terraform-registry-gateway
+      sectionName: https
+  hostnames:
+    - "registry.yourdomain.com"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: frontend
+          port: 80

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -1,0 +1,83 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# ============================================================
+# GKE overlay — Google Kubernetes Engine
+# ============================================================
+# Uses:
+#   - GKE built-in Gateway controller + Gateway API for ingress
+#     (GatewayClass gke-l7-global-external-managed — no GatewayClass resource needed)
+#   - cert-manager + Let's Encrypt for TLS
+#   - GCP Secrets Manager + Secrets Store CSI Driver (GCP provider) for secrets
+#   - GKE Workload Identity for pod-level GCP IAM access
+#   - Google Cloud Storage (GCS) for module/provider artifact storage
+#   - Cloud SQL for PostgreSQL (via Auth Proxy sidecar or private IP)
+#
+# Prerequisites: See docs/deployment/gke-prerequisites.md
+# Deployment:   See docs/deployment/gke-deployment.md
+#
+# REQUIRED: Replace ALL <PLACEHOLDER> values before applying.
+#
+# Apply with:
+#   kubectl apply -k deployments/kubernetes/overlays/gke/
+# ============================================================
+
+namespace: terraform-registry
+
+resources:
+  - ../../base
+  - gateway.yaml
+  - httproute.yaml
+  - secretproviderclass.yaml
+  - clusterissuer.yaml
+  - certificate.yaml
+
+patches:
+  # 1. Add GKE Workload Identity annotation to ServiceAccount
+  - path: patches/serviceaccount-workload-identity.yaml
+    target:
+      kind: ServiceAccount
+      name: terraform-registry
+
+  # 2. Add CSI secret volume + zone topology spread to backend Deployment
+  - path: patches/backend-csi-and-topology.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # 3. Override ConfigMap with GKE-specific values (Cloud SQL, GCS storage)
+  - path: patches/configmap-gke.yaml
+    target:
+      kind: ConfigMap
+      name: terraform-registry-config
+
+  # 4. Add Cloud SQL Auth Proxy sidecar for database connectivity.
+  #    REQUIRED: Replace <PROJECT_ID>, <REGION>, <INSTANCE_NAME> in the patch.
+  #    If using private IP instead, remove this patch and set TFR_DATABASE_HOST
+  #    to the private IP in configmap-gke.yaml.
+  - path: patches/backend-cloudsql-proxy.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # 5. Remove the legacy nginx Ingress resource — all traffic is handled by
+  #    Gateway API (gateway.yaml + httproute.yaml) on GKE.
+  - target:
+      kind: Ingress
+      name: terraform-registry-ingress
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: terraform-registry-ingress
+
+# Pin image tags for GKE deployment.
+# Replace <REGION>, <PROJECT_ID>, <AR_REPO> with your Artifact Registry values.
+images:
+  - name: terraform-registry-backend
+    newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
+    newTag: v1.0.0
+  - name: terraform-registry-frontend
+    newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
+    newTag: v1.0.0

--- a/deployments/kubernetes/overlays/gke/patches/backend-cloudsql-proxy.yaml
+++ b/deployments/kubernetes/overlays/gke/patches/backend-cloudsql-proxy.yaml
@@ -1,0 +1,32 @@
+# Strategic merge patch: add Cloud SQL Auth Proxy sidecar to backend Deployment.
+# The proxy handles IAM authentication and TLS to Cloud SQL.
+#
+# REQUIRED: Replace <PROJECT_ID>, <REGION>, and <INSTANCE_NAME> before applying.
+#   <PROJECT_ID>    — gcloud config get-value project
+#   <REGION>        — your Cloud SQL instance region (e.g. us-central1)
+#   <INSTANCE_NAME> — your Cloud SQL instance name (e.g. terraform-registry-db)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      containers:
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.0
+          args:
+            - "--structured-logs"
+            - "--port=5432"
+            - "<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 10m
+            limits:
+              memory: 128Mi
+              cpu: 100m

--- a/deployments/kubernetes/overlays/gke/patches/backend-csi-and-topology.yaml
+++ b/deployments/kubernetes/overlays/gke/patches/backend-csi-and-topology.yaml
@@ -1,0 +1,36 @@
+# Strategic merge patch: add CSI secret volume + zone topology spread to backend.
+# Identical structure to the AKS and EKS overlays.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      containers:
+        - name: backend
+          volumeMounts:
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+      volumes:
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: terraform-registry-secrets

--- a/deployments/kubernetes/overlays/gke/patches/configmap-gke.yaml
+++ b/deployments/kubernetes/overlays/gke/patches/configmap-gke.yaml
@@ -1,0 +1,33 @@
+# JSON 6902 patch: GKE-specific ConfigMap overrides.
+#
+# Replace ALL <PLACEHOLDER> values before applying:
+#   <CLOUD_SQL_HOST>   Cloud SQL Private IP, or 127.0.0.1 if using Auth Proxy sidecar
+#   <GCS_BUCKET_NAME>  GCS bucket name for module/provider artifact storage
+#   <PROJECT_ID>       GCP Project ID
+#   <HOSTNAME>         Public hostname (e.g. registry.company.com)
+#
+# Cloud SQL Auth Proxy note:
+#   If using the Auth Proxy sidecar (recommended), set host to 127.0.0.1 and
+#   sslMode to disable. The proxy handles TLS and IAM authentication.
+#   Example sidecar: https://cloud.google.com/sql/docs/postgres/connect-kubernetes-engine
+- op: replace
+  path: /data/TFR_DATABASE_HOST
+  value: "127.0.0.1"
+- op: replace
+  path: /data/TFR_DATABASE_SSL_MODE
+  value: "disable"
+- op: replace
+  path: /data/TFR_STORAGE_DEFAULT_BACKEND
+  value: "gcs"
+- op: add
+  path: /data/TFR_STORAGE_GCS_BUCKET
+  value: "<GCS_BUCKET_NAME>"
+- op: add
+  path: /data/TFR_STORAGE_GCS_PROJECT_ID
+  value: "<PROJECT_ID>"
+- op: replace
+  path: /data/TFR_SERVER_BASE_URL
+  value: "https://<HOSTNAME>"
+- op: replace
+  path: /data/TFR_LOGGING_LEVEL
+  value: "warn"

--- a/deployments/kubernetes/overlays/gke/patches/serviceaccount-workload-identity.yaml
+++ b/deployments/kubernetes/overlays/gke/patches/serviceaccount-workload-identity.yaml
@@ -1,0 +1,25 @@
+# Strategic merge patch: add GKE Workload Identity annotation to ServiceAccount.
+#
+# GKE Workload Identity maps this Kubernetes ServiceAccount to a Google
+# Service Account (GSA), allowing pods to authenticate to GCP APIs without
+# long-lived service account keys.
+#
+# Required bindings:
+#   gcloud iam service-accounts add-iam-policy-binding \
+#     <GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com \
+#     --role roles/iam.workloadIdentityUser \
+#     --member "serviceAccount:<PROJECT_ID>.svc.id.goog[terraform-registry/terraform-registry]"
+#
+# The GSA must have:
+#   - roles/storage.objectAdmin on the GCS bucket
+#   - roles/secretmanager.secretAccessor on the registry secrets
+#   - roles/cloudsql.client (if using Cloud SQL)
+#
+# Replace <GSA_NAME> and <PROJECT_ID> before applying.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-registry
+  namespace: terraform-registry
+  annotations:
+    iam.gke.io/gcp-service-account: "<GSA_NAME>@<PROJECT_ID>.iam.gserviceaccount.com"

--- a/deployments/kubernetes/overlays/gke/secretproviderclass.yaml
+++ b/deployments/kubernetes/overlays/gke/secretproviderclass.yaml
@@ -1,0 +1,52 @@
+# ============================================================
+# SecretProviderClass — GCP Secret Manager + Secrets Store CSI Driver
+# ============================================================
+# Uses the GCP Secrets Store CSI Provider to fetch secrets from
+# GCP Secret Manager and sync them into the terraform-registry-secrets
+# Kubernetes Secret at pod start-up.
+#
+# Prerequisites:
+#   - GKE cluster with Config Connector or Secrets Store CSI add-on:
+#       gcloud container clusters create ... --addons=GcsFuseCsiDriver
+#   - Secrets Store CSI Driver with GCP provider:
+#       helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver \
+#         --namespace kube-system --set syncSecret.enabled=true
+#       kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/main/deploy/provider-gcp-plugin.yaml
+#   - GKE Workload Identity configured on the ServiceAccount
+#   - Google Service Account (GSA) with roles/secretmanager.secretAccessor role
+#   - Secrets created in GCP Secret Manager:
+#       gcloud secrets create terraform-registry-jwt-secret \
+#         --replication-policy=automatic
+#       echo -n "$(openssl rand -hex 32)" | \
+#         gcloud secrets versions add terraform-registry-jwt-secret --data-file=-
+#       (repeat for encryption-key and database-password)
+#
+# Before applying, replace:
+#   <PROJECT_ID>  — GCP Project ID
+# ============================================================
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: terraform-registry-secrets
+  namespace: terraform-registry
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/<PROJECT_ID>/secrets/terraform-registry-jwt-secret/versions/latest"
+        path: "TFR_JWT_SECRET"
+      - resourceName: "projects/<PROJECT_ID>/secrets/terraform-registry-encryption-key/versions/latest"
+        path: "ENCRYPTION_KEY"
+      - resourceName: "projects/<PROJECT_ID>/secrets/terraform-registry-database-password/versions/latest"
+        path: "TFR_DATABASE_PASSWORD"
+  # Sync fetched secrets into a Kubernetes Secret for use via envFrom.
+  secretObjects:
+    - secretName: terraform-registry-secrets
+      type: Opaque
+      data:
+        - objectName: TFR_JWT_SECRET
+          key: TFR_JWT_SECRET
+        - objectName: ENCRYPTION_KEY
+          key: ENCRYPTION_KEY
+        - objectName: TFR_DATABASE_PASSWORD
+          key: TFR_DATABASE_PASSWORD

--- a/deployments/kubernetes/overlays/production/backend-topology-spread.yaml
+++ b/deployments/kubernetes/overlays/production/backend-topology-spread.yaml
@@ -1,0 +1,17 @@
+# Strategic merge patch: spread backend pods across nodes.
+# For cloud-specific zone-spread, use the aks/eks/gke overlays instead.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend

--- a/deployments/kubernetes/overlays/production/kustomization.yaml
+++ b/deployments/kubernetes/overlays/production/kustomization.yaml
@@ -8,14 +8,13 @@ resources:
   - hpa.yaml
 
 patches:
-  # Higher replica counts for production
+  # Production resource sizing
   - target:
       kind: Deployment
       name: backend
     patch: |-
-      - op: replace
+      - op: remove
         path: /spec/replicas
-        value: 3
       - op: replace
         path: /spec/template/spec/containers/0/resources/requests/cpu
         value: 250m
@@ -36,7 +35,15 @@ patches:
         path: /spec/replicas
         value: 2
 
-  # Production logging
+  # Spread backend pods across nodes (best-effort, ScheduleAnyway).
+  # Cloud-specific overlays (aks/eks/gke) add zone-level spread instead.
+  - path: backend-topology-spread.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # Production logging and server config
+  # REQUIRED: Replace <YOUR_HOSTNAME> with your actual public hostname.
   - target:
       kind: ConfigMap
       name: terraform-registry-config
@@ -46,9 +53,15 @@ patches:
         value: warn
       - op: replace
         path: /data/TFR_SERVER_BASE_URL
-        value: "https://registry.example.com"
+        value: "https://<YOUR_HOSTNAME>"
 
-  # Larger PVC for production
+  # Larger PVC for production.
+  # WARNING: The base PVC uses ReadWriteOnce (RWO), which only allows a single
+  # node to mount the volume. With HPA scaling to multiple replicas, pods on
+  # different nodes will fail to schedule. For multi-replica production:
+  #   - Switch to a cloud storage backend (s3, azure, gcs) and remove the PVC, OR
+  #   - Change accessModes to ReadWriteMany and use a suitable StorageClass
+  #     (e.g. azurefile-csi on AKS, efs-sc on EKS, filestore-sc on GKE)
   - target:
       kind: PersistentVolumeClaim
       name: terraform-registry-storage
@@ -58,10 +71,17 @@ patches:
         value: 50Gi
 
 # Pin image tags for production
+# Replace <REGISTRY> with your container registry FQDN, e.g.:
+#   ACR:  myregistry.azurecr.io
+#   ECR:  123456789.dkr.ecr.us-east-1.amazonaws.com
+#   GCR:  us-docker.pkg.dev/my-project/my-repo
+#   GHCR: ghcr.io/myorg
+# Replace <IMAGE_TAG> with the semver tag to deploy (e.g. v1.0.0).
+# In CI/CD pipelines use: kustomize edit set image terraform-registry-backend=<repo>:<tag>
 images:
   - name: terraform-registry-backend
-    newName: your-registry.example.com/terraform-registry-backend
-    newTag: v0.1.0
+    newName: <REGISTRY>/terraform-registry-backend
+    newTag: <IMAGE_TAG>
   - name: terraform-registry-frontend
-    newName: your-registry.example.com/terraform-registry-frontend
-    newTag: v0.1.0
+    newName: <REGISTRY>/terraform-registry-frontend
+    newTag: <IMAGE_TAG>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,17 +5,17 @@ Choose the option that matches your environment and operational model.
 
 ## Deployment Options
 
-| Option | Best For | Location |
-| --- | --- | --- |
-| Docker Compose (dev) | Local development, quick evaluation | `deployments/docker-compose.yml` |
-| Docker Compose (prod) | Small teams, single-host production | `deployments/docker-compose.prod.yml` |
-| Kubernetes + Kustomize | Enterprise, multi-replica, GitOps | `deployments/kubernetes/` |
-| Helm Chart | Kubernetes with parameterized config | `deployments/helm/` |
-| Azure Container Apps | Azure-native, serverless scaling | `deployments/azure-container-apps/` |
-| AWS ECS Fargate | AWS-native, fully managed | `deployments/aws-ecs/` |
-| Google Cloud Run | GCP-native, serverless | `deployments/google-cloud-run/` |
-| Standalone Binary + systemd | On-premise, VMs, maximum control | `deployments/binary/` |
-| Terraform IaC | Reproducible cloud infrastructure | `deployments/terraform/` |
+| Option                      | Best For                             | Location                              |
+| --------------------------- | ------------------------------------ | ------------------------------------- |
+| Docker Compose (dev)        | Local development, quick evaluation  | `deployments/docker-compose.yml`      |
+| Docker Compose (prod)       | Small teams, single-host production  | `deployments/docker-compose.prod.yml` |
+| Kubernetes + Kustomize      | Enterprise, multi-replica, GitOps    | `deployments/kubernetes/`             |
+| Helm Chart                  | Kubernetes with parameterized config | `deployments/helm/`                   |
+| Azure Container Apps        | Azure-native, serverless scaling     | `deployments/azure-container-apps/`   |
+| AWS ECS Fargate             | AWS-native, fully managed            | `deployments/aws-ecs/`                |
+| Google Cloud Run            | GCP-native, serverless               | `deployments/google-cloud-run/`       |
+| Standalone Binary + systemd | On-premise, VMs, maximum control     | `deployments/binary/`                 |
+| Terraform IaC               | Reproducible cloud infrastructure    | `deployments/terraform/`              |
 
 ---
 
@@ -149,38 +149,44 @@ The production overlay includes:
 The Helm chart provides the most flexible deployment option for Kubernetes, supporting
 all storage backends, optional frontend deployment, and ingress customization.
 
-```bash
-# Preview the rendered manifests
-helm template terraform-registry deployments/helm/ \
-  --set config.baseUrl=https://registry.example.com \
-  --set config.jwtSecret=$(openssl rand -hex 32) \
-  --set config.databasePassword=yourpassword \
-  --set storage.backend=s3 \
-  --set storage.s3.bucket=my-registry-bucket \
-  --set storage.s3.region=us-east-1
+> **Security note:** Do not pass secrets (JWT secret, encryption key, database password)
+> via `--set` in production — values passed this way are stored in plain text in the
+> Helm release Secret. Use `security.existingSecret` and `externalDatabase.existingSecret`
+> to reference a pre-created Kubernetes Secret, or use Key Vault CSI / External Secrets
+> Operator to populate secrets externally.
 
-# Install to Kubernetes
+```bash
+# 1. Create secrets separately (not stored in Helm release history)
+kubectl create secret generic terraform-registry-secrets \
+  --from-literal=TFR_JWT_SECRET="$(openssl rand -hex 32)" \
+  --from-literal=ENCRYPTION_KEY="$(openssl rand -hex 16)" \
+  --from-literal=TFR_DATABASE_PASSWORD="yourpassword" \
+  -n terraform-registry
+
+# 2. Install the chart referencing the existing secret
 helm install terraform-registry deployments/helm/ \
   --namespace terraform-registry \
   --create-namespace \
+  --set security.existingSecret=terraform-registry-secrets \
+  --set externalDatabase.existingSecret=terraform-registry-secrets \
   -f my-values.yaml
 ```
 
 Key values in `values.yaml` to override:
 
-| Value | Description |
-| --- | --- |
-| `config.baseUrl` | Public URL returned to Terraform CLI (required) |
-| `config.jwtSecret` | JWT signing secret (required, min 32 chars) |
-| `config.databasePassword` | PostgreSQL password |
-| `config.encryptionKey` | SCM OAuth token encryption key |
-| `storage.backend` | `local` \| `azure` \| `s3` \| `gcs` |
-| `ingress.enabled` | Enable ingress resource |
-| `ingress.hostname` | Ingress hostname |
-| `ingress.tls.enabled` | Enable TLS on ingress |
-| `backend.replicas` | Number of backend replicas |
-| `autoscaling.enabled` | Enable HPA |
-| `frontend.enabled` | Deploy frontend container |
+| Value                     | Description                                     |
+| ------------------------- | ----------------------------------------------- |
+| `config.baseUrl`          | Public URL returned to Terraform CLI (required) |
+| `config.jwtSecret`        | JWT signing secret (required, min 32 chars)     |
+| `config.databasePassword` | PostgreSQL password                             |
+| `config.encryptionKey`    | SCM OAuth token encryption key                  |
+| `storage.backend`         | `local` \| `azure` \| `s3` \| `gcs`             |
+| `ingress.enabled`         | Enable ingress resource                         |
+| `ingress.hostname`        | Ingress hostname                                |
+| `ingress.tls.enabled`     | Enable TLS on ingress                           |
+| `backend.replicas`        | Number of backend replicas                      |
+| `autoscaling.enabled`     | Enable HPA                                      |
+| `frontend.enabled`        | Deploy frontend container                       |
 
 See `deployments/helm/values.yaml` for the full annotated values file.
 
@@ -247,10 +253,10 @@ its own public IP rather than a shared NAT address.
 The ALB routes traffic to backend or frontend using path-based listener rules. The backend
 serves two distinct URL namespaces:
 
-| Namespace    | Routes                                | Purpose                            |
-| ------------ | ------------------------------------- | ---------------------------------- |
-| `/v1/*` etc. | Terraform protocol, mirror, discovery | Used directly by `terraform init`  |
-| `/api/*`     | Admin UI, auth, dev login             | Used by the React frontend         |
+| Namespace    | Routes                                | Purpose                           |
+| ------------ | ------------------------------------- | --------------------------------- |
+| `/v1/*` etc. | Terraform protocol, mirror, discovery | Used directly by `terraform init` |
+| `/api/*`     | Admin UI, auth, dev login             | Used by the React frontend        |
 
 AWS ALB listener rules accept a maximum of **5 path-pattern values per rule**, so these
 must be split into two rules:
@@ -296,10 +302,10 @@ nginx should rarely be exercised.
 
 Two URL configuration variables serve different purposes:
 
-| Variable                | Value                          | Purpose                                                                                                               |
-| ----------------------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `TFR_SERVER_BASE_URL`   | `https://registry.example.com` | Terraform protocol — embedded in discovery responses and module/provider download URLs that `terraform` CLI will fetch|
-| `TFR_SERVER_PUBLIC_URL` | `https://registry.example.com` | OAuth redirect URL — where the browser is sent after OIDC login completes                                             |
+| Variable                | Value                          | Purpose                                                                                                                |
+| ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `TFR_SERVER_BASE_URL`   | `https://registry.example.com` | Terraform protocol — embedded in discovery responses and module/provider download URLs that `terraform` CLI will fetch |
+| `TFR_SERVER_PUBLIC_URL` | `https://registry.example.com` | OAuth redirect URL — where the browser is sent after OIDC login completes                                              |
 
 In an ECS deployment behind an ALB both should be set to your public domain. If
 `TFR_SERVER_PUBLIC_URL` is omitted it falls back to `TFR_SERVER_BASE_URL`, which works
@@ -359,13 +365,13 @@ curl -X POST https://registry.example.com/api/v1/dev/login \
 
 ### Estimated Cost (dev, us-east-1, single replicas)
 
-| Resource                                                            | Monthly (~) |
-| ------------------------------------------------------------------- | ----------- |
-| ECS Fargate (backend 0.5 vCPU/1 GB + frontend 0.25 vCPU/512 MB)     | ~$14        |
-| ALB                                                                 | ~$18        |
-| RDS `db.t3.micro`                                                   | ~$15        |
-| S3 + ECR + Secrets Manager                                          | ~$2         |
-| **Total**                                                           | **~$49**    |
+| Resource                                                        | Monthly (~) |
+| --------------------------------------------------------------- | ----------- |
+| ECS Fargate (backend 0.5 vCPU/1 GB + frontend 0.25 vCPU/512 MB) | ~$14        |
+| ALB                                                             | ~$18        |
+| RDS `db.t3.micro`                                               | ~$15        |
+| S3 + ECR + Secrets Manager                                      | ~$2         |
+| **Total**                                                       | **~$49**    |
 
 No NAT Gateway removes ~$32/month compared to the classic VPC design.
 
@@ -507,7 +513,7 @@ GET /healthz
 # Returns 200 OK: {"status": "ok"}
 ```
 
-Use `/health` for Kubernetes readiness probes (checks DB + storage connectivity) and `/healthz` for liveness probes (just process alive).
+Use `/healthz` for Kubernetes liveness probes (lightweight process-alive check) and `/health` for readiness probes (checks DB + storage connectivity). A startup probe on `/healthz` with a higher failure threshold allows slow-starting pods to initialize without being killed.
 
 ---
 
@@ -603,52 +609,58 @@ Verify each variable is set in the target environment before deploying. For the 
 
 #### Required — Database
 
-| Variable | Description |
-| --- | --- |
-| `DATABASE_URL` | PostgreSQL DSN `postgres://user:pass@host:5432/dbname?sslmode=require` |
-| `DB_MAX_OPEN_CONNS` | Max open connections (suggest: `25`) |
-| `DB_MAX_IDLE_CONNS` | Max idle connections (suggest: `5`) |
+| Variable                     | Description                                                      |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `TFR_DATABASE_HOST`          | PostgreSQL host (e.g., `mydb.postgres.database.azure.com`)       |
+| `TFR_DATABASE_PORT`          | PostgreSQL port (default `5432`)                                 |
+| `TFR_DATABASE_NAME`          | Database name (default `terraform_registry`)                     |
+| `TFR_DATABASE_USER`          | Database user                                                    |
+| `TFR_DATABASE_PASSWORD`      | Database password (from secret store)                            |
+| `TFR_DATABASE_SSLMODE`       | SSL mode (`require` for production)                              |
+| `TFR_DATABASE_MAX_CONNECTIONS` | Max open connections (suggest: `25`)                           |
 
-- [ ] `DATABASE_URL` is set and resolves from the deployment host
+- [ ] `TFR_DATABASE_HOST` is set and resolves from the deployment host
 - [ ] Database credentials are sourced from the secret store (not hard-coded)
 
 #### Required — Storage
 
-| Variable | Description |
-| --- | --- |
-| `STORAGE_BACKEND` | `s3`, `gcs`, `azure`, or `local` |
-| `STORAGE_BUCKET` | Name of the storage bucket / container |
+| Variable                          | Description                            |
+| --------------------------------- | -------------------------------------- |
+| `TFR_STORAGE_DEFAULT_BACKEND`     | `s3`, `gcs`, `azure`, or `local`       |
+| `TFR_STORAGE_S3_BUCKET` / `TFR_STORAGE_AZURE_CONTAINER_NAME` / `TFR_STORAGE_GCS_BUCKET` | Name of the storage bucket / container |
 
 Storage-backend-specific:
 
 ##### AWS S3
 
-- [ ] `AWS_REGION` set
-- [ ] IAM role or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` configured
+- [ ] `TFR_STORAGE_S3_REGION` set
+- [ ] IAM role (IRSA) or `TFR_STORAGE_S3_ACCESS_KEY_ID` / `TFR_STORAGE_S3_SECRET_ACCESS_KEY` configured
 - [ ] Bucket exists and the service account has `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`
 
 ##### GCS
 
-- [ ] `GOOGLE_APPLICATION_CREDENTIALS` or Workload Identity configured
+- [ ] `TFR_STORAGE_GCS_PROJECT_ID` set
+- [ ] GKE Workload Identity or `TFR_STORAGE_GCS_CREDENTIALS_FILE` configured
 - [ ] Bucket exists with appropriate ACLs
 
 ##### Azure Blob
 
-- [ ] `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` (or managed identity) configured
+- [ ] `TFR_STORAGE_AZURE_ACCOUNT_NAME` and `TFR_STORAGE_AZURE_ACCOUNT_KEY` (or Workload Identity) configured
 - [ ] Container exists
 
 ##### Local
 
-- [ ] `STORAGE_LOCAL_PATH` points to a persistent volume (not ephemeral container storage)
+- [ ] `TFR_STORAGE_LOCAL_BASE_PATH` points to a persistent volume (not ephemeral container storage)
 
 #### Required — Authentication / Authorization
 
-| Variable | Description |
-| --- | --- |
-| `AUTH_ENABLED` | `true` in production |
-| `OIDC_ISSUER_URL` | OIDC provider discovery URL |
-| `OIDC_CLIENT_ID` | Registered client ID |
-| `OIDC_CLIENT_SECRET` | Registered client secret (from secret store) |
+| Variable                      | Description                                  |
+| ----------------------------- | -------------------------------------------- |
+| `TFR_AUTH_API_KEYS_ENABLED`   | `true` for API key authentication            |
+| `TFR_AUTH_OIDC_ENABLED`       | `true` to enable OIDC authentication         |
+| `TFR_AUTH_OIDC_ISSUER_URL`    | OIDC provider discovery URL                  |
+| `TFR_AUTH_OIDC_CLIENT_ID`     | Registered client ID                         |
+| `TFR_AUTH_OIDC_CLIENT_SECRET` | Registered client secret (from secret store) |
 
 - [ ] OIDC provider is reachable from the deployment host
 - [ ] Redirect URI(s) registered in the OIDC provider match the deployment URL
@@ -656,27 +668,57 @@ Storage-backend-specific:
 
 #### Required — Server
 
-| Variable | Description |
-| --- | --- |
-| `PORT` | HTTP port (default `8080`) |
-| `BASE_URL` | Public-facing URL including scheme, e.g., `https://registry.example.com` |
-| `DEV_MODE` | Must be `false` in production |
-| `LOG_FORMAT` | `json` recommended for production |
-| `LOG_LEVEL` | `info` or `warn` for production |
+| Variable              | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `TFR_SERVER_PORT`     | HTTP port (default `8080`)                                               |
+| `TFR_SERVER_BASE_URL` | Public-facing URL including scheme, e.g., `https://registry.example.com` |
+| `DEV_MODE`            | Must be `false` in production                                            |
+| `TFR_LOGGING_FORMAT`  | `json` recommended for production                                        |
+| `TFR_LOGGING_LEVEL`   | `info` or `warn` for production                                          |
 
 - [ ] `DEV_MODE=false`
-- [ ] `BASE_URL` matches the DNS entry that will serve traffic
+- [ ] `TFR_SERVER_BASE_URL` matches the DNS entry that will serve traffic
 
 #### Optional — Observability
 
-| Variable | Description |
-| --- | --- |
-| `METRICS_ENABLED` | `true` to expose `/metrics` (Prometheus scrape target) |
-| `SENTRY_DSN` | Sentry error-tracking DSN *(optional)* |
+| Variable                    | Description                                            |
+| --------------------------- | ------------------------------------------------------ |
+| `TFR_TELEMETRY_ENABLED`    | `true` to expose `/metrics` (Prometheus scrape target) |
 
 ### 3. Database Migrations
 
-- [ ] A database backup has been taken immediately before migrating
+- [ ] A database backup has been taken immediately before migrating:
+
+  **Azure Database for PostgreSQL:**
+
+  ```bash
+  # Create an on-demand backup (Flexible Server backs up automatically, but
+  # an explicit backup before migration is good practice)
+  az postgres flexible-server backup create \
+    --resource-group <RG> --name <SERVER> --backup-name pre-migration-$(date +%Y%m%d)
+  ```
+
+  **Amazon RDS:**
+
+  ```bash
+  aws rds create-db-snapshot \
+    --db-instance-identifier terraform-registry-db \
+    --db-snapshot-identifier pre-migration-$(date +%Y%m%d)
+  aws rds wait db-snapshot-available \
+    --db-snapshot-identifier pre-migration-$(date +%Y%m%d)
+  ```
+
+  **Cloud SQL:**
+
+  ```bash
+  gcloud sql backups create --instance=terraform-registry-db --description="pre-migration"
+  ```
+
+  **Self-hosted PostgreSQL / Docker Compose:**
+
+  ```bash
+  pg_dump -h <HOST> -U registry -d terraform_registry -Fc -f pre-migration-$(date +%Y%m%d).dump
+  ```
 - [ ] The migration is idempotent (re-running it is safe)
 - [ ] Migration command confirmed:
 
@@ -688,7 +730,12 @@ Storage-backend-specific:
 
   ```bash
   docker run --rm \
-    -e DATABASE_URL="$DATABASE_URL" \
+    -e TFR_DATABASE_HOST="$TFR_DATABASE_HOST" \
+    -e TFR_DATABASE_PORT="$TFR_DATABASE_PORT" \
+    -e TFR_DATABASE_USER="$TFR_DATABASE_USER" \
+    -e TFR_DATABASE_PASSWORD="$TFR_DATABASE_PASSWORD" \
+    -e TFR_DATABASE_NAME="$TFR_DATABASE_NAME" \
+    -e TFR_DATABASE_SSLMODE="$TFR_DATABASE_SSLMODE" \
     ghcr.io/sethbacon/terraform-registry-backend:<version> \
     migrate up
   ```
@@ -862,6 +909,139 @@ terraform-registry migrate down 1
 - [ ] Rollback decision logged in the incident channel
 - [ ] Rollback completed and verified via smoke tests (Section 7)
 - [ ] Post-mortem scheduled
+
+---
+
+## Backup & Restore
+
+### Database Backup
+
+#### Azure Database for PostgreSQL Flexible Server
+
+Flexible Server creates automatic backups daily (configurable 1–35 day retention).
+For on-demand backups before upgrades:
+
+```bash
+az postgres flexible-server backup create \
+  --resource-group <RG> --name <SERVER> --backup-name manual-$(date +%Y%m%d)
+
+# List backups
+az postgres flexible-server backup list --resource-group <RG> --name <SERVER> -o table
+
+# Restore to a point in time (creates a new server)
+az postgres flexible-server restore \
+  --resource-group <RG> --name <SERVER>-restored \
+  --source-server <SERVER> --restore-time "2026-03-04T10:00:00Z"
+```
+
+#### Amazon RDS
+
+RDS creates automated snapshots daily (configurable 0–35 day retention).
+
+```bash
+# Manual snapshot
+aws rds create-db-snapshot \
+  --db-instance-identifier terraform-registry-db \
+  --db-snapshot-identifier manual-$(date +%Y%m%d)
+
+# Point-in-time restore (creates a new instance)
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier terraform-registry-db \
+  --target-db-instance-identifier terraform-registry-db-restored \
+  --restore-time "2026-03-04T10:00:00Z"
+```
+
+#### Cloud SQL
+
+Cloud SQL creates automated backups with configurable retention.
+
+```bash
+# Manual backup
+gcloud sql backups create --instance=terraform-registry-db --description="manual backup"
+
+# List backups
+gcloud sql backups list --instance=terraform-registry-db
+
+# Restore from a backup
+gcloud sql backups restore <BACKUP_ID> --restore-instance=terraform-registry-db
+```
+
+#### Self-hosted PostgreSQL / Docker Compose
+
+```bash
+# Dump (compressed custom format)
+pg_dump -h <HOST> -U registry -d terraform_registry -Fc -f backup-$(date +%Y%m%d).dump
+
+# Restore
+pg_restore -h <HOST> -U registry -d terraform_registry --clean --if-exists backup-20260304.dump
+```
+
+### Storage Backup (PVC-based local storage)
+
+When using `TFR_STORAGE_DEFAULT_BACKEND=local`, module and provider artifacts are stored
+on a PersistentVolumeClaim. This data must be backed up separately from the database.
+
+> **Note:** If you use a cloud storage backend (S3, Azure Blob, GCS), backup and
+> versioning are handled by the cloud provider. Enable object versioning on your
+> bucket/container for point-in-time recovery.
+
+#### Kubernetes PVC Backup
+
+Use [Velero](https://velero.io/) for PVC-level backup and restore:
+
+```bash
+# Install Velero with appropriate storage provider plugin
+
+# Backup the namespace (includes PVCs)
+velero backup create terraform-registry-backup \
+  --include-namespaces terraform-registry \
+  --include-resources pvc,pv
+
+# Restore
+velero restore create --from-backup terraform-registry-backup
+```
+
+Alternatively, copy data out of the running pod:
+
+```bash
+# Snapshot PVC data to a local archive
+kubectl exec -n terraform-registry deployment/backend -- \
+  tar czf - /app/storage > storage-backup-$(date +%Y%m%d).tar.gz
+
+# Restore from archive
+kubectl exec -i -n terraform-registry deployment/backend -- \
+  tar xzf - -C / < storage-backup-20260304.tar.gz
+```
+
+#### Docker Compose (named volume)
+
+```bash
+# Backup
+docker run --rm \
+  -v terraform-registry_storage_data:/data:ro \
+  -v $(pwd):/backup \
+  alpine tar czf /backup/storage-backup-$(date +%Y%m%d).tar.gz -C /data .
+
+# Restore
+docker run --rm \
+  -v terraform-registry_storage_data:/data \
+  -v $(pwd):/backup \
+  alpine sh -c "rm -rf /data/* && tar xzf /backup/storage-backup-20260304.tar.gz -C /data"
+```
+
+#### Standalone Binary
+
+```bash
+# Backup the storage directory (default /app/storage)
+sudo tar czf /var/backups/terraform-registry-storage-$(date +%Y%m%d).tar.gz \
+  -C /app storage/
+
+# Restore
+sudo systemctl stop terraform-registry
+sudo tar xzf /var/backups/terraform-registry-storage-20260304.tar.gz -C /app
+sudo chown -R registry:registry /app/storage
+sudo systemctl start terraform-registry
+```
 
 ### 10. Sign-off
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,161 @@
+# Deployment Guide
+
+This directory contains comprehensive documentation for deploying the Terraform Registry.
+
+## Deployment Targets
+
+| Target                     | Method                      | Guide                                                           |
+| -------------------------- | --------------------------- | --------------------------------------------------------------- |
+| **Local development**      | Docker Compose              | `deployments/docker-compose.yml`                                |
+| **AKS — new cluster**      | Helm or Kustomize           | [aks-new-cluster.md](aks-new-cluster.md)                        |
+| **AKS — existing cluster** | Helm or Kustomize           | [aks-existing-cluster.md](aks-existing-cluster.md)              |
+| **AWS EKS**                | Helm or Kustomize           | [eks-deployment.md](eks-deployment.md)                          |
+| **Google GKE**             | Helm or Kustomize           | [gke-deployment.md](gke-deployment.md)                          |
+| **Azure Container Apps**   | Bicep or Azure CLI          | `deployments/azure-container-apps/`                             |
+| **Azure (full infra)**     | Terraform                   | `deployments/terraform/azure/`                                  |
+| **AWS ECS**                | CloudFormation or Terraform | `deployments/aws-ecs/` or `deployments/terraform/aws/`          |
+| **GCP Cloud Run**          | Terraform or gcloud         | `deployments/terraform/gcp/` or `deployments/google-cloud-run/` |
+| **Bare metal / VM**        | systemd + nginx             | `deployments/binary/`                                           |
+
+## Kubernetes Deployment Methods
+
+Two deployment methods are provided for Kubernetes (AKS, EKS, GKE, and generic):
+
+### 1. Helm (recommended)
+
+The Helm chart at `deployments/helm/` deploys both the backend and frontend in a single release.
+
+```bash
+# Standard Kubernetes (non-AKS) with default values
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  --set externalDatabase.host=<DB_HOST> \
+  --set security.jwtSecret=<JWT_SECRET> \
+  --set security.encryptionKey=<ENC_KEY>
+
+# AKS with Application Gateway for Containers + Key Vault
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f deployments/helm/values-aks.yaml
+
+# EKS with AWS Load Balancer Controller + Secrets Manager
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f deployments/helm/values-eks.yaml
+
+# GKE with GKE built-in Gateway + Secret Manager CSI
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f deployments/helm/values-gke.yaml
+```
+
+### 2. Kustomize
+
+Five overlays are provided at `deployments/kubernetes/overlays/`:
+
+| Overlay       | Description                                                                                   |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `dev/`        | Development (1 replica, debug logging, small PVC)                                             |
+| `production/` | Generic production (3 replicas, larger resources, pinned images)                              |
+| `aks/`        | **AKS-specific** (AGfC Gateway API, Key Vault CSI, Workload Identity, NetworkPolicy)          |
+| `eks/`        | **EKS-specific** (AWS LBC Gateway API, ASCP Secrets Manager, IRSA, NetworkPolicy)             |
+| `gke/`        | **GKE-specific** (GKE built-in Gateway, Secret Manager CSI, Workload Identity, NetworkPolicy) |
+
+```bash
+# AKS deployment
+kubectl apply -k deployments/kubernetes/overlays/aks/
+
+# EKS deployment
+kubectl apply -k deployments/kubernetes/overlays/eks/
+
+# GKE deployment
+kubectl apply -k deployments/kubernetes/overlays/gke/
+
+# Generic production
+kubectl apply -k deployments/kubernetes/overlays/production/
+```
+
+## Ingress Architecture
+
+### AKS — Application Gateway for Containers
+
+Uses **Application Gateway for Containers (AGfC)** with the Kubernetes **Gateway API** (v1 GA):
+
+```txt
+Internet
+    │
+    ▼
+Application Gateway for Containers (AGfC)
+    │  GatewayClass: azure-alb-external
+    │  Gateway: terraform-registry-gateway
+    │
+    ├─ /api/* /v1/* /.well-known/* /terraform/* ──▶ backend:8080
+    │  /health /ready /swagger.json /webhooks/*
+    │
+    └─ /* (catch-all) ──────────────────────────▶ frontend:80 ──▶ backend:8080
+                                                    (nginx SPA)    (proxy for
+                                                                   remaining paths)
+```
+
+### EKS — AWS Load Balancer Controller
+
+Uses **AWS Application Load Balancer (ALB)** via the **Kubernetes Gateway API**:
+
+```txt
+Internet
+    │
+    ▼
+ALB (internet-facing)
+    │  GatewayClass: aws-application-lb
+    │  Gateway: terraform-registry-gateway
+    │
+    ├─ /api/* /v1/* /.well-known/* /terraform/* ──▶ backend:8080
+    └─ /* (catch-all) ──────────────────────────▶ frontend:80
+```
+
+### GKE — Built-in GKE Gateway Controller
+
+Uses the **GKE built-in external Application Load Balancer** via **Kubernetes Gateway API**:
+
+```txt
+Internet
+    │
+    ▼
+GKE External ALB
+    │  GatewayClass: gke-l7-global-external-managed (pre-provisioned)
+    │  Gateway: terraform-registry-gateway
+    │
+    ├─ /api/* /v1/* /.well-known/* /terraform/* ──▶ backend:8080
+    └─ /* (catch-all) ──────────────────────────▶ frontend:80
+```
+
+### Generic Kubernetes (non-cloud)
+
+Uses the legacy nginx `Ingress` resource with `ingressClassName: nginx`. The upstream
+`ingress-nginx` project ended maintenance in March 2026. Plan to migrate.
+
+## Key Architecture Decisions
+
+- **No in-cluster PostgreSQL**: The chart and manifests expect an external database (Azure Database for PostgreSQL Flexible Server for AKS; Amazon RDS for EKS; Cloud SQL for GKE). No StatefulSet for Postgres is deployed.
+- **Storage**: Default is `local` (PVC). For cloud deployments with multiple replicas, switch to `azure` (Azure Blob), `s3` (Amazon S3), or `gcs` (Google Cloud Storage). See the cloud-specific values files.
+- **Secrets**: For AKS use Azure Key Vault + Secrets Store CSI Driver. For EKS use AWS Secrets Manager + ASCP. For GKE use GCP Secret Manager + CSI provider. For other environments use Sealed Secrets, External Secrets Operator, or CI/CD injection.
+- **Frontend k8s manifests live in the backend repo**: A single Helm release or `kubectl apply -k` deploys both services.
+
+## Quick Links
+
+### AKS
+
+- [AKS Prerequisites](aks-prerequisites.md) — Required Azure resources and cluster features
+- [AKS New Cluster Guide](aks-new-cluster.md) — Full setup walkthrough from scratch
+- [AKS Existing Cluster Guide](aks-existing-cluster.md) — Deploy into an existing AKS cluster
+- [AKS Operations](aks-operations.md) — Upgrades, certificate renewal, scaling, troubleshooting
+
+### EKS
+
+- [EKS Prerequisites](eks-prerequisites.md) — Required AWS resources and cluster setup
+- [EKS Deployment Guide](eks-deployment.md) — Deploy the registry to EKS
+
+### GKE
+
+- [GKE Prerequisites](gke-prerequisites.md) — Required GCP resources and cluster setup
+- [GKE Deployment Guide](gke-deployment.md) — Deploy the registry to GKE

--- a/docs/deployment/aks-existing-cluster.md
+++ b/docs/deployment/aks-existing-cluster.md
@@ -1,0 +1,237 @@
+# AKS Existing Cluster — Deployment Guide
+
+This guide covers deploying the Terraform Registry into an existing AKS cluster.
+
+## Prerequisites Check
+
+Run the following to verify your cluster has the required features:
+
+```bash
+RESOURCE_GROUP="<RG>"
+CLUSTER_NAME="<CLUSTER>"
+
+az aks show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --query '{
+    oidcEnabled: oidcIssuerProfile.enabled,
+    workloadIdentityEnabled: securityProfile.workloadIdentity.enabled,
+    networkPlugin: networkProfile.networkPlugin,
+    networkPolicy: networkProfile.networkPolicy,
+    csiDriverEnabled: addonProfiles.azureKeyvaultSecretsProvider.enabled
+  }' -o json
+```
+
+Required values:
+- `oidcEnabled: true`
+- `workloadIdentityEnabled: true`
+- `networkPlugin: "azure"` or `"azure-overlay"` (required for NetworkPolicy)
+- `csiDriverEnabled: true`
+
+### Enable Missing Features
+
+Enable features on the existing cluster as needed:
+
+```bash
+# Enable OIDC Issuer (required before Workload Identity)
+# WARNING: This operation may cause a brief node pool rolling restart.
+az aks update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --enable-oidc-issuer
+
+# Enable Workload Identity (safe to run on running clusters)
+az aks update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --enable-workload-identity
+
+# Enable Secrets Store CSI Driver add-on
+az aks enable-addons \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --addons azure-keyvault-secrets-provider
+
+# Attach ACR for image pull without explicit pull secrets
+az aks update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --attach-acr "<ACR_NAME>"
+```
+
+> **Note on NetworkPolicy**: Changing `networkPlugin` or `networkPolicy` on an existing cluster
+> is a destructive operation that requires cluster recreation. If your cluster uses Kubenet,
+> set `networkPolicy.enabled=false` in Helm values and manage ingress security via Azure NSGs.
+
+---
+
+## Provision Required Azure Resources
+
+If not already provisioned, create the Azure resources listed in [aks-prerequisites.md](aks-prerequisites.md). At minimum you need:
+
+1. PostgreSQL Flexible Server + `terraform_registry` database
+2. Storage Account + blob container
+3. Key Vault + secrets (`jwt-secret`, `encryption-key`, `database-password`)
+4. User-Assigned Managed Identity with Key Vault Secret User role
+5. Application Gateway for Containers resource + Frontend
+
+---
+
+## Create Federated Credential
+
+Link the managed identity to the Kubernetes ServiceAccount in this cluster:
+
+```bash
+OIDC_ISSUER=$(az aks show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --query oidcIssuerProfile.issuerURL -o tsv)
+
+az identity federated-credential create \
+  --name terraform-registry-aks \
+  --identity-name "<REGISTRY_IDENTITY_NAME>" \
+  --resource-group "<RESOURCE_GROUP>" \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:terraform-registry:terraform-registry" \
+  --audiences "api://AzureADTokenExchange"
+```
+
+---
+
+## Install Kubernetes Add-ons
+
+### Check if Gateway API CRDs are present
+
+```bash
+kubectl get crd gateways.gateway.networking.k8s.io 2>&1 | grep -v "Error" || \
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+```
+
+### Check if cert-manager is installed
+
+```bash
+kubectl get pods -n cert-manager 2>/dev/null || {
+  helm repo add jetstack https://charts.jetstack.io --force-update
+  helm upgrade --install cert-manager jetstack/cert-manager \
+    --namespace cert-manager --create-namespace \
+    --set crds.enabled=true \
+    --set featureGates="ExperimentalGatewayAPISupport=true"
+}
+```
+
+If cert-manager is already installed, verify the feature gate is enabled:
+
+```bash
+kubectl get deployment cert-manager -n cert-manager \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ',' '\n' | grep Gateway
+```
+
+If `ExperimentalGatewayAPISupport=true` is not present, upgrade cert-manager:
+
+```bash
+helm upgrade cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --reuse-values \
+  --set featureGates="ExperimentalGatewayAPISupport=true"
+```
+
+### Check if ALB Controller is installed
+
+```bash
+kubectl get pods -n azure-alb-system 2>/dev/null | grep alb-controller || {
+  echo "ALB Controller not found — install it following aks-prerequisites.md"
+}
+```
+
+---
+
+## Namespace Isolation
+
+If the `terraform-registry` namespace already exists (e.g. from a previous deployment):
+
+```bash
+# Check existing resources
+kubectl get all -n terraform-registry
+
+# If doing a fresh install into existing namespace, clean up first:
+# kubectl delete namespace terraform-registry  # WARNING: deletes all resources
+# kubectl create namespace terraform-registry
+```
+
+For upgrading an existing Helm release:
+
+```bash
+helm list -n terraform-registry
+helm history terraform-registry -n terraform-registry
+```
+
+---
+
+## Deploy
+
+### Helm Upgrade/Install
+
+Copy `deployments/helm/values-aks.yaml` and fill in your values:
+
+```bash
+cp deployments/helm/values-aks.yaml my-values.yaml
+# Edit my-values.yaml — replace all <PLACEHOLDER> values
+
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --create-namespace \
+  -f my-values.yaml
+
+# Verify rollout
+kubectl rollout status deployment/terraform-registry-backend -n terraform-registry
+kubectl rollout status deployment/terraform-registry-frontend -n terraform-registry
+```
+
+### Kustomize Apply
+
+Edit all placeholder values in `deployments/kubernetes/overlays/aks/` (see comments in each file):
+
+```bash
+kubectl apply -k deployments/kubernetes/overlays/aks/
+
+# Watch pod start-up
+kubectl get pods -n terraform-registry --watch
+```
+
+---
+
+## Post-Deploy Verification
+
+```bash
+# Pods should be Running
+kubectl get pods -n terraform-registry
+
+# Gateway address assigned
+kubectl get gateway -n terraform-registry
+
+# HTTPRoutes accepted
+kubectl get httproute -n terraform-registry -o wide
+
+# Certificate issued (may take a few minutes after DNS propagates)
+kubectl get certificate -n terraform-registry
+
+# Health check via port-forward
+kubectl port-forward svc/terraform-registry-backend 8080:8080 -n terraform-registry &
+curl http://localhost:8080/health
+
+# Full HTTPS stack
+curl https://<HOSTNAME>/health
+curl https://<HOSTNAME>/.well-known/terraform.json
+```
+
+---
+
+## Rollback
+
+```bash
+# List Helm history
+helm history terraform-registry -n terraform-registry
+
+# Rollback to previous revision
+helm rollback terraform-registry -n terraform-registry
+```

--- a/docs/deployment/aks-new-cluster.md
+++ b/docs/deployment/aks-new-cluster.md
@@ -1,0 +1,535 @@
+# AKS New Cluster — Deployment Guide
+
+This guide walks through provisioning all required Azure infrastructure and deploying
+the Terraform Registry to a brand-new AKS cluster using Helm.
+
+Complete [aks-prerequisites.md](aks-prerequisites.md) first to understand what is required.
+
+---
+
+## Variables Used in This Guide
+
+Set these shell variables once and reuse throughout:
+
+```bash
+# Azure
+SUBSCRIPTION_ID="<UUID>"
+RESOURCE_GROUP="tfr-prod-rg"
+LOCATION="eastus"
+
+# AKS
+CLUSTER_NAME="tfr-aks"
+NODE_COUNT=3           # Minimum 3 for zone spread + PDB
+VM_SIZE="Standard_D4s_v3"
+VNET_NAME="tfr-vnet"
+
+# Registry
+ACR_NAME="tfrregistry"    # Must be globally unique, alphanumeric only, 5-50 chars
+
+# PostgreSQL
+PG_SERVER="tfr-postgres"
+PG_ADMIN_USER="registry"
+PG_ADMIN_PASSWORD="<GENERATE_WITH: openssl rand -hex 24>"
+
+# Storage
+STORAGE_ACCOUNT="tfrblob$(openssl rand -hex 4)"  # Must be globally unique
+
+# Key Vault
+KEY_VAULT_NAME="tfr-kv-$(openssl rand -hex 4)"   # Must be globally unique
+
+# AGfC
+AGFC_NAME="tfr-agfc"
+
+# Managed Identity
+REGISTRY_IDENTITY_NAME="terraform-registry-identity"
+ALB_IDENTITY_NAME="alb-controller-identity"
+
+# Application
+HOSTNAME="registry.company.com"          # Replace with your domain
+OPS_EMAIL="ops@company.com"
+IMAGE_TAG="v1.0.0"
+```
+
+---
+
+## Step 1 — Create Azure Infrastructure
+
+### 1.1 Resource Group and VNet
+
+```bash
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+az network vnet create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VNET_NAME" \
+  --address-prefix 10.0.0.0/8
+
+# AKS node subnet
+az network vnet subnet create \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name aks-subnet \
+  --address-prefix 10.240.0.0/16
+
+# AGfC subnet (delegated, /24 or smaller)
+az network vnet subnet create \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name agfc-subnet \
+  --address-prefix 10.225.0.0/24
+
+az network vnet subnet update \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name agfc-subnet \
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+```
+
+### 1.2 Container Registry
+
+```bash
+az acr create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$ACR_NAME" \
+  --sku Standard \
+  --location "$LOCATION"
+```
+
+### 1.3 PostgreSQL Flexible Server
+
+```bash
+AKS_SUBNET_ID=$(az network vnet subnet show \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name aks-subnet --query id -o tsv)
+
+az postgres flexible-server create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$PG_SERVER" \
+  --location "$LOCATION" \
+  --admin-user "$PG_ADMIN_USER" \
+  --admin-password "$PG_ADMIN_PASSWORD" \
+  --sku-name Standard_D2ds_v5 \
+  --tier GeneralPurpose \
+  --version 16 \
+  --storage-size 32 \
+  --backup-retention 7
+
+az postgres flexible-server db create \
+  --resource-group "$RESOURCE_GROUP" \
+  --server-name "$PG_SERVER" \
+  --database-name terraform_registry
+
+# Allow connections from AKS (update firewall rule after cluster is created)
+# For sandbox: allow all Azure services temporarily
+az postgres flexible-server firewall-rule create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$PG_SERVER" \
+  --rule-name AllowAzureServices \
+  --start-ip-address 0.0.0.0 \
+  --end-ip-address 0.0.0.0
+```
+
+### 1.4 Storage Account
+
+```bash
+az storage account create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$STORAGE_ACCOUNT" \
+  --sku Standard_LRS \
+  --kind StorageV2 \
+  --https-only true \
+  --min-tls-version TLS1_2 \
+  --allow-blob-public-access false
+
+az storage container create \
+  --account-name "$STORAGE_ACCOUNT" \
+  --name terraform-registry \
+  --auth-mode login
+```
+
+### 1.5 Key Vault + Secrets
+
+```bash
+az keyvault create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$KEY_VAULT_NAME" \
+  --location "$LOCATION" \
+  --enable-rbac-authorization true
+
+# Store secrets
+az keyvault secret set --vault-name "$KEY_VAULT_NAME" \
+  --name jwt-secret --value "$(openssl rand -hex 32)"
+
+az keyvault secret set --vault-name "$KEY_VAULT_NAME" \
+  --name encryption-key --value "$(openssl rand -hex 16)"
+
+az keyvault secret set --vault-name "$KEY_VAULT_NAME" \
+  --name database-password --value "$PG_ADMIN_PASSWORD"
+
+# Store blob account key (used when not using Workload Identity for storage)
+BLOB_KEY=$(az storage account keys list \
+  --resource-group "$RESOURCE_GROUP" \
+  --account-name "$STORAGE_ACCOUNT" \
+  --query '[0].value' -o tsv)
+az keyvault secret set --vault-name "$KEY_VAULT_NAME" \
+  --name azure-blob-account-key --value "$BLOB_KEY"
+```
+
+### 1.6 Managed Identities
+
+```bash
+# Registry application identity
+az identity create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$REGISTRY_IDENTITY_NAME" \
+  --location "$LOCATION"
+
+REGISTRY_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" \
+  -n "$REGISTRY_IDENTITY_NAME" --query clientId -o tsv)
+REGISTRY_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" \
+  -n "$REGISTRY_IDENTITY_NAME" --query principalId -o tsv)
+
+# ALB Controller identity
+az identity create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$ALB_IDENTITY_NAME" \
+  --location "$LOCATION"
+
+ALB_CLIENT_ID=$(az identity show -g "$RESOURCE_GROUP" \
+  -n "$ALB_IDENTITY_NAME" --query clientId -o tsv)
+ALB_PRINCIPAL_ID=$(az identity show -g "$RESOURCE_GROUP" \
+  -n "$ALB_IDENTITY_NAME" --query principalId -o tsv)
+
+# Grant registry identity: Key Vault Secret User
+KEY_VAULT_ID=$(az keyvault show --name "$KEY_VAULT_NAME" --query id -o tsv)
+az role assignment create \
+  --role "Key Vault Secrets User" \
+  --assignee-object-id "$REGISTRY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$KEY_VAULT_ID"
+
+# Grant registry identity: Storage Blob Data Contributor
+STORAGE_ID=$(az storage account show -g "$RESOURCE_GROUP" \
+  -n "$STORAGE_ACCOUNT" --query id -o tsv)
+az role assignment create \
+  --role "Storage Blob Data Contributor" \
+  --assignee-object-id "$REGISTRY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$STORAGE_ID"
+
+# Grant ALB Controller identity: Reader + AGfC Configuration Manager on resource group
+RG_ID=$(az group show --name "$RESOURCE_GROUP" --query id -o tsv)
+az role assignment create \
+  --role "Reader" \
+  --assignee-object-id "$ALB_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$RG_ID"
+
+az role assignment create \
+  --role "AppGw for Containers Configuration Manager" \
+  --assignee-object-id "$ALB_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$RG_ID"
+```
+
+### 1.7 Application Gateway for Containers
+
+```bash
+az network alb create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AGFC_NAME" \
+  --location "$LOCATION"
+
+az network alb frontend create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name registry-frontend \
+  --alb-name "$AGFC_NAME"
+
+AGFC_ID=$(az network alb show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AGFC_NAME" --query id -o tsv)
+```
+
+---
+
+## Step 2 — Create AKS Cluster
+
+```bash
+AKS_SUBNET_ID=$(az network vnet subnet show \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name aks-subnet --query id -o tsv)
+
+az aks create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --location "$LOCATION" \
+  --node-count "$NODE_COUNT" \
+  --node-vm-size "$VM_SIZE" \
+  --vnet-subnet-id "$AKS_SUBNET_ID" \
+  --network-plugin azure \
+  --network-policy azure \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --enable-addons azure-keyvault-secrets-provider \
+  --attach-acr "$ACR_NAME" \
+  --zones 1 2 3 \
+  --generate-ssh-keys
+
+# Get credentials
+az aks get-credentials \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --overwrite-existing
+
+kubectl get nodes
+```
+
+---
+
+## Step 3 — Create Federated Credentials
+
+```bash
+OIDC_ISSUER=$(az aks show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" \
+  --query oidcIssuerProfile.issuerURL -o tsv)
+
+# Registry application identity → terraform-registry ServiceAccount
+az identity federated-credential create \
+  --name terraform-registry-aks \
+  --identity-name "$REGISTRY_IDENTITY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:terraform-registry:terraform-registry" \
+  --audiences "api://AzureADTokenExchange"
+
+# ALB Controller identity → alb-controller ServiceAccount
+az identity federated-credential create \
+  --name alb-controller-aks \
+  --identity-name "$ALB_IDENTITY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:azure-alb-system:alb-controller-sa" \
+  --audiences "api://AzureADTokenExchange"
+```
+
+---
+
+## Step 4 — Install Kubernetes Add-ons
+
+### 4.1 Gateway API CRDs
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=60s
+```
+
+### 4.2 cert-manager
+
+```bash
+helm repo add jetstack https://charts.jetstack.io --force-update
+
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --set featureGates="ExperimentalGatewayAPISupport=true"
+
+kubectl wait --for=condition=Ready pods --all -n cert-manager --timeout=120s
+```
+
+### 4.3 ALB Controller
+
+```bash
+helm install azure-alb-controller \
+  oci://mcr.microsoft.com/application-lb/charts/azure-alb-controller \
+  --namespace azure-alb-system \
+  --create-namespace \
+  --set albController.namespace=azure-alb-system \
+  --set albController.podIdentity.clientID="$ALB_CLIENT_ID"
+
+kubectl wait --for=condition=Ready pods --all -n azure-alb-system --timeout=120s
+```
+
+---
+
+## Step 5 — Push Container Images to ACR
+
+```bash
+az acr login --name "$ACR_NAME"
+
+# Build and push backend (from terraform-registry-backend repo root)
+docker build -t "$ACR_NAME.azurecr.io/terraform-registry-backend:$IMAGE_TAG" ./backend
+docker push "$ACR_NAME.azurecr.io/terraform-registry-backend:$IMAGE_TAG"
+
+# Build and push frontend (from terraform-registry-frontend repo root)
+docker build -t "$ACR_NAME.azurecr.io/terraform-registry-frontend:$IMAGE_TAG" \
+  --build-arg VITE_MODE=production ./frontend
+docker push "$ACR_NAME.azurecr.io/terraform-registry-frontend:$IMAGE_TAG"
+```
+
+---
+
+## Step 6 — Deploy the Terraform Registry
+
+### Option A: Deploy with Helm
+
+```bash
+helm upgrade --install terraform-registry \
+  ./deployments/helm \
+  --namespace terraform-registry \
+  --create-namespace \
+  --set backend.image.repository="$ACR_NAME.azurecr.io/terraform-registry-backend" \
+  --set backend.image.tag="$IMAGE_TAG" \
+  --set frontend.image.repository="$ACR_NAME.azurecr.io/terraform-registry-frontend" \
+  --set frontend.image.tag="$IMAGE_TAG" \
+  --set server.baseUrl="https://$HOSTNAME" \
+  --set externalDatabase.host="$PG_SERVER.postgres.database.azure.com" \
+  --set storage.backend=azure \
+  --set storage.azure.accountName="$STORAGE_ACCOUNT" \
+  --set storage.azure.containerName=terraform-registry \
+  --set storage.persistence.enabled=false \
+  --set workloadIdentity.enabled=true \
+  --set workloadIdentity.clientId="$REGISTRY_CLIENT_ID" \
+  --set keyVault.enabled=true \
+  --set keyVault.name="$KEY_VAULT_NAME" \
+  --set keyVault.tenantId="$(az account show --query tenantId -o tsv)" \
+  --set keyVault.clientId="$REGISTRY_CLIENT_ID" \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.albId="$AGFC_ID" \
+  --set gatewayAPI.hostname="$HOSTNAME" \
+  --set gatewayAPI.certManagerIssuer=letsencrypt-staging \
+  --set gatewayAPI.email="$OPS_EMAIL" \
+  --set ingress.enabled=false \
+  --set networkPolicy.enabled=true \
+  --set autoscaling.enabled=true
+```
+
+Alternatively, copy `deployments/helm/values-aks.yaml`, fill in all placeholders, and run:
+
+```bash
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f my-values-aks.yaml
+```
+
+### Option B: Deploy with Kustomize
+
+Edit all `<PLACEHOLDER>` values in the overlay files first:
+
+```bash
+# Files to edit:
+#   deployments/kubernetes/overlays/aks/kustomization.yaml   (image tags + ACR name)
+#   deployments/kubernetes/overlays/aks/gateway.yaml          (albId, hostname)
+#   deployments/kubernetes/overlays/aks/httproute.yaml        (hostname)
+#   deployments/kubernetes/overlays/aks/secretproviderclass.yaml (clientId, keyvaultName, tenantId)
+#   deployments/kubernetes/overlays/aks/clusterissuer.yaml    (email)
+#   deployments/kubernetes/overlays/aks/certificate.yaml      (hostname)
+#   deployments/kubernetes/overlays/aks/patches/serviceaccount-workload-identity.yaml (clientId)
+#   deployments/kubernetes/overlays/aks/patches/configmap-aks.yaml (DB host, storage account, hostname)
+
+kubectl apply -k deployments/kubernetes/overlays/aks/
+```
+
+---
+
+## Step 7 — Configure DNS
+
+After the Gateway is created and the ALB Controller reconciles it:
+
+```bash
+# Wait for the Gateway to have an address (can take 1-2 minutes)
+kubectl get gateway -n terraform-registry --watch
+
+# Get the public IP
+GATEWAY_IP=$(kubectl get gateway -n terraform-registry terraform-registry-gateway \
+  -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GATEWAY_IP"
+```
+
+Create an A record in your DNS zone: `$HOSTNAME → $GATEWAY_IP`
+
+For Azure DNS:
+
+```bash
+az network dns record-set a add-record \
+  --resource-group <DNS_RESOURCE_GROUP> \
+  --zone-name company.com \
+  --record-set-name registry \
+  --ipv4-address "$GATEWAY_IP"
+```
+
+---
+
+## Step 8 — Verify Certificate Issuance
+
+The cert-manager Certificate request was created during the Helm install. Once DNS
+propagates (verify with `dig +short $HOSTNAME`), cert-manager will complete the ACME
+HTTP-01 challenge automatically.
+
+```bash
+# Check certificate status
+kubectl get certificate -n terraform-registry
+
+# Detailed status (look for Ready: True)
+kubectl describe certificate terraform-registry-tls -n terraform-registry
+
+# If using Helm: certificate name is <release-name>-tls
+kubectl describe certificate terraform-registry-tls -n terraform-registry
+```
+
+Once the staging certificate issues successfully, promote to the production issuer:
+
+```bash
+# With Helm
+helm upgrade terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --reuse-values \
+  --set gatewayAPI.certManagerIssuer=letsencrypt-prod
+
+# With Kustomize: edit certificate.yaml issuerRef.name to letsencrypt-prod, then:
+kubectl apply -k deployments/kubernetes/overlays/aks/
+```
+
+---
+
+## Step 9 — Verify Deployment
+
+```bash
+# All pods should be Running/Ready
+kubectl get pods -n terraform-registry
+
+# Gateway should have a valid address
+kubectl get gateway -n terraform-registry
+
+# HTTPRoutes should show Accepted / Programmed
+kubectl get httproute -n terraform-registry -o wide
+
+# Check backend health
+kubectl port-forward -n terraform-registry svc/terraform-registry-backend 8080:8080 &
+curl http://localhost:8080/health
+curl http://localhost:8080/ready
+
+# Check full stack
+curl https://$HOSTNAME/health
+curl https://$HOSTNAME/.well-known/terraform.json
+
+# Check logs
+kubectl logs -n terraform-registry \
+  -l app.kubernetes.io/component=backend \
+  --tail=100 -f
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Resolution |
+|---|---|---|
+| Pods stuck in `ContainerCreating` | CSI volume can't mount | Check `kubectl describe pod -n terraform-registry <pod>` for SecretProviderClass errors; verify Key Vault name, clientId, tenantId |
+| Pods in `CrashLoopBackOff` | Missing env var or DB connection failed | Check `kubectl logs`; verify `TFR_DATABASE_HOST` in ConfigMap patch |
+| Gateway has no IP | ALB Controller not running | Check `kubectl get pods -n azure-alb-system`; verify ALB Controller federated credential |
+| Certificate in `False` / challenge failing | DNS not propagated or HTTP-01 unreachable | Verify `dig +short $HOSTNAME` returns Gateway IP; check `kubectl describe challenge -n terraform-registry` |
+| 502 Bad Gateway | Backend pods not ready | Check backend readiness probe; check `kubectl get endpoints -n terraform-registry` |

--- a/docs/deployment/aks-operations.md
+++ b/docs/deployment/aks-operations.md
@@ -1,0 +1,359 @@
+# AKS Operations
+
+Day-2 operational procedures for the Terraform Registry on AKS.
+
+---
+
+## Upgrading
+
+### Helm Upgrade
+
+```bash
+# Pull latest chart changes
+git pull
+
+# Upgrade keeping existing values, only changing the image tag
+helm upgrade terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --reuse-values \
+  --set backend.image.tag=v1.1.0 \
+  --set frontend.image.tag=v1.1.0
+
+# Monitor rollout
+kubectl rollout status deployment/terraform-registry-backend -n terraform-registry
+kubectl rollout status deployment/terraform-registry-frontend -n terraform-registry
+```
+
+### Kustomize Upgrade
+
+```bash
+# Edit overlays/aks/kustomization.yaml — update image newTag values, then:
+kubectl apply -k deployments/kubernetes/overlays/aks/
+
+# Watch rolling update
+kubectl get pods -n terraform-registry --watch
+```
+
+### Rolling Update Behaviour
+
+The backend and frontend Deployments use the default `RollingUpdate` strategy.
+
+With `minAvailable: 1` (PDB) and `replicas: 3` (production):
+- Maximum 1 pod is unavailable during a rolling update
+- The HPA allows scaling down to `minReplicas: 3`
+- Plan for at least `replicas + 1` schedulable nodes during node pool upgrades
+
+---
+
+## Certificate Management
+
+### cert-manager Auto-Renewal
+
+cert-manager automatically renews Let's Encrypt certificates before expiry (default: 30 days before the 90-day expiry). No manual intervention is needed in normal operation.
+
+### Check Certificate Status
+
+```bash
+kubectl get certificate -n terraform-registry
+kubectl describe certificate terraform-registry-tls -n terraform-registry
+
+# Check the renewal schedule
+kubectl get certificate terraform-registry-tls -n terraform-registry \
+  -o jsonpath='{.status.renewalTime}'
+```
+
+### Force Renewal (emergency re-issue)
+
+```bash
+# Delete the existing certificate Secret — cert-manager will re-issue immediately
+kubectl delete secret terraform-registry-tls -n terraform-registry
+```
+
+### Promote Staging → Production Issuer
+
+Used when first going live or after a staging certificate has proven the ACME flow works.
+
+```bash
+# Helm
+helm upgrade terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --reuse-values \
+  --set gatewayAPI.certManagerIssuer=letsencrypt-prod
+
+# Kustomize: edit certificate.yaml issuerRef.name to letsencrypt-prod, then apply
+```
+
+After changing the issuer, delete the old certificate Secret to trigger immediate re-issue:
+
+```bash
+kubectl delete secret terraform-registry-tls -n terraform-registry
+kubectl get certificate -n terraform-registry --watch
+```
+
+---
+
+## Rotating Secrets in Azure Key Vault
+
+When you update a secret value in Key Vault, the Secrets Store CSI Driver does **not**
+automatically update running pods. The new value is picked up on the next pod restart.
+
+### Rotate a secret
+
+```bash
+# Update the secret in Key Vault
+az keyvault secret set --vault-name <KEY_VAULT_NAME> \
+  --name jwt-secret \
+  --value "$(openssl rand -hex 32)"
+
+# Restart backend pods to pick up the new value
+kubectl rollout restart deployment/terraform-registry-backend -n terraform-registry
+
+# Verify the rollout
+kubectl rollout status deployment/terraform-registry-backend -n terraform-registry
+```
+
+### Enable auto-rotation (CSI Driver feature)
+
+The Secrets Store CSI Driver can poll Key Vault periodically:
+
+```bash
+# Check if auto-rotation is enabled on the CSI driver add-on
+kubectl get daemonset secrets-store-csi-driver -n kube-system \
+  -o jsonpath='{.spec.template.spec.containers[0].args}' | tr ' ' '\n' | grep rotation
+```
+
+Enable via AKS add-on parameters (requires cluster update):
+
+```bash
+az aks update \
+  --resource-group <RG> \
+  --name <CLUSTER> \
+  --enable-secret-rotation \
+  --rotation-poll-interval 2m
+```
+
+---
+
+## Scaling
+
+### Manual Scaling
+
+```bash
+# Scale backend replicas immediately
+kubectl scale deployment/terraform-registry-backend \
+  --replicas=5 -n terraform-registry
+
+# Scale frontend
+kubectl scale deployment/terraform-registry-frontend \
+  --replicas=3 -n terraform-registry
+```
+
+### HPA Status
+
+```bash
+kubectl get hpa -n terraform-registry
+kubectl describe hpa terraform-registry-backend -n terraform-registry
+```
+
+### Adjust HPA Bounds (Helm)
+
+```bash
+helm upgrade terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --reuse-values \
+  --set autoscaling.minReplicas=5 \
+  --set autoscaling.maxReplicas=20
+```
+
+---
+
+## Accessing Logs
+
+```bash
+# Backend logs (all replicas, follow)
+kubectl logs -n terraform-registry \
+  -l app.kubernetes.io/component=backend \
+  --tail=100 -f
+
+# Frontend logs
+kubectl logs -n terraform-registry \
+  -l app.kubernetes.io/component=frontend \
+  --tail=50 -f
+
+# Previous crashed pod
+kubectl logs -n terraform-registry <POD_NAME> --previous
+
+# Structured JSON logs with jq
+kubectl logs -n terraform-registry \
+  -l app.kubernetes.io/component=backend \
+  --tail=200 | jq 'select(.level == "error")'
+```
+
+With Azure Monitor / Container Insights, query logs from Log Analytics:
+
+```kusto
+ContainerLogV2
+| where ContainerName == "backend"
+| where TimeGenerated > ago(1h)
+| where LogMessage contains "error"
+| project TimeGenerated, LogMessage
+| order by TimeGenerated desc
+```
+
+---
+
+## Connecting to the Database
+
+### Port-forward to PostgreSQL (for admin tasks)
+
+```bash
+# If PostgreSQL allows connections from AKS node pool IPs, port-forward via a debug pod:
+kubectl run pg-debug --rm -it \
+  --namespace terraform-registry \
+  --image=postgres:16-alpine \
+  --env="PGPASSWORD=<PASSWORD>" \
+  -- psql -h <PG_SERVER>.postgres.database.azure.com \
+          -U registry \
+          -d terraform_registry
+```
+
+### Check active connections
+
+```sql
+SELECT count(*), state, wait_event_type, wait_event
+FROM pg_stat_activity
+WHERE datname = 'terraform_registry'
+GROUP BY state, wait_event_type, wait_event
+ORDER BY count DESC;
+```
+
+---
+
+## Troubleshooting Checklist
+
+### Pods Not Starting
+
+```bash
+# Get pod events
+kubectl describe pod <POD_NAME> -n terraform-registry
+
+# Common causes:
+# 1. CSI volume can't mount (Key Vault access denied)
+#    → Check managed identity federated credential and Key Vault RBAC roles
+#    → kubectl describe secretproviderclasssecret -n terraform-registry
+
+# 2. Image pull failure (ACR access)
+#    → Verify AKS → ACR attachment: az aks check-acr --name <CLUSTER> --acr <ACR>
+
+# 3. Resource limits too low
+#    → kubectl top pods -n terraform-registry
+```
+
+### Backend CrashLoopBackOff
+
+```bash
+kubectl logs <POD_NAME> -n terraform-registry --previous
+
+# Common causes:
+# - TFR_DATABASE_HOST is empty or wrong FQDN
+#   → Check: kubectl get configmap terraform-registry-config -n terraform-registry -o yaml
+# - Database password wrong
+#   → Check Key Vault secret: az keyvault secret show --vault-name <KV> --name database-password
+# - TFR_JWT_SECRET shorter than 32 chars
+#   → Regenerate: openssl rand -hex 32
+```
+
+### Gateway Has No IP / Stays in Programmed=False
+
+```bash
+kubectl describe gateway terraform-registry-gateway -n terraform-registry
+
+# Common causes:
+# - ALB Controller not running
+kubectl get pods -n azure-alb-system
+# - alb-id annotation wrong (check ARM resource ID format)
+# - Missing role assignment for ALB Controller identity
+```
+
+### Certificate Stuck in Pending
+
+```bash
+kubectl describe certificate terraform-registry-tls -n terraform-registry
+kubectl get challenges -n terraform-registry
+kubectl describe challenge -n terraform-registry <CHALLENGE_NAME>
+
+# Common causes:
+# - DNS A record not yet propagated
+#   → dig +short <HOSTNAME> should return the Gateway IP
+# - HTTP-01 challenge HTTPRoute not created (cert-manager feature gate missing)
+#   → kubectl get httproute -n terraform-registry (look for cm-acme-http-solver-)
+# - Gateway port 80 not accessible from public internet
+#   → Verify AGfC security rules / NSG
+```
+
+### NetworkPolicy Blocking Traffic
+
+```bash
+# Temporarily disable NetworkPolicy to test if it's the cause
+kubectl delete networkpolicy --all -n terraform-registry
+
+# If traffic flows without NetworkPolicy, check the individual rules:
+kubectl get networkpolicy -n terraform-registry
+kubectl describe networkpolicy <POLICY_NAME> -n terraform-registry
+```
+
+---
+
+## Monitoring
+
+### Prometheus / Grafana
+
+The backend exposes Prometheus metrics at port 9090 (`/metrics`). Pod annotations
+enable scraping by a Prometheus operator:
+
+```yaml
+prometheus.io/scrape: "true"
+prometheus.io/port: "9090"
+prometheus.io/path: "/metrics"
+```
+
+Enable a `ServiceMonitor` (if using prometheus-operator):
+
+```bash
+helm upgrade terraform-registry ./deployments/helm \
+  --namespace terraform-registry \
+  --reuse-values \
+  --set serviceMonitor.enabled=true \
+  --set serviceMonitor.labels.release=kube-prometheus-stack
+```
+
+### Azure Monitor / Container Insights
+
+Enable Container Insights for the cluster:
+
+```bash
+az aks enable-addons \
+  --resource-group <RG> \
+  --name <CLUSTER> \
+  --addons monitoring
+```
+
+---
+
+## Maintenance and Patching
+
+### Node Pool Upgrades
+
+During an AKS node pool upgrade, Kubernetes drains nodes. The PDB (`minAvailable: 1`)
+ensures at least one backend pod is running throughout:
+
+```bash
+# Check available upgrade versions
+az aks get-upgrades --resource-group <RG> --name <CLUSTER> -o table
+
+# Upgrade (performs rolling node replacement)
+az aks upgrade --resource-group <RG> --name <CLUSTER> --kubernetes-version 1.31.0
+
+# Monitor progress
+kubectl get nodes --watch
+```

--- a/docs/deployment/aks-prerequisites.md
+++ b/docs/deployment/aks-prerequisites.md
@@ -1,0 +1,390 @@
+# AKS Prerequisites
+
+Before deploying the Terraform Registry to Azure Kubernetes Service, provision all
+required Azure resources and ensure the AKS cluster has the necessary features enabled.
+
+## Required Tooling
+
+| Tool | Minimum Version | Install |
+|---|---|---|
+| Azure CLI (`az`) | 2.61.0 | `brew install azure-cli` or [docs.microsoft.com](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) |
+| `kubectl` | 1.29+ | `az aks install-cli` |
+| `helm` | 3.12+ | `brew install helm` or [helm.sh](https://helm.sh/docs/intro/install/) |
+| `kustomize` | 5.0+ | `brew install kustomize` (optional — `kubectl apply -k` includes kustomize) |
+
+```bash
+az login
+az account set --subscription "<SUBSCRIPTION_ID>"
+```
+
+## Required Azure Resources
+
+### 1. Resource Group
+
+```bash
+az group create --name <RESOURCE_GROUP> --location eastus
+```
+
+### 2. Azure Container Registry (ACR)
+
+```bash
+az acr create \
+  --resource-group <RESOURCE_GROUP> \
+  --name <ACR_NAME> \
+  --sku Standard
+
+# Push images (see build instructions in the backend and frontend repos)
+az acr login --name <ACR_NAME>
+docker push <ACR_NAME>.azurecr.io/terraform-registry-backend:v1.0.0
+docker push <ACR_NAME>.azurecr.io/terraform-registry-frontend:v1.0.0
+```
+
+### 3. Azure Database for PostgreSQL Flexible Server
+
+```bash
+az postgres flexible-server create \
+  --resource-group <RESOURCE_GROUP> \
+  --name <POSTGRES_SERVER_NAME> \
+  --location eastus \
+  --admin-user registry \
+  --admin-password '<STRONG_PASSWORD>' \
+  --sku-name Standard_D2s_v3 \
+  --tier GeneralPurpose \
+  --version 16 \
+  --public-access None     # Use private endpoint or VNet integration for production
+
+# Create the database
+az postgres flexible-server db create \
+  --resource-group <RESOURCE_GROUP> \
+  --server-name <POSTGRES_SERVER_NAME> \
+  --database-name terraform_registry
+```
+
+> **Note:** For sandbox testing with public access, use `--public-access 0.0.0.0` temporarily. For production, configure VNet integration and firewall rules.
+
+### 4. Azure Storage Account + Blob Container
+
+```bash
+az storage account create \
+  --resource-group <RESOURCE_GROUP> \
+  --name <STORAGE_ACCOUNT_NAME> \
+  --sku Standard_LRS \
+  --kind StorageV2 \
+  --https-only true \
+  --min-tls-version TLS1_2
+
+az storage container create \
+  --account-name <STORAGE_ACCOUNT_NAME> \
+  --name terraform-registry \
+  --auth-mode login
+```
+
+### 5. Azure Key Vault + Secrets
+
+```bash
+az keyvault create \
+  --resource-group <RESOURCE_GROUP> \
+  --name <KEY_VAULT_NAME> \
+  --location eastus \
+  --enable-rbac-authorization true
+
+# Create secrets
+az keyvault secret set --vault-name <KEY_VAULT_NAME> \
+  --name jwt-secret \
+  --value "$(openssl rand -hex 32)"
+
+az keyvault secret set --vault-name <KEY_VAULT_NAME> \
+  --name encryption-key \
+  --value "$(openssl rand -hex 16)"
+
+az keyvault secret set --vault-name <KEY_VAULT_NAME> \
+  --name database-password \
+  --value '<STRONG_PASSWORD>'   # Same password used when creating the PostgreSQL server
+
+# Only needed if NOT using Workload Identity for Blob Storage access:
+az keyvault secret set --vault-name <KEY_VAULT_NAME> \
+  --name azure-blob-account-key \
+  --value "$(az storage account keys list -g <RESOURCE_GROUP> -n <STORAGE_ACCOUNT_NAME> --query '[0].value' -o tsv)"
+```
+
+### 6. User-Assigned Managed Identity
+
+```bash
+az identity create \
+  --resource-group <RESOURCE_GROUP> \
+  --name terraform-registry-identity
+
+# Capture the client ID for later use
+IDENTITY_CLIENT_ID=$(az identity show \
+  --resource-group <RESOURCE_GROUP> \
+  --name terraform-registry-identity \
+  --query clientId -o tsv)
+
+IDENTITY_PRINCIPAL_ID=$(az identity show \
+  --resource-group <RESOURCE_GROUP> \
+  --name terraform-registry-identity \
+  --query principalId -o tsv)
+```
+
+#### Grant Key Vault access (Key Vault Secret User role)
+
+```bash
+KEY_VAULT_ID=$(az keyvault show \
+  --name <KEY_VAULT_NAME> --query id -o tsv)
+
+az role assignment create \
+  --role "Key Vault Secrets User" \
+  --assignee-object-id "$IDENTITY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$KEY_VAULT_ID"
+```
+
+#### Grant Blob Storage access (optional — alternative to account key)
+
+```bash
+STORAGE_ID=$(az storage account show \
+  --resource-group <RESOURCE_GROUP> \
+  --name <STORAGE_ACCOUNT_NAME> --query id -o tsv)
+
+az role assignment create \
+  --role "Storage Blob Data Contributor" \
+  --assignee-object-id "$IDENTITY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$STORAGE_ID"
+```
+
+### 7. Application Gateway for Containers (AGfC)
+
+AGfC requires a dedicated subnet with `Microsoft.ServiceNetworking/trafficControllers` delegation.
+
+```bash
+# Create or use existing VNet — the AKS cluster VNet is typically the right target.
+# AGfC subnet must be /24 or smaller and delegated.
+az network vnet subnet create \
+  --resource-group <RESOURCE_GROUP> \
+  --vnet-name <VNET_NAME> \
+  --name agfc-subnet \
+  --address-prefix 10.225.0.0/24
+
+az network vnet subnet update \
+  --resource-group <RESOURCE_GROUP> \
+  --vnet-name <VNET_NAME> \
+  --name agfc-subnet \
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+
+# Create AGfC resource
+az network alb create \
+  --resource-group <RESOURCE_GROUP> \
+  --name <AGFC_NAME>
+
+# Create Frontend (public-facing IP/DNS)
+az network alb frontend create \
+  --resource-group <RESOURCE_GROUP> \
+  --name registry-frontend \
+  --alb-name <AGFC_NAME>
+
+# Note the AGfC resource ID for use in values-aks.yaml / kustomize overlay
+az network alb show \
+  --resource-group <RESOURCE_GROUP> \
+  --name <AGFC_NAME> \
+  --query id -o tsv
+```
+
+### 8. DNS Record
+
+After the AKS deployment creates a Gateway that references the AGfC, the ALB Controller
+provisions a public IP. Retrieve the IP and create your DNS A record:
+
+```bash
+# Run after deploying — the IP is available once the Gateway is fully reconciled
+kubectl get gateway -n terraform-registry terraform-registry-gateway \
+  -o jsonpath='{.status.addresses[0].value}'
+```
+
+Create an A record in your DNS zone pointing `<HOSTNAME>` to that IP before attempting
+certificate issuance (the ACME HTTP-01 challenge requires DNS resolution).
+
+---
+
+## Required AKS Cluster Features
+
+The AKS cluster must have the following features enabled:
+
+| Feature | Flag | Notes |
+|---|---|---|
+| OIDC Issuer | `--enable-oidc-issuer` | Required for Workload Identity |
+| Workload Identity | `--enable-workload-identity` | Required for Key Vault CSI + Managed Identity |
+| Secrets Store CSI Driver | `--enable-addons azure-keyvault-secrets-provider` | Required for Key Vault secret sync |
+| Azure CNI Networking | `--network-plugin azure` (or `azure-overlay`) | Required for NetworkPolicy enforcement and AGfC |
+| ACR Attach | `--attach-acr <ACR_NAME>` | Grants AKS pull access to ACR without explicit pull secrets |
+
+Check existing cluster features:
+
+```bash
+az aks show --resource-group <RG> --name <CLUSTER_NAME> \
+  --query '{oidcIssuerProfile:oidcIssuerProfile,securityProfile:securityProfile,addonProfiles:addonProfiles}' \
+  -o json
+```
+
+Enable missing features on an existing cluster:
+
+```bash
+# Enable OIDC Issuer (required before Workload Identity)
+az aks update --resource-group <RG> --name <CLUSTER_NAME> --enable-oidc-issuer
+
+# Enable Workload Identity (requires OIDC Issuer)
+az aks update --resource-group <RG> --name <CLUSTER_NAME> --enable-workload-identity
+
+# Enable Secrets Store CSI Driver add-on
+az aks enable-addons \
+  --resource-group <RG> \
+  --name <CLUSTER_NAME> \
+  --addons azure-keyvault-secrets-provider
+
+# Attach ACR
+az aks update \
+  --resource-group <RG> \
+  --name <CLUSTER_NAME> \
+  --attach-acr <ACR_NAME>
+```
+
+---
+
+## Workload Identity Federated Credential
+
+After the AKS cluster and managed identity are created, link them with a federated credential:
+
+```bash
+OIDC_ISSUER=$(az aks show \
+  --resource-group <RG> \
+  --name <CLUSTER_NAME> \
+  --query oidcIssuerProfile.issuerURL -o tsv)
+
+az identity federated-credential create \
+  --name terraform-registry-aks \
+  --identity-name terraform-registry-identity \
+  --resource-group <RESOURCE_GROUP> \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:terraform-registry:terraform-registry" \
+  --audiences "api://AzureADTokenExchange"
+```
+
+The `--subject` must match:
+- Kubernetes namespace: `terraform-registry`
+- Kubernetes ServiceAccount name: `terraform-registry`
+
+---
+
+## Kubernetes Add-ons to Install
+
+Two Helm-based add-ons must be installed into the cluster before deploying the registry.
+
+### cert-manager
+
+```bash
+helm repo add jetstack https://charts.jetstack.io --force-update
+
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --set featureGates="ExperimentalGatewayAPISupport=true"
+
+# Verify
+kubectl get pods -n cert-manager
+```
+
+> **Important:** `ExperimentalGatewayAPISupport=true` is required for cert-manager to create
+> `HTTPRoute` resources for the ACME HTTP-01 challenge. Without this, certificate issuance will fail.
+
+### ALB Controller (AGfC)
+
+The ALB Controller reconciles `Gateway` and `HTTPRoute` resources into AGfC configuration.
+
+```bash
+# The ALB Controller requires its own managed identity for ARM operations.
+az identity create \
+  --resource-group <RESOURCE_GROUP> \
+  --name alb-controller-identity
+
+ALB_CLIENT_ID=$(az identity show \
+  --resource-group <RESOURCE_GROUP> \
+  --name alb-controller-identity \
+  --query clientId -o tsv)
+
+ALB_PRINCIPAL_ID=$(az identity show \
+  --resource-group <RESOURCE_GROUP> \
+  --name alb-controller-identity \
+  --query principalId -o tsv)
+
+# Grant Reader + AppGW for Containers Configuration Manager on the resource group
+RESOURCE_GROUP_ID=$(az group show --name <RESOURCE_GROUP> --query id -o tsv)
+az role assignment create \
+  --role "Reader" \
+  --assignee-object-id "$ALB_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$RESOURCE_GROUP_ID"
+
+az role assignment create \
+  --role "AppGw for Containers Configuration Manager" \
+  --assignee-object-id "$ALB_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --scope "$RESOURCE_GROUP_ID"
+
+# Federated credential for ALB Controller ServiceAccount
+OIDC_ISSUER=$(az aks show -g <RG> -n <CLUSTER_NAME> \
+  --query oidcIssuerProfile.issuerURL -o tsv)
+
+az identity federated-credential create \
+  --name alb-controller-fedcred \
+  --identity-name alb-controller-identity \
+  --resource-group <RESOURCE_GROUP> \
+  --issuer "$OIDC_ISSUER" \
+  --subject "system:serviceaccount:azure-alb-system:alb-controller-sa" \
+  --audiences "api://AzureADTokenExchange"
+
+# Install ALB Controller
+helm install azure-alb-controller \
+  oci://mcr.microsoft.com/application-lb/charts/azure-alb-controller \
+  --namespace azure-alb-system \
+  --create-namespace \
+  --set albController.namespace=azure-alb-system \
+  --set albController.podIdentity.clientID="$ALB_CLIENT_ID"
+
+# Verify
+kubectl get pods -n azure-alb-system
+```
+
+### Gateway API CRDs
+
+Install Gateway API CRDs if not already present on the cluster:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+```
+
+Verify:
+
+```bash
+kubectl get crd gateways.gateway.networking.k8s.io
+kubectl get crd httproutes.gateway.networking.k8s.io
+```
+
+---
+
+## Summary Checklist
+
+Before running the deployment:
+
+- [ ] ACR created and images pushed
+- [ ] PostgreSQL Flexible Server created, `terraform_registry` database created
+- [ ] Storage Account and blob container created
+- [ ] Key Vault created with secrets: `jwt-secret`, `encryption-key`, `database-password`
+- [ ] User-Assigned Managed Identity created with Key Vault Secret User role
+- [ ] AGfC resource and Frontend created; subnet delegated
+- [ ] AKS cluster has OIDC Issuer, Workload Identity, Secrets Store CSI Driver, Azure CNI
+- [ ] Federated credential created (terraform-registry identity → AKS OIDC → ServiceAccount)
+- [ ] cert-manager installed with `ExperimentalGatewayAPISupport=true`
+- [ ] ALB Controller installed with its own managed identity
+- [ ] Gateway API CRDs installed
+- [ ] DNS record created (or ready to create after first deploy)

--- a/docs/deployment/eks-deployment.md
+++ b/docs/deployment/eks-deployment.md
@@ -1,0 +1,136 @@
+# EKS Deployment Guide — Terraform Registry
+
+Complete all steps in [eks-prerequisites.md](eks-prerequisites.md) first.
+
+---
+
+## Step 1 — Fill in placeholder values
+
+Collect the values you captured during prerequisites:
+
+| Placeholder        | How to get it                                                                                                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `<ACCOUNT_ID>`     | `aws sts get-caller-identity --query Account --output text`                                                                            |
+| `<AWS_REGION>`     | Your chosen region                                                                                                                     |
+| `<RDS_ENDPOINT>`   | `aws rds describe-db-instances --db-instance-identifier terraform-registry-db --query "DBInstances[0].Endpoint.Address" --output text` |
+| `<S3_BUCKET_NAME>` | `terraform-registry-artifacts-<ACCOUNT_ID>`                                                                                            |
+| `<IRSA_ROLE_NAME>` | `terraform-registry-irsa`                                                                                                              |
+| `<HOSTNAME>`       | Your public DNS name                                                                                                                   |
+| `<EMAIL>`          | Your ops email                                                                                                                         |
+| `<IMAGE_TAG>`      | `v1.0.0`                                                                                                                               |
+
+---
+
+## Step 2 — Deploy
+
+### Option A: Helm
+
+```bash
+cp deployments/helm/values-eks.yaml deployments/helm/values-eks-prod.yaml
+# Edit values-eks-prod.yaml — replace every <PLACEHOLDER>
+
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f deployments/helm/values-eks-prod.yaml \
+  --wait --timeout 5m
+
+# Apply the SecretProviderClass separately (not in the Helm chart for EKS)
+# Edit deployments/kubernetes/overlays/eks/secretproviderclass.yaml, then:
+kubectl apply -f deployments/kubernetes/overlays/eks/secretproviderclass.yaml
+```
+
+### Option B: Kustomize
+
+```bash
+# Edit all overlay files, replace every <PLACEHOLDER>:
+#   overlays/eks/gateway.yaml              → hostname
+#   overlays/eks/httproute.yaml            → hostname (x3)
+#   overlays/eks/certificate.yaml          → dnsNames
+#   overlays/eks/clusterissuer.yaml        → email (x2)
+#   overlays/eks/secretproviderclass.yaml  → AWS_REGION, ACCOUNT_ID
+#   overlays/eks/patches/serviceaccount-irsa.yaml → role-arn annotation
+#   overlays/eks/patches/configmap-eks.yaml → RDS endpoint, S3 bucket, hostname
+#   overlays/eks/kustomization.yaml        → ECR repo, image tag
+
+kubectl apply -k deployments/kubernetes/overlays/eks/
+```
+
+---
+
+## Step 3 — Verify ALB provisioning
+
+```bash
+kubectl get gateway -n terraform-registry -w
+# Wait for ADDRESS field to show the ALB DNS name
+
+kubectl describe gateway terraform-registry-gateway -n terraform-registry
+```
+
+---
+
+## Step 4 — Configure DNS
+
+```bash
+ALB_DNS=$(kubectl get gateway terraform-registry-gateway \
+  -n terraform-registry -o jsonpath='{.status.addresses[0].value}')
+echo "ALB DNS: $ALB_DNS"
+```
+
+Create a CNAME record (or ALIAS for Route53) pointing `registry.yourdomain.com` to `$ALB_DNS`.
+
+> **Note:** For Route53 ALIAS records, select "Alias to Application and Classic Load Balancer" and select the correct region and ALB.
+
+---
+
+## Step 5 — Verify certificate and application
+
+```bash
+# Certificate (takes 1-3 minutes after DNS propagates)
+kubectl get certificate -n terraform-registry -w
+
+# All pods running
+kubectl get pods -n terraform-registry
+
+# Smoke test
+curl https://registry.yourdomain.com/health
+curl https://registry.yourdomain.com/.well-known/terraform.json
+```
+
+---
+
+## Step 6 — Promote to production TLS
+
+```bash
+kubectl delete secret terraform-registry-tls -n terraform-registry
+
+# Helm
+helm upgrade terraform-registry ./deployments/helm \
+  -n terraform-registry -f deployments/helm/values-eks-prod.yaml \
+  --set gatewayAPI.certManagerIssuer=letsencrypt-prod
+
+# Kustomize: edit overlays/eks/certificate.yaml → letsencrypt-prod, then apply
+```
+
+---
+
+## Troubleshooting
+
+### ALB not provisioning
+
+```bash
+kubectl logs -n kube-system \
+  -l app.kubernetes.io/name=aws-load-balancer-controller --tail=50
+```
+
+- Verify public subnets are tagged with `kubernetes.io/role/elb=1`.
+- Verify IRSA role for LBC has the required IAM policy.
+
+### Secrets not syncing
+
+```bash
+kubectl describe secretproviderclass terraform-registry-secrets -n terraform-registry
+kubectl logs -n kube-system -l app=csi-secrets-store-provider-aws
+```
+
+- Verify the IRSA role has `secretsmanager:GetSecretValue` on the secrets.
+- Verify the secret ARNs in the `SecretProviderClass` are correct.

--- a/docs/deployment/eks-prerequisites.md
+++ b/docs/deployment/eks-prerequisites.md
@@ -1,0 +1,275 @@
+# EKS Prerequisites — Terraform Registry
+
+Resources and tooling required before deploying to AWS EKS.
+
+---
+
+## 1. Required tools
+
+| Tool            | Min version | Install                                                               |
+| --------------- | ----------- | --------------------------------------------------------------------- |
+| AWS CLI (`aws`) | 2.x         | <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html> |
+| `eksctl`        | 0.170       | <https://eksctl.io/installation/>                                     |
+| kubectl         | 1.28        | `aws eks install-kubectl`                                             |
+| Helm            | 3.12        | <https://helm.sh/docs/intro/install/>                                 |
+
+```bash
+aws configure
+# Set: AWS Access Key ID, Secret Access Key, Default region, Output format
+```
+
+---
+
+## 2. AWS resources to provision
+
+### 2a. Amazon ECR Repositories
+
+```bash
+aws ecr create-repository \
+  --repository-name terraform-registry-backend \
+  --region <AWS_REGION>
+
+aws ecr create-repository \
+  --repository-name terraform-registry-frontend \
+  --region <AWS_REGION>
+
+# Authenticate and push images
+aws ecr get-login-password --region <AWS_REGION> | \
+  docker login --username AWS \
+  --password-stdin <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
+
+docker tag terraform-registry-backend:latest \
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
+
+docker tag terraform-registry-frontend:latest \
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
+```
+
+### 2b. Amazon RDS for PostgreSQL
+
+```bash
+# Create a subnet group first (using existing VPC subnets, created with EKS cluster)
+# Or provision via CloudFormation / Terraform
+
+aws rds create-db-instance \
+  --db-instance-identifier terraform-registry-db \
+  --db-instance-class db.t3.medium \
+  --engine postgres \
+  --engine-version 16.2 \
+  --master-username registry \
+  --master-user-password <STRONG_PASSWORD> \
+  --db-name terraform_registry \
+  --storage-type gp2 \
+  --allocated-storage 32 \
+  --backup-retention-period 7 \
+  --no-publicly-accessible \
+  --vpc-security-group-ids <SG_ID>
+```
+
+Note the `Endpoint.Address` output — this is your `<RDS_ENDPOINT>`.
+
+### 2c. Amazon S3 Bucket
+
+```bash
+aws s3api create-bucket \
+  --bucket terraform-registry-artifacts-<ACCOUNT_ID> \
+  --region <AWS_REGION>
+
+aws s3api put-public-access-block \
+  --bucket terraform-registry-artifacts-<ACCOUNT_ID> \
+  --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+
+aws s3api put-bucket-versioning \
+  --bucket terraform-registry-artifacts-<ACCOUNT_ID> \
+  --versioning-configuration Status=Enabled
+```
+
+### 2d. AWS Secrets Manager
+
+```bash
+# Store secrets as individual entries:
+aws secretsmanager create-secret \
+  --name "terraform-registry/jwt-secret" \
+  --secret-string "$(openssl rand -hex 32)" \
+  --region <AWS_REGION>
+
+aws secretsmanager create-secret \
+  --name "terraform-registry/encryption-key" \
+  --secret-string "$(openssl rand -hex 16)" \
+  --region <AWS_REGION>
+
+aws secretsmanager create-secret \
+  --name "terraform-registry/database-password" \
+  --secret-string "<STRONG_PASSWORD>" \
+  --region <AWS_REGION>
+```
+
+### 2e. IAM Policy for the Registry workload
+
+```bash
+cat > terraform-registry-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject","s3:PutObject","s3:DeleteObject","s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::terraform-registry-artifacts-<ACCOUNT_ID>",
+        "arn:aws:s3:::terraform-registry-artifacts-<ACCOUNT_ID>/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue","secretsmanager:DescribeSecret"],
+      "Resource": "arn:aws:secretsmanager:<AWS_REGION>:<ACCOUNT_ID>:secret:terraform-registry/*"
+    }
+  ]
+}
+EOF
+
+aws iam create-policy \
+  --policy-name TerraformRegistryPolicy \
+  --policy-document file://terraform-registry-policy.json
+```
+
+---
+
+## 3. EKS cluster creation
+
+```bash
+eksctl create cluster \
+  --name terraform-registry-cluster \
+  --region <AWS_REGION> \
+  --version 1.30 \
+  --nodegroup-name standard-nodes \
+  --node-type t3.large \
+  --nodes 3 \
+  --nodes-min 2 \
+  --nodes-max 6 \
+  --zones <REGION>a,<REGION>b,<REGION>c \
+  --with-oidc \
+  --ssh-access \
+  --ssh-public-key <KEY_PAIR_NAME> \
+  --managed
+
+aws eks update-kubeconfig \
+  --region <AWS_REGION> \
+  --name terraform-registry-cluster
+```
+
+---
+
+## 4. IRSA setup
+
+```bash
+# Associate OIDC (already done by eksctl --with-oidc, verify with:)
+aws eks describe-cluster --name terraform-registry-cluster \
+  --query "cluster.identity.oidc.issuer" --output text
+
+# Create IRSA service account + role
+eksctl create iamserviceaccount \
+  --namespace terraform-registry \
+  --name terraform-registry \
+  --cluster terraform-registry-cluster \
+  --region <AWS_REGION> \
+  --role-name terraform-registry-irsa \
+  --attach-policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/TerraformRegistryPolicy \
+  --approve
+
+# Get role ARN for overlay patch
+aws iam get-role --role-name terraform-registry-irsa \
+  --query "Role.Arn" --output text
+```
+
+---
+
+## 5. AWS Load Balancer Controller
+
+```bash
+# Download IAM policy for LBC
+curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.7.2/docs/install/iam_policy.json
+
+aws iam create-policy \
+  --policy-name AWSLoadBalancerControllerIAMPolicy \
+  --policy-document file://iam_policy.json
+
+# Create IRSA for LBC
+eksctl create iamserviceaccount \
+  --cluster terraform-registry-cluster \
+  --namespace kube-system \
+  --name aws-load-balancer-controller \
+  --role-name AmazonEKSLoadBalancerControllerRole \
+  --attach-policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/AWSLoadBalancerControllerIAMPolicy \
+  --approve
+
+# Install LBC via Helm
+helm repo add eks https://aws.github.io/eks-charts
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName=terraform-registry-cluster \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller
+```
+
+---
+
+## 6. Secrets Store CSI Driver + ASCP
+
+```bash
+# Install CSI driver
+helm repo add secrets-store-csi-driver \
+  https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+helm install csi-secrets-store \
+  secrets-store-csi-driver/secrets-store-csi-driver \
+  --namespace kube-system \
+  --set syncSecret.enabled=true \
+  --set enableSecretRotation=true
+
+# Install AWS provider (ASCP)
+kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
+```
+
+---
+
+## 7. cert-manager
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true \
+  --set "featureGates=ExperimentalGatewayAPISupport=true"
+```
+
+---
+
+## 8. Public subnets tagged for ALB
+
+EKS public subnets must be tagged for the LBC ALB auto-discovery:
+
+```bash
+aws ec2 create-tags \
+  --resources <PUBLIC_SUBNET_ID_1> <PUBLIC_SUBNET_ID_2> <PUBLIC_SUBNET_ID_3> \
+  --tags Key=kubernetes.io/role/elb,Value=1 \
+  Key=kubernetes.io/cluster/terraform-registry-cluster,Value=shared
+```
+
+---
+
+## Placeholder reference
+
+| Placeholder        | Value                                                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `<ACCOUNT_ID>`     | `aws sts get-caller-identity --query Account --output text`                                                                            |
+| `<AWS_REGION>`     | e.g. `us-east-1`                                                                                                                       |
+| `<RDS_ENDPOINT>`   | `aws rds describe-db-instances --db-instance-identifier terraform-registry-db --query "DBInstances[0].Endpoint.Address" --output text` |
+| `<S3_BUCKET_NAME>` | `terraform-registry-artifacts-<ACCOUNT_ID>`                                                                                            |
+| `<IRSA_ROLE_NAME>` | `terraform-registry-irsa`                                                                                                              |
+| `<HOSTNAME>`       | Your public DNS name                                                                                                                   |
+| `<OPS_EMAIL>`      | Email for Let's Encrypt                                                                                                                |

--- a/docs/deployment/gke-deployment.md
+++ b/docs/deployment/gke-deployment.md
@@ -1,0 +1,223 @@
+# GKE Deployment Guide — Terraform Registry
+
+Complete all steps in [gke-prerequisites.md](gke-prerequisites.md) first.
+
+---
+
+## Step 1 — Cloud SQL Auth Proxy sidecar
+
+The GKE overlay connects to Cloud SQL via the **Cloud SQL Auth Proxy** sidecar,
+which handles IAM authentication and TLS. Add the sidecar to the backend Deployment.
+
+Create `overlays/gke/patches/backend-cloudsql-proxy.yaml`:
+
+```yaml
+# Strategic merge patch: add Cloud SQL Auth Proxy sidecar to backend Deployment.
+# Replace <PROJECT_ID>, <REGION>, and <INSTANCE_NAME> before applying.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: terraform-registry
+spec:
+  template:
+    spec:
+      containers:
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.11.0
+          args:
+            - "--structured-logs"
+            - "--port=5432"
+            - "<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 10m
+            limits:
+              memory: 128Mi
+              cpu: 100m
+```
+
+Add this patch to `overlays/gke/kustomization.yaml`:
+
+```yaml
+patches:
+  # ... existing patches ...
+  - path: patches/backend-cloudsql-proxy.yaml
+    target:
+      kind: Deployment
+      name: backend
+```
+
+---
+
+## Step 2 — Fill in placeholder values
+
+| Placeholder         | How to get it                               |
+| ------------------- | ------------------------------------------- |
+| `<PROJECT_ID>`      | `gcloud config get-value project`           |
+| `<REGION>`          | Your chosen region                          |
+| `<AR_REPO>`         | `terraform-registry`                        |
+| `<GSA_NAME>`        | `terraform-registry-sa`                     |
+| `<GCS_BUCKET_NAME>` | `terraform-registry-artifacts-<PROJECT_ID>` |
+| `<HOSTNAME>`        | Your public DNS name                        |
+| `<EMAIL>`           | Your ops email                              |
+| `<INSTANCE_NAME>`   | `terraform-registry-db`                     |
+| `<IMAGE_TAG>`       | `v1.0.0`                                    |
+
+---
+
+## Step 3 — Reserve a static IP (recommended)
+
+```bash
+gcloud compute addresses create terraform-registry-ip --global
+
+REGISTRY_IP=$(gcloud compute addresses describe terraform-registry-ip \
+  --global --format='value(address)')
+echo "Reserved IP: $REGISTRY_IP"
+```
+
+Configure `gateway.yaml` to use this IP (add annotation):
+
+```yaml
+  annotations:
+    networking.gke.io/stable-ip-address: "true"
+    networking.gke.io/certmap: ""   # only if using GCP Certificate Manager
+```
+
+---
+
+## Step 4 — Deploy
+
+### Option A: Helm
+
+```bash
+cp deployments/helm/values-gke.yaml deployments/helm/values-gke-prod.yaml
+# Edit values-gke-prod.yaml — replace every <PLACEHOLDER>
+# Also add Cloud SQL proxy sidecar via backend.extraContainers (or use Kustomize)
+
+helm upgrade --install terraform-registry ./deployments/helm \
+  --namespace terraform-registry --create-namespace \
+  -f deployments/helm/values-gke-prod.yaml \
+  --wait --timeout 5m
+
+# Apply SecretProviderClass separately
+kubectl apply -f deployments/kubernetes/overlays/gke/secretproviderclass.yaml
+```
+
+### Option B: Kustomize
+
+```bash
+# Edit all overlay files, replace every <PLACEHOLDER>:
+#   overlays/gke/gateway.yaml               → hostname
+#   overlays/gke/httproute.yaml             → hostname (x3)
+#   overlays/gke/certificate.yaml           → dnsNames
+#   overlays/gke/clusterissuer.yaml         → email (x2)
+#   overlays/gke/secretproviderclass.yaml   → PROJECT_ID (x3)
+#   overlays/gke/patches/serviceaccount-workload-identity.yaml → GSA_NAME@PROJECT_ID
+#   overlays/gke/patches/configmap-gke.yaml → GCS bucket, PROJECT_ID, hostname
+#   overlays/gke/patches/backend-cloudsql-proxy.yaml → PROJECT_ID, REGION, INSTANCE_NAME
+#   overlays/gke/kustomization.yaml         → Artifact Registry repo, image tag
+
+kubectl apply -k deployments/kubernetes/overlays/gke/
+```
+
+---
+
+## Step 5 — Configure DNS
+
+```bash
+GATEWAY_IP=$(kubectl get gateway terraform-registry-gateway \
+  -n terraform-registry -o jsonpath='{.status.addresses[0].value}')
+echo "Gateway IP: $GATEWAY_IP"
+```
+
+Create an A record in Cloud DNS (or your external DNS provider):
+
+```bash
+# Cloud DNS example:
+gcloud dns record-sets create registry.yourdomain.com. \
+  --zone=<MANAGED_ZONE> \
+  --type=A \
+  --ttl=300 \
+  --rrdatas="$GATEWAY_IP"
+```
+
+---
+
+## Step 6 — Verify certificate and application
+
+```bash
+kubectl get gateway,httproute,certificate -n terraform-registry
+
+# Application smoke test
+curl https://registry.yourdomain.com/health
+curl https://registry.yourdomain.com/.well-known/terraform.json
+```
+
+---
+
+## Step 7 — Promote to production TLS
+
+```bash
+kubectl delete secret terraform-registry-tls -n terraform-registry
+
+# Helm
+helm upgrade terraform-registry ./deployments/helm \
+  -n terraform-registry -f deployments/helm/values-gke-prod.yaml \
+  --set gatewayAPI.certManagerIssuer=letsencrypt-prod
+
+# Kustomize: edit overlays/gke/certificate.yaml → letsencrypt-prod, then apply
+```
+
+---
+
+## GKE-specific notes
+
+### Google-managed certificates (alternative to cert-manager)
+
+If you prefer Google-managed certificates over cert-manager, annotate the Gateway:
+
+```yaml
+metadata:
+  annotations:
+    networking.gke.io/certmap: <CERT_MAP_NAME>
+```
+
+And provision the certificate using GCP Certificate Manager:
+
+```bash
+gcloud certificate-manager certificates create terraform-registry-cert \
+  --domains="registry.yourdomain.com"
+
+gcloud certificate-manager maps create terraform-registry-cert-map
+
+gcloud certificate-manager maps entries create terraform-registry-cert-entry \
+  --map=terraform-registry-cert-map \
+  --certificates=terraform-registry-cert \
+  --hostname=registry.yourdomain.com
+```
+
+Remove the `cert-manager.io/cluster-issuer` annotation from the Gateway
+and the `certificate.yaml` from the overlay when using this approach.
+
+### Troubleshooting
+
+```bash
+# Gateway controller logs
+kubectl logs -n kube-system -l k8s-app=glbc --tail=50
+
+# HTTPRoute status (check for "Accepted" and "ResolvedRefs")
+kubectl describe httproute backend-routes -n terraform-registry
+
+# GCP Secret Manager access (run as test pod with GSA identity)
+kubectl run test-gsm --image=google/cloud-sdk:latest \
+  --restart=Never --rm -it \
+  --serviceaccount=terraform-registry \
+  -n terraform-registry \
+  -- gcloud secrets versions access latest \
+     --secret=terraform-registry-jwt-secret
+```

--- a/docs/deployment/gke-prerequisites.md
+++ b/docs/deployment/gke-prerequisites.md
@@ -1,0 +1,216 @@
+# GKE Prerequisites — Terraform Registry
+
+Resources and tooling required before deploying to Google Kubernetes Engine.
+
+---
+
+## 1. Required tools
+
+| Tool                        | Min version | Install                                              |
+| --------------------------- | ----------- | ---------------------------------------------------- |
+| Google Cloud CLI (`gcloud`) | 474+        | <https://cloud.google.com/sdk/docs/install>          |
+| `gke-gcloud-auth-plugin`    | latest      | `gcloud components install gke-gcloud-auth-plugin`   |
+| kubectl                     | 1.28        | `gcloud components install kubectl`                  |
+| Helm                        | 3.12        | <https://helm.sh/docs/intro/install/>                |
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+gcloud config set project <PROJECT_ID>
+gcloud config set compute/region <REGION>
+```
+
+---
+
+## 2. Enable required APIs
+
+```bash
+gcloud services enable \
+  container.googleapis.com \
+  artifactregistry.googleapis.com \
+  sqladmin.googleapis.com \
+  storage.googleapis.com \
+  secretmanager.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  iam.googleapis.com
+```
+
+---
+
+## 3. GCP resources to provision
+
+### 3a. Artifact Registry
+
+```bash
+gcloud artifacts repositories create terraform-registry \
+  --repository-format=docker \
+  --location=<REGION>
+
+# Authenticate and push images
+gcloud auth configure-docker <REGION>-docker.pkg.dev
+
+docker tag terraform-registry-backend:latest \
+  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v1.0.0
+docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v1.0.0
+
+docker tag terraform-registry-frontend:latest \
+  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v1.0.0
+docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v1.0.0
+```
+
+### 3b. Cloud SQL for PostgreSQL
+
+```bash
+gcloud sql instances create terraform-registry-db \
+  --database-version=POSTGRES_16 \
+  --tier=db-g1-small \
+  --region=<REGION> \
+  --no-assign-ip \
+  --enable-google-private-path
+
+gcloud sql databases create terraform_registry \
+  --instance=terraform-registry-db
+
+gcloud sql users create registry \
+  --instance=terraform-registry-db \
+  --password=<STRONG_PASSWORD>
+```
+
+> **Note:** `--no-assign-ip --enable-google-private-path` creates a private-IP-only instance. The Cloud SQL Auth Proxy in the GKE pod handles connectivity via IAM.
+
+### 3c. Google Cloud Storage bucket
+
+```bash
+gcloud storage buckets create gs://terraform-registry-artifacts-<PROJECT_ID> \
+  --location=<REGION> \
+  --uniform-bucket-level-access
+
+# Enable versioning
+gcloud storage buckets update gs://terraform-registry-artifacts-<PROJECT_ID> \
+  --versioning
+```
+
+### 3d. GCP Secret Manager
+
+```bash
+# Create secrets
+printf "$(openssl rand -hex 32)" | \
+  gcloud secrets create terraform-registry-jwt-secret \
+  --replication-policy=automatic --data-file=-
+
+printf "$(openssl rand -hex 16)" | \
+  gcloud secrets create terraform-registry-encryption-key \
+  --replication-policy=automatic --data-file=-
+
+printf "<STRONG_PASSWORD>" | \
+  gcloud secrets create terraform-registry-database-password \
+  --replication-policy=automatic --data-file=-
+```
+
+### 3e. Google Service Account (GSA)
+
+```bash
+gcloud iam service-accounts create terraform-registry-sa \
+  --display-name="Terraform Registry Service Account"
+
+GSA_EMAIL="terraform-registry-sa@<PROJECT_ID>.iam.gserviceaccount.com"
+
+# Grant roles
+gcloud storage buckets add-iam-policy-binding \
+  gs://terraform-registry-artifacts-<PROJECT_ID> \
+  --member="serviceAccount:$GSA_EMAIL" \
+  --role=roles/storage.objectAdmin
+
+gcloud secrets add-iam-policy-binding terraform-registry-jwt-secret \
+  --member="serviceAccount:$GSA_EMAIL" --role=roles/secretmanager.secretAccessor
+
+gcloud secrets add-iam-policy-binding terraform-registry-encryption-key \
+  --member="serviceAccount:$GSA_EMAIL" --role=roles/secretmanager.secretAccessor
+
+gcloud secrets add-iam-policy-binding terraform-registry-database-password \
+  --member="serviceAccount:$GSA_EMAIL" --role=roles/secretmanager.secretAccessor
+
+# Cloud SQL client role (for Auth Proxy sidecar)
+gcloud projects add-iam-policy-binding <PROJECT_ID> \
+  --member="serviceAccount:$GSA_EMAIL" \
+  --role=roles/cloudsql.client
+```
+
+---
+
+## 4. GKE cluster creation
+
+```bash
+gcloud container clusters create terraform-registry-cluster \
+  --region=<REGION> \
+  --release-channel=regular \
+  --num-nodes=1 \
+  --machine-type=e2-standard-4 \
+  --workload-pool=<PROJECT_ID>.svc.id.goog \
+  --enable-ip-alias \
+  --enable-network-policy \
+  --gateway-api=standard \
+  --addons=GcsFuseCsiDriver
+
+# Get cluster credentials
+gcloud container clusters get-credentials \
+  terraform-registry-cluster --region=<REGION>
+```
+
+> `--gateway-api=standard` installs Gateway API CRDs and enables the GKE built-in Gateway controller.
+> `--enable-network-policy` enables Calico for NetworkPolicy enforcement.
+> `--workload-pool` enables GKE Workload Identity.
+
+---
+
+## 5. GKE Workload Identity binding
+
+```bash
+# Bind Kubernetes ServiceAccount to GSA
+gcloud iam service-accounts add-iam-policy-binding $GSA_EMAIL \
+  --role=roles/iam.workloadIdentityUser \
+  --member="serviceAccount:<PROJECT_ID>.svc.id.goog[terraform-registry/terraform-registry]"
+```
+
+---
+
+## 6. Secrets Store CSI Driver + GCP provider
+
+```bash
+helm repo add secrets-store-csi-driver \
+  https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+helm install csi-secrets-store \
+  secrets-store-csi-driver/secrets-store-csi-driver \
+  --namespace kube-system \
+  --set syncSecret.enabled=true \
+  --set enableSecretRotation=true
+
+# GCP provider
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/main/deploy/provider-gcp-plugin.yaml
+```
+
+---
+
+## 7. cert-manager
+
+```bash
+helm repo add jetstack https://charts.jetstack.io --force-update
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true \
+  --set "featureGates=ExperimentalGatewayAPISupport=true"
+```
+
+---
+
+## Placeholder reference
+
+| Placeholder         | Value                                       |
+| ------------------- | ------------------------------------------- |
+| `<PROJECT_ID>`      | `gcloud config get-value project`           |
+| `<REGION>`          | e.g. `us-central1`                          |
+| `<GSA_NAME>`        | `terraform-registry-sa`                     |
+| `<AR_REPO>`         | `terraform-registry`                        |
+| `<GCS_BUCKET_NAME>` | `terraform-registry-artifacts-<PROJECT_ID>` |
+| `<HOSTNAME>`        | Your public DNS name                        |
+| `<OPS_EMAIL>`       | Email for Let's Encrypt                     |


### PR DESCRIPTION
## Summary

Addresses all 23 findings from a comprehensive security and best-practice audit of the Kubernetes and Helm deployment artifacts. Covers critical functional blockers, security hardening, documentation accuracy, and operational improvements.

Closes #7

## Changelog

### Fixed
- Fix Dockerfile health check using `https://` against an HTTP-only listener — changed to `http://localhost:8080/health`
- Fix NetworkPolicy (`allow-backend-ingress`) that silently dropped direct Gateway/load-balancer traffic to the backend on all cloud overlays (AKS/EKS/GKE)
- Fix HPA oscillation in production overlay caused by `spec.replicas` being re-applied on every `kubectl apply` — removed the field from the patch so HPA owns the replica count
- Fix liveness probe using `/health` (dependency-checking) — moved to `/healthz` (lightweight); readiness probe now uses `/health`
- Fix ambiguous `latest` image tag in base manifests (overlays already pin tags; base now documents this)
- Fix stale Azure-specific `<ACR_NAME>.azurecr.io` placeholder in the generic production overlay image references
- Fix production overlay base URL patch being a no-op (now uses `<YOUR_HOSTNAME>` to make the requirement visible)
- Fix incomplete `## Changelog` entries for variable naming in deployment docs (all `TFR_*` prefixed names throughout)

### Added
- Add `startupProbe` on `/healthz` to backend Kustomize and Helm deployments
- Add `readOnlyRootFilesystem: true` with `/tmp` emptyDir volume to backend container
- Add pod and container `securityContext` to Helm frontend Deployment (was absent; matches Kustomize base)
- Add `serviceAccountName` to Helm frontend Deployment
- Add `topologySpreadConstraints` patch to generic production overlay (`backend-topology-spread.yaml`)
- Add GKE Cloud SQL Auth Proxy sidecar patch to `overlays/gke/patches/backend-cloudsql-proxy.yaml` (was documentation-only)
- Add nginx `Permissions-Policy` security header to frontend nginx ConfigMap (Kustomize base + Helm template)
- Add `$patch: delete` for the legacy nginx `Ingress` resource in AKS, EKS, and GKE overlays
- Add Workload Identity annotation support to Helm `serviceaccount.yaml` template
- Add cloud-specific Helm values files: `values-aks.yaml`, `values-eks.yaml`, `values-gke.yaml`
- Add Helm templates: `gateway.yaml`, `httproute.yaml`, `networkpolicy.yaml`, `clusterissuer.yaml`, `secretproviderclass.yaml`
- Add egress NetworkPolicy template (commented-out scaffold in both Kustomize and Helm)
- Add warning comment on unauthenticated Prometheus metrics port exposure
- Add RWO PVC multi-replica warning to production overlay

### Changed
- Default Helm `cors.allowedOrigins` from `["*"]` to `[]` (requires explicit configuration)
- Default Helm `networkPolicy.enabled` from `false` to `true`
- Default Helm `securityContext.readOnlyRootFilesystem` from `false` to `true`
- Document `existingSecret` as the preferred path over `--set` for Helm secret values

### Documentation
- Fix all deployment checklist environment variable names to use `TFR_` prefix (was generic names like `DATABASE_URL`, `PORT`)
- Fix health endpoint documentation to match actual probe paths (`/healthz` for liveness, `/health` for readiness)
- Add concrete database backup commands for Azure Flexible Server, RDS, Cloud SQL, and self-hosted `pg_dump`
- Add full Backup & Restore section covering database snapshots and PVC storage (Velero, `kubectl exec tar`, Docker Compose)
- Add Helm security note for `existingSecret` pattern
- Add `docs/deployment/` directory with cloud-specific guides (AKS, EKS, GKE: prerequisites, deployment, operations)
- Verify all `docs/deployment/README.md` directory references exist on disk