### PR TITLE
fix: setup wizard storage FK violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.10] - 2026-03-17
+
+### Fixed
+
+- fix: resolve FK violation in `SetStorageConfigured` where `uuid.Nil` violated the `storage_configured_by → users(id)` FK, silently leaving `storage_configured = false` after a successful setup wizard save (#51)
+- fix: log encryption error when storage credential encryption fails in setup wizard (#51)
+
+---
+
 ## [0.2.9] - 2026-03-17
 
 ### Fixed

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -357,6 +357,7 @@ func (h *Handlers) SaveStorageConfig(c *gin.Context) {
 	// Encrypt sensitive fields
 	storageCfg, err := h.buildEncryptedStorageConfig(&input)
 	if err != nil {
+		slog.Error("setup: failed to encrypt storage credentials", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt storage credentials"})
 		return
 	}

--- a/backend/internal/db/repositories/storage_config_repository.go
+++ b/backend/internal/db/repositories/storage_config_repository.go
@@ -46,13 +46,16 @@ func (r *StorageConfigRepository) IsStorageConfigured(ctx context.Context) (bool
 	return configured, err
 }
 
-// SetStorageConfigured marks storage as configured
+// SetStorageConfigured marks storage as configured.
+// storage_configured_by is nullable; uuid.Nil (all zeros) is treated as NULL so
+// that the FK to users(id) is not violated during initial setup when no user
+// exists yet.
 func (r *StorageConfigRepository) SetStorageConfigured(ctx context.Context, userID uuid.UUID) error {
 	query := `
 		UPDATE system_settings SET
 			storage_configured = true,
 			storage_configured_at = $1,
-			storage_configured_by = $2,
+			storage_configured_by = NULLIF($2, '00000000-0000-0000-0000-000000000000'::uuid),
 			updated_at = $1
 		WHERE id = 1`
 


### PR DESCRIPTION
Fixes #51

## Changes
- `SetStorageConfigured`: use `NULLIF` to store NULL instead of `uuid.Nil` for `storage_configured_by`, preventing FK violation against `users(id)` during setup when no user exists yet
- `SaveStorageConfig`: add missing `slog.Error` for encryption failure path