### PR TITLE
fix: reset stale in_progress mirror sync status on backend startup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Normalize line endings to LF in the repo; check out as-is on all platforms.
+* text=auto eol=lf
+
+# Explicitly LF for Go and common text files
+*.go    text eol=lf
+*.mod   text eol=lf
+*.sum   text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.json  text eol=lf
+*.toml  text eol=lf
+*.sql   text eol=lf
+*.sh    text eol=lf
+*.env   text eol=lf
+*.txt   text eol=lf
+
+# Binary files — never touch line endings
+*.zip   binary
+*.tar   binary
+*.gz    binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.exe   binary

--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -208,6 +208,37 @@ func (r *MirrorRepository) UpdateSyncStatus(ctx context.Context, id uuid.UUID, s
 	return nil
 }
 
+// ResetStaleSyncs resets mirrors stuck in 'in_progress' state due to a previous process crash.
+// It marks the stale mirror_sync_history records as 'failed' and resets mirror_configurations
+// so they will be picked up by the next scheduled sync.
+func (r *MirrorRepository) ResetStaleSyncs(ctx context.Context) (int64, error) {
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE mirror_sync_history
+		SET status = 'failed',
+		    completed_at = NOW(),
+		    error_message = 'Sync interrupted: backend process restarted'
+		WHERE status = 'running'
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reset stale sync history: %w", err)
+	}
+
+	historyRows, _ := result.RowsAffected()
+
+	_, err = r.db.ExecContext(ctx, `
+		UPDATE mirror_configurations
+		SET last_sync_status = 'failed',
+		    last_sync_error = 'Sync interrupted: backend process restarted',
+		    updated_at = NOW()
+		WHERE last_sync_status = 'in_progress'
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reset stale mirror sync status: %w", err)
+	}
+
+	return historyRows, nil
+}
+
 // GetMirrorsNeedingSync retrieves mirror configurations that need to be synced
 func (r *MirrorRepository) GetMirrorsNeedingSync(ctx context.Context) ([]models.MirrorConfiguration, error) {
 	query := `

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -288,6 +288,13 @@ func NewMirrorSyncJob(
 func (j *MirrorSyncJob) Start(ctx context.Context, intervalMinutes int) {
 	log.Printf("Starting mirror sync job with interval of %d minutes", intervalMinutes)
 
+	// Reset any syncs left in 'in_progress' / 'running' state from a previous process crash.
+	if n, err := j.mirrorRepo.ResetStaleSyncs(ctx); err != nil {
+		log.Printf("Warning: failed to reset stale syncs on startup: %v", err)
+	} else if n > 0 {
+		log.Printf("Reset %d stale sync history record(s) from previous process", n)
+	}
+
 	j.wg.Add(1)
 	go func() {
 		close(j.startedCh) // signal that the goroutine is running (wg.Add already done)


### PR DESCRIPTION
Closes #41

When the backend restarts mid-sync, `mirror_configurations.last_sync_status` is left as `in_progress` and the scheduler permanently skips the mirror. This adds startup cleanup to recover automatically.

## Changelog
- fix: reset stale `in_progress` mirror sync status on startup so mirrors are automatically re-scheduled after a backend restart or ECS task replacement
- chore: add `.gitattributes` to enforce LF line endings repo-wide