### PR TITLE
fix: resolve GoReleaser dirty-state failure and upgrade Node.js 20 CI actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,10 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: Package deployment configs
-        run: tar -czf "deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
+        run: tar -czf "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -117,10 +117,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: backend/
           file: backend/Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ release:
     name: terraform-registry-backend
   name_template: "Release {{ .Tag }}"
   extra_files:
-    - glob: "./deployment-configs-*.tar.gz"
+    - glob: "/tmp/deployment-configs-*.tar.gz"
   footer: |
     ## Docker Image
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ git remote prune origin                          # prune stale remote-tracking r
    Closes #<issue-number>"
    ```
 
+   Do not add `Co-Authored-By:` trailers or `🤖 Generated with [Claude Code]` footers to commit messages or PR bodies.
+
 6. **Rebase onto `development` before pushing** to minimise merge conflicts with sibling branches:
 
    ```bash


### PR DESCRIPTION
## Summary

**Root cause of v0.2.24 release failure:** the `Package deployment configs` step created `deployment-configs-v0.2.24.tar.gz` inside the git working tree before GoReleaser started. GoReleaser's early git dirty-state check found the untracked tarball and exited with code 1.

**Fix:** write the tarball to `/tmp/` (outside the git working tree) and update the `extra_files` glob in `.goreleaser.yml` accordingly. GoReleaser then finds the file on disk at upload time without it ever appearing in `git status`.

Also upgrades all remaining Node.js 20 actions to their Node.js 24-compatible major versions ahead of the June 2 2026 enforcement deadline:

| Action | Before | After |
|---|---|---|
| `goreleaser/goreleaser-action` | `v6` | `v7` |
| `docker/login-action` | `v3` | `v4` |
| `docker/metadata-action` | `v5` | `v6` |
| `docker/setup-buildx-action` | `v3` | `v4` |
| `docker/build-push-action` | `v6` | `v7` |

> **Note:** `schneegans/dynamic-badges-action` is pinned at `v1.7.0` — no newer release exists upstream. This will produce a deprecation warning but will not block the workflow.

## Test plan

- [ ] CI passes on this PR
- [ ] After merging to development and then to main, re-tag or push a new patch tag and confirm the release workflow completes without the dirty-state error
- [ ] Confirm `deployment-configs-vX.Y.Z.tar.gz` is attached to the GitHub release