### PR TITLE
feat: expose real version and build date from GET /version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
           docker compose -f docker-compose.test.yml config --quiet
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "latest"
 
@@ -290,7 +290,7 @@ jobs:
         run: kubectl kustomize deployments/kubernetes/overlays/production > /dev/null
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: latest
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -56,9 +56,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const (
-	version = "0.1.0"
-)
+// Version and BuildDate are injected at build time by GoReleaser via ldflags:
+//
+//	-X main.Version=x.y.z  -X main.BuildDate=<RFC3339>
+var Version = "dev"
+var BuildDate = "unknown"
 
 func main() {
 	if err := run(); err != nil {
@@ -83,6 +85,8 @@ func run() error {
 	// Execute command
 	switch command {
 	case "serve":
+		api.AppVersion = Version
+		api.AppBuildDate = BuildDate
 		return serve(cfg)
 	case "migrate":
 		if len(os.Args) < 3 {
@@ -90,7 +94,7 @@ func run() error {
 		}
 		return runMigrations(cfg, os.Args[2])
 	case "version":
-		fmt.Printf("Terraform Registry v%s\n", version)
+		fmt.Printf("Terraform Registry v%s (built %s)\n", Version, BuildDate)
 		return nil
 	default:
 		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version", command)

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10078,6 +10078,9 @@
                 "api_version": {
                     "type": "string"
                 },
+                "build_date": {
+                    "type": "string"
+                },
                 "protocols": {
                     "$ref": "#/definitions/api.ProtocolVersions"
                 },

--- a/backend/internal/api/responses.go
+++ b/backend/internal/api/responses.go
@@ -37,6 +37,7 @@ type ProtocolVersions struct {
 // VersionResponse is returned by GET /version.
 type VersionResponse struct {
 	Version    string           `json:"version"`
+	BuildDate  string           `json:"build_date"`
 	APIVersion string           `json:"api_version"`
 	Protocols  ProtocolVersions `json:"protocols"`
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -90,6 +90,11 @@ func (bg *BackgroundServices) Shutdown() {
 	slog.Info("all background services stopped")
 }
 
+// AppVersion and AppBuildDate are set by main before NewRouter is called.
+// They are populated from ldflags injected by GoReleaser at release time.
+var AppVersion = "dev"
+var AppBuildDate = "unknown"
+
 // NewRouter creates and configures the Gin router
 func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices) {
 	router := gin.New()
@@ -882,7 +887,8 @@ func serviceDiscoveryHandler(cfg *config.Config) gin.HandlerFunc {
 func versionHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"version":     "0.1.0",
+			"version":     AppVersion,
+			"build_date":  AppBuildDate,
 			"api_version": "v1",
 			"protocols": gin.H{
 				"modules":   "v1",

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -222,6 +222,9 @@ func TestVersionHandler(t *testing.T) {
 	if body["version"] == nil {
 		t.Error("response missing 'version'")
 	}
+	if body["build_date"] == nil {
+		t.Error("response missing 'build_date'")
+	}
 	if body["api_version"] == nil {
 		t.Error("response missing 'api_version'")
 	}


### PR DESCRIPTION
## Summary

Wires GoReleaser ldflags into the existing \`/version\` endpoint so the frontend About modal can display the running backend release and build date.

- \`main.go\`: \`const version\` → \`var Version/BuildDate\` (populated via \`-X main.Version\` / \`-X main.BuildDate\` ldflags, already set in \`.goreleaser.yml\`)
- \`api/router.go\`: \`AppVersion\`/\`AppBuildDate\` package vars set by \`main\` before \`NewRouter\`
- \`api/responses.go\`: add \`build_date\` field to \`VersionResponse\`
- \`api/router_test.go\`: assert \`build_date\` present in response

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/api/...\` passes
- [ ] CI passes