### PR TITLE
release: v0.2.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
           docker compose -f docker-compose.test.yml config --quiet
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "latest"
 
@@ -290,7 +290,7 @@ jobs:
         run: kubectl kustomize deployments/kubernetes/overlays/production > /dev/null
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,10 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: Package deployment configs
-        run: tar -czf "deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
+        run: tar -czf "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -117,10 +117,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: backend/
           file: backend/Dockerfile

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,7 +39,7 @@ release:
     name: terraform-registry-backend
   name_template: "Release {{ .Tag }}"
   extra_files:
-    - glob: "./deployment-configs-*.tar.gz"
+    - glob: "/tmp/deployment-configs-*.tar.gz"
   footer: |
     ## Docker Image
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ git remote prune origin                          # prune stale remote-tracking r
    Closes #<issue-number>"
    ```
 
+   Do not add `Co-Authored-By:` trailers or `🤖 Generated with [Claude Code]` footers to commit messages or PR bodies.
+
 6. **Rebase onto `development` before pushing** to minimise merge conflicts with sibling branches:
 
    ```bash

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -56,9 +56,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const (
-	version = "0.1.0"
-)
+// Version and BuildDate are injected at build time by GoReleaser via ldflags:
+//
+//	-X main.Version=x.y.z  -X main.BuildDate=<RFC3339>
+var Version = "dev"
+var BuildDate = "unknown"
 
 func main() {
 	if err := run(); err != nil {
@@ -83,6 +85,8 @@ func run() error {
 	// Execute command
 	switch command {
 	case "serve":
+		api.AppVersion = Version
+		api.AppBuildDate = BuildDate
 		return serve(cfg)
 	case "migrate":
 		if len(os.Args) < 3 {
@@ -90,7 +94,7 @@ func run() error {
 		}
 		return runMigrations(cfg, os.Args[2])
 	case "version":
-		fmt.Printf("Terraform Registry v%s\n", version)
+		fmt.Printf("Terraform Registry v%s (built %s)\n", Version, BuildDate)
 		return nil
 	default:
 		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version", command)

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10078,6 +10078,9 @@
                 "api_version": {
                     "type": "string"
                 },
+                "build_date": {
+                    "type": "string"
+                },
                 "protocols": {
                     "$ref": "#/definitions/api.ProtocolVersions"
                 },

--- a/backend/internal/api/responses.go
+++ b/backend/internal/api/responses.go
@@ -37,6 +37,7 @@ type ProtocolVersions struct {
 // VersionResponse is returned by GET /version.
 type VersionResponse struct {
 	Version    string           `json:"version"`
+	BuildDate  string           `json:"build_date"`
 	APIVersion string           `json:"api_version"`
 	Protocols  ProtocolVersions `json:"protocols"`
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -90,6 +90,11 @@ func (bg *BackgroundServices) Shutdown() {
 	slog.Info("all background services stopped")
 }
 
+// AppVersion and AppBuildDate are set by main before NewRouter is called.
+// They are populated from ldflags injected by GoReleaser at release time.
+var AppVersion = "dev"
+var AppBuildDate = "unknown"
+
 // NewRouter creates and configures the Gin router
 func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices) {
 	router := gin.New()
@@ -882,7 +887,8 @@ func serviceDiscoveryHandler(cfg *config.Config) gin.HandlerFunc {
 func versionHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"version":     "0.1.0",
+			"version":     AppVersion,
+			"build_date":  AppBuildDate,
 			"api_version": "v1",
 			"protocols": gin.H{
 				"modules":   "v1",

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -222,6 +222,9 @@ func TestVersionHandler(t *testing.T) {
 	if body["version"] == nil {
 		t.Error("response missing 'version'")
 	}
+	if body["build_date"] == nil {
+		t.Error("response missing 'build_date'")
+	}
 	if body["api_version"] == nil {
 		t.Error("response missing 'api_version'")
 	}


### PR DESCRIPTION
## Summary

- `feat: expose real version and build date from GET /version` — wires `main.Version` and `main.BuildDate` ldflags into the `/version` response
- `ci: upgrade azure/setup-helm to v5 and hashicorp/setup-terraform to v4` — eliminates Node.js 20 deprecation annotations
- `fix: resolve GoReleaser dirty-state failure and upgrade Node.js 20 actions` — moves deployment-configs tarball to `/tmp/`, upgrades goreleaser-action v6→v7, docker actions to latest

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, tag `v0.2.25` on main to trigger release workflow
- [ ] GoReleaser produces 5 binaries + checksums.txt + deployment-configs tarball
- [ ] Docker image pushed to ghcr.io with `v0.2.25` and `latest` tags