### PR TITLE
fix: surface audit log errors and fix nil metadata causing silent jsonb failures

### DIFF
--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -203,12 +204,14 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
-				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 					Action:       action,
 					ResourceType: &resourceType,
 					ResourceID:   &versionIDForAudit,
 					IPAddress:    &ip,
-				})
+				}); err != nil {
+					slog.Error("failed to write audit log for mirror platform index", "error", err, "action", action)
+				}
 			}()
 		}
 

--- a/backend/internal/api/modules/download.go
+++ b/backend/internal/api/modules/download.go
@@ -8,6 +8,7 @@ package modules
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -143,14 +144,16 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
-				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 					Action:         action,
 					ResourceType:   &resourceType,
 					ResourceID:     &versionIDForAudit,
 					IPAddress:      &ip,
 					UserID:         userIDStr,
 					OrganizationID: orgIDStr,
-				})
+				}); err != nil {
+					slog.Error("failed to write audit log for module download", "error", err, "action", action)
+				}
 			}()
 		}
 

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -94,14 +94,12 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			}
 			action := "GET " + c.Request.URL.Path
 			ip := c.ClientIP()
-			filePathForAudit := filePath
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 					Action:       action,
 					ResourceType: &resourceType,
-					ResourceID:   &filePathForAudit,
 					IPAddress:    &ip,
 				})
 			}()

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -4,6 +4,7 @@ package modules
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -97,11 +98,13 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
-				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 					Action:       action,
 					ResourceType: &resourceType,
 					IPAddress:    &ip,
-				})
+				}); err != nil {
+					slog.Error("failed to write audit log for file download", "error", err, "action", action)
+				}
 			}()
 		}
 

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -8,6 +8,7 @@ package providers
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -178,14 +179,16 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
-				_ = auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 					Action:         action,
 					ResourceType:   &resourceType,
 					ResourceID:     &versionIDForAudit,
 					IPAddress:      &ip,
 					UserID:         userIDStr,
 					OrganizationID: orgIDStr,
-				})
+				}); err != nil {
+					slog.Error("failed to write audit log for provider download", "error", err, "action", action)
+				}
 			}()
 		}
 

--- a/backend/internal/api/terraform_binaries/binaries.go
+++ b/backend/internal/api/terraform_binaries/binaries.go
@@ -14,6 +14,7 @@ package terraform_binaries
 import (
 	"context"
 	"log"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -319,14 +320,16 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			_ = h.auditRepo.CreateAuditLog(ctx, &models.AuditLog{
+			if err := h.auditRepo.CreateAuditLog(ctx, &models.AuditLog{
 				Action:         action,
 				ResourceType:   &resourceType,
 				ResourceID:     &versionIDForAudit,
 				IPAddress:      &ip,
 				UserID:         userIDStr,
 				OrganizationID: orgIDStr,
-			})
+			}); err != nil {
+				slog.Error("failed to write audit log for binary download", "error", err, "action", action)
+			}
 		}()
 	}
 

--- a/backend/internal/db/repositories/audit_repository.go
+++ b/backend/internal/db/repositories/audit_repository.go
@@ -39,14 +39,14 @@ func (r *AuditRepository) CreateAuditLog(ctx context.Context, log *models.AuditL
 	log.ID = uuid.New().String()
 	log.CreatedAt = time.Now()
 
-	// Marshal metadata to JSONB
-	var metadataJSON []byte
-	var err error
+	// Marshal metadata to JSONB; use nil interface so lib/pq sends SQL NULL when absent.
+	var metadataArg interface{}
 	if log.Metadata != nil {
-		metadataJSON, err = json.Marshal(log.Metadata)
+		metadataJSON, err := json.Marshal(log.Metadata)
 		if err != nil {
 			return err
 		}
+		metadataArg = metadataJSON
 	}
 
 	query := `
@@ -54,6 +54,7 @@ func (r *AuditRepository) CreateAuditLog(ctx context.Context, log *models.AuditL
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 
+	var err error
 	_, err = r.db.ExecContext(ctx, query,
 		log.ID,
 		log.UserID,
@@ -61,7 +62,7 @@ func (r *AuditRepository) CreateAuditLog(ctx context.Context, log *models.AuditL
 		log.Action,
 		log.ResourceType,
 		log.ResourceID,
-		metadataJSON,
+		metadataArg,
 		log.IPAddress,
 		log.CreatedAt,
 	)


### PR DESCRIPTION
Closes #27

## Root Cause

Two compounding issues caused all download audit log events to be silently dropped:

1. **`nil []byte` → empty string → invalid jsonb**: `audit_repository.go` used `var metadataJSON []byte`, which is typed nil. `lib/pq` sends a typed nil `[]byte` as an empty string `""`, not SQL NULL. PostgreSQL's `jsonb` column rejects `""` as invalid JSON syntax — every insert failed with `pq: invalid input syntax for type json`.

2. **Silent discard**: All five download handlers used `_ = auditRepo.CreateAuditLog(...)`, so the errors were completely invisible in logs.

A third issue in the original commit (now included here): `ServeFileHandler` was also passing the file path string as `ResourceID` to a `uuid` column, causing an additional cast failure.

## Fix

- `audit_repository.go`: Replace `var metadataJSON []byte` (typed nil) with `var metadataArg interface{}` (untyped nil) so `lib/pq` correctly sends SQL NULL to the jsonb column when no metadata is set
- All five download handlers (`modules/download.go`, `providers/download.go`, `terraform_binaries/binaries.go`, `modules/serve.go`, `mirror/platform_index.go`): Replace `_ = auditRepo.CreateAuditLog(...)` with error-checked if blocks and `slog.Error` logging so failures surface in logs
- `modules/serve.go`: Remove `ResourceID` from the `ServeFileHandler` audit entry (file path is not a UUID; the full path is already captured in the `action` field)

## Verification

After these fixes, a single `terraform init` produces 4 expected audit log rows:
- `GET /v1/files/providers/...` | provider
- `GET /terraform/providers/.../version.json` | provider
- `GET /v1/files/modules/.../module.tar.gz` | module
- `GET /v1/modules/.../download` | module

## Changelog
- fix: surface audit log errors and fix nil metadata causing silent jsonb failures in all download handlers