### PR TITLE
fix: strip pre-release and build-metadata suffixes before semver CAST

### DIFF
--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -543,9 +543,9 @@ func (r *MirrorRepository) ListMirroredProviderVersions(ctx context.Context, mir
 		FROM mirrored_provider_versions
 		WHERE mirrored_provider_id = $1
 		ORDER BY
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 	`
 
 	var versions []models.MirroredProviderVersion

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -541,9 +541,9 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 			SELECT
 				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id
 			 ORDER BY
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 			 LIMIT 1) AS latest_version,
 				SUM(mv.download_count) AS total_downloads
 			FROM module_versions mv

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -691,9 +691,9 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 			SELECT
 				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id
 				 ORDER BY
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 				 LIMIT 1) AS latest_version,
 				(SELECT COALESCE(SUM(pp.download_count), 0) FROM provider_platforms pp
 				 JOIN provider_versions pv3 ON pp.provider_version_id = pv3.id

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -365,7 +365,7 @@ func (r *TerraformMirrorRepository) ListVersions(ctx context.Context, configID u
 		query += " AND sync_status = 'synced'"
 	}
 
-	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC"
+	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC"
 
 	var versions []models.TerraformVersion
 	err := r.db.SelectContext(ctx, &versions, query, configID)


### PR DESCRIPTION
Closes #69

## Summary

- Version strings like `5.0.0-beta` or `4.0.0-rc1` survive `NULLIF` (not empty) but break `CAST ... AS INTEGER` on the suffix-contaminated patch part (e.g. `0-beta`)
- Adds a second `REGEXP_REPLACE(..., '[-+].*$', '')` pass to reduce any version string to its clean `X.Y.Z` numeric core before `SPLIT_PART`
- Fixes the provider search 500 and the mirror detail "No providers synced" empty-state caused by the handler aborting on the inner `ListMirroredProviderVersions` error
- Applied consistently across all four affected repositories

## Changelog
- fix: semver sort no longer crashes on pre-release or build-metadata version strings (`5.0.0-beta`, `4.0.0-rc1`, `1.2.3+build`)