### PR TITLE
fix: APIKey JSON tags, provider org_id, GET admin module endpoint

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1034,6 +1034,59 @@
             }
         },
         "/api/v1/admin/modules/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieve a module record by its UUID. Requires modules:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Get module record by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module record UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Module"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Module not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
             "put": {
                 "security": [
                     {
@@ -8804,6 +8857,9 @@
                     "type": "string"
                 },
                 "namespace": {
+                    "type": "string"
+                },
+                "organization_id": {
                     "type": "string"
                 },
                 "source": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2158,6 +2158,78 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Update the description and/or source of a provider record. Requires providers:write scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "Update provider record by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider record UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "req",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.UpdateProviderRecordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Provider"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Provider not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
             }
         },
         "/api/v1/admin/role-templates": {
@@ -9685,6 +9757,17 @@
             "type": "object",
             "properties": {
                 "display_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.UpdateProviderRecordRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "source": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -555,3 +555,32 @@ func (h *ModuleAdminHandlers) UpdateModuleRecord(c *gin.Context) {
 
 	c.JSON(http.StatusOK, module)
 }
+
+// @Summary      Get module record by ID
+// @Description  Retrieve a module record by its UUID. Requires modules:read scope.
+// @Tags         Modules
+// @Security     Bearer
+// @Produce      json
+// @Param        id  path  string  true  "Module record UUID"
+// @Success      200  {object}  models.Module
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Module not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/modules/{id} [get]
+// GetModuleByIDRecord retrieves a module record by UUID
+// GET /api/v1/admin/modules/:id
+func (h *ModuleAdminHandlers) GetModuleByIDRecord(c *gin.Context) {
+	id := c.Param("id")
+
+	module, err := h.moduleRepo.GetModuleByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get module"})
+		return
+	}
+	if module == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "module not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, module)
+}

--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -511,6 +511,62 @@ func (h *ProviderAdminHandlers) CreateProviderRecord(c *gin.Context) {
 	c.JSON(http.StatusCreated, provider)
 }
 
+// UpdateProviderRecordRequest is the payload for updating a provider record's metadata.
+type UpdateProviderRecordRequest struct {
+	Description *string `json:"description,omitempty"`
+	Source      *string `json:"source,omitempty"`
+}
+
+// @Summary      Update provider record by ID
+// @Description  Update the description and/or source of a provider record. Requires providers:write scope.
+// @Tags         Providers
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        id   path      string                      true  "Provider record UUID"
+// @Param        req  body      admin.UpdateProviderRecordRequest  true  "Fields to update"
+// @Success      200  {object}  models.Provider
+// @Failure      400  {object}  map[string]interface{}  "Bad request"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Provider not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/providers/{id} [put]
+// UpdateProviderRecord updates description/source of a provider record by UUID.
+// PUT /api/v1/admin/providers/:id
+func (h *ProviderAdminHandlers) UpdateProviderRecord(c *gin.Context) {
+	id := c.Param("id")
+
+	var req UpdateProviderRecordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+
+	provider, err := h.providerRepo.GetProviderByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get provider"})
+		return
+	}
+	if provider == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Provider not found"})
+		return
+	}
+
+	if req.Description != nil {
+		provider.Description = req.Description
+	}
+	if req.Source != nil {
+		provider.Source = req.Source
+	}
+
+	if err := h.providerRepo.UpdateProvider(c.Request.Context(), provider); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update provider: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, provider)
+}
+
 // @Summary      Get provider record by ID
 // @Description  Retrieve a provider record by its UUID. Requires providers:read scope.
 // @Tags         Providers

