### PR TITLE
release: v0.2.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11
 
       - name: Run gosec
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: backend/go.sum
 
       - name: Check go mod tidy
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache-dependency-path: backend/go.sum
 
       - name: Install gosec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       contents: write # needed to push auto-generated swagger.json back to the branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: backend/go.sum
@@ -100,7 +100,7 @@ jobs:
           }'
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: go-coverage
           path: backend/coverage.out
@@ -149,10 +149,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: backend/go.sum
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload gosec results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gosec-results
           path: backend/gosec-results.json
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build backend Docker image
         run: docker build -t terraform-registry-backend:ci backend/
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Docker Compose configs
         working-directory: deployments

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,15 @@ name: Release
 # pushed.  Tags must match `v*.*.*` (e.g., v1.2.3, v0.10.0-rc.1).
 #
 # Artifacts produced:
-#   - Multi-platform Go binaries attached to the GitHub Release
+#   - Multi-platform Go binaries attached to the GitHub Release (via GoReleaser)
 #   - SHA-256 checksum file (checksums.txt)
+#   - Deployment configs tarball attached to the GitHub Release
 #   - Docker image pushed to ghcr.io (tagged with version + latest)
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag name to release (e.g., v1.2.3)'
-        required: true
-        type: string
+  workflow_dispatch: {}
 
 env:
   REGISTRY: ghcr.io
@@ -32,7 +28,7 @@ jobs:
     name: Verify tag is on main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need full history to walk ancestry
 
@@ -60,119 +56,35 @@ jobs:
     secrets: inherit  # passes GIST_TOKEN (coverage badge) and other secrets to the reusable workflow
     uses: ./.github/workflows/ci.yml
 
-  # ── Build binaries ───────────────────────────────────────────────────────
-  build-binaries:
-    name: Build binaries
+  # ── Build binaries + create GitHub Release ───────────────────────────────
+  goreleaser:
+    name: GoReleaser — binaries + GitHub Release
     runs-on: ubuntu-latest
     needs: ci
-
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-            suffix: ''
-          - goos: linux
-            goarch: arm64
-            suffix: ''
-          - goos: darwin
-            goarch: amd64
-            suffix: ''
-          - goos: darwin
-            goarch: arm64
-            suffix: ''
-          - goos: windows
-            goarch: amd64
-            suffix: '.exe'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-          cache-dependency-path: backend/go.sum
-
-      - name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: '0'
-        working-directory: backend
-        run: |
-          VERSION="${{ github.ref_name }}"
-          BINARY_NAME="terraform-registry-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}"
-          go build \
-            -ldflags "-s -w -X main.Version=${VERSION} -X main.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o "../dist/${BINARY_NAME}" \
-            ./cmd/server
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: binary-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/
-          retention-days: 1
-
-  # ── Create checksums + GitHub Release ────────────────────────────────────
-  release:
-    name: Publish GitHub Release
-    runs-on: ubuntu-latest
-    needs: [build-binaries, docker]
     permissions:
       contents: write   # required to create releases and upload assets
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0   # needed for changelog generation
+          fetch-depth: 0   # GoReleaser needs full history to resolve previous tag
 
-      - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/setup-go@v6
         with:
-          pattern: binary-*
-          path: dist/
-          merge-multiple: true
-
-      - name: Generate checksums
-        working-directory: dist
-        run: sha256sum * > checksums.txt
-
-      - name: List release artifacts
-        run: ls -lh dist/
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
 
       - name: Package deployment configs
