### PR TITLE
fix: helm nginx /version proxy (chart-only, no release)

### DIFF
--- a/deployments/helm/templates/configmap-frontend-nginx.yaml
+++ b/deployments/helm/templates/configmap-frontend-nginx.yaml
@@ -82,5 +82,13 @@ data:
         location /ready {
             proxy_pass {{ $backendUrl }};
         }
+
+        location /version {
+            proxy_pass {{ $backendUrl }};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
     }
 {{- end }}


### PR DESCRIPTION
Adds `/version` proxy block to the Helm nginx ConfigMap. No Go code changed, no new binary release needed. The frontend deploy pipeline always checks out backend/main at deploy time, so re-running the deploy pipeline after this merge is sufficient.