### PR TITLE
chore: release v0.2.18

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.associations": {
+    "deployments/helm/templates/**/*.yaml": "helm",
+    "deployments/helm/templates/**/*.tpl": "helm"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.18] - 2026-03-20
+
+### Fixed
+
+- fix: mirror config detail **Latest Version** field now shows the highest semver version rather than the first version returned by the upstream registry (#74)
+- fix: storage config creation no longer unconditionally activates the new config — `activate=true` must be explicitly passed to make it active (#75)
+- fix: org creation now auto-adds the requesting user as an admin member so subsequent API calls succeed without a separate membership step (#76)
+
+### Added
+
+- feat: `POST /api/v1/admin/providers` and `GET /api/v1/admin/providers/:id` CRUD endpoints for provider records, enabling the Terraform provider `registry_provider_record` resource to create and read provider entries by UUID (#77)
+
+---
+
 ## [0.2.17] - 2026-03-17
 
 ### Fixed

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1911,6 +1911,128 @@
                 }
             }
         },
+        "/api/v1/admin/providers": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Create a new provider record in the registry. Requires providers:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "Create provider record",
+                "parameters": [
+                    {
+                        "description": "Provider namespace, type, optional description and source",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.CreateProviderRecordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Provider"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Provider already exists",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/providers/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieve a provider record by its UUID. Requires providers:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "Get provider record by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider record UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Provider"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Provider not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/role-templates": {
             "get": {
                 "security": [
@@ -8597,6 +8719,27 @@
                 }
             }
         },
+        "admin.CreateProviderRecordRequest": {
+            "type": "object",
+            "required": [
+                "namespace",
+                "type"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.CreateRoleTemplateRequest": {
             "type": "object",
             "required": [
@@ -10188,6 +10331,43 @@
                 "PolicyTypeDeny"
             ]
         },
+        "models.Provider": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "description": "User ID who created this provider",
+                    "type": "string"
+                },
+                "createdByName": {
+                    "description": "Joined fields (not stored in providers table)",
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "organizationID": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "models.RoleTemplate": {
             "type": "object",
             "properties": {
@@ -10249,6 +10429,10 @@
                 "backend_type"
             ],
             "properties": {
+                "activate": {
+                    "description": "When true, make this config active on creation; defaults to false",
+                    "type": "boolean"
+                },
                 "azure_account_key": {
                     "description": "Plain text input, encrypted before storage",
                     "type": "string"

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -240,6 +241,13 @@ func (h *OrganizationHandlers) CreateOrganizationHandler() gin.HandlerFunc {
 				"error": "Failed to create organization",
 			})
 			return
+		}
+
+		// Auto-add the creating user as an admin member so they can immediately access the org
+		if rawUID, exists := c.Get("user_id"); exists {
+			if uid, ok := rawUID.(uuid.UUID); ok {
+				_ = h.orgRepo.AddMemberWithParams(c.Request.Context(), org.ID, uid.String(), "admin")
+			}
 		}
 
 		c.JSON(http.StatusCreated, gin.H{

--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
@@ -427,4 +429,113 @@ func (h *ProviderAdminHandlers) UndeprecateVersion(c *gin.Context) {
 		"type":      providerType,
 		"version":   version,
 	})
+}
+
+// CreateProviderRecordRequest is the payload for creating a new provider record
+type CreateProviderRecordRequest struct {
+	Namespace   string  `json:"namespace" binding:"required"`
+	Type        string  `json:"type" binding:"required"`
+	Description *string `json:"description,omitempty"`
+	Source      *string `json:"source,omitempty"`
+}
+
+// @Summary      Create provider record
+// @Description  Create a new provider record in the registry. Requires providers:write scope.
+// @Tags         Providers
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        body  body  CreateProviderRecordRequest  true  "Provider namespace, type, optional description and source"
+// @Success      201  {object}  models.Provider
+// @Failure      400  {object}  map[string]interface{}  "Invalid request body"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      409  {object}  map[string]interface{}  "Provider already exists"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/providers [post]
+// CreateProviderRecord creates a new provider record
+// POST /api/v1/admin/providers
+func (h *ProviderAdminHandlers) CreateProviderRecord(c *gin.Context) {
+	var req CreateProviderRecordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+
+	// Get organization context (default org for single-tenant mode)
+	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get organization context"})
+		return
+	}
+
+	var orgID string
+	if org != nil {
+		orgID = org.ID
+	}
+
+	// Check for duplicate
+	existing, err := h.providerRepo.GetProvider(c.Request.Context(), orgID, req.Namespace, req.Type)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check existing provider"})
+		return
+	}
+	if existing != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "Provider already exists"})
+		return
+	}
+
+	// Capture creating user
+	var createdBy *string
+	if rawUID, exists := c.Get("user_id"); exists {
+		if uid, ok := rawUID.(uuid.UUID); ok {
+			s := uid.String()
+			createdBy = &s
+		}
+	}
+
+	provider := &models.Provider{
+		OrganizationID: orgID,
+		Namespace:      req.Namespace,
+		Type:           req.Type,
+		Description:    req.Description,
+		Source:         req.Source,
+		CreatedBy:      createdBy,
+	}
+
+	if err := h.providerRepo.CreateProvider(c.Request.Context(), provider); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create provider: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, provider)
+}
+
+// @Summary      Get provider record by ID
+// @Description  Retrieve a provider record by its UUID. Requires providers:read scope.
+// @Tags         Providers
+// @Security     Bearer
+// @Produce      json
+// @Param        id  path  string  true  "Provider record UUID"
+// @Success      200  {object}  models.Provider
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Provider not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/providers/{id} [get]
+// GetProviderByID retrieves a provider record by UUID
+// GET /api/v1/admin/providers/:id
+func (h *ProviderAdminHandlers) GetProviderByID(c *gin.Context) {
+	id := c.Param("id")
+
+	provider, err := h.providerRepo.GetProviderByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get provider"})
+		return
+	}
+
+	if provider == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Provider not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, provider)
 }

