### PR TITLE
chore: release v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.23] - 2026-03-22
+
+### Added
+
+- feat: provider documentation browsing — new `provider_version_docs` table stores doc metadata fetched from the HashiCorp registry v1 API during mirror sync; two new endpoints (`GET /api/v1/providers/:namespace/:type/versions/:version/docs` and `GET /api/v1/providers/:namespace/:type/versions/:version/docs/:category/:slug`) serve the doc index and proxy markdown content from the registry v2 API with a 15-minute in-memory TTL cache
+
+---
+
 ## [0.2.22] - 2026-03-21
 
 ### Fixed

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5593,6 +5593,153 @@
                 }
             }
         },
+        "/api/v1/providers/{namespace}/{type}/versions/{version}/docs": {
+            "get": {
+                "description": "Returns documentation metadata (title, slug, category) for a specific provider version. Only available for mirrored providers whose doc index was fetched during sync.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "List provider documentation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider type",
+                        "name": "type",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by doc category (overview, resources, data-sources, etc.)",
+                        "name": "category",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by language (hcl, python, typescript)",
+                        "name": "language",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/providers.ProviderDocsListResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Provider or version not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/providers/{namespace}/{type}/versions/{version}/docs/{category}/{slug}": {
+            "get": {
+                "description": "Returns the full markdown content for a single documentation page, proxied from the upstream registry. Results are cached in memory for 15 minutes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "Get provider documentation content",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider type",
+                        "name": "type",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Documentation category (overview, resources, data-sources, etc.)",
+                        "name": "category",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Documentation slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/providers.ProviderDocContentResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Documentation not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to fetch from upstream",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/scm-providers": {
             "get": {
                 "security": [
@@ -11399,6 +11546,63 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "providers.ProviderDocContentResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "providers.ProviderDocEntryResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "subcategory": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "providers.ProviderDocsListResponse": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "docs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/providers.ProviderDocEntryResponse"
+                    }
                 }
             }
         },

--- a/backend/internal/api/providers/docs.go
+++ b/backend/internal/api/providers/docs.go
@@ -1,0 +1,270 @@
+// docs.go implements provider documentation endpoints that serve cached doc metadata
+// from the database and proxy doc content from the upstream registry's v2 API.
+package providers
+
+import (
+	"database/sql"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+)
+
+// ProviderDocEntryResponse represents a single doc entry in list responses.
+type ProviderDocEntryResponse struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Slug        string  `json:"slug"`
+	Category    string  `json:"category"`
+	Subcategory *string `json:"subcategory,omitempty"`
+	Language    string  `json:"language"`
+}
+
+// ProviderDocsListResponse is returned by the doc listing endpoint.
+type ProviderDocsListResponse struct {
+	Docs       []ProviderDocEntryResponse `json:"docs"`
+	Categories []string                   `json:"categories"`
+}
+
+// ProviderDocContentResponse is returned by the doc content endpoint.
+type ProviderDocContentResponse struct {
+	Content  string `json:"content"`
+	Title    string `json:"title"`
+	Category string `json:"category"`
+	Slug     string `json:"slug"`
+}
+
+// docCacheEntry holds a cached doc content response.
+type docCacheEntry struct {
+	content   string
+	fetchedAt time.Time
+}
+
+// docContentCache is a simple in-memory LRU-ish cache with TTL eviction.
+type docContentCache struct {
+	mu      sync.RWMutex
+	entries map[string]docCacheEntry
+	maxSize int
+	ttl     time.Duration
+}
+
+func newDocContentCache(maxSize int, ttl time.Duration) *docContentCache {
+	return &docContentCache{
+		entries: make(map[string]docCacheEntry),
+		maxSize: maxSize,
+		ttl:     ttl,
+	}
+}
+
+func (c *docContentCache) get(key string) (string, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if time.Since(entry.fetchedAt) > c.ttl {
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
+		return "", false
+	}
+	return entry.content, true
+}
+
+func (c *docContentCache) set(key, content string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Simple eviction: if at capacity, drop the oldest entry.
+	if len(c.entries) >= c.maxSize {
+		var oldestKey string
+		var oldestTime time.Time
+		for k, v := range c.entries {
+			if oldestKey == "" || v.fetchedAt.Before(oldestTime) {
+				oldestKey = k
+				oldestTime = v.fetchedAt
+			}
+		}
+		delete(c.entries, oldestKey)
+	}
+	c.entries[key] = docCacheEntry{content: content, fetchedAt: time.Now()}
+}
+
+// @Summary      List provider documentation
+// @Description  Returns documentation metadata (title, slug, category) for a specific provider version. Only available for mirrored providers whose doc index was fetched during sync.
+// @Tags         Providers
+// @Produce      json
+// @Param        namespace  path   string  true  "Provider namespace"
+// @Param        type       path   string  true  "Provider type"
+// @Param        version    path   string  true  "Provider version"
+// @Param        category   query  string  false "Filter by doc category (overview, resources, data-sources, etc.)"
+// @Param        language   query  string  false "Filter by language (hcl, python, typescript)"
+// @Success      200  {object}  ProviderDocsListResponse
+// @Failure      404  {object}  map[string]interface{}  "Provider or version not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/providers/{namespace}/{type}/versions/{version}/docs [get]
+func ListProviderDocsHandler(db *sql.DB) gin.HandlerFunc {
+	providerRepo := repositories.NewProviderRepository(db)
+	docsRepo := repositories.NewProviderDocsRepository(db)
+
+	return func(c *gin.Context) {
+		namespace := c.Param("namespace")
+		providerType := c.Param("type")
+		version := c.Param("version")
+
+		// Look up provider then version
+		provider, err := providerRepo.GetProviderByNamespaceType(c.Request.Context(), "", namespace, providerType)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to look up provider"})
+			return
+		}
+		if provider == nil {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "Provider not found"})
+			return
+		}
+
+		versionRecord, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, version)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to look up provider version"})
+			return
+		}
+		if versionRecord == nil {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "Provider version not found"})
+			return
+		}
+
+		// Optional filters
+		var category, language *string
+		if cat := c.Query("category"); cat != "" {
+			category = &cat
+		}
+		if lang := c.Query("language"); lang != "" {
+			language = &lang
+		}
+
+		docs, err := docsRepo.ListProviderVersionDocs(c.Request.Context(), versionRecord.ID, category, language)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to list documentation"})
+			return
+		}
+
+		// Build response
+		resp := ProviderDocsListResponse{
+			Docs:       make([]ProviderDocEntryResponse, 0, len(docs)),
+			Categories: []string{},
+		}
+		categorySet := make(map[string]bool)
+		for _, d := range docs {
+			resp.Docs = append(resp.Docs, ProviderDocEntryResponse{
+				ID:          d.UpstreamDocID,
+				Title:       d.Title,
+				Slug:        d.Slug,
+				Category:    d.Category,
+				Subcategory: d.Subcategory,
+				Language:    d.Language,
+			})
+			if !categorySet[d.Category] {
+				categorySet[d.Category] = true
+				resp.Categories = append(resp.Categories, d.Category)
+			}
+		}
+
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// @Summary      Get provider documentation content
+// @Description  Returns the full markdown content for a single documentation page, proxied from the upstream registry. Results are cached in memory for 15 minutes.
+// @Tags         Providers
+// @Produce      json
+// @Param        namespace  path  string  true  "Provider namespace"
+// @Param        type       path  string  true  "Provider type"
+// @Param        version    path  string  true  "Provider version"
+// @Param        category   path  string  true  "Documentation category (overview, resources, data-sources, etc.)"
+// @Param        slug       path  string  true  "Documentation slug"
+// @Success      200  {object}  ProviderDocContentResponse
+// @Failure      404  {object}  map[string]interface{}  "Documentation not found"
+// @Failure      502  {object}  map[string]interface{}  "Failed to fetch from upstream"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/providers/{namespace}/{type}/versions/{version}/docs/{category}/{slug} [get]
+func GetProviderDocContentHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
+	providerRepo := repositories.NewProviderRepository(db)
+	docsRepo := repositories.NewProviderDocsRepository(db)
+	cache := newDocContentCache(500, 15*time.Minute)
+
+	return func(c *gin.Context) {
+		namespace := c.Param("namespace")
+		providerType := c.Param("type")
+		version := c.Param("version")
+		category := c.Param("category")
+		slug := c.Param("slug")
+
+		// Look up provider then version
+		provider, err := providerRepo.GetProviderByNamespaceType(c.Request.Context(), "", namespace, providerType)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to look up provider"})
+			return
+		}
+		if provider == nil {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "Provider not found"})
+			return
+		}
+
+		versionRecord, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, version)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to look up provider version"})
+			return
+		}
+		if versionRecord == nil {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "Provider version not found"})
+			return
+		}
+
+		// Look up the doc entry to get the upstream doc ID
+		doc, err := docsRepo.GetProviderVersionDocBySlug(c.Request.Context(), versionRecord.ID, category, slug)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "Failed to look up documentation entry"})
+			return
+		}
+		if doc == nil {
+			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "Documentation page not found"})
+			return
+		}
+
+		// Check cache
+		cacheKey := doc.UpstreamDocID
+		if content, ok := cache.get(cacheKey); ok {
+			c.JSON(http.StatusOK, ProviderDocContentResponse{
+				Content:  content,
+				Title:    doc.Title,
+				Category: doc.Category,
+				Slug:     doc.Slug,
+			})
+			return
+		}
+
+		// Proxy from upstream registry
+		upstreamURL := "https://registry.terraform.io"
+		upstream := mirror.NewUpstreamRegistry(upstreamURL)
+
+		content, err := upstream.GetProviderDocContent(c.Request.Context(), doc.UpstreamDocID)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"status": "error", "message": "Failed to fetch documentation from upstream registry"})
+			return
+		}
+
+		// Cache the result
+		cache.set(cacheKey, content)
+
+		c.JSON(http.StatusOK, ProviderDocContentResponse{
+			Content:  content,
+			Title:    doc.Title,
+			Category: doc.Category,
+			Slug:     doc.Slug,
+		})
+	}
+}

