### PR TITLE
fix: restore provider download tracking for network mirror protocol (#36)

### DIFF
--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
@@ -252,6 +254,29 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			"archives": archives,
 		}
 
+		// Track provider downloads for storage backends that do not route through
+		// ServeFileHandler.  When local storage has ServeDirectly: true, Terraform
+		// fetches the binary via /v1/files/… and ServeFileHandler increments the
+		// counter there.  For every other configuration (S3, Azure, GCS, or local
+		// without ServeDirectly) the binary is delivered from a signed/external URL
+		// and ServeFileHandler is never called, so this is the only place to count it.
+		if cfg.Storage.DefaultBackend != "local" || !cfg.Storage.Local.ServeDirectly {
+			if clientOS, clientArch := parseTerraformPlatform(c.GetHeader("User-Agent")); clientOS != "" {
+				for _, platform := range platforms {
+					if platform.OS == clientOS && platform.Arch == clientArch {
+						platformID := platform.ID
+						go func() {
+							if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
+								slog.Error("failed to increment download count for mirror provider", "error", err)
+							}
+						}()
+						telemetry.ProviderDownloadsTotal.WithLabelValues(namespace, providerType, clientOS, clientArch).Inc()
+						break
+					}
+				}
+			}
+		}
+
 		// Audit log the mirror platform index request asynchronously
 		if auditRepo != nil {
 			resourceType := "provider"
@@ -293,4 +318,23 @@ func formatZhHash(hexChecksum string) string {
 		return ""
 	}
 	return "zh:" + hexChecksum
+}
+
+// terraformPlatformRe matches the OS/arch pair in a Terraform/OpenTofu User-Agent string.
+// Terraform sends User-Agent headers in one of these forms:
+//
+//	Terraform/1.5.0 (+https://www.terraform.io) linux_amd64
+//	OpenTofu/1.6.0 linux_arm64
+//
+// The regex captures (os)_(arch) from the trailing platform token.
+var terraformPlatformRe = regexp.MustCompile(`(?:Terraform|OpenTofu)/\S+.*?\b([a-z]+)_([a-z0-9]+)`)
+
+// parseTerraformPlatform extracts (os, arch) from a Terraform/OpenTofu User-Agent.
+// Returns ("", "") if the header is absent or does not match.
+func parseTerraformPlatform(ua string) (string, string) {
+	m := terraformPlatformRe.FindStringSubmatch(ua)
+	if m == nil {
+		return "", ""
+	}
+	return m[1], m[2]
 }


### PR DESCRIPTION
Closes #36

## Root cause

`dade1ff` (v0.2.3) moved `IncrementDownloadCount` from `PlatformIndexHandler` to `ServeFileHandler`. `ServeFileHandler` is only reached when local storage has `ServeDirectly: true` (because `local.GetURL` only returns `/v1/files/…` URLs in that configuration). For S3, Azure Blob, GCS, and local storage without `ServeDirectly`, the binary is fetched from a signed/external URL — `ServeFileHandler` is never called, so `download_count` in `provider_platforms` was never incremented.

`cb62a3e` (also v0.2.3) added audit logging to `PlatformIndexHandler`, which made the audit log appear active (one entry per mirror index request) while the counter stayed at zero for affected configurations. This is why audit logs show many downloads but the dashboard showed only 2 (the 2 that happened via the direct registry protocol, which was never broken).

## Fix

Restore the User-Agent platform detection (`parseTerraformPlatform` / `terraformPlatformRe`) and `IncrementDownloadCount` call to `PlatformIndexHandler`, guarded by:

```go
if cfg.Storage.DefaultBackend != "local" || !cfg.Storage.Local.ServeDirectly {
```

This fires for every storage backend that does **not** route downloads through `ServeFileHandler`, eliminating double-counting for `local + ServeDirectly: true` users while restoring accurate tracking for all other configurations (S3, Azure, GCS, local without ServeDirectly).

## Testing

- All existing tests pass (`go test ./...` — 69.5% coverage, above the 65% threshold)
- `go vet ./...` clean
- `gosec ./...` — 6 pre-existing findings, none in the changed file

## Changelog
- fix: restore provider download count tracking for network mirror protocol when using S3, Azure, GCS, or local storage without ServeDirectly