--- a/backend/internal/api/admin/storage.go
+++ b/backend/internal/api/admin/storage.go
@@ -214,8 +214,8 @@ func (h *StorageHandlers) CreateStorageConfig(c *gin.Context) {
 		return
 	}
 
-	// If storage is already configured, deactivate existing configs first
-	if configured {
+	// If activating, deactivate any existing active configs first
+	if input.Activate != nil && *input.Activate {
 		if err := h.storageConfigRepo.DeactivateAllStorageConfigs(ctx); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update existing configurations"})
 			return
@@ -584,10 +584,11 @@ func (h *StorageHandlers) validateStorageConfig(input *models.StorageConfigInput
 
 func (h *StorageHandlers) buildStorageConfig(input *models.StorageConfigInput, userID uuid.NullUUID) (*models.StorageConfig, error) {
 	now := time.Now()
+	isActive := input.Activate != nil && *input.Activate
 	config := &models.StorageConfig{
 		ID:          uuid.New(),
 		BackendType: input.BackendType,
-		IsActive:    true,
+		IsActive:    isActive,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 		CreatedBy:   userID,

--- a/backend/internal/api/admin/storage_test.go
+++ b/backend/internal/api/admin/storage_test.go
@@ -1106,11 +1106,11 @@ func TestStorageCreateConfig_S3StaticSuccess(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/storage/configs",
 		jsonBody(map[string]interface{}{
-			"backend_type":        "s3",
-			"s3_bucket":           "my-bucket",
-			"s3_region":           "us-east-1",
-			"s3_auth_method":      "static",
-			"s3_access_key_id":    "AKIATEST",
+			"backend_type":         "s3",
+			"s3_bucket":            "my-bucket",
+			"s3_region":            "us-east-1",
+			"s3_auth_method":       "static",
+			"s3_access_key_id":     "AKIATEST",
 			"s3_secret_access_key": "secret123",
 		})))
 
@@ -1250,11 +1250,11 @@ func TestStorageUpdateConfig_S3StaticWithKeysSuccess(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("PUT", "/storage/configs/"+knownUUID,
 		jsonBody(map[string]interface{}{
-			"backend_type":        "s3",
-			"s3_bucket":           "my-bucket",
-			"s3_region":           "us-east-1",
-			"s3_auth_method":      "static",
-			"s3_access_key_id":    "AKIATEST",
+			"backend_type":         "s3",
+			"s3_bucket":            "my-bucket",
+			"s3_region":            "us-east-1",
+			"s3_auth_method":       "static",
+			"s3_access_key_id":     "AKIATEST",
 			"s3_secret_access_key": "secret123",
 		})))
 

--- a/backend/internal/api/admin/storage_test.go
+++ b/backend/internal/api/admin/storage_test.go
@@ -770,6 +770,7 @@ func TestStorageCreateConfig_AlreadyConfiguredDeactivates(t *testing.T) {
 		jsonBody(map[string]interface{}{
 			"backend_type":    "local",
 			"local_base_path": "/tmp/new-storage",
+			"activate":        true,
 		})))
 
 	if w.Code != http.StatusCreated {
@@ -789,6 +790,7 @@ func TestStorageCreateConfig_DeactivateError(t *testing.T) {
 		jsonBody(map[string]interface{}{
 			"backend_type":    "local",
 			"local_base_path": "/tmp/storage",
+			"activate":        true,
 		})))
 
 	if w.Code != http.StatusInternalServerError {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -521,6 +521,14 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 				middleware.RequireScope(auth.ScopeProvidersWrite),
 				providerAdminHandlers.UndeprecateVersion)
 
+			// Provider record admin endpoints (create + get by UUID)
+			authenticatedGroup.POST("/admin/providers",
+				middleware.RequireScope(auth.ScopeProvidersWrite),
+				providerAdminHandlers.CreateProviderRecord)
+			authenticatedGroup.GET("/admin/providers/:id",
+				middleware.RequireScope(auth.ScopeProvidersRead),
+				providerAdminHandlers.GetProviderByID)
+
 			// Modules admin endpoints - delete, deprecate (GET moved to publicDetailGroup above)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system",
 				middleware.RequireScope(auth.ScopeModulesWrite),

--- a/backend/internal/db/models/storage_config.go
+++ b/backend/internal/db/models/storage_config.go
@@ -69,6 +69,7 @@ type StorageConfig struct {
 // StorageConfigInput is used for creating/updating storage configuration
 type StorageConfigInput struct {
 	BackendType string `json:"backend_type" binding:"required,oneof=local azure s3 gcs"`
+	Activate    *bool  `json:"activate,omitempty"` // When true, make this config active on creation; defaults to false
 
 	// Local storage settings
 	LocalBasePath      string `json:"local_base_path,omitempty"`

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -56,6 +56,45 @@ func (r *ProviderRepository) CreateProvider(ctx context.Context, provider *model
 	return nil
 }
 
+// GetProviderByID retrieves a provider record by its UUID
+func (r *ProviderRepository) GetProviderByID(ctx context.Context, id string) (*models.Provider, error) {
+	query := `
+		SELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,
+		       p.created_by, p.created_at, p.updated_at, u.name as created_by_name
+		FROM providers p
+		LEFT JOIN users u ON p.created_by = u.id
+		WHERE p.id = $1
+	`
+
+	provider := &models.Provider{}
+	var scannedOrgID sql.NullString
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&provider.ID,
+		&scannedOrgID,
+		&provider.Namespace,
+		&provider.Type,
+		&provider.Description,
+		&provider.Source,
+		&provider.CreatedBy,
+		&provider.CreatedAt,
+		&provider.UpdatedAt,
+		&provider.CreatedByName,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // Not found
+		}
+		return nil, fmt.Errorf("failed to get provider by ID: %w", err)
+	}
+
+	if scannedOrgID.Valid {
+		provider.OrganizationID = scannedOrgID.String
+	}
+
+	return provider, nil
+}
+
 // GetProvider retrieves a provider by organization, namespace, and type
 // In single-tenant mode (or when provider has NULL org_id), also matches providers with NULL organization_id
 func (r *ProviderRepository) GetProvider(ctx context.Context, orgID, namespace, providerType string) (*models.Provider, error) {

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -770,7 +770,13 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient *mirror
 	if mirroredProvider != nil {
 		mirroredProvider.LastSyncedAt = time.Now()
 		if len(versions) > 0 {
-			mirroredProvider.LastSyncVersion = &versions[0].Version
+			highest := versions[0].Version
+			for _, v := range versions[1:] {
+				if compareSemver(v.Version, highest) > 0 {
+					highest = v.Version
+				}
+			}
+			mirroredProvider.LastSyncVersion = &highest
 		}
 		if err := j.mirrorRepo.UpdateMirroredProvider(ctx, mirroredProvider); err != nil {
 			log.Printf("Warning: failed to update mirrored provider sync time for %s/%s: %v", namespace, providerName, err)

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -93,6 +93,8 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 
 ### Provider Registry
 
+- [x] `POST /api/v1/admin/providers` - Create provider record
+- [x] `GET /api/v1/admin/providers/:id` - Get provider record by UUID
 - [x] `GET /v1/providers/:namespace/:type/versions` - List provider versions (public)
 - [x] `GET /v1/providers/:namespace/:type/:version/download/:os/:arch` - Download provider (public)
 - [x] `GET /api/v1/providers/search` - Search providers (public)
@@ -104,7 +106,7 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `DELETE /api/v1/providers/:namespace/:type/versions/:version/deprecate` - Remove deprecation
 
 **Files**: `backend/internal/api/providers/versions.go`, `download.go`, `search.go`, `upload.go`, `backend/internal/api/admin/providers.go`
-**Progress**: 9/9 annotated ✅
+**Progress**: 11/11 annotated ✅
 
 ---
 
@@ -271,8 +273,8 @@ complete operational coverage.
 ---
 
 ```txt
-Total Gin-router Endpoints: 104
-Annotated: 104
+Total Gin-router Endpoints: 106
+Annotated: 106
 Remaining: 0
 Completion: 100% ✅
 
@@ -283,7 +285,7 @@ Out-of-Band Endpoints (not in OpenAPI spec):
 Phase Breakdown:
   Phase 1 (Auth & API Keys):      10/10 (100%) ✅
   Phase 2 (Users & Orgs):         18/18 (100%) ✅
-  Phase 3 (Modules & Providers):  19/19 (100%) ✅
+  Phase 3 (Modules & Providers):  21/21 (100%) ✅
   Phase 4 (Storage):               9/9  (100%) ✅
   Phase 5 (SCM):                  18/18 (100%) ✅
   Phase 6 (Mirror):                9/9  (100%) ✅
@@ -310,5 +312,5 @@ Then visit `https://localhost/api-docs` to verify in the Swagger UI.
 
 ---
 
-**Last Updated**: 2026-02-20
-**Status**: ✅ All 104 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist
+**Last Updated**: 2026-03-20
+**Status**: ✅ All 106 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist


### PR DESCRIPTION
## Release v0.2.18

### Fixed
- fix: mirror config detail **Latest Version** field now shows the highest semver version rather than the first version returned by the upstream registry (#74)
- fix: storage config creation no longer unconditionally activates the new config — `activate=true` must be explicitly passed to make it active (#75)
- fix: org creation now auto-adds the requesting user as an admin member so subsequent API calls succeed without a separate membership step (#76)

### Added
- feat: `POST /api/v1/admin/providers` and `GET /api/v1/admin/providers/:id` CRUD endpoints for provider records (#77)