### PR TITLE
fix: AuditMiddleware logs failed writes when LogFailedRequests=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.11] - 2026-03-17
+
+### Fixed
+
+- fix: AuditMiddleware logs failed write operations even when `LogFailedRequests=false` — removed erroneous `&& isReadOp` guard from the failed-request skip condition (#29)
+
+---
+
 ## [0.2.10] - 2026-03-17
 
 ### Fixed

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -47,8 +47,8 @@ func AuditMiddlewareWithShipper(auditRepo *repositories.AuditRepository, shipper
 			if isReadOp && !logReadOps {
 				return
 			}
-			if isFailed && !logFailedReqs && isReadOp {
-				// Skip failed read operations if not configured to log them
+			if isFailed && !logFailedReqs {
+				// Skip failed operations if not configured to log them
 				return
 			}
 		}

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/audit"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
 // captureShipper collects audit log entries via a buffered channel.
@@ -140,6 +141,27 @@ func TestAuditMiddleware_FailedPostSkippedWithNilConfig(t *testing.T) {
 	select {
 	case <-cs.ch:
 		t.Error("shipper called for failed POST with nil config, want no shipping")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAuditMiddleware_FailedWriteSkippedWhenLogFailedRequestsFalse(t *testing.T) {
+	// Regression test for #29: failed write operations were logged even when
+	// LogFailedRequests=false because the guard condition incorrectly required
+	// isReadOp to also be true before skipping.
+	cs := newCaptureShipper(1)
+	cfg := &config.AuditConfig{LogFailedRequests: false, LogReadOperations: false}
+	r := gin.New()
+	r.Use(AuditMiddlewareWithShipper(nil, cs, cfg))
+	r.POST("/modules/test", func(c *gin.Context) { c.Status(http.StatusBadRequest) })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/modules/test", nil)
+	r.ServeHTTP(w, req)
+
+	select {
+	case <-cs.ch:
+		t.Error("shipper called for failed POST with LogFailedRequests=false, want no shipping")
 	case <-time.After(100 * time.Millisecond):
 	}
 }


### PR DESCRIPTION
Closes #29

Removes the erroneous `&& isReadOp` guard from the failed-request skip condition — failed write operations (POST/PUT/DELETE) were being logged even when `LogFailedRequests=false`.

Also adds a regression test to prevent recurrence.