### PR TITLE
docs: promote unreleased items to v0.2.26 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.2.26] - 2026-03-24
+
 ### Fixed
 - fix: add `/version` proxy location to Helm nginx ConfigMap — the ConfigMap was missing the location block, causing the SPA fallback to intercept backend API requests in Kubernetes deployments
 - fix: remove `go mod tidy` and swag doc generation from Dockerfile — both steps fail in environments with corporate TLS interception; `swagger.json` is committed to the repo by CI and `go.sum` already pins all dependencies


### PR DESCRIPTION
## Summary

Moves the [Unreleased] items into the [0.2.26] section now that v0.2.26 has been tagged and released. Leaves [Unreleased] empty for future changes.

## Changelog
- docs: promote unreleased CHANGELOG items to v0.2.26