### PR TITLE
chore: release v0.2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.19] - 2026-03-20
+
+### Fixed
+
+- fix: org creator membership fails silently due to wrong type assertion — `c.Get("user_id")` returns a `string`, not `uuid.UUID`; the incorrect assertion always silently failed, leaving org creators without membership and causing 403 on all member-gated endpoints (#80, #82)
+- fix: add postgres healthcheck and required env vars (`TFR_DATABASE_SSL_MODE`, `ENCRYPTION_KEY`, `TFR_JWT_SECRET`) to `docker-compose.test.yml` so the acceptance-test stack starts correctly (#82)
+
+### Added
+
+- feat: `PUT /api/v1/admin/modules/{id}` endpoint for updating module records — the repository layer already had `UpdateModule`; only the HTTP handler and route registration were missing (#81, #82)
+
+---
+
 ## [0.2.18] - 2026-03-20
 
 ### Fixed

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1033,6 +1033,80 @@
                 }
             }
         },
+        "/api/v1/admin/modules/{id}": {
+            "put": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Update a module record's description or source URL. Requires modules:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Update module record",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Module"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Module not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/modules/{id}/scm": {
             "get": {
                 "security": [

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -499,3 +499,57 @@ func (h *ModuleAdminHandlers) UndeprecateVersion(c *gin.Context) {
 		"version":   version,
 	})
 }
+
+// UpdateModuleRecord handler
+// @Summary      Update module record
+// @Description  Update a module record's description or source URL. Requires modules:write scope.
+// @Tags         Modules
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        id    path  string  true  "Module UUID"
+// @Param        body  body  object  true  "Fields to update"
+// @Success      200  {object}  models.Module
+// @Failure      400  {object}  map[string]interface{}  "Invalid request"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Module not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/modules/{id} [put]
+// UpdateModuleRecord updates a module record
+// PUT /api/v1/admin/modules/:id
+func (h *ModuleAdminHandlers) UpdateModuleRecord(c *gin.Context) {
+	id := c.Param("id")
+
+	var req struct {
+		Description *string `json:"description"`
+		Source      *string `json:"source"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	module, err := h.moduleRepo.GetModuleByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get module"})
+		return
+	}
+	if module == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "module not found"})
+		return
+	}
+
+	if req.Description != nil {
+		module.Description = req.Description
+	}
+	if req.Source != nil {
+		module.Source = req.Source
+	}
+
+	if err := h.moduleRepo.UpdateModule(c.Request.Context(), module); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update module"})
+		return
+	}
+
+	c.JSON(http.StatusOK, module)
+}

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -245,8 +244,8 @@ func (h *OrganizationHandlers) CreateOrganizationHandler() gin.HandlerFunc {
 
 		// Auto-add the creating user as an admin member so they can immediately access the org
 		if rawUID, exists := c.Get("user_id"); exists {
-			if uid, ok := rawUID.(uuid.UUID); ok {
-				_ = h.orgRepo.AddMemberWithParams(c.Request.Context(), org.ID, uid.String(), "admin")
+			if uid, ok := rawUID.(string); ok && uid != "" {
+				_ = h.orgRepo.AddMemberWithParams(c.Request.Context(), org.ID, uid, "admin")
 			}
 		}
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -498,6 +498,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.POST("/admin/modules/create",
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.CreateModuleRecord)
+			authenticatedGroup.PUT("/admin/modules/:id",
+				middleware.RequireScope(auth.ScopeModulesWrite),
+				moduleAdminHandlers.UpdateModuleRecord)
 			authenticatedGroup.POST("/modules",
 				middleware.RateLimitMiddleware(uploadRateLimiter), // Stricter rate limit for uploads
 				middleware.RequireScope(auth.ScopeModulesWrite),

--- a/deployments/docker-compose.test.yml
+++ b/deployments/docker-compose.test.yml
@@ -9,24 +9,32 @@ services:
       - "5433:5432"
     volumes:
       - postgres-data-test:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d terraform_registry"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
 
   backend:
     build:
-      context: ..
-      dockerfile: backend/Dockerfile
+      context: ../backend
     environment:
       - TFR_DATABASE_HOST=postgres
       - TFR_DATABASE_PORT=5432
       - TFR_DATABASE_NAME=terraform_registry
       - TFR_DATABASE_USER=registry
       - TFR_DATABASE_PASSWORD=registry
+      - TFR_DATABASE_SSL_MODE=disable
+      - ENCRYPTION_KEY=test-encryption-key-must-be-32ch
+      - TFR_JWT_SECRET=test-jwt-secret-that-is-32-chars!!
       - DEV_MODE=true
       - TFR_SERVER_HOST=0.0.0.0
       - TFR_SERVER_PORT=8080
     ports:
-      - "8080:8080"
+      - "8081:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres-data-test:

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -6,7 +6,7 @@ This checklist tracks Swagger/OpenAPI annotation progress for all API endpoints 
 
 **Target**: 100% API coverage with Swagger annotations
 
-**Current Status**: ✅ 104/104 annotated (100%) — All Gin-router endpoints complete
+**Current Status**: ✅ 107/107 annotated (100%) — All Gin-router endpoints complete
 
 See the **Out-of-Band Endpoints** section at the bottom for observability endpoints that live
 on dedicated ports and are deliberately excluded from the OpenAPI spec.
@@ -87,9 +87,10 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `POST /api/v1/modules/:namespace/:name/:system/versions/:version/deprecate` - Deprecate version
 - [x] `DELETE /api/v1/modules/:namespace/:name/:system/versions/:version/deprecate` - Remove deprecation
 - [x] `POST /api/v1/admin/modules/create` - Create module record
+- [x] `PUT /api/v1/admin/modules/:id` - Update module record
 
 **Files**: `backend/internal/api/modules/versions.go`, `download.go`, `search.go`, `upload.go`, `backend/internal/api/admin/modules.go`
-**Progress**: 10/10 annotated ✅
+**Progress**: 11/11 annotated ✅
 
 ### Provider Registry
 


### PR DESCRIPTION
## Release v0.2.19

### Fixed

- fix: org creator membership fails silently due to wrong type assertion — `c.Get("user_id")` returns a `string`, not `uuid.UUID`; the incorrect assertion always silently failed, leaving org creators without membership and causing 403 on all member-gated endpoints (#80)
- fix: add postgres healthcheck and required env vars to `docker-compose.test.yml` so the acceptance-test stack starts correctly (#82)

### Added

- feat: `PUT /api/v1/admin/modules/{id}` endpoint for updating module records (#81)