### PR TITLE
fix: correct helm probe path from /healthz to /health

### DIFF
--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -63,13 +63,13 @@ spec:
           {{- end }}
           startupProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: http
             periodSeconds: 5
             failureThreshold: 12
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: http
             periodSeconds: 30
             timeoutSeconds: 5


### PR DESCRIPTION
Closes #44

## Changelog
- fix: correct helm liveness and startup probe path from /healthz to /health