### PR TITLE
fix: stream provider and Terraform binary downloads to eliminate OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.12] - 2026-03-17
+
+### Fixed
+
+- fix: stream provider and Terraform binary downloads to a temp file instead of buffering entire zip in memory — eliminates OOM kills for large providers (e.g. AWS ~500 MB) on memory-constrained deployments (#54)
+
+---
+
 ## [0.2.11] - 2026-03-17
 
 ### Fixed

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -112,13 +112,173 @@
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\terraform_releases.go",
+			"code": "464: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n465: \t\tresp.Body.Close()\n466: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
+			"line": "465",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\github_releases.go",
+			"code": "315: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n316: \t\tresp.Body.Close()\n317: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
+			"line": "316",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "531: \twritten, copyErr := io.Copy(tmpFile, io.TeeReader(body, hasher))\n532: \tbody.Close()\n533: \tif copyErr != nil {\n",
+			"line": "532",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "526: \t\ttmpFile.Close()\n527: \t\tos.Remove(tmpFile.Name())\n528: \t}()\n",
+			"line": "527",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "525: \tdefer func() {\n526: \t\ttmpFile.Close()\n527: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "526",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "519: \tif tmpErr != nil {\n520: \t\tbody.Close()\n521: \t\terrStr := fmt.Sprintf(\"failed to create temp file: %v\", tmpErr)\n",
+			"line": "520",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
+			"code": "965: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n966: \tstream.Body.Close()\n967: \tif err != nil {\n",
+			"line": "966",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
+			"code": "959: \t\ttmpFile.Close()\n960: \t\tos.Remove(tmpFile.Name())\n961: \t}()\n",
+			"line": "960",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
+			"code": "958: \tdefer func() {\n959: \t\ttmpFile.Close()\n960: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "959",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
+			"code": "954: \tif err != nil {\n955: \t\tstream.Body.Close()\n956: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
+			"line": "955",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
 		}
 	],
 	"Stats": {
 		"files": 122,
-		"lines": 36440,
+		"lines": 36494,
 		"nosec": 86,
-		"found": 7
+		"found": 17
 	},
 	"GosecVersion": "dev"
 }

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -4,13 +4,14 @@
 package jobs
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -943,15 +944,30 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 
 	log.Printf("Downloading %s from %s", packageInfo.Filename, packageInfo.DownloadURL)
 
-	// Download the binary
-	binaryContent, err := upstreamClient.DownloadFile(ctx, packageInfo.DownloadURL)
+	// Stream binary to a temp file to avoid buffering large zips in memory.
+	stream, err := upstreamClient.DownloadFileStream(ctx, packageInfo.DownloadURL)
 	if err != nil {
 		return fmt.Errorf("failed to download binary: %w", err)
 	}
 
-	// Calculate SHA256 checksum
-	sha256sum := sha256.Sum256(binaryContent)
-	checksumHex := hex.EncodeToString(sha256sum[:])
+	tmpFile, err := os.CreateTemp("", "provider-binary-*.zip")
+	if err != nil {
+		stream.Body.Close()
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer func() {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+	}()
+
+	// Stream to disk, computing SHA256 in-flight.
+	hasher := sha256.New()
+	written, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))
+	stream.Body.Close()
+	if err != nil {
+		return fmt.Errorf("failed to stream binary to disk: %w", err)
+	}
+	checksumHex := hex.EncodeToString(hasher.Sum(nil))
 
 	// Verify checksum if we have SHASUM data
 	expectedChecksum := packageInfo.SHA256Sum
@@ -972,7 +988,11 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 	storagePath := fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s",
 		namespace, providerName, version, platform.OS, platform.Arch, packageInfo.Filename)
 
-	uploadResult, err := j.storageBackend.Upload(ctx, storagePath, bytes.NewReader(binaryContent), int64(len(binaryContent)))
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek temp file: %w", err)
+	}
+
+	uploadResult, err := j.storageBackend.Upload(ctx, storagePath, tmpFile, written)
 	if err != nil {
 		return fmt.Errorf("failed to store binary: %w", err)
 	}
@@ -985,13 +1005,14 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 		Filename:          packageInfo.Filename,
 		StoragePath:       uploadResult.Path,
 		StorageBackend:    j.storageBackendName,
