### PR TITLE
fix: point coverage badge at the gist CI actually writes to

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://go.dev/)
-[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sethbacon/52d7faafe77a38f35ea962247c7ec210/raw/coverage.json)](https://github.com/sethbacon/terraform-registry-backend/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sethbacon/59239e8575b4f784f875647e2b344b41/raw/coverage.json)](https://github.com/sethbacon/terraform-registry-backend/actions/workflows/ci.yml)
 
 - [Enterprise Terraform Registry — Backend](#enterprise-terraform-registry-%E2%80%94-backend)
   - [Features](#features)


### PR DESCRIPTION
Closes #31

## Root Cause

Two different gist IDs were in use:

| Location | Gist ID |
|---|---|
| README.md badge URL | `52d7faafe77a38f35ea962247c7ec210` |
| `vars.COVERAGE_GIST_ID` (written by CI) | `59239e8575b4f784f875647e2b344b41` |

CI was successfully updating the correct gist on every push, but the badge was reading from the wrong one — so it stayed at 65% and CI always logged "Content did not change".

## Fix

Update the `shields.io` endpoint URL in README.md to match the gist CI writes to.

## Changelog
- fix: point coverage badge at the gist CI actually writes to (#31)