--- a/backend/internal/api/providers/docs_test.go
+++ b/backend/internal/api/providers/docs_test.go
@@ -1,0 +1,340 @@
+package providers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// Column definitions for docs handler tests
+// ---------------------------------------------------------------------------
+
+// GetProviderByNamespaceType (single-tenant / empty orgID): 8 columns
+var docsProviderCols = []string{
+	"id", "organization_id", "namespace", "type", "description", "source",
+	"created_at", "updated_at",
+}
+
+// provider version row (GetVersion): id, provider_id, version, protocols, gpg_key, shasums_url, shasums_sig_url, published_by, deprecated, deprecated_at, deprecation_message, created_at
+var docsVersionCols = []string{
+	"id", "provider_id", "version", "protocols", "gpg_public_key",
+	"shasums_url", "shasums_signature_url", "published_by",
+	"deprecated", "deprecated_at", "deprecation_message", "created_at",
+}
+
+// doc entry row: id, provider_version_id, upstream_doc_id, title, slug, category, subcategory, path, language
+var docsDocCols = []string{
+	"id", "provider_version_id", "upstream_doc_id",
+	"title", "slug", "category", "subcategory", "path", "language",
+}
+
+// ---------------------------------------------------------------------------
+// ListProviderDocsHandler
+// ---------------------------------------------------------------------------
+
+func TestListProviderDocsHandler_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// GetProviderByNamespaceType
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("hashicorp", "random").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols).
+			AddRow("prov-1", nil, "hashicorp", "random", nil, "https://registry.terraform.io/hashicorp/random", time.Now(), time.Now()))
+
+	// GetVersion
+	mock.ExpectQuery("SELECT.*FROM provider_versions").
+		WithArgs("prov-1", "3.6.0").
+		WillReturnRows(sqlmock.NewRows(docsVersionCols).
+			AddRow("ver-1", "prov-1", "3.6.0", []byte(`["5.0"]`), "", "", "", nil, false, nil, nil, time.Now()))
+
+	// ListProviderVersionDocs
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1").
+		WillReturnRows(sqlmock.NewRows(docsDocCols).
+			AddRow("d1", "ver-1", "101", "overview", "index", "overview", nil, "docs/index.md", "hcl").
+			AddRow("d2", "ver-1", "102", "random_id", "random_id", "resources", nil, "docs/resources/random_id.md", "hcl"))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "hashicorp"},
+		{Key: "type", Value: "random"},
+		{Key: "version", Value: "3.6.0"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/hashicorp/random/versions/3.6.0/docs", nil)
+
+	handler := ListProviderDocsHandler(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	var resp ProviderDocsListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Docs) != 2 {
+		t.Errorf("docs count = %d, want 2", len(resp.Docs))
+	}
+	if len(resp.Categories) != 2 {
+		t.Errorf("categories count = %d, want 2", len(resp.Categories))
+	}
+}
+
+func TestListProviderDocsHandler_ProviderNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// GetProviderByNamespaceType returns no rows
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("acme", "nonexistent").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "acme"},
+		{Key: "type", Value: "nonexistent"},
+		{Key: "version", Value: "1.0.0"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/acme/nonexistent/versions/1.0.0/docs", nil)
+
+	handler := ListProviderDocsHandler(db)
+	handler(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestListProviderDocsHandler_VersionNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// Provider found
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("hashicorp", "random").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols).
+			AddRow("prov-1", nil, "hashicorp", "random", nil, nil, time.Now(), time.Now()))
+
+	// Version not found
+	mock.ExpectQuery("SELECT.*FROM provider_versions").
+		WithArgs("prov-1", "99.0.0").
+		WillReturnRows(sqlmock.NewRows(docsVersionCols))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "hashicorp"},
+		{Key: "type", Value: "random"},
+		{Key: "version", Value: "99.0.0"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/hashicorp/random/versions/99.0.0/docs", nil)
+
+	handler := ListProviderDocsHandler(db)
+	handler(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestListProviderDocsHandler_EmptyDocs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("hashicorp", "random").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols).
+			AddRow("prov-1", nil, "hashicorp", "random", nil, nil, time.Now(), time.Now()))
+
+	mock.ExpectQuery("SELECT.*FROM provider_versions").
+		WithArgs("prov-1", "3.6.0").
+		WillReturnRows(sqlmock.NewRows(docsVersionCols).
+			AddRow("ver-1", "prov-1", "3.6.0", []byte(`["5.0"]`), "", "", "", nil, false, nil, nil, time.Now()))
+
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1").
+		WillReturnRows(sqlmock.NewRows(docsDocCols))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "hashicorp"},
+		{Key: "type", Value: "random"},
+		{Key: "version", Value: "3.6.0"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/hashicorp/random/versions/3.6.0/docs", nil)
+
+	handler := ListProviderDocsHandler(db)
+	handler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp ProviderDocsListResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Docs) != 0 {
+		t.Errorf("docs count = %d, want 0", len(resp.Docs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetProviderDocContentHandler
+// ---------------------------------------------------------------------------
+
+func TestGetProviderDocContentHandler_ProviderNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("acme", "nonexistent").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "acme"},
+		{Key: "type", Value: "nonexistent"},
+		{Key: "version", Value: "1.0.0"},
+		{Key: "category", Value: "overview"},
+		{Key: "slug", Value: "index"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/acme/nonexistent/versions/1.0.0/docs/overview/index", nil)
+
+	cfg := &config.Config{}
+	handler := GetProviderDocContentHandler(db, cfg)
+	handler(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestGetProviderDocContentHandler_DocNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// Provider found
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WithArgs("hashicorp", "random").
+		WillReturnRows(sqlmock.NewRows(docsProviderCols).
+			AddRow("prov-1", nil, "hashicorp", "random", nil, nil, time.Now(), time.Now()))
+
+	// Version found
+	mock.ExpectQuery("SELECT.*FROM provider_versions").
+		WithArgs("prov-1", "3.6.0").
+		WillReturnRows(sqlmock.NewRows(docsVersionCols).
+			AddRow("ver-1", "prov-1", "3.6.0", []byte(`["5.0"]`), "", "", "", nil, false, nil, nil, time.Now()))
+
+	// Doc slug not found
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1", "overview", "nonexistent").
+		WillReturnRows(sqlmock.NewRows(docsDocCols))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "namespace", Value: "hashicorp"},
+		{Key: "type", Value: "random"},
+		{Key: "version", Value: "3.6.0"},
+		{Key: "category", Value: "overview"},
+		{Key: "slug", Value: "nonexistent"},
+	}
+	c.Request = httptest.NewRequest("GET", "/api/v1/providers/hashicorp/random/versions/3.6.0/docs/overview/nonexistent", nil)
+
+	cfg := &config.Config{}
+	handler := GetProviderDocContentHandler(db, cfg)
+	handler(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// docContentCache
+// ---------------------------------------------------------------------------
+
+func TestDocContentCache_SetAndGet(t *testing.T) {
+	cache := newDocContentCache(10, 15*time.Minute)
+
+	cache.set("key1", "content1")
+	content, ok := cache.get("key1")
+	if !ok {
+		t.Error("expected cache hit")
+	}
+	if content != "content1" {
+		t.Errorf("content = %q, want content1", content)
+	}
+}
+
+func TestDocContentCache_Miss(t *testing.T) {
+	cache := newDocContentCache(10, 15*time.Minute)
+
+	_, ok := cache.get("nonexistent")
+	if ok {
+		t.Error("expected cache miss")
+	}
+}
+
+func TestDocContentCache_Expiry(t *testing.T) {
+	cache := newDocContentCache(10, 1*time.Millisecond)
+
+	cache.set("key1", "content1")
+	time.Sleep(5 * time.Millisecond)
+
+	_, ok := cache.get("key1")
+	if ok {
+		t.Error("expected cache miss after TTL expiry")
+	}
+}
+
+func TestDocContentCache_Eviction(t *testing.T) {
+	cache := newDocContentCache(2, 15*time.Minute)
+
+	cache.set("key1", "content1")
+	cache.set("key2", "content2")
+	cache.set("key3", "content3") // should evict key1
+
+	_, ok := cache.get("key1")
+	if ok {
+		t.Error("expected key1 to be evicted")
+	}
+
+	content, ok := cache.get("key3")
+	if !ok {
+		t.Error("expected cache hit for key3")
+	}
+	if content != "content3" {
+		t.Errorf("content = %q, want content3", content)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -116,8 +116,10 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	storageConfigRepo := repositories.NewStorageConfigRepository(sqlxDB)
 	oidcConfigRepo := repositories.NewOIDCConfigRepository(sqlxDB)
 
+	providerDocsRepo := repositories.NewProviderDocsRepository(db)
+
 	// Initialize mirror sync job
-	mirrorSyncJob := jobs.NewMirrorSyncJob(mirrorRepo, providerRepo, orgRepo, storageBackend, cfg.Storage.DefaultBackend)
+	mirrorSyncJob := jobs.NewMirrorSyncJob(mirrorRepo, providerRepo, providerDocsRepo, orgRepo, storageBackend, cfg.Storage.DefaultBackend)
 	// Start background sync job - check every 10 minutes for mirrors that need syncing
 	mirrorSyncJob.Start(context.Background(), 10)
 	log.Println("Mirror sync job started (checking every 10 minutes)")
@@ -479,6 +481,8 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 		{
 			publicDetailGroup.GET("/modules/:namespace/:name/:system", moduleAdminHandlers.GetModule)
 			publicDetailGroup.GET("/providers/:namespace/:type", providerAdminHandlers.GetProvider)
+			publicDetailGroup.GET("/providers/:namespace/:type/versions/:version/docs", providers.ListProviderDocsHandler(db))
+			publicDetailGroup.GET("/providers/:namespace/:type/versions/:version/docs/:category/:slug", providers.GetProviderDocContentHandler(db, cfg))
 		}
 
 		// Authenticated-only endpoints

--- a/backend/internal/db/migrations/000012_provider_version_docs.down.sql
+++ b/backend/internal/db/migrations/000012_provider_version_docs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS provider_version_docs;

--- a/backend/internal/db/migrations/000012_provider_version_docs.up.sql
+++ b/backend/internal/db/migrations/000012_provider_version_docs.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE provider_version_docs (
+    id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider_version_id UUID         NOT NULL REFERENCES provider_versions(id) ON DELETE CASCADE,
+    upstream_doc_id     VARCHAR(50)  NOT NULL,
+    title               VARCHAR(255) NOT NULL,
+    slug                VARCHAR(255) NOT NULL,
+    category            VARCHAR(50)  NOT NULL,
+    subcategory         VARCHAR(255),
+    path                VARCHAR(512),
+    language            VARCHAR(20)  NOT NULL DEFAULT 'hcl',
+    created_at          TIMESTAMP    NOT NULL DEFAULT NOW(),
+    UNIQUE (provider_version_id, upstream_doc_id)
+);
+
+CREATE INDEX idx_pvd_version  ON provider_version_docs(provider_version_id);
+CREATE INDEX idx_pvd_category ON provider_version_docs(provider_version_id, category);

--- a/backend/internal/db/models/provider.go
+++ b/backend/internal/db/models/provider.go
@@ -55,6 +55,21 @@ type ProviderVersionShasum struct {
 	SHA256Hex         string // lowercase hex SHA256 of the zip archive
 }
 
+// ProviderVersionDoc holds documentation metadata for a provider version, sourced
+// from the upstream registry's v1 provider API.  Only the index entry is stored;
+// the full markdown content is fetched on demand from the v2 API.
+type ProviderVersionDoc struct {
+	ID                string  `json:"id"`
+	ProviderVersionID string  `json:"provider_version_id"`
+	UpstreamDocID     string  `json:"upstream_doc_id"`
+	Title             string  `json:"title"`
+	Slug              string  `json:"slug"`
+	Category          string  `json:"category"`
+	Subcategory       *string `json:"subcategory,omitempty"`
+	Path              *string `json:"path,omitempty"`
+	Language          string  `json:"language"`
+}
+
 // ProviderPlatform represents a platform-specific binary for a provider version
 type ProviderPlatform struct {
 	ID                string

--- a/backend/internal/db/repositories/provider_docs_repository.go
+++ b/backend/internal/db/repositories/provider_docs_repository.go
@@ -1,0 +1,136 @@
+// provider_docs_repository.go implements ProviderDocsRepository, providing database
+// queries for provider version documentation metadata (doc index entries synced from
+// the upstream registry).
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// ProviderDocsRepository handles database operations for provider documentation metadata.
+type ProviderDocsRepository struct {
+	db *sql.DB
+}
+
+// NewProviderDocsRepository creates a new provider docs repository.
+func NewProviderDocsRepository(db *sql.DB) *ProviderDocsRepository {
+	return &ProviderDocsRepository{db: db}
+}
+
+// BulkCreateProviderVersionDocs inserts multiple doc index entries for a provider version.
+// Existing entries with the same (provider_version_id, upstream_doc_id) are skipped.
+func (r *ProviderDocsRepository) BulkCreateProviderVersionDocs(ctx context.Context, versionID string, docs []models.ProviderVersionDoc) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	// Build a batched INSERT with ON CONFLICT DO NOTHING
+	const batchSize = 500
+	for i := 0; i < len(docs); i += batchSize {
+		end := i + batchSize
+		if end > len(docs) {
+			end = len(docs)
+		}
+		batch := docs[i:end]
+
+		var b strings.Builder
+		b.WriteString(`INSERT INTO provider_version_docs (provider_version_id, upstream_doc_id, title, slug, category, subcategory, path, language) VALUES `)
+		args := make([]interface{}, 0, len(batch)*8)
+		for j, doc := range batch {
+			if j > 0 {
+				b.WriteString(", ")
+			}
+			base := j * 8
+			fmt.Fprintf(&b, "($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+				base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8)
+			args = append(args, versionID, doc.UpstreamDocID, doc.Title, doc.Slug, doc.Category, doc.Subcategory, doc.Path, doc.Language)
+		}
+		b.WriteString(" ON CONFLICT (provider_version_id, upstream_doc_id) DO NOTHING")
+
+		if _, err := r.db.ExecContext(ctx, b.String(), args...); err != nil {
+			return fmt.Errorf("failed to bulk insert provider version docs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ListProviderVersionDocs returns doc index entries for a provider version,
+// optionally filtered by category and/or language.
+func (r *ProviderDocsRepository) ListProviderVersionDocs(ctx context.Context, versionID string, category, language *string) ([]models.ProviderVersionDoc, error) {
+	var b strings.Builder
+	b.WriteString(`SELECT id, provider_version_id, upstream_doc_id, title, slug, category, subcategory, path, language
+		FROM provider_version_docs WHERE provider_version_id = $1`)
+	args := []interface{}{versionID}
+	argIdx := 2
+
+	if category != nil && *category != "" {
+		fmt.Fprintf(&b, " AND category = $%d", argIdx)
+		args = append(args, *category)
+		argIdx++
+	}
+	if language != nil && *language != "" {
+		fmt.Fprintf(&b, " AND language = $%d", argIdx)
+		args = append(args, *language)
+		argIdx++
+	}
+	_ = argIdx
+
+	b.WriteString(" ORDER BY category, title")
+
+	rows, err := r.db.QueryContext(ctx, b.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list provider version docs: %w", err)
+	}
+	defer rows.Close()
+
+	var docs []models.ProviderVersionDoc
+	for rows.Next() {
+		var doc models.ProviderVersionDoc
+		if err := rows.Scan(
+			&doc.ID, &doc.ProviderVersionID, &doc.UpstreamDocID,
+			&doc.Title, &doc.Slug, &doc.Category, &doc.Subcategory,
+			&doc.Path, &doc.Language,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan provider version doc: %w", err)
+		}
+		docs = append(docs, doc)
+	}
+	return docs, rows.Err()
+}
+
+// GetProviderVersionDocBySlug retrieves a single doc entry by category and slug.
+func (r *ProviderDocsRepository) GetProviderVersionDocBySlug(ctx context.Context, versionID, category, slug string) (*models.ProviderVersionDoc, error) {
+	query := `SELECT id, provider_version_id, upstream_doc_id, title, slug, category, subcategory, path, language
+		FROM provider_version_docs
+		WHERE provider_version_id = $1 AND category = $2 AND slug = $3
+		LIMIT 1`
+
+	doc := &models.ProviderVersionDoc{}
+	err := r.db.QueryRowContext(ctx, query, versionID, category, slug).Scan(
+		&doc.ID, &doc.ProviderVersionID, &doc.UpstreamDocID,
+		&doc.Title, &doc.Slug, &doc.Category, &doc.Subcategory,
+		&doc.Path, &doc.Language,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider version doc by slug: %w", err)
+	}
+	return doc, nil
+}
+
+// DeleteProviderVersionDocs removes all doc entries for a provider version.
+func (r *ProviderDocsRepository) DeleteProviderVersionDocs(ctx context.Context, versionID string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM provider_version_docs WHERE provider_version_id = $1`, versionID)
+	if err != nil {
+		return fmt.Errorf("failed to delete provider version docs: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/db/repositories/provider_docs_repository_test.go
+++ b/backend/internal/db/repositories/provider_docs_repository_test.go
@@ -1,0 +1,287 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// ---------------------------------------------------------------------------
+// Column definitions
+// ---------------------------------------------------------------------------
+
+var provDocCols = []string{
+	"id", "provider_version_id", "upstream_doc_id",
+	"title", "slug", "category", "subcategory", "path", "language",
+}
+
+// ---------------------------------------------------------------------------
+// BulkCreateProviderVersionDocs
+// ---------------------------------------------------------------------------
+
+func TestBulkCreateProviderVersionDocs_Empty(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProviderDocsRepository(db)
+	if err := repo.BulkCreateProviderVersionDocs(context.Background(), "ver-1", nil); err != nil {
+		t.Errorf("empty slice should not error: %v", err)
+	}
+}
+
+func TestBulkCreateProviderVersionDocs_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO provider_version_docs").
+		WithArgs(
+			"ver-1", "101", "overview", "index", "overview", nil, sqlmock.AnyArg(), "hcl",
+			"ver-1", "102", "random_id", "random_id", "resources", nil, sqlmock.AnyArg(), "hcl",
+		).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	repo := NewProviderDocsRepository(db)
+	path1 := "docs/index.md"
+	path2 := "docs/resources/random_id.md"
+	docs := []models.ProviderVersionDoc{
+		{UpstreamDocID: "101", Title: "overview", Slug: "index", Category: "overview", Path: &path1, Language: "hcl"},
+		{UpstreamDocID: "102", Title: "random_id", Slug: "random_id", Category: "resources", Path: &path2, Language: "hcl"},
+	}
+
+	if err := repo.BulkCreateProviderVersionDocs(context.Background(), "ver-1", docs); err != nil {
+		t.Fatalf("BulkCreateProviderVersionDocs error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestBulkCreateProviderVersionDocs_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("INSERT INTO provider_version_docs").
+		WillReturnError(errDB)
+
+	repo := NewProviderDocsRepository(db)
+	docs := []models.ProviderVersionDoc{
+		{UpstreamDocID: "101", Title: "overview", Slug: "index", Category: "overview", Language: "hcl"},
+	}
+
+	if err := repo.BulkCreateProviderVersionDocs(context.Background(), "ver-1", docs); err == nil {
+		t.Error("expected error on DB failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListProviderVersionDocs
+// ---------------------------------------------------------------------------
+
+func TestListProviderVersionDocs_NoFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows(provDocCols).
+		AddRow("d1", "ver-1", "101", "overview", "index", "overview", nil, "docs/index.md", "hcl").
+		AddRow("d2", "ver-1", "102", "random_id", "random_id", "resources", nil, "docs/resources/random_id.md", "hcl")
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1").
+		WillReturnRows(rows)
+
+	repo := NewProviderDocsRepository(db)
+	docs, err := repo.ListProviderVersionDocs(context.Background(), "ver-1", nil, nil)
+	if err != nil {
+		t.Fatalf("ListProviderVersionDocs error: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("got %d docs, want 2", len(docs))
+	}
+}
+
+func TestListProviderVersionDocs_WithCategoryFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows(provDocCols).
+		AddRow("d1", "ver-1", "101", "overview", "index", "overview", nil, "docs/index.md", "hcl")
+	category := "overview"
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1", "overview").
+		WillReturnRows(rows)
+
+	repo := NewProviderDocsRepository(db)
+	docs, err := repo.ListProviderVersionDocs(context.Background(), "ver-1", &category, nil)
+	if err != nil {
+		t.Fatalf("ListProviderVersionDocs error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("got %d docs, want 1", len(docs))
+	}
+	if docs[0].Category != "overview" {
+		t.Errorf("category = %q, want overview", docs[0].Category)
+	}
+}
+
+func TestListProviderVersionDocs_WithBothFilters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows(provDocCols)
+	category := "resources"
+	language := "python"
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1", "resources", "python").
+		WillReturnRows(rows)
+
+	repo := NewProviderDocsRepository(db)
+	docs, err := repo.ListProviderVersionDocs(context.Background(), "ver-1", &category, &language)
+	if err != nil {
+		t.Fatalf("ListProviderVersionDocs error: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("got %d docs, want 0", len(docs))
+	}
+}
+
+func TestListProviderVersionDocs_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WillReturnError(errDB)
+
+	repo := NewProviderDocsRepository(db)
+	_, err = repo.ListProviderVersionDocs(context.Background(), "ver-1", nil, nil)
+	if err == nil {
+		t.Error("expected error on DB failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetProviderVersionDocBySlug
+// ---------------------------------------------------------------------------
+
+func TestGetProviderVersionDocBySlug_Found(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	rows := sqlmock.NewRows(provDocCols).
+		AddRow("d1", "ver-1", "101", "overview", "index", "overview", nil, "docs/index.md", "hcl")
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1", "overview", "index").
+		WillReturnRows(rows)
+
+	repo := NewProviderDocsRepository(db)
+	doc, err := repo.GetProviderVersionDocBySlug(context.Background(), "ver-1", "overview", "index")
+	if err != nil {
+		t.Fatalf("GetProviderVersionDocBySlug error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected doc, got nil")
+	}
+	if doc.UpstreamDocID != "101" {
+		t.Errorf("upstream_doc_id = %q, want 101", doc.UpstreamDocID)
+	}
+}
+
+func TestGetProviderVersionDocBySlug_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WithArgs("ver-1", "overview", "nonexistent").
+		WillReturnRows(sqlmock.NewRows(provDocCols))
+
+	repo := NewProviderDocsRepository(db)
+	doc, err := repo.GetProviderVersionDocBySlug(context.Background(), "ver-1", "overview", "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc != nil {
+		t.Errorf("expected nil doc for nonexistent slug, got %+v", doc)
+	}
+}
+
+func TestGetProviderVersionDocBySlug_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM provider_version_docs").
+		WillReturnError(errDB)
+
+	repo := NewProviderDocsRepository(db)
+	_, err = repo.GetProviderVersionDocBySlug(context.Background(), "ver-1", "overview", "index")
+	if err == nil {
+		t.Error("expected error on DB failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteProviderVersionDocs
+// ---------------------------------------------------------------------------
+
+func TestDeleteProviderVersionDocs_Success(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM provider_version_docs").
+		WithArgs("ver-1").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	repo := NewProviderDocsRepository(db)
+	if err := repo.DeleteProviderVersionDocs(context.Background(), "ver-1"); err != nil {
+		t.Errorf("DeleteProviderVersionDocs error: %v", err)
+	}
+}
+
+func TestDeleteProviderVersionDocs_DBError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("DELETE FROM provider_version_docs").
+		WillReturnError(errDB)
+
+	repo := NewProviderDocsRepository(db)
+	if err := repo.DeleteProviderVersionDocs(context.Background(), "ver-1"); err == nil {
+		t.Error("expected error on DB failure")
+	}
+}

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -254,6 +254,7 @@ func filterPlatforms(platforms []mirror.ProviderPlatform, filter *string) []mirr
 type MirrorSyncJob struct {
 	mirrorRepo         *repositories.MirrorRepository
 	providerRepo       *repositories.ProviderRepository
+	providerDocsRepo   *repositories.ProviderDocsRepository
 	orgRepo            *repositories.OrganizationRepository
 	storageBackend     storage.Storage
 	storageBackendName string
@@ -268,6 +269,7 @@ type MirrorSyncJob struct {
 func NewMirrorSyncJob(
 	mirrorRepo *repositories.MirrorRepository,
 	providerRepo *repositories.ProviderRepository,
+	providerDocsRepo *repositories.ProviderDocsRepository,
 	orgRepo *repositories.OrganizationRepository,
 	storageBackend storage.Storage,
 	storageBackendName string,
@@ -275,6 +277,7 @@ func NewMirrorSyncJob(
 	return &MirrorSyncJob{
 		mirrorRepo:         mirrorRepo,
 		providerRepo:       providerRepo,
+		providerDocsRepo:   providerDocsRepo,
 		orgRepo:            orgRepo,
 		storageBackend:     storageBackend,
 		storageBackendName: storageBackendName,
@@ -881,6 +884,33 @@ func (j *MirrorSyncJob) syncProviderVersion(
 	if len(shasumMap) > 0 {
 		if err := j.providerRepo.UpsertProviderVersionShasums(ctx, versionRecord.ID, shasumMap); err != nil {
 			log.Printf("Warning: failed to store SHA256SUMS for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+		}
+	}
+
+	// Fetch and store documentation index entries from upstream.
+	// This is non-critical — a failure is logged but does not block the sync.
+	if j.providerDocsRepo != nil {
+		docEntries, err := upstreamClient.GetProviderDocIndex(ctx, namespace, providerName)
+		if err != nil {
+			log.Printf("Warning: failed to fetch doc index for %s/%s: %v", namespace, providerName, err)
+		} else if len(docEntries) > 0 {
+			docModels := make([]models.ProviderVersionDoc, len(docEntries))
+			for i, d := range docEntries {
+				docModels[i] = models.ProviderVersionDoc{
+					UpstreamDocID: d.ID,
+					Title:         d.Title,
+					Slug:          d.Slug,
+					Category:      d.Category,
+					Subcategory:   d.Subcategory,
+					Path:          &d.Path,
+					Language:      d.Language,
+				}
+			}
+			if err := j.providerDocsRepo.BulkCreateProviderVersionDocs(ctx, versionRecord.ID, docModels); err != nil {
+				log.Printf("Warning: failed to store doc index for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+			} else {
+				log.Printf("Stored %d doc index entries for %s/%s@%s", len(docModels), namespace, providerName, version.Version)
+			}
 		}
 	}
 

--- a/backend/internal/jobs/mirror_sync_test.go
+++ b/backend/internal/jobs/mirror_sync_test.go
@@ -433,7 +433,7 @@ func TestFilterPlatforms_CaseInsensitive(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNewMirrorSyncJob(t *testing.T) {
-	job := NewMirrorSyncJob(nil, nil, nil, nil, "")
+	job := NewMirrorSyncJob(nil, nil, nil, nil, nil, "")
 	if job == nil {
 		t.Fatal("NewMirrorSyncJob returned nil")
 	}
@@ -472,7 +472,7 @@ func TestMirrorSyncJob_StartStop_ContextCancel(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM mirror_configurations").
 		WillReturnRows(sqlmock.NewRows(mirrorConfigCols))
 
-	job := NewMirrorSyncJob(mirrorRepo, nil, nil, nil, "")
+	job := NewMirrorSyncJob(mirrorRepo, nil, nil, nil, nil, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -499,7 +499,7 @@ func TestMirrorSyncJob_Stop_DirectStop(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM mirror_configurations").
 		WillReturnRows(sqlmock.NewRows(mirrorConfigCols))
 
-	job := NewMirrorSyncJob(mirrorRepo, nil, nil, nil, "")
+	job := NewMirrorSyncJob(mirrorRepo, nil, nil, nil, nil, "")
 
 	ctx := context.Background()
 	done := make(chan struct{})

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -313,6 +313,109 @@ func (u *UpstreamRegistry) DownloadFileStream(ctx context.Context, fileURL strin
 	return &DownloadStream{Body: resp.Body, ContentLength: resp.ContentLength}, nil
 }
 
+// ProviderDocEntry represents a single documentation entry from the upstream
+// registry's v1 provider detail response.
+type ProviderDocEntry struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Slug        string  `json:"slug"`
+	Category    string  `json:"category"`
+	Subcategory *string `json:"subcategory"`
+	Path        string  `json:"path"`
+	Language    string  `json:"language"`
+}
+
+// providerDetailResponse is the v1 provider detail response that includes the docs array.
+type providerDetailResponse struct {
+	Docs []ProviderDocEntry `json:"docs"`
+}
+
+// providerDocContentV2 is the JSONAPI envelope returned by the v2 provider-docs endpoint.
+type providerDocContentV2 struct {
+	Data struct {
+		Attributes struct {
+			Content   string  `json:"content"`
+			Title     string  `json:"title"`
+			Category  string  `json:"category"`
+			Slug      string  `json:"slug"`
+			Language  string  `json:"language"`
+			Truncated bool    `json:"truncated"`
+			Path      *string `json:"path"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+// GetProviderDocIndex fetches the documentation metadata array from the upstream
+// registry's v1 provider detail endpoint.
+func (u *UpstreamRegistry) GetProviderDocIndex(ctx context.Context, namespace, providerName string) ([]ProviderDocEntry, error) {
+	discovery, err := u.DiscoverServices(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("service discovery failed: %w", err)
+	}
+
+	base, _ := url.Parse(u.BaseURL)
+	provRef, _ := url.Parse(discovery.ProvidersV1)
+	providersBase := base.ResolveReference(provRef)
+	detailURL := fmt.Sprintf("%s/%s/%s",
+		strings.TrimSuffix(providersBase.String(), "/"),
+		namespace,
+		providerName)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", detailURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create doc index request: %w", err)
+	}
+
+	resp, err := u.HTTPClient.Do(req) // #nosec G107 -- URL is sourced from admin-controlled mirror configuration
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch provider doc index: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("provider doc index request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var detail providerDetailResponse
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		return nil, fmt.Errorf("failed to decode provider detail response: %w", err)
+	}
+
+	return detail.Docs, nil
+}
+
+// GetProviderDocContent fetches the full markdown content for a single documentation
+// entry from the upstream registry's v2 provider-docs endpoint.
+func (u *UpstreamRegistry) GetProviderDocContent(ctx context.Context, upstreamDocID string) (string, error) {
+	docURL := fmt.Sprintf("%s/v2/provider-docs/%s",
+		strings.TrimSuffix(u.BaseURL, "/"),
+		upstreamDocID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", docURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create doc content request: %w", err)
+	}
+
+	resp, err := u.HTTPClient.Do(req) // #nosec G107 -- URL is sourced from admin-controlled mirror configuration
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch provider doc content: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("provider doc content request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var v2Resp providerDocContentV2
+	if err := json.NewDecoder(resp.Body).Decode(&v2Resp); err != nil {
+		return "", fmt.Errorf("failed to decode v2 provider doc response: %w", err)
+	}
+
+	return v2Resp.Data.Attributes.Content, nil
+}
+
 // ValidateRegistryURL validates that a registry URL is properly formatted
 func ValidateRegistryURL(registryURL string) error {
 	if registryURL == "" {

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -269,3 +269,134 @@ func TestDownloadFile_ContextCancelled(t *testing.T) {
 		t.Error("expected error for cancelled context, got nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GetProviderDocIndex
+// ---------------------------------------------------------------------------
+
+func TestGetProviderDocIndex_Success(t *testing.T) {
+	sub := "random"
+	_, u := newTestRegistry(t, newDiscoveryHandler("/v1/providers/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/hashicorp/"+sub) {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(providerDetailResponse{
+			Docs: []ProviderDocEntry{
+				{ID: "100", Title: "overview", Slug: "index", Category: "overview", Language: "hcl"},
+				{ID: "101", Title: "random_id", Slug: "random_id", Category: "resources", Language: "hcl"},
+			},
+		})
+	})))
+
+	docs, err := u.GetProviderDocIndex(context.Background(), "hashicorp", sub)
+	if err != nil {
+		t.Fatalf("GetProviderDocIndex error: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("got %d docs, want 2", len(docs))
+	}
+	if docs[0].ID != "100" {
+		t.Errorf("first doc ID = %q, want 100", docs[0].ID)
+	}
+	if docs[1].Category != "resources" {
+		t.Errorf("second doc category = %q, want resources", docs[1].Category)
+	}
+}
+
+func TestGetProviderDocIndex_HTTPError(t *testing.T) {
+	_, u := newTestRegistry(t, newDiscoveryHandler("/v1/providers/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})))
+
+	_, err := u.GetProviderDocIndex(context.Background(), "acme", "nonexistent")
+	if err == nil {
+		t.Error("expected error for non-200 response")
+	}
+}
+
+func TestGetProviderDocIndex_EmptyDocs(t *testing.T) {
+	_, u := newTestRegistry(t, newDiscoveryHandler("/v1/providers/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(providerDetailResponse{Docs: []ProviderDocEntry{}})
+	})))
+
+	docs, err := u.GetProviderDocIndex(context.Background(), "hashicorp", "null")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected empty docs, got %d", len(docs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetProviderDocContent
+// ---------------------------------------------------------------------------
+
+func TestGetProviderDocContent_Success(t *testing.T) {
+	_, u := newTestRegistry(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/provider-docs/12345" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(providerDocContentV2{
+			Data: struct {
+				Attributes struct {
+					Content   string  `json:"content"`
+					Title     string  `json:"title"`
+					Category  string  `json:"category"`
+					Slug      string  `json:"slug"`
+					Language  string  `json:"language"`
+					Truncated bool    `json:"truncated"`
+					Path      *string `json:"path"`
+				} `json:"attributes"`
+			}{
+				Attributes: struct {
+					Content   string  `json:"content"`
+					Title     string  `json:"title"`
+					Category  string  `json:"category"`
+					Slug      string  `json:"slug"`
+					Language  string  `json:"language"`
+					Truncated bool    `json:"truncated"`
+					Path      *string `json:"path"`
+				}{
+					Content:  "# Random Provider\n\nThis is the overview.",
+					Title:    "overview",
+					Category: "overview",
+					Slug:     "index",
+					Language: "hcl",
+				},
+			},
+		})
+	})
+
+	content, err := u.GetProviderDocContent(context.Background(), "12345")
+	if err != nil {
+		t.Fatalf("GetProviderDocContent error: %v", err)
+	}
+	if !strings.Contains(content, "Random Provider") {
+		t.Errorf("content = %q, expected to contain 'Random Provider'", content)
+	}
+}
+
+func TestGetProviderDocContent_HTTPError(t *testing.T) {
+	_, u := newTestRegistry(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	_, err := u.GetProviderDocContent(context.Background(), "99999")
+	if err == nil {
+		t.Error("expected error for non-200 response")
+	}
+}
+
+func TestGetProviderDocContent_InvalidJSON(t *testing.T) {
+	_, u := newTestRegistry(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("not json"))
+	})
+
+	_, err := u.GetProviderDocContent(context.Background(), "12345")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}


### PR DESCRIPTION
## Summary

- feat: provider documentation browsing — new `provider_version_docs` table stores doc metadata fetched from HashiCorp registry v1 API during mirror sync
- feat: two new API endpoints serve the doc index and proxy markdown content from the registry v2 API with a 15-minute in-memory TTL cache (500 entries max)
- feat: migration `000012_provider_version_docs` with indexes on `provider_version_id` and `(provider_version_id, category)`

## Changelog

- feat: provider documentation browsing — `provider_version_docs` table, doc metadata sync during mirror, `GET /docs` and `GET /docs/:category/:slug` endpoints with TTL-cached upstream proxy