### PR TITLE
fix: mirror Latest Version now shows highest semver, not first upstream version

### DIFF
--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -770,7 +770,13 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient *mirror
 	if mirroredProvider != nil {
 		mirroredProvider.LastSyncedAt = time.Now()
 		if len(versions) > 0 {
-			mirroredProvider.LastSyncVersion = &versions[0].Version
+			highest := versions[0].Version
+			for _, v := range versions[1:] {
+				if compareSemver(v.Version, highest) > 0 {
+					highest = v.Version
+				}
+			}
+			mirroredProvider.LastSyncVersion = &highest
 		}
 		if err := j.mirrorRepo.UpdateMirroredProvider(ctx, mirroredProvider); err != nil {
 			log.Printf("Warning: failed to update mirrored provider sync time for %s/%s: %v", namespace, providerName, err)


### PR DESCRIPTION
Closes #73

## Summary

`versions[0]` in `syncProvider` assumed the upstream API returns versions in semver descending order. Only `filterLatestVersions` sorts before slicing; all other filter paths (`filterVersionsBySemverConstraint`, `filterVersionsByPrefix`, etc.) preserve upstream order, so `last_sync_version` was set to whatever the registry returned first.

Fix: scan the full filtered slice with the existing `compareSemver` helper and take the highest version.

## Changelog
- fix: mirror config detail **Latest Version** field now shows the highest semver version rather than the first version returned by the upstream registry