### PR TITLE
fix: make frontend pod security context configurable via values

### DIFF
--- a/deployments/helm/templates/deployment-frontend.yaml
+++ b/deployments/helm/templates/deployment-frontend.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        {{- with .Values.frontend.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: frontend
           image: {{ include "terraform-registry.frontendImage" . }}


### PR DESCRIPTION
## Summary

- Adds `{{- with .Values.frontend.podSecurityContext }}` merge into the pod-level security context in the frontend deployment template
- Enables AKS deployments to set `runAsUser: 101` via values to avoid nginx setuid/setgid failures when capabilities are dropped

## Changelog

### Fixed
- fix: make frontend pod security context configurable via Helm values to support rootless nginx on AKS (#47)

## Test plan
- [ ] CI passes
- [ ] Frontend pod starts on AKS with `runAsUser: 101` in values