### PR TITLE
fix: add /version proxy location to Helm nginx ConfigMap

### DIFF
--- a/deployments/helm/templates/configmap-frontend-nginx.yaml
+++ b/deployments/helm/templates/configmap-frontend-nginx.yaml
@@ -82,5 +82,13 @@ data:
         location /ready {
             proxy_pass {{ $backendUrl }};
         }
+
+        location /version {
+            proxy_pass {{ $backendUrl }};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
     }
 {{- end }}


### PR DESCRIPTION
The nginx config in k8s is served from this Helm ConfigMap, **not** from the Docker image. The `/version` fix applied to `frontend/nginx.conf` in the image has no effect in k8s.

Without this `location /version` block, requests fall through to the SPA root location which returns `index.html`. The frontend's About modal then calls `GET /version`, receives HTML, and shows **Backend vundefined**.

No release needed — the deploy pipeline always checks out backend/main at deploy time.