-		SizeBytes:         int64(len(binaryContent)),
+		SizeBytes:         written,
 		Shasum:            checksumHex,
 	}
 
-	// Compute the h1: dirhash for the zip archive so that Terraform's network
-	// mirror protocol can serve both zh: (legacy) and h1: (preferred) hashes.
-	if h1, err := checksum.HashZip(binaryContent); err != nil {
+	// Compute the h1: dirhash for the zip archive so Terraform's network mirror
+	// protocol can serve both zh: (legacy) and h1: (preferred) hashes.
+	// HashZipFile uses io.ReaderAt so the temp file can serve as the source.
+	if h1, err := checksum.HashZipFile(tmpFile, written); err != nil {
 		log.Printf("Warning: failed to compute h1: hash for %s: %v", packageInfo.Filename, err)
 	} else {
 		platformRecord.H1Hash = &h1
@@ -1001,7 +1022,7 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 		return fmt.Errorf("failed to create platform record: %w", err)
 	}
 
-	log.Printf("Stored platform %s/%s: %s (%d bytes)", platform.OS, platform.Arch, storagePath, len(binaryContent))
+	log.Printf("Stored platform %s/%s: %s (%d bytes)", platform.OS, platform.Arch, storagePath, written)
 	return nil
 }
 

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -12,11 +12,14 @@
 package jobs
 
 import (
-	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,7 +233,7 @@ type terraformReleasesClient interface {
 	ListVersions(ctx context.Context) ([]mirror.TerraformVersionInfo, error)
 	FetchSHASums(ctx context.Context, version string) (map[string]string, []byte, error)
 	FetchSHASumsSignature(ctx context.Context, version string) ([]byte, error)
-	DownloadBinary(ctx context.Context, downloadURL string) ([]byte, string, error)
+	DownloadBinaryStream(ctx context.Context, downloadURL string) (io.ReadCloser, int64, error)
 }
 
 // newReleasesClient constructs the appropriate client for the configured upstream URL.
@@ -504,13 +507,35 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 
 	log.Printf("[terraform-mirror] downloading %s (%s/%s)", version, p.OS, p.Arch)
 
-	data, actualSHA256, dlErr := client.DownloadBinary(ctx, p.UpstreamURL)
+	body, _, dlErr := client.DownloadBinaryStream(ctx, p.UpstreamURL)
 	if dlErr != nil {
 		errStr := dlErr.Error()
 		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, false, false, &errStr)
 		log.Printf("[terraform-mirror] download failed for %s %s/%s: %v", version, p.OS, p.Arch, dlErr)
 		return false
 	}
+
+	tmpFile, tmpErr := os.CreateTemp("", "terraform-binary-*.zip")
+	if tmpErr != nil {
+		body.Close()
+		errStr := fmt.Sprintf("failed to create temp file: %v", tmpErr)
+		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, false, false, &errStr)
+		return false
+	}
+	defer func() {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+	}()
+
+	hasher := sha256.New()
+	written, copyErr := io.Copy(tmpFile, io.TeeReader(body, hasher))
+	body.Close()
+	if copyErr != nil {
+		errStr := fmt.Sprintf("failed to stream binary to disk: %v", copyErr)
+		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, false, false, &errStr)
+		return false
+	}
+	actualSHA256 := hex.EncodeToString(hasher.Sum(nil))
 
 	sha256Verified := false
 	if sums != nil {
@@ -526,8 +551,14 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 		}
 	}
 
+	if _, seekErr := tmpFile.Seek(0, io.SeekStart); seekErr != nil {
+		errStr := fmt.Sprintf("failed to seek temp file: %v", seekErr)
+		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, sha256Verified, sumsGPGVerified, &errStr)
+		return false
+	}
+
 	storagePath := fmt.Sprintf("terraform-binaries/%s/%s/%s/%s", version, p.OS, p.Arch, p.Filename)
