### PR TITLE
fix: compute and store h1: hash for directly-uploaded provider binaries

### DIFF
--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -356,6 +356,17 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			Shasum:            sha256sum,
 		}
 
+		// Compute the h1: dirhash from the already-spooled temp file so the
+		// network mirror protocol can serve the preferred hash scheme without
+		// reloading the binary from storage.
+		if h1, err := checksum.HashZipFile(tmpFile, size); err != nil {
+			slog.Warn("failed to compute h1: hash for uploaded provider binary; zh: will be used as fallback",
+				"provider", fmt.Sprintf("%s/%s@%s %s/%s", namespace, providerType, version, targetOS, arch),
+				"error", err)
+		} else {
+			platform.H1Hash = &h1
+		}
+
 		if err := providerRepo.CreatePlatform(c.Request.Context(), platform); err != nil {
 			// Try to clean up uploaded file
 			if delErr := storageBackend.Delete(c.Request.Context(), uploadResult.Path); delErr != nil {

--- a/backend/pkg/checksum/checksum.go
+++ b/backend/pkg/checksum/checksum.go
@@ -52,7 +52,23 @@ func HashZip(zipContent []byte) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read zip archive: %w", err)
 	}
+	return hashZipReader(r)
+}
 
+// HashZipFile computes the Terraform h1: dirhash for a zip archive given as an
+// io.ReaderAt plus its byte length. This avoids loading the entire file into
+// memory, making it suitable for large provider binaries spooled to disk (e.g.
+// during a direct-upload via the API). The algorithm is identical to HashZip.
+func HashZipFile(r io.ReaderAt, size int64) (string, error) {
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		return "", fmt.Errorf("failed to read zip archive: %w", err)
+	}
+	return hashZipReader(zr)
+}
+
+// hashZipReader is the shared implementation of the h1: dirhash algorithm.
+func hashZipReader(r *zip.Reader) (string, error) {
 	// Collect and sort entry names for deterministic ordering.
 	names := make([]string, 0, len(r.File))
 	files := make(map[string]*zip.File, len(r.File))

--- a/backend/pkg/checksum/checksum_test.go
+++ b/backend/pkg/checksum/checksum_test.go
@@ -294,3 +294,40 @@ func referenceDirhash(t *testing.T, files [][2]string) string {
 	}
 	return "h1:" + base64.StdEncoding.EncodeToString(outer.Sum(nil))
 }
+
+func TestHashZipFile(t *testing.T) {
+	t.Run("invalid bytes return error", func(t *testing.T) {
+		data := []byte("not a zip file")
+		_, err := HashZipFile(bytes.NewReader(data), int64(len(data)))
+		if err == nil {
+			t.Error("HashZipFile() expected error for invalid zip bytes, got nil")
+		}
+	})
+
+	t.Run("produces same result as HashZip", func(t *testing.T) {
+		files := [][2]string{{"terraform-provider-example_v1.0.0", "binary"}, {"LICENSE", "MIT"}}
+		zf := buildOrderedTestZip(t, files)
+		want, err := HashZip(zf)
+		if err != nil {
+			t.Fatalf("HashZip() error: %v", err)
+		}
+		got, err := HashZipFile(bytes.NewReader(zf), int64(len(zf)))
+		if err != nil {
+			t.Fatalf("HashZipFile() error: %v", err)
+		}
+		if got != want {
+			t.Errorf("HashZipFile() = %q, want %q (same as HashZip)", got, want)
+		}
+	})
+
+	t.Run("empty zip returns h1: prefix", func(t *testing.T) {
+		zf := buildOrderedTestZip(t, nil)
+		got, err := HashZipFile(bytes.NewReader(zf), int64(len(zf)))
+		if err != nil {
+			t.Fatalf("HashZipFile() error: %v", err)
+		}
+		if !strings.HasPrefix(got, "h1:") {
+			t.Errorf("HashZipFile() = %q, want h1: prefix", got)
+		}
+	})
+}


### PR DESCRIPTION
Closes #33

## Root Cause

\`upload.go\` built the \`ProviderPlatform\` record without ever calling \`checksum.HashZip\`, leaving \`H1Hash = nil\` for every provider uploaded via the API. The network mirror protocol served only the legacy \`zh:\` hash, which caused Terraform to compute the \`h1:\` hash locally and emit:

> Due to your customized provider installation methods, Terraform was forced to calculate lock file checksums locally

The mirror-sync path already computes \`h1:\` correctly (using the in-memory binary bytes); only the direct-upload path was missing it.

## Changes

**\`pkg/checksum/checksum.go\`**
- Add \`HashZipFile(r io.ReaderAt, size int64)\` — calls \`zip.NewReader\` directly on the \`io.ReaderAt\` so the full zip need not be loaded into memory (providers can be up to 500 MB)
- Refactor \`HashZip\` to share logic via a private \`hashZipReader(*zip.Reader)\` helper

**\`internal/api/providers/upload.go\`**
- After the storage upload, call \`checksum.HashZipFile(tmpFile, size)\` and set \`platform.H1Hash\`
- On failure, log a \`slog.Warn\` and continue — \`zh:\` remains as the fallback

**\`pkg/checksum/checksum_test.go\`**
- Add \`TestHashZipFile\`: invalid input returns error, same result as \`HashZip\`, \`h1:\` prefix on empty zip

## Changelog
- fix: compute and store h1: hash for directly-uploaded provider binaries (#33)