--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -433,10 +432,11 @@ func (h *ProviderAdminHandlers) UndeprecateVersion(c *gin.Context) {
 
 // CreateProviderRecordRequest is the payload for creating a new provider record
 type CreateProviderRecordRequest struct {
-	Namespace   string  `json:"namespace" binding:"required"`
-	Type        string  `json:"type" binding:"required"`
-	Description *string `json:"description,omitempty"`
-	Source      *string `json:"source,omitempty"`
+	OrganizationID string  `json:"organization_id,omitempty"`
+	Namespace      string  `json:"namespace" binding:"required"`
+	Type           string  `json:"type" binding:"required"`
+	Description    *string `json:"description,omitempty"`
+	Source         *string `json:"source,omitempty"`
 }
 
 // @Summary      Create provider record
@@ -468,12 +468,14 @@ func (h *ProviderAdminHandlers) CreateProviderRecord(c *gin.Context) {
 		return
 	}
 
+	// Use organization from request if provided, otherwise fall back to default
 	var orgID string
-	if org != nil {
+	if req.OrganizationID != "" {
+		orgID = req.OrganizationID
+	} else if org != nil {
 		orgID = org.ID
 	}
 
-	// Check for duplicate
 	existing, err := h.providerRepo.GetProvider(c.Request.Context(), orgID, req.Namespace, req.Type)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check existing provider"})
@@ -487,9 +489,8 @@ func (h *ProviderAdminHandlers) CreateProviderRecord(c *gin.Context) {
 	// Capture creating user
 	var createdBy *string
 	if rawUID, exists := c.Get("user_id"); exists {
-		if uid, ok := rawUID.(uuid.UUID); ok {
-			s := uid.String()
-			createdBy = &s
+		if uid, ok := rawUID.(string); ok && uid != "" {
+			createdBy = &uid
 		}
 	}
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -534,6 +534,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.GET("/admin/providers/:id",
 				middleware.RequireScope(auth.ScopeProvidersRead),
 				providerAdminHandlers.GetProviderByID)
+			authenticatedGroup.PUT("/admin/providers/:id",
+				middleware.RequireScope(auth.ScopeProvidersWrite),
+				providerAdminHandlers.UpdateProviderRecord)
 
 			// Modules admin endpoints - delete, deprecate (GET moved to publicDetailGroup above)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system",

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -498,6 +498,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.POST("/admin/modules/create",
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.CreateModuleRecord)
+			authenticatedGroup.GET("/admin/modules/:id",
+				middleware.RequireScope(auth.ScopeModulesRead),
+				moduleAdminHandlers.GetModuleByIDRecord)
 			authenticatedGroup.PUT("/admin/modules/:id",
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UpdateModuleRecord)

--- a/backend/internal/db/models/api_key.go
+++ b/backend/internal/db/models/api_key.go
@@ -7,18 +7,18 @@ import "time"
 
 // APIKey represents an API key for authentication
 type APIKey struct {
-	ID                       string
-	UserID                   *string // Optional: can be service account key
-	OrganizationID           string
-	Name                     string     // Friendly name (e.g., "CI/CD Pipeline Key")
-	Description              *string    // Optional human-friendly description
-	KeyHash                  string     // Bcrypt hash of the full key
-	KeyPrefix                string     // First 8-10 chars for display (e.g., "tfr_abc123")
-	Scopes                   []string   // JSONB array: ["modules:read", "modules:write", "providers:write"]
-	ExpiresAt                *time.Time // Optional expiration
-	LastUsedAt               *time.Time // Track last usage
-	ExpiryNotificationSentAt *time.Time // Set when expiry warning email was sent
-	CreatedAt                time.Time
+	ID                       string     `json:"id"`
+	UserID                   *string    `json:"user_id,omitempty"`
+	OrganizationID           string     `json:"organization_id"`
+	Name                     string     `json:"name"`
+	Description              *string    `json:"description,omitempty"`
+	KeyHash                  string     `json:"key_hash"`
+	KeyPrefix                string     `json:"key_prefix"`
+	Scopes                   []string   `json:"scopes"`
+	ExpiresAt                *time.Time `json:"expires_at,omitempty"`
+	LastUsedAt               *time.Time `json:"last_used_at,omitempty"`
+	ExpiryNotificationSentAt *time.Time `json:"expiry_notification_sent_at,omitempty"`
+	CreatedAt                time.Time  `json:"created_at"`
 	// Joined fields (not stored in api_keys table)
-	UserName *string // User name who created this key (joined from users table)
+	UserName *string `json:"user_name,omitempty"`
 }

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -6,7 +6,7 @@ This checklist tracks Swagger/OpenAPI annotation progress for all API endpoints 
 
 **Target**: 100% API coverage with Swagger annotations
 
-**Current Status**: ✅ 107/107 annotated (100%) — All Gin-router endpoints complete
+**Current Status**: ✅ 108/108 annotated (100%) — All Gin-router endpoints complete
 
 See the **Out-of-Band Endpoints** section at the bottom for observability endpoints that live
 on dedicated ports and are deliberately excluded from the OpenAPI spec.
@@ -87,10 +87,11 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `POST /api/v1/modules/:namespace/:name/:system/versions/:version/deprecate` - Deprecate version
 - [x] `DELETE /api/v1/modules/:namespace/:name/:system/versions/:version/deprecate` - Remove deprecation
 - [x] `POST /api/v1/admin/modules/create` - Create module record
+- [x] `GET /api/v1/admin/modules/:id` - Get module record by UUID
 - [x] `PUT /api/v1/admin/modules/:id` - Update module record
 
 **Files**: `backend/internal/api/modules/versions.go`, `download.go`, `search.go`, `upload.go`, `backend/internal/api/admin/modules.go`
-**Progress**: 11/11 annotated ✅
+**Progress**: 12/12 annotated ✅
 
 ### Provider Registry
 
@@ -274,8 +275,8 @@ complete operational coverage.
 ---
 
 ```txt
-Total Gin-router Endpoints: 106
-Annotated: 106
+Total Gin-router Endpoints: 108
+Annotated: 108
 Remaining: 0
 Completion: 100% ✅
 
@@ -286,7 +287,7 @@ Out-of-Band Endpoints (not in OpenAPI spec):
 Phase Breakdown:
   Phase 1 (Auth & API Keys):      10/10 (100%) ✅
   Phase 2 (Users & Orgs):         18/18 (100%) ✅
-  Phase 3 (Modules & Providers):  21/21 (100%) ✅
+  Phase 3 (Modules & Providers):  23/23 (100%) ✅
   Phase 4 (Storage):               9/9  (100%) ✅
   Phase 5 (SCM):                  18/18 (100%) ✅
   Phase 6 (Mirror):                9/9  (100%) ✅
@@ -313,5 +314,5 @@ Then visit `https://localhost/api-docs` to verify in the Swagger UI.
 
 ---
 
-**Last Updated**: 2026-03-20
-**Status**: ✅ All 106 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist
+**Last Updated**: 2026-03-21
+**Status**: ✅ All 108 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -6,7 +6,7 @@ This checklist tracks Swagger/OpenAPI annotation progress for all API endpoints 
 
 **Target**: 100% API coverage with Swagger annotations
 
-**Current Status**: ✅ 108/108 annotated (100%) — All Gin-router endpoints complete
+**Current Status**: ✅ 109/109 annotated (100%) — All Gin-router endpoints complete
 
 See the **Out-of-Band Endpoints** section at the bottom for observability endpoints that live
 on dedicated ports and are deliberately excluded from the OpenAPI spec.
@@ -97,6 +97,7 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 
 - [x] `POST /api/v1/admin/providers` - Create provider record
 - [x] `GET /api/v1/admin/providers/:id` - Get provider record by UUID
+- [x] `PUT /api/v1/admin/providers/:id` - Update provider record description/source
 - [x] `GET /v1/providers/:namespace/:type/versions` - List provider versions (public)
 - [x] `GET /v1/providers/:namespace/:type/:version/download/:os/:arch` - Download provider (public)
 - [x] `GET /api/v1/providers/search` - Search providers (public)
@@ -108,7 +109,7 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `DELETE /api/v1/providers/:namespace/:type/versions/:version/deprecate` - Remove deprecation
 
 **Files**: `backend/internal/api/providers/versions.go`, `download.go`, `search.go`, `upload.go`, `backend/internal/api/admin/providers.go`
-**Progress**: 11/11 annotated ✅
+**Progress**: 12/12 annotated ✅
 
 ---
 
@@ -275,8 +276,8 @@ complete operational coverage.
 ---
 
 ```txt
-Total Gin-router Endpoints: 108
-Annotated: 108
+Total Gin-router Endpoints: 109
+Annotated: 109
 Remaining: 0
 Completion: 100% ✅
 
@@ -287,7 +288,7 @@ Out-of-Band Endpoints (not in OpenAPI spec):
 Phase Breakdown:
   Phase 1 (Auth & API Keys):      10/10 (100%) ✅
   Phase 2 (Users & Orgs):         18/18 (100%) ✅
-  Phase 3 (Modules & Providers):  23/23 (100%) ✅
+  Phase 3 (Modules & Providers):  24/24 (100%) ✅
   Phase 4 (Storage):               9/9  (100%) ✅
   Phase 5 (SCM):                  18/18 (100%) ✅
   Phase 6 (Mirror):                9/9  (100%) ✅
@@ -315,4 +316,4 @@ Then visit `https://localhost/api-docs` to verify in the Swagger UI.
 ---
 
 **Last Updated**: 2026-03-21
-**Status**: ✅ All 108 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist
+**Status**: ✅ All 109 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist


### PR DESCRIPTION
## Summary
- `models.APIKey`: add snake_case JSON tags — `organization_id` was decoding as empty on the client side
- `admin/providers.go`: add `organization_id` to CreateProviderRecordRequest; fix created_by type assertion
- `admin/modules.go` + `router.go`: add GET /api/v1/admin/modules/:id handler
- `admin/providers.go` + `router.go`: add PUT /api/v1/admin/providers/:id update endpoint
- Swagger regenerated; annotation checklist updated to 109/109

## Fixes
Closes #88 (APIKey JSON tags)
Closes #89 (Provider org_id + created_by type assertion)
Closes #90 (GET module by ID)

## Changelog
- fix: add snake_case JSON tags to APIKey model fields
- fix: add organization_id to CreateProviderRecordRequest and fix created_by type assertion
- feat: add GET /api/v1/admin/modules/:id endpoint
- feat: add PUT /api/v1/admin/providers/:id update endpoint