### PR TITLE
fix: goreleaser extra_files absolute path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload deployment configs to release
+        run: gh release upload "${GITHUB_REF_NAME}" "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # ── Build + push Docker image ────────────────────────────────────────────
   docker:
     name: Publish Docker image

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,8 +38,6 @@ release:
     owner: sethbacon
     name: terraform-registry-backend
   name_template: "Release {{ .Tag }}"
-  extra_files:
-    - glob: "/tmp/deployment-configs-*.tar.gz"
   footer: |
     ## Docker Image
 


### PR DESCRIPTION
Hotfix: GoReleaser extra_files glob does not support absolute paths. Upload deployment-configs tarball via gh release upload instead.