### PR TITLE
fix: run frontend nginx on port 8080 for rootless container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.8] - 2026-03-17
+
+### Fixed
+
+- fix: make frontend pod security context configurable via Helm values to support rootless nginx on AKS (#47)
+
+---
+
 ## [0.2.7] - 2026-03-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,23 @@ When a release is called for:
    > Tagging on `development` before the merge leaves the tag pointing at the wrong commit —
    > it will never appear in `main`'s history as a tagged release.
 
+7. **Trigger the release workflow.** The `push` tag trigger can silently fail if the tag was
+   previously pushed pointing to a different commit. Always verify the workflow fired within
+   ~60 seconds by checking:
+
+   ```bash
+   gh run list --workflow=release.yml --limit=3
+   ```
+
+   If no new run appears, trigger it manually:
+
+   ```bash
+   gh workflow run release.yml --ref vX.Y.Z
+   ```
+
+   The workflow will: run CI → build multi-platform binaries → push Docker image to
+   `ghcr.io/sethbacon/terraform-registry-backend:vX.Y.Z` → create a GitHub Release.
+
 ---
 
 ## Project Overview

--- a/deployments/helm/templates/configmap-frontend-nginx.yaml
+++ b/deployments/helm/templates/configmap-frontend-nginx.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   default.conf: |
     server {
-        listen 80;
+        listen 8080;
         server_name _;
         root /usr/share/nginx/html;
         index index.html;

--- a/deployments/helm/templates/deployment-frontend.yaml
+++ b/deployments/helm/templates/deployment-frontend.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        {{- with .Values.frontend.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: frontend
           image: {{ include "terraform-registry.frontendImage" . }}

--- a/deployments/helm/templates/deployment-frontend.yaml
+++ b/deployments/helm/templates/deployment-frontend.yaml
@@ -36,11 +36,9 @@ spec:
             capabilities:
               drop:
                 - ALL
-              add:
-                - NET_BIND_SERVICE
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Summary

- Change nginx listen port from 80 to 8080 in the frontend ConfigMap
- Change containerPort from 80 to 8080 in the frontend Deployment
- Remove `NET_BIND_SERVICE` capability (not needed for port > 1023)
- Service external port remains 80 via `targetPort: http` named port mapping

Non-root processes can bind to ports > 1023 without any capabilities, making this the correct fix for running nginx as uid 101.

## Changelog

### Fixed
- fix: run frontend nginx on port 8080 so non-root container can bind without NET_BIND_SERVICE capability (#49)

## Test plan
- [ ] CI passes
- [ ] Frontend pod starts without permission errors on AKS