### PR TITLE
fix: compute and serve h1: dirhash for provider mirror packages

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -789,9 +789,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "providers: []models.MirroredProvider with versions",
+                        "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/admin.WebhookEventsResponse"
+                            "$ref": "#/definitions/admin.ListMirroredProvidersResponse"
                         }
                     },
                     "400": {
@@ -8791,6 +8791,17 @@
                 "mirrors": {}
             }
         },
+        "admin.ListMirroredProvidersResponse": {
+            "type": "object",
+            "properties": {
+                "providers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.MirroredProviderSummary"
+                    }
+                }
+            }
+        },
         "admin.ListOrganizationsResponse": {
             "type": "object",
             "properties": {
@@ -8906,6 +8917,90 @@
             "type": "object",
             "properties": {
                 "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.MirroredPlatformSummary": {
+            "type": "object",
+            "properties": {
+                "arch": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "provider_version_id": {
+                    "type": "string"
+                },
+                "shasum": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.MirroredProviderSummary": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_synced_at": {
+                    "type": "string"
+                },
+                "mirror_config_id": {
+                    "type": "string"
+                },
+                "provider_id": {
+                    "type": "string"
+                },
+                "sync_enabled": {
+                    "type": "boolean"
+                },
+                "upstream_namespace": {
+                    "type": "string"
+                },
+                "upstream_type": {
+                    "type": "string"
+                },
+                "versions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.MirroredVersionSummary"
+                    }
+                }
+            }
+        },
+        "admin.MirroredVersionSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "mirrored_provider_id": {
+                    "type": "string"
+                },
+                "platforms": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.MirroredPlatformSummary"
+                    }
+                },
+                "provider_version_id": {
+                    "type": "string"
+                },
+                "synced_at": {
+                    "type": "string"
+                },
+                "upstream_version": {
                     "type": "string"
                 }
             }
@@ -9100,10 +9195,16 @@
                 "download_count": {
                     "type": "integer"
                 },
