### PR TITLE
fix: provider card shows latest semver version instead of latest uploaded version

### DIFF
--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -689,7 +689,12 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 		LEFT JOIN users u ON p.created_by = u.id
 		LEFT JOIN LATERAL (
 			SELECT
-				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id ORDER BY pv2.created_at DESC LIMIT 1) AS latest_version,
+				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id
+				 ORDER BY
+				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1) AS INTEGER) DESC,
+				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2) AS INTEGER) DESC,
+				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3) AS INTEGER) DESC
+				 LIMIT 1) AS latest_version,
 				(SELECT COALESCE(SUM(pp.download_count), 0) FROM provider_platforms pp
 				 JOIN provider_versions pv3 ON pp.provider_version_id = pv3.id
 				 WHERE pv3.provider_id = p.id) AS total_downloads


### PR DESCRIPTION
Closes #62

## Summary

`SearchProvidersWithStats` was ordering its `latest_version` subquery by `pv2.created_at DESC`, returning the most recently *uploaded* version rather than the highest *semver* version. Providers whose versions were mirrored, backfilled, or published out of order would display the wrong version on the provider card.

The subquery now sorts by integer major/minor/patch parts, matching the `compareSemver` logic already used by `ListVersions`.

## Changelog
- fix: provider card shows latest semver version instead of latest uploaded version