### PR TITLE
fix: move mirror download tracking from User-Agent parsing to file serve path

### DIFF
--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -2,12 +2,10 @@
 package mirror
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sync"
 	"time"
 
@@ -15,7 +13,6 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
-	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
@@ -195,24 +192,6 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			"archives": archives,
 		}
 
-		// Track the download: parse the Terraform User-Agent to determine
-		// which platform the client will actually fetch, then increment
-		// only that platform's download counter.
-		if clientOS, clientArch := parseTerraformPlatform(c.GetHeader("User-Agent")); clientOS != "" {
-			for _, platform := range platforms {
-				if platform.OS == clientOS && platform.Arch == clientArch {
-					platformID := platform.ID
-					go func() {
-						if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
-							// Log error but don't fail the request
-						}
-					}()
-					telemetry.ProviderDownloadsTotal.WithLabelValues(namespace, providerType, clientOS, clientArch).Inc()
-					break
-				}
-			}
-		}
-
 		// Use c.Data with plain "application/json" (no charset) to satisfy the
 		// Terraform Network Mirror Protocol spec, which rejects unknown content-type
 		// parameters. Gin's c.JSON would append "; charset=utf-8" and trigger a
@@ -234,23 +213,4 @@ func formatZhHash(hexChecksum string) string {
 		return ""
 	}
 	return "zh:" + hexChecksum
-}
-
-// terraformPlatformRe matches the OS/arch pair in a Terraform User-Agent string.
-// Terraform sends User-Agent headers in the form:
-//
-//	Terraform/1.5.0 (+https://www.terraform.io) linux_amd64
-//	OpenTofu/1.6.0 linux_arm64
-//
-// The regex captures (os)_(arch) from the trailing platform token.
-var terraformPlatformRe = regexp.MustCompile(`(?:Terraform|OpenTofu)/\S+.*?\b([a-z]+)_([a-z0-9]+)`)
-
-// parseTerraformPlatform extracts (os, arch) from a Terraform/OpenTofu User-Agent.
-// Returns ("", "") if the header doesn't match.
-func parseTerraformPlatform(ua string) (string, string) {
-	m := terraformPlatformRe.FindStringSubmatch(ua)
-	if m == nil {
-		return "", ""
-	}
-	return m[1], m[2]
 }

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -166,7 +166,7 @@ func newDownloadRouter(t *testing.T, store *mockStore) (sqlmock.Sqlmock, *gin.En
 func newServeRouter(t *testing.T, store *mockStore) *gin.Engine {
 	t.Helper()
 	r := gin.New()
-	r.GET("/v1/files/*filepath", ServeFileHandler(store, &config.Config{}))
+	r.GET("/v1/files/*filepath", ServeFileHandler(store, &config.Config{}, nil))
 	return r
 }
 

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -1,18 +1,30 @@
-// serve.go handles direct file serving of module archives from local storage backends.
+// serve.go handles direct file serving of module and provider archives from local storage backends.
 package modules
 
 import (
+	"context"
+	"database/sql"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
 // ServeFileHandler handles direct file serving for local storage
 // Implements: GET /v1/files/*filepath
 // Only used when local storage has ServeDirectly: true
-func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config) gin.HandlerFunc {
+func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sql.DB) gin.HandlerFunc {
+	var providerRepo *repositories.ProviderRepository
+	var orgRepo *repositories.OrganizationRepository
+	if db != nil {
+		providerRepo = repositories.NewProviderRepository(db)
+		orgRepo = repositories.NewOrganizationRepository(db)
+	}
+
 	return func(c *gin.Context) {
 		// Get file path from URL
 		filePath := c.Param("filepath")
@@ -62,6 +74,14 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config) gin.Ha
 		}
 		defer reader.Close()
 
+		// Track provider downloads: path is providers/{namespace}/{type}/{version}/{os}/{arch}/{file}
+		if providerRepo != nil {
+			if ns, pt, ver, osName, arch, ok := parseProviderFilePath(filePath); ok {
+				go trackProviderDownload(providerRepo, orgRepo, ns, pt, ver, osName, arch)
+				telemetry.ProviderDownloadsTotal.WithLabelValues(ns, pt, osName, arch).Inc()
+			}
+		}
+
 		// Set response headers
 		c.Header("Content-Type", "application/gzip")
 		c.Header("Content-Disposition", "attachment")
@@ -69,5 +89,42 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config) gin.Ha
 
 		// Stream file to client
 		c.DataFromReader(http.StatusOK, metadata.Size, "application/gzip", reader, nil)
+	}
+}
+
+// parseProviderFilePath extracts components from a provider file path of the form:
+// providers/{namespace}/{type}/{version}/{os}/{arch}/{filename}
+func parseProviderFilePath(path string) (namespace, providerType, version, os, arch string, ok bool) {
+	parts := strings.Split(path, "/")
+	if len(parts) < 7 || parts[0] != "providers" {
+		return "", "", "", "", "", false
+	}
+	return parts[1], parts[2], parts[3], parts[4], parts[5], true
+}
+
+// trackProviderDownload looks up the provider platform and increments its download count.
+func trackProviderDownload(providerRepo *repositories.ProviderRepository, orgRepo *repositories.OrganizationRepository, namespace, providerType, version, osName, arch string) {
+	ctx := context.Background()
+	org, err := orgRepo.GetDefaultOrganization(ctx)
+	if err != nil || org == nil {
+		return
+	}
+	provider, err := providerRepo.GetProvider(ctx, org.ID, namespace, providerType)
+	if err != nil || provider == nil {
+		return
+	}
+	pv, err := providerRepo.GetVersion(ctx, provider.ID, version)
+	if err != nil || pv == nil {
+		return
+	}
+	platforms, err := providerRepo.ListPlatforms(ctx, pv.ID)
+	if err != nil {
+		return
+	}
+	for _, p := range platforms {
+		if p.OS == osName && p.Arch == arch {
+			_ = providerRepo.IncrementDownloadCount(ctx, p.ID)
+			return
+		}
 	}
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -318,7 +318,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	}
 
 	// File serving endpoint for local storage with ServeDirectly enabled
-	router.GET("/v1/files/*filepath", modules.ServeFileHandler(storageBackend, cfg))
+	router.GET("/v1/files/*filepath", modules.ServeFileHandler(storageBackend, cfg, db))
 
 	// Provider Registry endpoints (v1)
 	// These are for the standard Provider Registry Protocol


### PR DESCRIPTION
Closes #20

## Summary

The v0.2.2 User-Agent parsing approach fails because Terraform 1.14.6 sends `Terraform/1.14.6` without an `os_arch` suffix. Moves download tracking to `ServeFileHandler` (`serve.go`), which handles the actual binary download at `/v1/files/providers/{ns}/{type}/{ver}/{os}/{arch}/{file}`. The path always contains the OS and arch, making this approach reliable for all Terraform versions.

- Remove User-Agent regex and tracking code from `platform_index.go`
- Add path-based provider download tracking to `serve.go`
- Update `router.go` to pass `db` to `ServeFileHandler`

## Changelog
- fix: move mirror download tracking to file serve handler for reliable platform detection from URL path