### PR TITLE
chore: release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.16] - 2026-03-17
+
+### Fixed
+
+- fix: module card, terraform binary mirror list, and mirror config detail modal now sort versions by semver instead of upload/sync time — `SearchModulesWithStats`, `TerraformMirrorRepository.ListVersions`, and `ListMirroredProviderVersions` all used `created_at`/`synced_at` ordering
+- fix: harden semver sort in `SearchProvidersWithStats` (v0.2.15) to guard against empty split parts with `COALESCE(CAST(NULLIF(...) AS INTEGER), 0)`
+
+---
+
 ## [0.2.15] - 2026-03-17
 
 ### Fixed

--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -542,7 +542,10 @@ func (r *MirrorRepository) ListMirroredProviderVersions(ctx context.Context, mir
 		       synced_at, shasum_verified, gpg_verified
 		FROM mirrored_provider_versions
 		WHERE mirrored_provider_id = $1
-		ORDER BY synced_at DESC
+		ORDER BY
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
 	`
 
 	var versions []models.MirroredProviderVersion

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -539,7 +539,12 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 		LEFT JOIN users u ON m.created_by = u.id
 		LEFT JOIN LATERAL (
 			SELECT
-				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id ORDER BY mv2.created_at DESC LIMIT 1) AS latest_version,
+				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id
+			 ORDER BY
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			 LIMIT 1) AS latest_version,
 				SUM(mv.download_count) AS total_downloads
 			FROM module_versions mv
 			WHERE mv.module_id = m.id

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -691,9 +691,9 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 			SELECT
 				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id
 				 ORDER BY
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1) AS INTEGER) DESC,
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2) AS INTEGER) DESC,
-				   CAST(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3) AS INTEGER) DESC
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
 				 LIMIT 1) AS latest_version,
 				(SELECT COALESCE(SUM(pp.download_count), 0) FROM provider_platforms pp
 				 JOIN provider_versions pv3 ON pp.provider_version_id = pv3.id

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -365,7 +365,7 @@ func (r *TerraformMirrorRepository) ListVersions(ctx context.Context, configID u
 		query += " AND sync_status = 'synced'"
 	}
 
-	query += " ORDER BY created_at DESC"
+	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC"
 
 	var versions []models.TerraformVersion
 	err := r.db.SelectContext(ctx, &versions, query, configID)


### PR DESCRIPTION
## v0.2.16

### Fixed

- fix: module card, terraform binary mirror list, and mirror config detail modal now sort versions by semver instead of upload/sync time — `SearchModulesWithStats`, `TerraformMirrorRepository.ListVersions`, and `ListMirroredProviderVersions` all used `created_at`/`synced_at` ordering
- fix: harden semver sort in `SearchProvidersWithStats` (v0.2.15) to guard against empty split parts with `COALESCE(CAST(NULLIF(...) AS INTEGER), 0)`