### PR TITLE
chore: release v0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.20] - 2026-03-21
+
+### Fixed
+
+- fix: add snake_case JSON tags to `models.Provider` — without them `CreateProviderRecord` and `GetProviderByID` responses decoded to empty structs on the client, leaving `organization_id` blank on every Read (#84, #86)
+- fix: add `organization_id`, `source`, and `created_by` to `GetModule` response — their absence caused a provider inconsistency error on every module update step since `UpdateModuleRecord` returns the full struct but `GetModule` did not (#85, #86)
+
+---
+
 ## [0.2.19] - 2026-03-20
 
 ### Fixed

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10408,14 +10408,13 @@
         "models.Provider": {
             "type": "object",
             "properties": {
-                "createdAt": {
+                "created_at": {
                     "type": "string"
                 },
-                "createdBy": {
-                    "description": "User ID who created this provider",
+                "created_by": {
                     "type": "string"
                 },
-                "createdByName": {
+                "created_by_name": {
                     "description": "Joined fields (not stored in providers table)",
                     "type": "string"
                 },
@@ -10428,7 +10427,7 @@
                 "namespace": {
                     "type": "string"
                 },
-                "organizationID": {
+                "organization_id": {
                     "type": "string"
                 },
                 "source": {
@@ -10437,7 +10436,7 @@
                 "type": {
                     "type": "string"
                 },
-                "updatedAt": {
+                "updated_at": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -171,16 +171,18 @@ func (h *ModuleAdminHandlers) GetModule(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"id":             module.ID,
-		"namespace":      module.Namespace,
-		"name":           module.Name,
-		"system":         module.System,
-		"description":    module.Description,
-		"source":         module.Source,
-		"download_count": totalDownloads,
-		"versions":       versionsList,
-		"created_at":     module.CreatedAt,
-		"updated_at":     module.UpdatedAt,
+		"id":              module.ID,
+		"organization_id": module.OrganizationID,
+		"namespace":       module.Namespace,
+		"name":            module.Name,
+		"system":          module.System,
+		"description":     module.Description,
+		"source":          module.Source,
+		"created_by":      module.CreatedBy,
+		"download_count":  totalDownloads,
+		"versions":        versionsList,
+		"created_at":      module.CreatedAt,
+		"updated_at":      module.UpdatedAt,
 	})
 }
 

--- a/backend/internal/db/models/provider.go
+++ b/backend/internal/db/models/provider.go
@@ -6,17 +6,17 @@ import "time"
 
 // Provider represents a Terraform provider in the registry
 type Provider struct {
-	ID             string
-	OrganizationID string
-	Namespace      string
-	Type           string
-	Description    *string
-	Source         *string
-	CreatedBy      *string // User ID who created this provider
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id"`
+	Namespace      string    `json:"namespace"`
+	Type           string    `json:"type"`
+	Description    *string   `json:"description,omitempty"`
+	Source         *string   `json:"source,omitempty"`
+	CreatedBy      *string   `json:"created_by,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 	// Joined fields (not stored in providers table)
-	CreatedByName *string // User name who created this provider (joined from users table)
+	CreatedByName *string `json:"created_by_name,omitempty"`
 }
 
 // ProviderSearchResult is returned by the search endpoint and includes aggregated


### PR DESCRIPTION
## Release v0.2.20

### Fixed

- fix: add snake_case JSON tags to `models.Provider` — `CreateProviderRecord` and `GetProviderByID` responses decoded to empty structs, leaving `organization_id` blank on every Read (#84)
- fix: add `organization_id`, `source`, and `created_by` to `GetModule` response — their absence caused a provider inconsistency error on every module update (#85)