### PR TITLE
fix: make mirror provider lookup deterministic

### DIFF
--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -66,6 +66,7 @@ func (r *ProviderRepository) GetProvider(ctx context.Context, orgID, namespace, 
 		FROM providers p
 		LEFT JOIN users u ON p.created_by = u.id
 		WHERE (p.organization_id = $1 OR p.organization_id IS NULL) AND p.namespace = $2 AND p.type = $3
+		ORDER BY CASE WHEN p.organization_id = $1 THEN 0 ELSE 1 END, p.created_at DESC
 		LIMIT 1
 	`
 

--- a/backend/internal/db/repositories/provider_repository_test.go
+++ b/backend/internal/db/repositories/provider_repository_test.go
@@ -152,6 +152,36 @@ func TestGetProvider_DBError(t *testing.T) {
 	}
 }
 
+func TestGetProvider_QueryIncludesDeterministicOrdering(t *testing.T) {
+	repo, mock := newProviderRepo(t)
+	mock.ExpectQuery("ORDER BY CASE WHEN p.organization_id = \\$1 THEN 0 ELSE 1 END").
+		WillReturnRows(sampleProviderRow())
+
+	_, err := repo.GetProvider(context.Background(), "org-1", "hashicorp", "aws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetProvider_ScansOrganizationIDWhenPresent(t *testing.T) {
+	repo, mock := newProviderRepo(t)
+	rows := sqlmock.NewRows(providerCols).
+		AddRow("prov-2", "org-1", "hashicorp", "aws", nil, nil, nil, time.Now(), time.Now(), nil)
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").
+		WillReturnRows(rows)
+
+	p, err := repo.GetProvider(context.Background(), "org-1", "hashicorp", "aws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatal("expected provider, got nil")
+	}
+	if p.OrganizationID != "org-1" {
+		t.Errorf("OrganizationID = %q, want org-1", p.OrganizationID)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetVersion
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes nondeterministic provider selection in mirror protocol lookups when both org-scoped and NULL-org providers exist.

## Validation
- go vet ./...
- go test ./internal/db/repositories -cover
- go test ./internal/api/mirror -cover
- go test ./internal/jobs -cover
- gosec ./internal/db/repositories/...

## Changelog
- fix: make mirror provider lookup deterministic to prevent mirror version/index mismatch errors during terraform init