### PR TITLE
chore: release v0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.17] - 2026-03-17
+
+### Fixed
+
+- fix: semver sort no longer crashes on pre-release or build-metadata version strings (e.g. `5.0.0-beta`, `4.0.0-rc1`, `1.2.3+build`) — `NULLIF` only guarded against empty strings; the new `REGEXP_REPLACE(..., '[-+].*$', '')` strips suffixes before `SPLIT_PART` and `CAST` in all four semver `ORDER BY` expressions. Resolves the provider search 500 and the mirror detail "No providers synced" empty-state (#69)
+
+---
+
 ## [0.2.16] - 2026-03-17
 
 ### Fixed

--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -543,9 +543,9 @@ func (r *MirrorRepository) ListMirroredProviderVersions(ctx context.Context, mir
 		FROM mirrored_provider_versions
 		WHERE mirrored_provider_id = $1
 		ORDER BY
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(upstream_version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(upstream_version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 	`
 
 	var versions []models.MirroredProviderVersion

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -541,9 +541,9 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 			SELECT
 				(SELECT mv2.version FROM module_versions mv2 WHERE mv2.module_id = m.id
 			 ORDER BY
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(mv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+			   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(mv2.version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 			 LIMIT 1) AS latest_version,
 				SUM(mv.download_count) AS total_downloads
 			FROM module_versions mv

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -691,9 +691,9 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 			SELECT
 				(SELECT pv2.version FROM provider_versions pv2 WHERE pv2.provider_id = p.id
 				 ORDER BY
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC,
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC,
-				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(pv2.version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC,
+				   COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(pv2.version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC
 				 LIMIT 1) AS latest_version,
 				(SELECT COALESCE(SUM(pp.download_count), 0) FROM provider_platforms pp
 				 JOIN provider_versions pv3 ON pp.provider_version_id = pv3.id

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -365,7 +365,7 @@ func (r *TerraformMirrorRepository) ListVersions(ctx context.Context, configID u
 		query += " AND sync_status = 'synced'"
 	}
 
-	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(version, '^v', ''), '.', 3), '') AS INTEGER), 0) DESC"
+	query += " ORDER BY COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 1), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 2), '') AS INTEGER), 0) DESC, COALESCE(CAST(NULLIF(SPLIT_PART(REGEXP_REPLACE(REGEXP_REPLACE(version, '^v', ''), '[-+].*$', ''), '.', 3), '') AS INTEGER), 0) DESC"
 
 	var versions []models.TerraformVersion
 	err := r.db.SelectContext(ctx, &versions, query, configID)


### PR DESCRIPTION
## v0.2.17

### Fixed

- fix: semver sort no longer crashes on pre-release or build-metadata version strings (e.g. `5.0.0-beta`, `4.0.0-rc1`, `1.2.3+build`) — resolves provider search 500 and mirror detail "No providers synced" (#69)