### PR TITLE
fix: add audit logging to file download and mirror platform index handlers

### DIFF
--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -67,7 +67,7 @@ func newMirrorAPIRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	cfg := &config.Config{}
 	r := gin.New()
 	r.GET("/providers/:hostname/:namespace/:type/index.json", IndexHandler(db, cfg))
-	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg))
+	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg, nil))
 	return mock, r
 }
 
@@ -363,7 +363,7 @@ func TestPlatformIndex_StorageInitError(t *testing.T) {
 	cfg.Storage.DefaultBackend = "nonexistent-backend"
 
 	r := gin.New()
-	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg))
+	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg, nil))
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
@@ -396,7 +396,7 @@ func TestPlatformIndex_Success_EmptyPlatforms(t *testing.T) {
 	cfg.Server.BaseURL = "http://localhost:8080"
 
 	r := gin.New()
-	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg))
+	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg, nil))
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
@@ -447,7 +447,7 @@ func TestPlatformIndex_Success_WithPlatforms(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg))
+	r.GET("/providers/:hostname/:namespace/:type/:versionfile", PlatformIndexHandler(db, cfg, nil))
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -2,6 +2,7 @@
 package mirror
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -32,7 +34,7 @@ import (
 // PlatformIndexHandler handles network mirror platform index requests
 // Implements: GET /terraform/providers/:hostname/:namespace/:type/:version.json
 // Returns download URLs and hashes for all platforms of a specific version
-func PlatformIndexHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
+func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 	providerRepo := repositories.NewProviderRepository(db)
 	orgRepo := repositories.NewOrganizationRepository(db)
 
@@ -190,6 +192,24 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 
 		response := gin.H{
 			"archives": archives,
+		}
+
+		// Audit log the mirror platform index request asynchronously
+		if auditRepo != nil {
+			resourceType := "provider"
+			action := "GET " + c.Request.URL.Path
+			ip := c.ClientIP()
+			versionIDForAudit := providerVersion.ID
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+					Action:       action,
+					ResourceType: &resourceType,
+					ResourceID:   &versionIDForAudit,
+					IPAddress:    &ip,
+				})
+			}()
 		}
 
 		// Use c.Data with plain "application/json" (no charset) to satisfy the

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -166,7 +166,7 @@ func newDownloadRouter(t *testing.T, store *mockStore) (sqlmock.Sqlmock, *gin.En
 func newServeRouter(t *testing.T, store *mockStore) *gin.Engine {
 	t.Helper()
 	r := gin.New()
-	r.GET("/v1/files/*filepath", ServeFileHandler(store, &config.Config{}, nil))
+	r.GET("/v1/files/*filepath", ServeFileHandler(store, &config.Config{}, nil, nil))
 	return r
 }
 

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -6,9 +6,11 @@ import (
 	"database/sql"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
@@ -17,7 +19,7 @@ import (
 // ServeFileHandler handles direct file serving for local storage
 // Implements: GET /v1/files/*filepath
 // Only used when local storage has ServeDirectly: true
-func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sql.DB) gin.HandlerFunc {
+func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sql.DB, auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 	var providerRepo *repositories.ProviderRepository
 	var orgRepo *repositories.OrganizationRepository
 	if db != nil {
@@ -80,6 +82,29 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 				go trackProviderDownload(providerRepo, orgRepo, ns, pt, ver, osName, arch)
 				telemetry.ProviderDownloadsTotal.WithLabelValues(ns, pt, osName, arch).Inc()
 			}
+		}
+
+		// Audit log the file download event asynchronously
+		if auditRepo != nil {
+			resourceType := "file"
+			if strings.HasPrefix(filePath, "providers/") {
+				resourceType = "provider"
+			} else if strings.HasPrefix(filePath, "modules/") {
+				resourceType = "module"
+			}
+			action := "GET " + c.Request.URL.Path
+			ip := c.ClientIP()
+			filePathForAudit := filePath
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+					Action:       action,
+					ResourceType: &resourceType,
+					ResourceID:   &filePathForAudit,
+					IPAddress:    &ip,
+				})
+			}()
 		}
 
 		// Set response headers

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -318,7 +318,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	}
 
 	// File serving endpoint for local storage with ServeDirectly enabled
-	router.GET("/v1/files/*filepath", modules.ServeFileHandler(storageBackend, cfg, db))
+	router.GET("/v1/files/*filepath", modules.ServeFileHandler(storageBackend, cfg, db, auditRepo))
 
 	// Provider Registry endpoints (v1)
 	// These are for the standard Provider Registry Protocol
@@ -335,7 +335,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	v1Mirror := router.Group("/terraform/providers")
 	{
 		v1Mirror.GET("/:hostname/:namespace/:type/index.json", mirror.IndexHandler(db, cfg))
-		v1Mirror.GET("/:hostname/:namespace/:type/:versionfile", mirror.PlatformIndexHandler(db, cfg))
+		v1Mirror.GET("/:hostname/:namespace/:type/:versionfile", mirror.PlatformIndexHandler(db, cfg, auditRepo))
 	}
 
 	// Terraform Binary Mirror endpoints (public, no auth required)


### PR DESCRIPTION
Closes #25

## Summary

ServeFileHandler (`/v1/files/*`) and PlatformIndexHandler (`/terraform/providers/.../version.json`) were missing audit log entries for download events. All three other download handlers (module download, provider download, terraform binary download) already had audit logging. This restores parity so all download events are tracked in the audit log.

### Changes
- **serve.go**: Added `auditRepo` parameter to `ServeFileHandler`; audit logs file downloads with resource type `provider`, `module`, or `file` depending on the path prefix
- **platform_index.go**: Added `auditRepo` parameter to `PlatformIndexHandler`; audit logs mirror platform index requests with resource type `provider`
- **router.go**: Updated both handler registrations to pass `auditRepo`
- **modules_test.go, mirror_test.go**: Updated test call sites for new function signatures

## Changelog
- fix: add audit logging to file download and mirror platform index handlers