+                "filename": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
                 "os": {
+                    "type": "string"
+                },
+                "shasum": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -548,7 +548,7 @@ func (h *MirrorHandler) GetMirrorStatus(c *gin.Context) {
 // @Security     Bearer
 // @Produce      json
 // @Param        id  path  string  true  "Mirror configuration ID (UUID)"
-// @Success      200  {object}  admin.WebhookEventsResponse  "providers: []models.MirroredProvider with versions"
+// @Success      200  {object}  admin.ListMirroredProvidersResponse
 // @Failure      400  {object}  map[string]interface{}  "Invalid mirror ID"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Mirror configuration not found"

--- a/backend/internal/api/admin/mirror_test.go
+++ b/backend/internal/api/admin/mirror_test.go
@@ -831,7 +831,7 @@ var mirroredProviderVersionCols = []string{
 
 var providerPlatformCols = []string{
 	"id", "provider_version_id", "os", "arch", "filename",
-	"storage_path", "storage_backend", "size_bytes", "shasum", "download_count",
+	"storage_path", "storage_backend", "size_bytes", "shasum", "h1_hash", "download_count",
 }
 
 func newMirrorProvidersRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
@@ -932,7 +932,7 @@ func TestListMirroredProviders_WithProviderAndVersions(t *testing.T) {
 			knownUUID, versionID, "linux", "amd64",
 			"terraform-provider-aws_1.0.0_linux_amd64.zip",
 			"providers/hashicorp/aws/1.0.0/linux_amd64.zip",
-			"local", int64(1024), "abc123", int64(0),
+			"local", int64(1024), "abc123", nil, int64(0),
 		))
 
 	w := httptest.NewRecorder()

--- a/backend/internal/api/admin/providers_test.go
+++ b/backend/internal/api/admin/providers_test.go
@@ -57,7 +57,7 @@ var versionCols = []string{
 
 var platformCols = []string{
 	"id", "provider_version_id", "os", "arch",
-	"filename", "storage_path", "storage_backend", "size_bytes", "shasum", "download_count",
+	"filename", "storage_path", "storage_backend", "size_bytes", "shasum", "h1_hash", "download_count",
 }
 
 var versionGetCols = []string{
@@ -349,7 +349,7 @@ func TestDeleteProvider_Success_WithVersionsAndPlatforms(t *testing.T) {
 			AddRow("plat-1", "ver-1", "linux", "amd64",
 				"terraform-provider-aws_5.0.0_linux_amd64.zip",
 				"providers/hashicorp/aws/5.0.0/linux_amd64.zip",
-				"local", 1024, "abc123", 0))
+				"local", 1024, "abc123", nil, 0))
 	// DeleteProvider
 	mock.ExpectExec("DELETE FROM providers").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -245,6 +245,8 @@ type ProviderPlatformItem struct {
 	ID            string `json:"id"`
 	OS            string `json:"os"`
 	Arch          string `json:"arch"`
+	Filename      string `json:"filename"`
+	Shasum        string `json:"shasum"`
 	DownloadCount int64  `json:"download_count"`
 }
 
@@ -270,6 +272,44 @@ type ProviderDetailResponse struct {
 	Versions    []ProviderVersionItem `json:"versions"`
 	CreatedAt   time.Time             `json:"created_at"`
 	UpdatedAt   time.Time             `json:"updated_at"`
+}
+
+// MirroredPlatformSummary describes a single platform entry in the ListMirroredProviders response.
+type MirroredPlatformSummary struct {
+	ID                string `json:"id"`
+	ProviderVersionID string `json:"provider_version_id"`
+	OS                string `json:"os"`
+	Arch              string `json:"arch"`
+	Filename          string `json:"filename"`
+	Shasum            string `json:"shasum"`
+}
+
+// MirroredVersionSummary describes a provider version with its platforms in the ListMirroredProviders response.
+type MirroredVersionSummary struct {
+	ID                 string                    `json:"id"`
+	MirroredProviderID string                    `json:"mirrored_provider_id"`
+	ProviderVersionID  string                    `json:"provider_version_id"`
+	UpstreamVersion    string                    `json:"upstream_version"`
+	SyncedAt           time.Time                 `json:"synced_at"`
+	Platforms          []MirroredPlatformSummary `json:"platforms"`
+}
+
+// MirroredProviderSummary describes a provider with its versions in the ListMirroredProviders response.
+type MirroredProviderSummary struct {
+	ID                string                   `json:"id"`
+	MirrorConfigID    string                   `json:"mirror_config_id"`
+	ProviderID        string                   `json:"provider_id"`
+	UpstreamNamespace string                   `json:"upstream_namespace"`
+	UpstreamType      string                   `json:"upstream_type"`
+	LastSyncedAt      time.Time                `json:"last_synced_at"`
+	SyncEnabled       bool                     `json:"sync_enabled"`
+	CreatedAt         time.Time                `json:"created_at"`
+	Versions          []MirroredVersionSummary `json:"versions"`
+}
+
+// ListMirroredProvidersResponse is returned by GET /api/v1/admin/mirrors/{id}/providers.
+type ListMirroredProvidersResponse struct {
+	Providers []MirroredProviderSummary `json:"providers"`
 }
 
 // AuditLogResponse represents a single audit log entry in list or get responses.

--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -240,33 +240,35 @@ func TestPlatformIndex_VersionNotFound(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// formatH1Hash
+// formatZhHash
 // ---------------------------------------------------------------------------
 
-func TestFormatH1Hash_ZeroHash(t *testing.T) {
+func TestFormatZhHash_ZeroHash(t *testing.T) {
 	// 64 hex chars (32 bytes = sha256.Size) all zeros
-	result := formatH1Hash("0000000000000000000000000000000000000000000000000000000000000000")
-	if !strings.HasPrefix(result, "h1:") {
-		t.Errorf("result = %q, should start with h1:", result)
+	result := formatZhHash("0000000000000000000000000000000000000000000000000000000000000000")
+	if !strings.HasPrefix(result, "zh:") {
+		t.Errorf("result = %q, should start with zh:", result)
 	}
 }
 
-func TestFormatH1Hash_KnownHash(t *testing.T) {
+func TestFormatZhHash_KnownHash(t *testing.T) {
 	// SHA256 of "hello" = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
-	result := formatH1Hash("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
-	if !strings.HasPrefix(result, "h1:") {
-		t.Errorf("result = %q, should start with h1:", result)
+	// zh: prepends the prefix directly to the hex string (lowercase hex, per Terraform spec)
+	result := formatZhHash("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+	expected := "zh:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	if result != expected {
+		t.Errorf("result = %q, want %q", result, expected)
 	}
 	// Verify it's different from zero hash
-	zeroResult := formatH1Hash("0000000000000000000000000000000000000000000000000000000000000000")
+	zeroResult := formatZhHash("0000000000000000000000000000000000000000000000000000000000000000")
 	if result == zeroResult {
 		t.Error("non-zero hash should differ from zero hash")
 	}
 }
 
-func TestFormatH1Hash_Empty(t *testing.T) {
-	result := formatH1Hash("")
-	if !strings.HasPrefix(result, "h1:") {
-		t.Errorf("result = %q, should start with h1:", result)
+func TestFormatZhHash_Empty(t *testing.T) {
+	result := formatZhHash("")
+	if result != "" {
+		t.Errorf("result = %q, want empty string for empty input", result)
 	}
 }

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -3,8 +3,6 @@ package mirror
 
 import (
 	"database/sql"
-	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -173,15 +171,15 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 				return
 			}
 
-			// Format hashes according to Network Mirror Protocol
-			// Network Mirror expects:
-			// - "h1:" prefix = SHA256 hash in base64
-			// - "zh:" prefix = ZIP hash (also SHA256, but may include file headers)
-			//
-			// For now, we'll provide the h1 hash from our SHA256 checksum
-			hashes := []string{
-				formatH1Hash(platform.Shasum),
+			// Build the hashes list for this platform.
+			// h1: (dirhash of zip contents) is the preferred scheme; include it first when
+			// available so that Terraform can populate its lock file with the better hash.
+			// zh: (hex SHA256 of the zip archive) is the legacy fallback and is always present.
+			var hashes []string
+			if platform.H1Hash != nil && *platform.H1Hash != "" {
+				hashes = append(hashes, *platform.H1Hash)
 			}
+			hashes = append(hashes, formatZhHash(platform.Shasum))
 
 			// Add to archives
 			archives[platformKey] = gin.H{
@@ -207,12 +205,12 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 	}
 }
 
-// formatH1Hash converts a hex SHA256 checksum to the "h1:" format used by Terraform.
-// "h1:" format is the SHA256 hash encoded as base64.
-func formatH1Hash(hexChecksum string) string {
-	hashBytes, err := hex.DecodeString(hexChecksum)
-	if err != nil {
+// formatZhHash converts a hex SHA256 checksum to the "zh:" format used by Terraform's
+// Network Mirror Protocol. zh: is the lowercase hex SHA256 of the zip archive bytes,
+// as defined by Terraform's PackageHashLegacyZipSHA scheme.
+func formatZhHash(hexChecksum string) string {
+	if hexChecksum == "" {
 		return ""
 	}
-	return "h1:" + base64.StdEncoding.EncodeToString(hashBytes)
+	return "zh:" + hexChecksum
 }

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -75,10 +75,10 @@ var providerVersionGetCols = []string{
 	"deprecated", "deprecated_at", "deprecation_message", "created_at",
 }
 
-// GetPlatform: id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, download_count
+// GetPlatform: id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, h1_hash, download_count
 var platformCols = []string{
 	"id", "provider_version_id", "os", "arch", "filename",
-	"storage_path", "storage_backend", "size_bytes", "shasum", "download_count",
+	"storage_path", "storage_backend", "size_bytes", "shasum", "h1_hash", "download_count",
 }
 
 // SearchProvidersWithStats result: id, org_id, namespace, type, description, source,
@@ -125,7 +125,7 @@ func samplePlatformRow() *sqlmock.Rows {
 		AddRow("plat-1", "ver-1", "linux", "amd64",
 			"terraform-provider-aws_4.0.0_linux_amd64.zip",
 			"providers/hashicorp/aws/4.0.0/terraform-provider-aws_linux_amd64.zip",
-			"local", int64(1024000), "sha256abc", int64(0))
+			"local", int64(1024000), "sha256abc", nil, int64(0))
 }
 
 func sampleProviderSearchRow() *sqlmock.Rows {

--- a/backend/internal/db/migrations/000010_provider_platforms_h1_hash.down.sql
+++ b/backend/internal/db/migrations/000010_provider_platforms_h1_hash.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE provider_platforms
+    DROP COLUMN IF EXISTS h1_hash;

--- a/backend/internal/db/migrations/000010_provider_platforms_h1_hash.up.sql
+++ b/backend/internal/db/migrations/000010_provider_platforms_h1_hash.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE provider_platforms
+    ADD COLUMN h1_hash TEXT DEFAULT NULL;
+
+COMMENT ON COLUMN provider_platforms.h1_hash IS 'Terraform h1: dirhash of the provider zip archive (sorted-file SHA-256 manifest). NULL for platforms synced before this migration.';

--- a/backend/internal/db/models/provider.go
+++ b/backend/internal/db/models/provider.go
@@ -49,12 +49,13 @@ type ProviderVersion struct {
 type ProviderPlatform struct {
 	ID                string
 	ProviderVersionID string
-	OS                string // Operating system (linux, darwin, windows, etc.)
-	Arch              string // Architecture (amd64, arm64, 386, etc.)
-	Filename          string // Original filename of the provider binary
-	StoragePath       string // Path in storage backend
-	StorageBackend    string // Storage backend type (local, azure, s3)
-	SizeBytes         int64  // File size in bytes
-	Shasum            string // SHA256 checksum of the binary
-	DownloadCount     int64  // Number of times this platform binary has been downloaded
+	OS                string  // Operating system (linux, darwin, windows, etc.)
+	Arch              string  // Architecture (amd64, arm64, 386, etc.)
+	Filename          string  // Original filename of the provider binary
+	StoragePath       string  // Path in storage backend
+	StorageBackend    string  // Storage backend type (local, azure, s3)
+	SizeBytes         int64   // File size in bytes
+	Shasum            string  // SHA256 checksum of the binary
+	H1Hash            *string // Terraform h1: dirhash of the zip archive; nil for legacy rows
+	DownloadCount     int64   // Number of times this platform binary has been downloaded
 }

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -400,8 +400,8 @@ func (r *ProviderRepository) UndeprecateVersion(ctx context.Context, versionID s
 // CreatePlatform inserts a new platform binary record
 func (r *ProviderRepository) CreatePlatform(ctx context.Context, platform *models.ProviderPlatform) error {
 	query := `
-		INSERT INTO provider_platforms (provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO provider_platforms (provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, h1_hash)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		RETURNING id
 	`
 
@@ -414,6 +414,7 @@ func (r *ProviderRepository) CreatePlatform(ctx context.Context, platform *model
 		platform.StorageBackend,
 		platform.SizeBytes,
 		platform.Shasum,
+		platform.H1Hash,
 	).Scan(&platform.ID)
 
 	if err != nil {
@@ -426,7 +427,7 @@ func (r *ProviderRepository) CreatePlatform(ctx context.Context, platform *model
 // GetPlatform retrieves a specific platform binary by version ID, OS, and arch
 func (r *ProviderRepository) GetPlatform(ctx context.Context, versionID, os, arch string) (*models.ProviderPlatform, error) {
 	query := `
-		SELECT id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, download_count
+		SELECT id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, h1_hash, download_count
 		FROM provider_platforms
 		WHERE provider_version_id = $1 AND os = $2 AND arch = $3
 	`
@@ -442,6 +443,7 @@ func (r *ProviderRepository) GetPlatform(ctx context.Context, versionID, os, arc
 		&platform.StorageBackend,
 		&platform.SizeBytes,
 		&platform.Shasum,
+		&platform.H1Hash,
 		&platform.DownloadCount,
 	)
 
@@ -458,7 +460,7 @@ func (r *ProviderRepository) GetPlatform(ctx context.Context, versionID, os, arc
 // ListPlatforms retrieves all platform binaries for a provider version
 func (r *ProviderRepository) ListPlatforms(ctx context.Context, versionID string) ([]*models.ProviderPlatform, error) {
 	query := `
-		SELECT id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, download_count
+		SELECT id, provider_version_id, os, arch, filename, storage_path, storage_backend, size_bytes, shasum, h1_hash, download_count
 		FROM provider_platforms
 		WHERE provider_version_id = $1
 		ORDER BY os, arch
@@ -483,6 +485,7 @@ func (r *ProviderRepository) ListPlatforms(ctx context.Context, versionID string
 			&p.StorageBackend,
 			&p.SizeBytes,
 			&p.Shasum,
+			&p.H1Hash,
 			&p.DownloadCount,
 		)
 		if err != nil {

--- a/backend/internal/db/repositories/provider_repository_test.go
+++ b/backend/internal/db/repositories/provider_repository_test.go
@@ -32,7 +32,7 @@ var provVersionListCols = []string{
 
 var platformCols = []string{
 	"id", "provider_version_id", "os", "arch",
-	"filename", "storage_path", "storage_backend", "size_bytes", "shasum", "download_count",
+	"filename", "storage_path", "storage_backend", "size_bytes", "shasum", "h1_hash", "download_count",
 }
 
 var provCreateCols = []string{"id", "created_at", "updated_at"}
@@ -71,7 +71,7 @@ func sampleProvVersionListRows() *sqlmock.Rows {
 
 func samplePlatformRow() *sqlmock.Rows {
 	return sqlmock.NewRows(platformCols).
-		AddRow("plat-1", "ver-1", "linux", "amd64", "file.zip", "path/to/file.zip", "default", int64(1024), "abc", int64(0))
+		AddRow("plat-1", "ver-1", "linux", "amd64", "file.zip", "path/to/file.zip", "default", int64(1024), "abc", nil, int64(0))
 }
 
 func emptyPlatformRows() *sqlmock.Rows {

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -23,6 +23,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
+	"github.com/terraform-registry/terraform-registry/pkg/checksum"
 
 	"github.com/google/uuid"
 )
@@ -926,8 +927,8 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 	}
 
 	// Calculate SHA256 checksum
-	checksum := sha256.Sum256(binaryContent)
-	checksumHex := hex.EncodeToString(checksum[:])
+	sha256sum := sha256.Sum256(binaryContent)
+	checksumHex := hex.EncodeToString(sha256sum[:])
 
 	// Verify checksum if we have SHASUM data
 	expectedChecksum := packageInfo.SHA256Sum
@@ -963,6 +964,14 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 		StorageBackend:    j.storageBackendName,
 		SizeBytes:         int64(len(binaryContent)),
 		Shasum:            checksumHex,
+	}
+
+	// Compute the h1: dirhash for the zip archive so that Terraform's network
+	// mirror protocol can serve both zh: (legacy) and h1: (preferred) hashes.
+	if h1, err := checksum.HashZip(binaryContent); err != nil {
+		log.Printf("Warning: failed to compute h1: hash for %s: %v", packageInfo.Filename, err)
+	} else {
+		platformRecord.H1Hash = &h1
 	}
 
 	if err := j.providerRepo.CreatePlatform(ctx, platformRecord); err != nil {

--- a/backend/pkg/checksum/checksum.go
+++ b/backend/pkg/checksum/checksum.go
@@ -7,10 +7,14 @@
 package checksum
 
 import (
+	"archive/zip"
+	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"sort"
 )
 
 // CalculateSHA256 calculates the SHA256 checksum of data from a reader
@@ -32,4 +36,49 @@ func VerifySHA256(reader io.Reader, expectedChecksum string) (bool, error) {
 	}
 
 	return actualChecksum == expectedChecksum, nil
+}
+
+// HashZip computes the Terraform h1: dirhash of a zip archive. It is the same
+// algorithm used by Terraform when verifying provider packages downloaded from a
+// network mirror: for each file inside the zip (sorted by name) the SHA-256 of
+// its raw content is computed, a manifest line of the form
+//
+//	"<sha256hex>  <filename>\n"
+//
+// is written to an outer SHA-256 hasher, and the final digest is returned as
+// "h1:<base64>". This matches Go's golang.org/x/mod/dirhash.HashZip behaviour.
+func HashZip(zipContent []byte) (string, error) {
+	r, err := zip.NewReader(bytes.NewReader(zipContent), int64(len(zipContent)))
+	if err != nil {
+		return "", fmt.Errorf("failed to read zip archive: %w", err)
+	}
+
+	// Collect and sort entry names for deterministic ordering.
+	names := make([]string, 0, len(r.File))
+	files := make(map[string]*zip.File, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+		files[f.Name] = f
+	}
+	sort.Strings(names)
+
+	// Build the manifest hash.
+	outer := sha256.New()
+	for _, name := range names {
+		inner := sha256.New()
+		rc, err := files[name].Open()
+		if err != nil {
+			return "", fmt.Errorf("failed to open zip entry %q: %w", name, err)
+		}
+		if _, err := io.Copy(inner, rc); err != nil {
+			rc.Close() // #nosec G104 -- best-effort close; the copy error takes precedence
+			return "", fmt.Errorf("failed to hash zip entry %q: %w", name, err)
+		}
+		if err := rc.Close(); err != nil {
+			return "", fmt.Errorf("failed to close zip entry %q: %w", name, err)
+		}
+		fmt.Fprintf(outer, "%x  %s\n", inner.Sum(nil), name)
+	}
+
+	return "h1:" + base64.StdEncoding.EncodeToString(outer.Sum(nil)), nil
 }

--- a/backend/pkg/checksum/checksum_test.go
+++ b/backend/pkg/checksum/checksum_test.go
@@ -1,8 +1,13 @@
 package checksum
 
 import (
+	"archive/zip"
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -133,4 +138,159 @@ type errReader struct{}
 
 func (errReader) Read(_ []byte) (int, error) {
 	return 0, io.ErrUnexpectedEOF
+}
+
+func TestHashZip(t *testing.T) {
+	t.Run("invalid bytes return error", func(t *testing.T) {
+		_, err := HashZip([]byte("not a zip file"))
+		if err == nil {
+			t.Error("HashZip() expected error for invalid zip bytes, got nil")
+		}
+	})
+
+	t.Run("empty zip returns h1: prefix", func(t *testing.T) {
+		zf := buildOrderedTestZip(t, nil)
+		got, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		if !strings.HasPrefix(got, "h1:") {
+			t.Errorf("HashZip() = %q, want h1: prefix", got)
+		}
+	})
+
+	t.Run("result has valid base64 payload", func(t *testing.T) {
+		zf := buildOrderedTestZip(t, [][2]string{{"hello.txt", "world"}})
+		got, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		if !strings.HasPrefix(got, "h1:") {
+			t.Fatalf("HashZip() = %q, want h1: prefix", got)
+		}
+		if _, err := base64.StdEncoding.DecodeString(got[len("h1:"):]); err != nil {
+			t.Errorf("HashZip() base64 payload is invalid: %v", err)
+		}
+	})
+
+	t.Run("deterministic — same zip yields same hash", func(t *testing.T) {
+		zf := buildOrderedTestZip(t, [][2]string{{"a.txt", "alpha"}, {"b.txt", "beta"}})
+		h1, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		h2, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		if h1 != h2 {
+			t.Error("HashZip() returned different hashes for identical input")
+		}
+	})
+
+	t.Run("zip entry order does not affect hash", func(t *testing.T) {
+		// Two zips with same files but stored in opposite order inside the archive.
+		zfAB := buildOrderedTestZip(t, [][2]string{{"a.txt", "alpha"}, {"b.txt", "beta"}})
+		zfBA := buildOrderedTestZip(t, [][2]string{{"b.txt", "beta"}, {"a.txt", "alpha"}})
+		hAB, err := HashZip(zfAB)
+		if err != nil {
+			t.Fatalf("HashZip() AB error: %v", err)
+		}
+		hBA, err := HashZip(zfBA)
+		if err != nil {
+			t.Fatalf("HashZip() BA error: %v", err)
+		}
+		if hAB != hBA {
+			t.Errorf("HashZip() gave different hashes for same content in different zip order: %q vs %q", hAB, hBA)
+		}
+	})
+
+	t.Run("different file content produces different hash", func(t *testing.T) {
+		zA := buildOrderedTestZip(t, [][2]string{{"file.txt", "content-a"}})
+		zB := buildOrderedTestZip(t, [][2]string{{"file.txt", "content-b"}})
+		hA, err := HashZip(zA)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		hB, err := HashZip(zB)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		if hA == hB {
+			t.Error("HashZip() returned same hash for different file content")
+		}
+	})
+
+	t.Run("different file names produce different hash", func(t *testing.T) {
+		zA := buildOrderedTestZip(t, [][2]string{{"a.txt", "same"}})
+		zB := buildOrderedTestZip(t, [][2]string{{"b.txt", "same"}})
+		hA, err := HashZip(zA)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		hB, err := HashZip(zB)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		if hA == hB {
+			t.Error("HashZip() returned same hash for different file names")
+		}
+	})
+
+	t.Run("matches dirhash reference implementation", func(t *testing.T) {
+		// Cross-validate HashZip against an inline reference of the same algorithm.
+		// This catches regressions without hard-coding a magic opaque base64 string.
+		files := [][2]string{{"terraform-provider-example_v1.0.0", "binary content here"}, {"LICENSE", "MIT"}}
+		zf := buildOrderedTestZip(t, files)
+		got, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		want := referenceDirhash(t, files)
+		if got != want {
+			t.Errorf("HashZip() = %q, want %q", got, want)
+		}
+	})
+}
+
+// buildOrderedTestZip creates a zip archive containing the given files in the
+// exact order provided. Pass nil for an empty archive.
+func buildOrderedTestZip(t *testing.T, files [][2]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for _, kv := range files {
+		f, err := w.Create(kv[0])
+		if err != nil {
+			t.Fatalf("buildOrderedTestZip: create %q: %v", kv[0], err)
+		}
+		if _, err := f.Write([]byte(kv[1])); err != nil {
+			t.Fatalf("buildOrderedTestZip: write %q: %v", kv[0], err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("buildOrderedTestZip: close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// referenceDirhash is an inline implementation of the h1: dirhash algorithm
+// used to cross-validate HashZip. It operates directly on string content
+// rather than zip entries, so it is independent of HashZip's zip-reading path.
+func referenceDirhash(t *testing.T, files [][2]string) string {
+	t.Helper()
+	names := make([]string, len(files))
+	content := make(map[string]string, len(files))
+	for i, kv := range files {
+		names[i] = kv[0]
+		content[kv[0]] = kv[1]
+	}
+	sort.Strings(names)
+	outer := sha256.New()
+	for _, name := range names {
+		inner := sha256.New()
+		inner.Write([]byte(content[name]))
+		fmt.Fprintf(outer, "%x  %s\n", inner.Sum(nil), name)
+	}
+	return "h1:" + base64.StdEncoding.EncodeToString(outer.Sum(nil))
 }


### PR DESCRIPTION
Closes #10

## Summary

The network mirror platform index handler was labelling `zh:` hashes (base64 of SHA256 of zip bytes) as `h1:`. Terraform CLI computes `h1:` using a dirhash algorithm (sorted per-file SHA256 manifest), so every `terraform init` checksum verification failed with a mismatch even after a clean re-download.

This PR fixes the root cause end-to-end:
- Implements the correct `h1:` dirhash algorithm in `pkg/checksum.HashZip`
- Stores the `h1:` hash in a new `provider_platforms.h1_hash` column (migration 000010) during mirror sync
- Serves both `h1:` (preferred, listed first) and `zh:` (legacy fallback) in the network mirror platform index response

Platforms synced before this migration will continue to work with `zh:` only until re-synced.

Also fixes two pre-existing swagger annotation inaccuracies:
- `ProviderPlatformItem` was missing `filename` and `shasum` fields
- `ListMirroredProviders` `@Success` was referencing unrelated `WebhookEventsResponse` type

## Changelog
- fix: compute and serve correct h1: dirhash hash for provider mirror packages, resolving terraform init checksum mismatch