### PR TITLE
feat: serve zh: hashes for all upstream platforms in mirror version JSON

### DIFF
--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -188,6 +189,57 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			archives[platformKey] = gin.H{
 				"url":    downloadURL,
 				"hashes": hashes,
+			}
+		}
+
+		// Enrich archives with zh: hashes for platforms present in the upstream
+		// SHA256SUMS file but not synced locally.  Terraform records all hashes it
+		// sees in the version JSON into the lock file, so including every platform's
+		// zh: here lets clients build a complete cross-platform lock file from this
+		// mirror alone when running `terraform providers lock -platform=...`.
+		//
+		// Unmirrored platforms are given their upstream HashiCorp download URL.  If
+		// the ShasumURL field is empty (e.g. manually-uploaded providers) the block
+		// is skipped gracefully.
+		if providerVersion.ShasumURL != "" {
+			upstreamBase := providerVersion.ShasumURL
+			if idx := strings.LastIndex(upstreamBase, "/"); idx >= 0 {
+				upstreamBase = upstreamBase[:idx]
+			}
+
+			shasums, err := providerRepo.ListProviderVersionShasums(c.Request.Context(), providerVersion.ID)
+			if err != nil {
+				slog.Warn("failed to list provider version shasums for platform index; unmirrored platform zh: hashes will be omitted",
+					"provider_version_id", providerVersion.ID, "error", err)
+			} else {
+				for _, s := range shasums {
+					// Only include zip archives; skip manifest.json and similar entries
+					if !strings.HasSuffix(s.Filename, ".zip") {
+						continue
+					}
+
+					// Derive the os_arch key from the filename.
+					// Format: terraform-provider-TYPE_VERSION_OS_ARCH.zip
+					// The OS and ARCH tokens are always the last two underscore-separated
+					// parts of the stem.
+					stem := strings.TrimSuffix(s.Filename, ".zip")
+					parts := strings.Split(stem, "_")
+					if len(parts) < 2 {
+						continue
+					}
+					platformKey := parts[len(parts)-2] + "_" + parts[len(parts)-1]
+
+					if _, alreadyMirrored := archives[platformKey]; alreadyMirrored {
+						// Platform is physically synced locally; its entry already has
+						// a full URL + h1: + zh: — no enrichment needed.
+						continue
+					}
+
+					archives[platformKey] = gin.H{
+						"url":    upstreamBase + "/" + s.Filename,
+						"hashes": []string{formatZhHash(s.SHA256Hex)},
+					}
+				}
 			}
 		}
 

--- a/backend/internal/db/migrations/000011_provider_version_shasums.down.sql
+++ b/backend/internal/db/migrations/000011_provider_version_shasums.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS provider_version_shasums;

--- a/backend/internal/db/migrations/000011_provider_version_shasums.up.sql
+++ b/backend/internal/db/migrations/000011_provider_version_shasums.up.sql
@@ -1,0 +1,14 @@
+-- Stores the full SHA256SUMS entry set for a provider version as fetched and
+-- GPG-verified during mirror sync.  Persisting all entries (including
+-- platforms that are not mirrored locally) lets the Network Mirror Protocol
+-- endpoint serve zh: hashes for every platform in the upstream release, so
+-- clients can build a complete cross-platform lock file from this mirror alone.
+CREATE TABLE provider_version_shasums (
+    provider_version_id UUID    NOT NULL REFERENCES provider_versions(id) ON DELETE CASCADE,
+    filename            TEXT    NOT NULL,
+    sha256_hex          TEXT    NOT NULL,
+    PRIMARY KEY (provider_version_id, filename)
+);
+
+COMMENT ON TABLE provider_version_shasums IS
+    'Per-file SHA256 checksums from the upstream HashiCorp SHA256SUMS file, stored verbatim after GPG verification during mirror sync.';

--- a/backend/internal/db/models/provider.go
+++ b/backend/internal/db/models/provider.go
@@ -45,6 +45,16 @@ type ProviderVersion struct {
 	PublishedByName *string // User name who published this version (joined from users table)
 }
 
+// ProviderVersionShasum holds one entry from the upstream SHA256SUMS file for a
+// provider version.  All entries are stored verbatim (including platforms that
+// are not locally mirrored) so the Network Mirror Protocol endpoint can serve
+// zh: hashes for every platform in the upstream release.
+type ProviderVersionShasum struct {
+	ProviderVersionID string // FK → provider_versions.id
+	Filename          string // e.g. "terraform-provider-aws_6.35.1_linux_amd64.zip"
+	SHA256Hex         string // lowercase hex SHA256 of the zip archive
+}
+
 // ProviderPlatform represents a platform-specific binary for a provider version
 type ProviderPlatform struct {
 	ID                string

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -732,6 +732,75 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 	return results, total, nil
 }
 
