### PR TITLE
docs: update CHANGELOG.md with v0.2.25 entries and Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- fix: add `/version` proxy location to Helm nginx ConfigMap — the ConfigMap was missing the location block, causing the SPA fallback to intercept backend API requests in Kubernetes deployments
+- fix: remove `go mod tidy` and swag doc generation from Dockerfile — both steps fail in environments with corporate TLS interception; `swagger.json` is committed to the repo by CI and `go.sum` already pins all dependencies
+
+### Maintenance
+- chore: add PR template, CI changelog enforcement, and collection script — `.github/PULL_REQUEST_TEMPLATE.md` pre-fills the changelog section; `pr-checks.yml` fails PRs without a valid entry; `collect-changelog.sh` automates release-time changelog collection
+
+---
+
+## [0.2.25] - 2026-03-24
+
+### Added
+- feat: expose real version and build date from `GET /version` — new endpoint returns `{"version":"x.y.z","build_date":"..."}` populated at build time via ldflags injected by GoReleaser and Docker `--build-arg`
+
+### Fixed
+- fix: resolve GoReleaser dirty-state failure — deployment-configs tarball now written to `/tmp/` to avoid untracked file detection
+- fix: upload deployment-configs tarball via `gh release upload` — GoReleaser's `extra_files` glob rejects absolute paths; tarball attachment moved to a post-GoReleaser step
+
+### Maintenance
+- chore: migrate release workflow to GoReleaser — replaces 5-platform matrix build job and hand-rolled `sha256sum` + release upload steps; binary names and checksums file unchanged
+- chore: upgrade GitHub Actions to Node 24 compatible versions
+
 ---
 
 ## [0.2.23] - 2026-03-22


### PR DESCRIPTION
## Summary

Backfills CHANGELOG.md entries for v0.2.25 (which shipped without changelog entries since the PR template didn't exist yet) and pre-fills the [Unreleased] section with changes currently on development targeting v0.2.26.

**v0.2.25** entries collected from PR bodies:
- GoReleaser migration (#95)
- Expose GET /version endpoint (#99)
- GoReleaser dirty-state + upload fix (#100, #102)

**Unreleased** (targeting v0.2.26):
- Helm nginx ConfigMap /version proxy fix (#104)
- Dockerfile go mod tidy + swag removal (#108)
- PR template + changelog enforcement (#106)

## Changelog
- docs: backfill v0.2.25 CHANGELOG entries and add Unreleased section for v0.2.26