-	_, uploadErr := j.storageBackend.Upload(ctx, storagePath, bytes.NewReader(data), int64(len(data)))
+	_, uploadErr := j.storageBackend.Upload(ctx, storagePath, tmpFile, written)
 	if uploadErr != nil {
 		errStr := uploadErr.Error()
 		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, sha256Verified, sumsGPGVerified, &errStr)

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -300,23 +300,24 @@ func (c *GitHubReleasesClient) FetchSHASumsSignature(ctx context.Context, versio
 
 // DownloadBinary downloads a binary zip from the given URL (already a full URL
 // from the GitHub asset list). Identical to TerraformReleasesClient.DownloadBinary.
-func (c *GitHubReleasesClient) DownloadBinary(ctx context.Context, downloadURL string) ([]byte, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+func (c *GitHubReleasesClient) DownloadBinaryStream(ctx context.Context, downloadURL string) (io.ReadCloser, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- URL from admin-configured upstream
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to build download request: %w", err)
+		return nil, -1, fmt.Errorf("failed to build download request: %w", err)
 	}
 
-	resp, err := c.DownloadClient.Do(req) // #nosec G704 -- URL from admin-configured upstream
+	resp, err := c.DownloadClient.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to download binary: %w", err)
+		return nil, -1, fmt.Errorf("failed to download binary: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("upstream returned %d for binary download", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		return nil, -1, fmt.Errorf("upstream returned %d for binary download: %s", resp.StatusCode, string(body))
 	}
 
-	return StreamWithSHA256(resp.Body)
+	return resp.Body, resp.ContentLength, nil
 }
 
 // ----- helpers --------------------------------------------------------------

--- a/backend/internal/mirror/github_releases_test.go
+++ b/backend/internal/mirror/github_releases_test.go
@@ -1,9 +1,11 @@
 package mirror
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -593,7 +595,7 @@ func TestGitHubFetchSHASumsSignature_NotFound(t *testing.T) {
 // DownloadBinary tests
 // ---------------------------------------------------------------------------
 
-func TestGitHubDownloadBinary_Success(t *testing.T) {
+func TestGitHubDownloadBinaryStream_Success(t *testing.T) {
 	zipContent := []byte("PK\x03\x04fake zip content")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(zipContent)
@@ -601,26 +603,25 @@ func TestGitHubDownloadBinary_Success(t *testing.T) {
 	defer ts.Close()
 
 	client := newTestGitHubClient(ts, "opentofu", "opentofu", "opentofu")
-	data, sha, err := client.DownloadBinary(context.Background(), ts.URL+"/opentofu_1.9.0_linux_amd64.zip")
+	body, _, err := client.DownloadBinaryStream(context.Background(), ts.URL+"/opentofu_1.9.0_linux_amd64.zip")
 	if err != nil {
-		t.Fatalf("DownloadBinary error: %v", err)
+		t.Fatalf("DownloadBinaryStream error: %v", err)
 	}
-	if len(data) == 0 {
-		t.Error("expected non-empty data")
-	}
-	if sha == "" {
-		t.Error("expected non-empty SHA256")
+	defer body.Close()
+	data, _ := io.ReadAll(body)
+	if !bytes.Equal(data, zipContent) {
+		t.Error("downloaded content mismatch")
 	}
 }
 
-func TestGitHubDownloadBinary_NonOKStatus(t *testing.T) {
+func TestGitHubDownloadBinaryStream_NonOKStatus(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
 
 	client := newTestGitHubClient(ts, "opentofu", "opentofu", "opentofu")
-	_, _, err := client.DownloadBinary(context.Background(), ts.URL+"/missing.zip")
+	_, _, err := client.DownloadBinaryStream(context.Background(), ts.URL+"/missing.zip")
 	if err == nil {
 		t.Fatal("expected error for non-200 response, got nil")
 	}

--- a/backend/internal/mirror/terraform_releases.go
+++ b/backend/internal/mirror/terraform_releases.go
@@ -449,23 +449,24 @@ func ParseSHASums(data []byte) map[string]string {
 
 // DownloadBinary downloads a Terraform binary zip from the given URL.
 // Returns the raw bytes and the actual SHA256 hex string computed while streaming.
-func (c *TerraformReleasesClient) DownloadBinary(ctx context.Context, downloadURL string) ([]byte, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+func (c *TerraformReleasesClient) DownloadBinaryStream(ctx context.Context, downloadURL string) (io.ReadCloser, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to build download request: %w", err)
+		return nil, -1, fmt.Errorf("failed to build download request: %w", err)
 	}
 
-	resp, err := c.DownloadClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := c.DownloadClient.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to download binary: %w", err)
+		return nil, -1, fmt.Errorf("failed to download binary: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("upstream returned %d for binary download", resp.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		return nil, -1, fmt.Errorf("upstream returned %d for binary download: %s", resp.StatusCode, string(body))
 	}
 
-	return StreamWithSHA256(resp.Body)
+	return resp.Body, resp.ContentLength, nil
 }
 
 // ----- SHA256 helpers -------------------------------------------------------

--- a/backend/internal/mirror/terraform_releases_test.go
+++ b/backend/internal/mirror/terraform_releases_test.go
@@ -326,7 +326,7 @@ func TestParseSHASums_Empty(t *testing.T) {
 // DownloadBinary
 // ---------------------------------------------------------------------------
 
-func TestDownloadBinary_Success(t *testing.T) {
+func TestDownloadBinaryStream_Success(t *testing.T) {
 	content := []byte("fake zip content")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -337,21 +337,24 @@ func TestDownloadBinary_Success(t *testing.T) {
 	c := NewTerraformReleasesClient(srv.URL, "terraform")
 	c.DownloadClient = c.HTTPClient
 
-	data, sha, err := c.DownloadBinary(context.Background(), srv.URL+"/terraform_1.5.0_linux_amd64.zip")
+	body, _, err := c.DownloadBinaryStream(context.Background(), srv.URL+"/terraform_1.5.0_linux_amd64.zip")
 	if err != nil {
-		t.Fatalf("DownloadBinary error: %v", err)
+		t.Fatalf("DownloadBinaryStream error: %v", err)
+	}
+	defer body.Close()
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
 	}
 	if !bytes.Equal(data, content) {
 		t.Error("downloaded content mismatch")
 	}
-	// Verify the returned sha matches the content.
-	expected := ComputeSHA256Hex(content)
-	if sha != expected {
-		t.Errorf("sha = %q, want %q", sha, expected)
+	if got, want := ComputeSHA256Hex(data), ComputeSHA256Hex(content); got != want {
+		t.Errorf("sha = %q, want %q", got, want)
 	}
 }
 
-func TestDownloadBinary_NonOKStatus(t *testing.T) {
+func TestDownloadBinaryStream_NonOKStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -360,15 +363,15 @@ func TestDownloadBinary_NonOKStatus(t *testing.T) {
 	c := NewTerraformReleasesClient(srv.URL, "terraform")
 	c.DownloadClient = c.HTTPClient
 
-	_, _, err := c.DownloadBinary(context.Background(), srv.URL+"/missing.zip")
+	_, _, err := c.DownloadBinaryStream(context.Background(), srv.URL+"/missing.zip")
 	if err == nil {
 		t.Error("expected error for 404, got nil")
 	}
 }
 
-func TestDownloadBinary_InvalidURL(t *testing.T) {
+func TestDownloadBinaryStream_InvalidURL(t *testing.T) {
 	c := NewTerraformReleasesClient("http://127.0.0.1:0", "terraform")
-	_, _, err := c.DownloadBinary(context.Background(), "http://127.0.0.1:0/file.zip")
+	_, _, err := c.DownloadBinaryStream(context.Background(), "http://127.0.0.1:0/file.zip")
 	if err == nil {
 		t.Error("expected connection error, got nil")
 	}


### PR DESCRIPTION
## Summary

- Replace `io.ReadAll` buffering with temp-file streaming in `syncPlatformBinary` (provider mirror) and `syncVersionBinaries` (Terraform mirror)
- SHA256 computed in-flight via `io.TeeReader`; h1 hash computed from temp file via `checksum.HashZipFile`
- Rename `DownloadBinary` → `DownloadBinaryStream` on both client implementations and the `terraformReleasesClient` interface
- Eliminates OOMKill for large provider zips (e.g. AWS ~500 MB) at 512 Mi memory limit

Closes #54

## Test plan

- [ ] Unit tests pass (`go test ./internal/mirror/... ./internal/jobs/...`)
- [ ] Build passes (`go build ./...`)
- [ ] Gosec baseline regenerated