+// UpsertProviderVersionShasums stores the full set of filename→sha256hex entries
+// from an upstream SHA256SUMS file for a provider version.  Using an upsert
+// means it is safe to call on both new syncs and re-syncs; existing rows are
+// silently overwritten with the latest checksum values.
+func (r *ProviderRepository) UpsertProviderVersionShasums(ctx context.Context, versionID string, shasums map[string]string) error {
+	if len(shasums) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO provider_version_shasums (provider_version_id, filename, sha256_hex)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (provider_version_id, filename) DO UPDATE SET sha256_hex = EXCLUDED.sha256_hex
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare upsert statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for filename, sha256hex := range shasums {
+		if _, err := stmt.ExecContext(ctx, versionID, filename, sha256hex); err != nil {
+			return fmt.Errorf("failed to upsert shasum for %s: %w", filename, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit shasums transaction: %w", err)
+	}
+	return nil
+}
+
+// ListProviderVersionShasums returns all SHA256SUMS entries stored for a
+// provider version, ordered by filename.
+func (r *ProviderRepository) ListProviderVersionShasums(ctx context.Context, versionID string) ([]models.ProviderVersionShasum, error) {
+	query := `
+		SELECT provider_version_id, filename, sha256_hex
+		FROM provider_version_shasums
+		WHERE provider_version_id = $1
+		ORDER BY filename
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list provider version shasums: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.ProviderVersionShasum
+	for rows.Next() {
+		var s models.ProviderVersionShasum
+		if err := rows.Scan(&s.ProviderVersionID, &s.Filename, &s.SHA256Hex); err != nil {
+			return nil, fmt.Errorf("failed to scan provider version shasum: %w", err)
+		}
+		result = append(result, s)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating provider version shasums: %w", err)
+	}
+
+	return result, nil
+}
+
 // compareSemver compares two semver strings
 // Returns: -1 if a < b, 0 if a == b, 1 if a > b
 func compareSemver(a, b string) int {

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -719,6 +719,13 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient *mirror
 			if pkgErr == nil {
 				shasumContent, _ := upstreamClient.DownloadFile(ctx, packageInfo.SHASumsURL)
 				shasumMap = parseSHASUMFile(string(shasumContent))
+				// Persist the full SHA256SUMS so the version JSON can serve zh: hashes
+				// for ALL platforms, including those not mirrored locally.
+				if len(shasumMap) > 0 {
+					if err := j.providerRepo.UpsertProviderVersionShasums(ctx, existingVersion.ID, shasumMap); err != nil {
+						log.Printf("Warning: failed to store SHA256SUMS for re-sync of %s/%s@%s: %v", namespace, providerName, version.Version, err)
+					}
+				}
 			} else {
 				log.Printf("Warning: failed to get package info for SHASUM for %s/%s@%s: %v", namespace, providerName, version.Version, pkgErr)
 			}
@@ -852,6 +859,15 @@ func (j *MirrorSyncJob) syncProviderVersion(
 
 	if err := j.providerRepo.CreateVersion(ctx, versionRecord); err != nil {
 		return fmt.Errorf("failed to create version record: %w", err)
+	}
+
+	// Persist the full SHA256SUMS map so the Network Mirror Protocol endpoint can
+	// serve zh: hashes for ALL platforms in the upstream release (not just the
+	// subset we sync locally).  A warning is logged on failure but is non-fatal.
+	if len(shasumMap) > 0 {
+		if err := j.providerRepo.UpsertProviderVersionShasums(ctx, versionRecord.ID, shasumMap); err != nil {
+			log.Printf("Warning: failed to store SHA256SUMS for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+		}
 	}
 
 	// Download and store each platform binary (using filtered platforms)


### PR DESCRIPTION
## Summary

- Adds a new `provider_version_shasums` table (migration 000011) to persist the full SHA256SUMS file content fetched and GPG-verified during mirror sync
- Updates mirror sync (both new-version and re-sync-missing-platforms paths) to call `UpsertProviderVersionShasums` after fetching and parsing the SHA256SUMS file
- Updates the Network Mirror Protocol `<version>.json` endpoint to include archives entries for **all 14 platforms** in the upstream SHA256SUMS — not only the subset physically synced to the mirror

**Before:** version JSON contained only synced platforms (e.g. `linux_amd64` + `windows_amd64`), each with `h1:` + `zh:`. Running `terraform init` on Windows produced a lock file with only 1 `h1:` hash.

**After:** version JSON contains all 14 platforms. Mirrored ones have our download URL + `h1:` + `zh:`. Unmirrored ones have the upstream HashiCorp CDN URL + `zh:` only. Running `terraform init` now gives Terraform access to `zh:` hashes for every platform, enabling a complete cross-platform lock file.

## Test plan

- [x] Build succeeds; migration 000011 applied (schema version → 11)
- [x] Re-sync of hashicorp/aws populates 15 rows per version in `provider_version_shasums`
- [x] `GET /terraform/providers/registry.terraform.io/hashicorp/aws/6.35.1.json` returns 14 platform entries (2 with `h1:` + `zh:`, 12 with `zh:` only)
- [ ] `terraform init` on clean test directory produces lock file with `zh:` hashes for all platforms