### PR TITLE
fix: sort versions by semver in module card, tf binary list, and mirror modal

### DIFF
--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -542,7 +542,10 @@ func (r *MirrorRepository) ListMirroredProviderVersions(ctx context.Context, mir
 		       synced_at, shasum_verified, gpg_verified
 		FROM mirrored_provider_versions
 		WHERE mirrored_provider_id = $1
-		ORDER BY synced_at DESC
+		ORDER BY
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
 	`
 
 	var versions []models.MirroredProviderVersion

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -539,7 +539,12 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 		LEFT JOIN users u ON m.created_by = u.id
 		LEFT JOIN LATERAL (
 			SELECT
-				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id ORDER BY mv2.created_at DESC LIMIT 1) AS latest_version,
+				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id
+			 ORDER BY
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			 LIMIT 1) AS latest_version,
 				SUM(mv.download_count) AS total_downloads
 			FROM module_versions mv
 			WHERE mv.module_id = m.id

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -691,9 +691,9 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 			SELECT
 				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id
 				 ORDER BY
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1) AS INTEGER) DESC,
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2) AS INTEGER) DESC,
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3) AS INTEGER) DESC
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
 				 LIMIT 1) AS latest_version,
 				(SELECT COALESCE(SUM(pp.download_count), 0) FROM provider_platforms pp
 				 JOIN provider_versions pv3 ON pp.provider_version_id = pv3.id

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -365,7 +365,7 @@ func (r *TerraformMirrorRepository) ListVersions(ctx context.Context, configID u
 		query += " AND sync_status = 'synced'"
 	}
 
-	query += " ORDER BY created_at DESC"
+	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC"
 
 	var versions []models.TerraformVersion
 	err := r.db.SelectContext(ctx, &versions, query, configID)


### PR DESCRIPTION
## Summary

Three additional version-ordering bugs matching the root cause of #62:

- **`SearchModulesWithStats`** — `latest_version` subquery used `mv2.created_at DESC`; module cards showed the most recently uploaded version instead of highest semver
- **`TerraformMirrorRepository.ListVersions`** — `ORDER BY created_at DESC`; binaries displayed in sync order rather than semver order
- **`ListMirroredProviderVersions`** — `ORDER BY synced_at DESC`; mirror detail modal showed versions in sync order

Also hardens the `SearchProvidersWithStats` fix from v0.2.15: all split-part casts now use `COALESCE(CAST(NULLIF(..., '') AS INTEGER), 0)` to guard against empty strings on short version strings.

## Changelog
- fix: sort versions by semver in module card, terraform binary list, and mirror config modal