### PR TITLE
chore: release v0.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.22] - 2026-03-21
+
+### Fixed
+
+- fix: ADO `FetchTags` now adds `peelTags=true` and uses `peeledObjectId` as the commit SHA for annotated tags — migration script creates annotated tags whose `objectId` is the tag-object SHA, not the commit SHA, causing `DownloadSourceArchive` to 404 with `versionType=commit`
+- fix: `LinkModuleToSCM` auto-detects the repository's true default branch via `FetchRepository` when `default_branch` is omitted, instead of always defaulting to `"main"` — repos migrated from ADO with `master` as default branch now store correct metadata
+- fix: `UpdateSCMLink` no longer overwrites optional string fields with empty strings on partial update — fields absent from the request body now preserve their existing values
+- fix: `GetModule` response now includes `created_by_name` (user display name) and per-version `published_by` / `published_by_name` — these were already populated by the DB join but excluded from the `gin.H` response map
+
+### Changed
+
+- test: `api-test` integration tool now covers `PUT /api/v1/admin/modules/{id}` (UpdateModuleRecord), `POST /api/v1/admin/providers` (CreateProviderRecord), and `GET /api/v1/admin/providers/{id}` (GetProviderByID)
+
+---
+
 ## [0.2.21] - 2026-03-21
 
 ### Fixed
 
 - fix: add snake_case JSON tags to `models.APIKey` — `organization_id` was decoding as empty on the client side because Go serialized fields as PascalCase without explicit tags (#88)
 - fix: add `organization_id` to `CreateProviderRecordRequest` and correct `created_by` type assertion (`uuid.UUID` → `string`) in provider create handler (#89)
-- fix: ADO `FetchTags` now adds `peelTags=true` and uses `peeledObjectId` as the commit SHA for annotated tags — migration script creates annotated tags whose `objectId` is the tag-object SHA, not the commit SHA, causing `DownloadSourceArchive` to 404 with `versionType=commit`
-- fix: `LinkModuleToSCM` auto-detects the repository's true default branch via `FetchRepository` when `default_branch` is omitted, instead of always defaulting to `"main"` — repos migrated from ADO with `master` as default branch now store correct metadata
-- fix: `UpdateSCMLink` no longer overwrites optional string fields with empty strings on partial update — fields absent from the request body now preserve their existing values
-- fix: `GetModule` response now includes `created_by_name` (user display name) and per-version `published_by` / `published_by_name` — these were already populated by the DB join but excluded from the `gin.H` response map
 
 ### Added
 
 - feat: `GET /api/v1/admin/modules/{id}` endpoint — required for Terraform provider `ImportState` on module resources (#90)
 - feat: `PUT /api/v1/admin/providers/{id}` endpoint for updating provider record description and source (#91)
-- test: `api-test` integration tool now covers `PUT /api/v1/admin/modules/{id}` (UpdateModuleRecord), `POST /api/v1/admin/providers` (CreateProviderRecord), and `GET /api/v1/admin/providers/{id}` (GetProviderByID)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix: add snake_case JSON tags to `models.APIKey` — `organization_id` was decoding as empty on the client side because Go serialized fields as PascalCase without explicit tags (#88)
 - fix: add `organization_id` to `CreateProviderRecordRequest` and correct `created_by` type assertion (`uuid.UUID` → `string`) in provider create handler (#89)
+- fix: ADO `FetchTags` now adds `peelTags=true` and uses `peeledObjectId` as the commit SHA for annotated tags — migration script creates annotated tags whose `objectId` is the tag-object SHA, not the commit SHA, causing `DownloadSourceArchive` to 404 with `versionType=commit`
+- fix: `LinkModuleToSCM` auto-detects the repository's true default branch via `FetchRepository` when `default_branch` is omitted, instead of always defaulting to `"main"` — repos migrated from ADO with `master` as default branch now store correct metadata
+- fix: `UpdateSCMLink` no longer overwrites optional string fields with empty strings on partial update — fields absent from the request body now preserve their existing values
+- fix: `GetModule` response now includes `created_by_name` (user display name) and per-version `published_by` / `published_by_name` — these were already populated by the DB join but excluded from the `gin.H` response map
 
 ### Added
 
 - feat: `GET /api/v1/admin/modules/{id}` endpoint — required for Terraform provider `ImportState` on module resources (#90)
 - feat: `PUT /api/v1/admin/providers/{id}` endpoint for updating provider record description and source (#91)
+- test: `api-test` integration tool now covers `PUT /api/v1/admin/modules/{id}` (UpdateModuleRecord), `POST /api/v1/admin/providers` (CreateProviderRecord), and `GET /api/v1/admin/providers/{id}` (GetProviderByID)
 
 ---
 

--- a/backend/cmd/api-test/main.go
+++ b/backend/cmd/api-test/main.go
@@ -31,19 +31,21 @@ var (
 )
 
 var state struct {
-	orgID           string // ID of test org we create (phase 4)
-	defaultOrgID    string // ID of an existing org the API-key user belongs to (phase 3)
-	userID          string
-	keyID           string
-	roleID          string
-	scmID           string
-	mirrorID        string
-	tfMirrorID      string
-	policyID        string
-	auditLogID      string // captured in phase 14 for detail-read test
-	approvalID      string // captured in phase 9 for phase 13 detail-read test
-	storageConfigID string // captured in phase 3 for phase 16 detail-read test
-	tfMirrorVersion string // captured in phase 10 for version-detail test
+	orgID            string // ID of test org we create (phase 4)
+	defaultOrgID     string // ID of an existing org the API-key user belongs to (phase 3)
+	userID           string
+	keyID            string
+	roleID           string
+	scmID            string
+	mirrorID         string
+	tfMirrorID       string
+	policyID         string
+	auditLogID       string // captured in phase 14 for detail-read test
+	approvalID       string // captured in phase 9 for phase 13 detail-read test
+	storageConfigID  string // captured in phase 3 for phase 16 detail-read test
+	tfMirrorVersion  string // captured in phase 10 for version-detail test
+	moduleID         string // captured in phase 11 for UpdateModuleRecord test
+	providerRecordID string // captured in phase 12 for CreateProviderRecord/GetProviderByID test
 }
 
 var (
@@ -797,7 +799,9 @@ func phase11() {
 
 	r := doJSON("POST", "/api/v1/admin/modules/create",
 		map[string]interface{}{"namespace": "testns", "name": "testmod", "system": "aws"}, true)
-	record("POST", "/api/v1/admin/modules/create", r.Code, []int{200, 201}, r.Elapsed, "")
+	if record("POST", "/api/v1/admin/modules/create", r.Code, []int{200, 201}, r.Elapsed, "") {
+		state.moduleID = str(r.Object, "id")
+	}
 
 	r = doMultipart("POST", "/api/v1/modules",
 		map[string]string{"namespace": "testns", "name": "testmod", "system": "aws", "version": "0.1.0"},
@@ -806,7 +810,21 @@ func phase11() {
 	record("POST", "/api/v1/modules", r.Code, []int{201}, r.Elapsed, note)
 
 	r = doJSON("GET", "/api/v1/modules/testns/testmod/aws", nil, true)
-	record("GET", "/api/v1/modules/testns/testmod/aws", r.Code, []int{200}, r.Elapsed, "")
+	note = checkFields(r.Object, "id", "created_by_name")
+	record("GET", "/api/v1/modules/testns/testmod/aws", r.Code, []int{200}, r.Elapsed, note)
+
+	// UpdateModuleRecord — new endpoint; use captured module ID
+	if state.moduleID != "" {
+		r = doJSON("PUT", "/api/v1/admin/modules/"+state.moduleID,
+			map[string]interface{}{
+				"description": "updated description",
+				"source":      "https://github.com/example/testmod",
+			}, true)
+		note = checkFields(r.Object, "id", "description", "source")
+		record("PUT", "/api/v1/admin/modules/"+state.moduleID, r.Code, []int{200}, r.Elapsed, note)
+	} else {
+		skipTest("PUT", "/api/v1/admin/modules/{id}", "module create failed — no ID available")
+	}
 
 	r = doJSON("GET", "/v1/modules/testns/testmod/aws/versions", nil, false)
 	record("GET", "/v1/modules/testns/testmod/aws/versions", r.Code, []int{200}, r.Elapsed, "")
@@ -890,6 +908,27 @@ func phase12() {
 
 	r = doJSON("DELETE", "/api/v1/providers/testns/testprovider", nil, true)
 	record("DELETE", "/api/v1/providers/testns/testprovider", r.Code, []int{200}, r.Elapsed, "")
+
+	// CreateProviderRecord — new endpoint (creates a provider stub without uploading a version)
+	r = doJSON("POST", "/api/v1/admin/providers",
+		map[string]interface{}{
+			"namespace":   "testns",
+			"type":        "testproviderrecord",
+			"description": "provider record test",
+		}, true)
+	note = checkFields(r.Object, "id", "namespace", "type")
+	if record("POST", "/api/v1/admin/providers", r.Code, []int{201}, r.Elapsed, note) {
+		state.providerRecordID = str(r.Object, "id")
+	}
+
+	// GetProviderByID — new endpoint
+	if state.providerRecordID != "" {
+		r = doJSON("GET", "/api/v1/admin/providers/"+state.providerRecordID, nil, true)
+		note = checkFields(r.Object, "id", "namespace", "type")
+		record("GET", "/api/v1/admin/providers/"+state.providerRecordID, r.Code, []int{200}, r.Elapsed, note)
+	} else {
+		skipTest("GET", "/api/v1/admin/providers/{id}", "CreateProviderRecord failed — no ID available")
+	}
 }
 
 // ── Phase 13: Policies & Approvals ───────────────────────────────────────────

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -153,13 +153,15 @@ func (h *ModuleAdminHandlers) GetModule(c *gin.Context) {
 	for _, v := range versions {
 		totalDownloads += v.DownloadCount
 		versionData := gin.H{
-			"id":             v.ID,
-			"version":        v.Version,
-			"size_bytes":     v.SizeBytes,
-			"checksum":       v.Checksum,
-			"download_count": v.DownloadCount,
-			"deprecated":     v.Deprecated,
-			"created_at":     v.CreatedAt,
+			"id":                v.ID,
+			"version":           v.Version,
+			"size_bytes":        v.SizeBytes,
+			"checksum":          v.Checksum,
+			"download_count":    v.DownloadCount,
+			"deprecated":        v.Deprecated,
+			"published_by":      v.PublishedBy,
+			"published_by_name": v.PublishedByName,
+			"created_at":        v.CreatedAt,
 		}
 		if v.DeprecatedAt != nil {
 			versionData["deprecated_at"] = v.DeprecatedAt
@@ -179,6 +181,7 @@ func (h *ModuleAdminHandlers) GetModule(c *gin.Context) {
 		"description":     module.Description,
 		"source":          module.Source,
 		"created_by":      module.CreatedBy,
+		"created_by_name": module.CreatedByName,
 		"download_count":  totalDownloads,
 		"versions":        versionsList,
 		"created_at":      module.CreatedAt,

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -118,7 +118,7 @@ func (h *SCMLinkingHandler) LinkModuleToSCM(c *gin.Context) {
 
 	// Set defaults
 	if req.DefaultBranch == "" {
-		req.DefaultBranch = "main"
+		req.DefaultBranch = h.detectDefaultBranch(c.Request.Context(), c, provider, req.RepositoryOwner, req.RepositoryName)
 	}
 	if req.ModulePath == "" {
 		req.ModulePath = "/"
@@ -230,12 +230,24 @@ func (h *SCMLinkingHandler) UpdateSCMLink(c *gin.Context) {
 		return
 	}
 
-	// Update fields
-	link.RepositoryOwner = req.RepositoryOwner
-	link.RepositoryName = req.RepositoryName
-	link.DefaultBranch = req.DefaultBranch
-	link.ModulePath = req.ModulePath
-	link.TagPattern = req.TagPattern
+	// Update fields — only overwrite string fields when the request provides a non-empty value
+	// so partial updates (e.g. only changing default_branch) don't clobber the rest.
+	if req.RepositoryOwner != "" {
+		link.RepositoryOwner = req.RepositoryOwner
+	}
+	if req.RepositoryName != "" {
+		link.RepositoryName = req.RepositoryName
+	}
+	if req.DefaultBranch != "" {
+		link.DefaultBranch = req.DefaultBranch
+	}
+	if req.ModulePath != "" {
+		link.ModulePath = req.ModulePath
+	}
+	if req.TagPattern != "" {
+		link.TagPattern = req.TagPattern
+	}
+	// AutoPublish is boolean: always update because false is a valid intentional value.
 	link.AutoPublish = req.AutoPublish
 
 	if err := h.scmRepo.UpdateModuleSourceRepo(c.Request.Context(), link); err != nil {
@@ -589,4 +601,54 @@ func getUserIDFromContext(c *gin.Context) (uuid.UUID, error) {
 	default:
 		return uuid.UUID{}, fmt.Errorf("unexpected user ID type")
 	}
+}
+
+// detectDefaultBranch attempts to auto-detect the default branch of a repository
+// using the calling user's OAuth token. Returns "main" on any failure (non-fatal).
+func (h *SCMLinkingHandler) detectDefaultBranch(ctx context.Context, c *gin.Context, provider *scm.SCMProvider, owner, repoName string) string {
+	userID, err := getUserIDFromContext(c)
+	if err != nil {
+		return "main"
+	}
+	tokenRecord, err := h.scmRepo.GetUserToken(ctx, userID, provider.ID)
+	if err != nil || tokenRecord == nil {
+		return "main"
+	}
+	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	if err != nil {
+		return "main"
+	}
+	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	if err != nil {
+		return "main"
+	}
+	baseURL := ""
+	if provider.BaseURL != nil {
+		baseURL = *provider.BaseURL
+	}
+	tenantID := ""
+	if provider.TenantID != nil {
+		tenantID = *provider.TenantID
+	}
+	connector, err := scm.BuildConnector(&scm.ConnectorSettings{
+		Kind:            provider.ProviderType,
+		InstanceBaseURL: baseURL,
+		ClientID:        provider.ClientID,
+		ClientSecret:    clientSecret,
+		CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, provider.ID),
+		TenantID:        tenantID,
+	})
+	if err != nil {
+		return "main"
+	}
+	token := &scm.OAuthToken{
+		AccessToken: accessToken,
+		TokenType:   tokenRecord.TokenType,
+		ExpiresAt:   tokenRecord.ExpiresAt,
+	}
+	sourceRepo, err := connector.FetchRepository(ctx, token, owner, repoName)
+	if err != nil || sourceRepo == nil || sourceRepo.DefaultBranch == "" {
+		return "main"
+	}
+	return sourceRepo.DefaultBranch
 }

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -359,7 +359,9 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 }
 
 func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitTag, error) {
-	endpoint := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/refs?filter=tags/&api-version=7.0", c.baseURL, c.organization, ownerName, repoName)
+	// peelTags=true causes ADO to include peeledObjectId for annotated tags,
+	// which is the actual commit SHA (objectId for annotated tags is the tag object SHA, not the commit).
+	endpoint := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/refs?filter=tags/&peelTags=true&api-version=7.0", c.baseURL, c.organization, ownerName, repoName)
 	fmt.Printf("[FetchTags] GET %s\n", endpoint)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
@@ -387,8 +389,9 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 
 	var result struct {
 		Value []struct {
-			Name     string `json:"name"`
-			ObjectID string `json:"objectId"`
+			Name           string `json:"name"`
+			ObjectID       string `json:"objectId"`
+			PeeledObjectID string `json:"peeledObjectId"` // commit SHA for annotated tags; absent for lightweight tags
 		} `json:"value"`
 	}
 
@@ -399,9 +402,15 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 	tags := make([]*scm.GitTag, len(result.Value))
 	for i, ref := range result.Value {
 		tagName := strings.TrimPrefix(ref.Name, "refs/tags/")
+		// For annotated tags peeledObjectId holds the commit SHA; objectId is the tag object SHA.
+		// For lightweight tags peeledObjectId is absent, so objectId is already the commit SHA.
+		commitSHA := ref.ObjectID
+		if ref.PeeledObjectID != "" {
+			commitSHA = ref.PeeledObjectID
+		}
 		tags[i] = &scm.GitTag{
 			TagName:      tagName,
-			TargetCommit: ref.ObjectID,
+			TargetCommit: commitSHA,
 		}
 	}
 

--- a/backend/internal/scm/azuredevops/connector_test.go
+++ b/backend/internal/scm/azuredevops/connector_test.go
@@ -193,6 +193,48 @@ func TestFetchTags_Success(t *testing.T) {
 	}
 }
 
+func TestFetchTags_AnnotatedTagUsesPeeledSHA(t *testing.T) {
+	// The migration script creates annotated tags; ADO returns peeledObjectId (commit SHA)
+	// alongside objectId (tag object SHA). FetchTags must use peeledObjectId.
+	result := map[string]interface{}{
+		"value": []map[string]interface{}{
+			{
+				"name":           "refs/tags/v1.2.3",
+				"objectId":       "tagobjectsha0000000000000000000000000000",
+				"peeledObjectId": "commitsha0000000000000000000000000000000",
+			},
+		},
+	}
+	_, c := newTestConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(result)
+	})
+
+	tags, err := c.FetchTags(context.Background(), creds(), "proj", "repo", scm.DefaultPagination())
+	if err != nil {
+		t.Fatalf("FetchTags error: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0].TargetCommit != "commitsha0000000000000000000000000000000" {
+		t.Errorf("TargetCommit = %q, want commit SHA (peeled); got tag object SHA", tags[0].TargetCommit)
+	}
+}
+
+func TestFetchTags_PeelTagsInURL(t *testing.T) {
+	// Verify the request includes peelTags=true so ADO returns peeledObjectId.
+	var requestURL string
+	_, c := newTestConnector(t, func(w http.ResponseWriter, r *http.Request) {
+		requestURL = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]interface{}{"value": []interface{}{}})
+	})
+
+	_, _ = c.FetchTags(context.Background(), creds(), "proj", "repo", scm.DefaultPagination())
+	if !strings.Contains(requestURL, "peelTags=true") {
+		t.Errorf("request URL query %q does not include peelTags=true", requestURL)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FetchTagByName (uses FetchTags then filters)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## v0.2.22

### Fixed

- fix: ADO \`FetchTags\` now adds \`peelTags=true\` and uses \`peeledObjectId\` as the commit SHA for annotated tags — migration script creates annotated tags whose \`objectId\` is the tag-object SHA, not the commit SHA, causing \`DownloadSourceArchive\` to 404 with \`versionType=commit\`
- fix: \`LinkModuleToSCM\` auto-detects the repository's true default branch via \`FetchRepository\` when \`default_branch\` is omitted, instead of always defaulting to \`"main"\` — repos migrated from ADO with \`master\` as default branch now store correct metadata
- fix: \`UpdateSCMLink\` no longer overwrites optional string fields with empty strings on partial update — fields absent from the request body now preserve their existing values
- fix: \`GetModule\` response now includes \`created_by_name\` (user display name) and per-version \`published_by\` / \`published_by_name\` — these were already populated by the DB join but excluded from the \`gin.H\` response map

### Changed

- test: \`api-test\` integration tool now covers \`PUT /api/v1/admin/modules/{id}\` (UpdateModuleRecord), \`POST /api/v1/admin/providers\` (CreateProviderRecord), and \`GET /api/v1/admin/providers/{id}\` (GetProviderByID)

## Checklist

- [x] All 38 test packages pass (\`go test ./...\`)
- [x] \`go build ./...\` clean
- [x] CHANGELOG.md updated (v0.2.22 section correctly separated from v0.2.21)
- [ ] Merge and tag \`v0.2.22\` on \`main\` post-merge