-        run: |
-          VERSION="${GITHUB_REF_NAME}"
-          tar -czf "dist/deployment-configs-${VERSION}.tar.gz" deployments/
+        run: tar -czf "deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          name: Release ${{ steps.version.outputs.version }}
-          tag_name: ${{ steps.version.outputs.version }}
-          body: |
-            ## Docker Image
-
-            ```bash
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ```
-
-            ## Deployment Configs
-
-            The `deployment-configs-*.tar.gz` asset contains all Helm, Kubernetes, Terraform, and
-            cloud-provider deployment configurations. Extract with:
-
-            ```bash
-            tar -xzf deployment-configs-${{ steps.version.outputs.version }}.tar.gz
-            ```
-          generate_release_notes: true
-          files: dist/*
-          fail_on_unmatched_files: true
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ── Build + push Docker image ────────────────────────────────────────────
   docker:
@@ -184,7 +96,7 @@ jobs:
       packages: write   # required to push to ghcr.io
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.26'
           cache-dependency-path: backend/go.sum
 
       # ── Backend ──────────────────────────────────────────────────────────

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: backend/go.sum
@@ -59,7 +59,7 @@ jobs:
       # ── Artifacts ────────────────────────────────────────────────────────
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: scheduled-coverage-${{ github.run_id }}
@@ -74,7 +74,7 @@ jobs:
     if: failure() && github.event_name == 'schedule'
     steps:
       - name: Create failure issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+builds:
+  - id: terraform-registry
+    dir: backend
+    main: ./cmd/server
+    binary: terraform-registry
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.Version={{ .Version }}
+      - -X main.BuildDate={{ .Date }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: terraform-registry-binaries
+    formats: [binary]
+    name_template: "terraform-registry-{{ .Os }}-{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+release:
+  github:
+    owner: sethbacon
+    name: terraform-registry-backend
+  name_template: "Release {{ .Tag }}"
+  extra_files:
+    - glob: "./deployment-configs-*.tar.gz"
+  footer: |
+    ## Docker Image
+
+    ```
+    docker pull ghcr.io/sethbacon/terraform-registry-backend:{{ .Tag }}
+    ```
+
+changelog:
+  use: github-native
+
+gomod:
+  proxy: false
+
+snapshot:
+  version_template: "{{ .Tag }}-dev"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-registry/terraform-registry
 
-go 1.24.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/storage v1.59.2

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -276,8 +276,8 @@
 	],
 	"Stats": {
 		"files": 124,
-		"lines": 37541,
-		"nosec": 88,
+		"lines": 37545,
+		"nosec": 93,
 		"found": 17
 	},
 	"GosecVersion": "dev"

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -11,8 +11,8 @@
 			"rule_id": "G115",
 			"details": "integer overflow conversion uint64 -\u003e int64",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\scm\\azuredevops\\connector.go",
-			"code": "538: \t\t\tName:     f.Name,\n539: \t\t\tSize:     int64(f.UncompressedSize64),\n540: \t\t\tMode:     int64(f.Mode()),\n",
-			"line": "539",
+			"code": "547: \t\t\tName:     f.Name,\n548: \t\t\tSize:     int64(f.UncompressedSize64),\n549: \t\t\tMode:     int64(f.Mode()),\n",
+			"line": "548",
 			"column": "19",
 			"nosec": false,
 			"suppressions": null
@@ -43,8 +43,8 @@
 			"rule_id": "G201",
 			"details": "SQL string formatting",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\db\\repositories\\provider_repository.go",
-			"code": "596: \t// Query with pagination and JOIN for created_by_name\n597: \tsearchQuery := fmt.Sprintf(`\n598: \t\tSELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,\n599: \t\t       p.created_by, u.name as created_by_name, p.created_at, p.updated_at\n600: \t\tFROM providers p\n601: \t\tLEFT JOIN users u ON p.created_by = u.id\n602: \t\t%s\n603: \t\tORDER BY p.created_at DESC\n604: \t\tLIMIT $%d OFFSET $%d\n605: \t`, whereClause, argCount+1, argCount+2)\n606: \n",
-			"line": "597-605",
+			"code": "635: \t// Query with pagination and JOIN for created_by_name\n636: \tsearchQuery := fmt.Sprintf(`\n637: \t\tSELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,\n638: \t\t       p.created_by, u.name as created_by_name, p.created_at, p.updated_at\n639: \t\tFROM providers p\n640: \t\tLEFT JOIN users u ON p.created_by = u.id\n641: \t\t%s\n642: \t\tORDER BY p.created_at DESC\n643: \t\tLIMIT $%d OFFSET $%d\n644: \t`, whereClause, argCount+1, argCount+2)\n645: \n",
+			"line": "636-644",
 			"column": "17",
 			"nosec": false,
 			"suppressions": null
@@ -59,8 +59,8 @@
 			"rule_id": "G201",
 			"details": "SQL string formatting",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\db\\repositories\\provider_repository.go",
-			"code": "588: \t// Count total results\n589: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM providers p %s\", whereClause)\n590: \tvar total int\n",
-			"line": "589",
+			"code": "627: \t// Count total results\n628: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM providers p %s\", whereClause)\n629: \tvar total int\n",
+			"line": "628",
 			"column": "16",
 			"nosec": false,
 			"suppressions": null
@@ -219,8 +219,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "965: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n966: \tstream.Body.Close()\n967: \tif err != nil {\n",
-			"line": "966",
+			"code": "1001: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n1002: \tstream.Body.Close()\n1003: \tif err != nil {\n",
+			"line": "1002",
 			"column": "2",
 			"nosec": false,
 			"suppressions": null
@@ -235,8 +235,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "959: \t\ttmpFile.Close()\n960: \t\tos.Remove(tmpFile.Name())\n961: \t}()\n",
-			"line": "960",
+			"code": "995: \t\ttmpFile.Close()\n996: \t\tos.Remove(tmpFile.Name())\n997: \t}()\n",
+			"line": "996",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -251,8 +251,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "958: \tdefer func() {\n959: \t\ttmpFile.Close()\n960: \t\tos.Remove(tmpFile.Name())\n",
-			"line": "959",
+			"code": "994: \tdefer func() {\n995: \t\ttmpFile.Close()\n996: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "995",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -267,17 +267,17 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "954: \tif err != nil {\n955: \t\tstream.Body.Close()\n956: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
-			"line": "955",
+			"code": "990: \tif err != nil {\n991: \t\tstream.Body.Close()\n992: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
+			"line": "991",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
 		}
 	],
 	"Stats": {
-		"files": 122,
-		"lines": 36494,
-		"nosec": 86,
+		"files": 124,
+		"lines": 37541,
+		"nosec": 88,
 		"found": 17
 	},
 	"GosecVersion": "dev"

--- a/backend/internal/api/providers/docs_test.go
+++ b/backend/internal/api/providers/docs_test.go
@@ -322,6 +322,7 @@ func TestDocContentCache_Eviction(t *testing.T) {
 	cache := newDocContentCache(2, 15*time.Minute)
 
 	cache.set("key1", "content1")
+	time.Sleep(time.Millisecond) // ensure key1 has a strictly older timestamp on low-resolution timers
 	cache.set("key2", "content2")
 	cache.set("key3", "content3") // should evict key1
 

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -1064,6 +1064,7 @@ func TestDownloadHandler_SuccessWithShasumURLs(t *testing.T) {
 func TestDownloadHandler_SuccessWithAuditContext(t *testing.T) {
 	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
 	db, mock, _ := sqlmock.New()
+	mock.MatchExpectationsInOrder(false)
 	t.Cleanup(func() { db.Close() })
 
 	auditRepo := repositories.NewAuditRepository(db)
@@ -1081,6 +1082,8 @@ func TestDownloadHandler_SuccessWithAuditContext(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").WillReturnRows(samplePlatformRow())
+	mock.ExpectExec("UPDATE provider_platforms").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO audit_logs").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	w := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
 	if w.Code != http.StatusOK {

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -179,6 +179,7 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			})
 			return
 		}
+		// #nosec G602 -- magic is guaranteed 4 bytes by io.ReadFull which only succeeds when exactly n bytes are read
 		if !((magic[0] == 0x50 && magic[1] == 0x4B && magic[2] == 0x03 && magic[3] == 0x04) ||
 			(magic[0] == 0x50 && magic[1] == 0x4B && magic[2] == 0x05 && magic[3] == 0x06)) {
 			c.JSON(http.StatusBadRequest, gin.H{

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -522,7 +522,7 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 	}
 
 	// Count total results
-	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM modules m %s", whereClause)
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM modules m %s", whereClause) // #nosec G201 -- whereClause contains only parameterized SQL structural conditions; user values are passed via args
 	var total int
 	if err := r.db.QueryRowContext(ctx, countSQL, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("failed to count modules: %w", err)
@@ -531,6 +531,7 @@ func (r *ModuleRepository) SearchModulesWithStats(ctx context.Context, orgID, se
 	// Single query: modules + latest version + total downloads via lateral join.
 	// The lateral subquery fetches the latest version (by created_at) and sums
 	// download counts across ALL versions — replacing the per-module ListVersions loop.
+	// #nosec G201 -- whereClause contains only parameterized SQL structural conditions; user values are passed via args
 	searchSQL := fmt.Sprintf(`
 		SELECT m.id, m.organization_id, m.namespace, m.name, m.system, m.description, m.source,
 		       m.created_by, u.name AS created_by_name, m.created_at, m.updated_at,

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -713,13 +713,14 @@ func (r *ProviderRepository) SearchProvidersWithStats(ctx context.Context, orgID
 	}
 
 	// Count total results
-	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM providers p %s", whereClause)
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM providers p %s", whereClause) // #nosec G201 -- whereClause contains only parameterized SQL structural conditions; user values are passed via args
 	var total int
 	if err := r.db.QueryRowContext(ctx, countSQL, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("failed to count providers: %w", err)
 	}
 
 	// Single query: providers + latest version + total platform downloads via lateral join
+	// #nosec G201 -- whereClause contains only parameterized SQL structural conditions; user values are passed via args
 	searchSQL := fmt.Sprintf(`
 		SELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,
 		       p.created_by, u.name AS created_by_name, p.created_at, p.updated_at,

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -528,7 +528,8 @@ func (p *SCMPublisher) publishModuleVersion(
 
 	// Extract README from the archive
 	var readmeContent *string
-	if readmeFile, err := os.Open(archivePath); err == nil { // #nosec G304 -- path is constructed from validated namespace/name/version components; path traversal is prevented at the API and archive-extraction layers
+	// #nosec G304 -- path is constructed from validated namespace/name/version components; path traversal is prevented at the API and archive-extraction layers
+	if readmeFile, err := os.Open(archivePath); err == nil {
 		if readme, err := validation.ExtractReadme(readmeFile); err == nil && readme != "" {
 			readmeContent = &readme
 		}


### PR DESCRIPTION
## Summary

- Migrates release workflow to GoReleaser (`goreleaser/goreleaser-action@v6`), removing ~100 lines of bespoke matrix-build boilerplate
- Upgrades all GitHub Actions to Node 24 compatible versions (`checkout@v6`, `setup-go@v6`, `upload-artifact@v7`, `github-script@v8`)
- Upgrades Go to 1.26 (matches local toolchain; unblocks `gosec@latest`)
- Establishes `gosec-baseline.json` and suppresses 7 Linux-only false positives (G201 parameterized SQL, G602 io.ReadFull-bounded slice, G304 nosec annotation form)
- Fixes two pre-existing flaky tests in `internal/api/providers`

## Test plan

- [x] GoReleaser snapshot validated locally
- [x] Full test suite green (68.4% coverage, above 65% floor)
- [x] CI passed on PR #95