### PR TITLE
fix: resolve numeric v2 provider-version ID before fetching doc index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.28] - 2026-03-25
+
+### Fixed
+- fix: resolve numeric v2 provider-version ID before fetching doc index — `GetProviderDocIndexByVersion` was passing the semver string as `filter[provider-version]` to the upstream registry's v2 `provider-docs` API, which requires the numeric JSON:API provider-version ID; this caused HTTP 400 errors during mirror sync, leaving doc index entries empty and the provider documentation tab blank in the UI
+
+---
+
 ## [0.2.27] - 2026-03-24
 
 ### Fixed

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -107,8 +107,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "404: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n405: \t\tresp.Body.Close()\n406: \t\tif decodeErr != nil {\n",
-			"line": "405",
+			"code": "483: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n484: \t\tresp.Body.Close()\n485: \t\tif decodeErr != nil {\n",
+			"line": "484",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -123,8 +123,40 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "398: \t\t\tbody, _ := io.ReadAll(resp.Body)\n399: \t\t\tresp.Body.Close()\n400: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "399",
+			"code": "477: \t\t\tbody, _ := io.ReadAll(resp.Body)\n478: \t\t\tresp.Body.Close()\n479: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "478",
+			"column": "4",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "423: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n424: \t\tresp.Body.Close()\n425: \t\tif decodeErr != nil {\n",
+			"line": "424",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "417: \t\t\tbody, _ := io.ReadAll(resp.Body)\n418: \t\t\tresp.Body.Close()\n419: \t\t\treturn \"\", fmt.Errorf(\"v2 provider versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "418",
 			"column": "4",
 			"nosec": false,
 			"suppressions": null
@@ -308,9 +340,9 @@
 	],
 	"Stats": {
 		"files": 124,
-		"lines": 37604,
-		"nosec": 93,
-		"found": 19
+		"lines": 37683,
+		"nosec": 94,
+		"found": 21
 	},
 	"GosecVersion": "dev"
 }

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -365,22 +365,101 @@ type providerDocContentV2 struct {
 	} `json:"data"`
 }
 
+// providerVersionListV2 is the JSON:API envelope for
+// GET /v2/providers/{namespace}/{name}/versions.
+type providerVersionListV2 struct {
+	Data []providerVersionEntryV2 `json:"data"`
+	Meta struct {
+		Pagination struct {
+			CurrentPage int  `json:"current-page"`
+			NextPage    *int `json:"next-page"`
+		} `json:"pagination"`
+	} `json:"meta"`
+}
+
+// providerVersionEntryV2 is a single entry in the v2 provider-versions list.
+type providerVersionEntryV2 struct {
+	ID         string `json:"id"`
+	Attributes struct {
+		Version string `json:"version"`
+	} `json:"attributes"`
+}
+
+// resolveProviderVersionID pages through the upstream v2
+// /v2/providers/{namespace}/{name}/versions endpoint to find the numeric
+// JSON:API ID for the given semver string. The v2 provider-docs API requires
+// this numeric ID as filter[provider-version]; passing the semver string
+// directly causes a 400 "provider-version filter is required" error.
+func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespace, providerName, semver string) (string, error) {
+	base := strings.TrimSuffix(u.BaseURL, "/")
+	pageNum := 1
+
+	for {
+		reqURL := fmt.Sprintf(
+			"%s/v2/providers/%s/%s/versions?page[size]=100&page[number]=%d",
+			base,
+			url.PathEscape(namespace),
+			url.PathEscape(providerName),
+			pageNum,
+		)
+
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+		if err != nil {
+			return "", fmt.Errorf("failed to create v2 provider versions request (page %d): %w", pageNum, err)
+		}
+
+		resp, err := u.HTTPClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch v2 provider versions (page %d): %w", pageNum, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return "", fmt.Errorf("v2 provider versions request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+
+		var page providerVersionListV2
+		decodeErr := json.NewDecoder(resp.Body).Decode(&page)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return "", fmt.Errorf("failed to decode v2 provider versions response (page %d): %w", pageNum, decodeErr)
+		}
+
+		for _, entry := range page.Data {
+			if entry.Attributes.Version == semver {
+				return entry.ID, nil
+			}
+		}
+
+		if page.Meta.Pagination.NextPage == nil {
+			break
+		}
+		pageNum++
+	}
+
+	return "", fmt.Errorf("provider version %s/%s@%s not found in upstream v2 versions API", namespace, providerName, semver)
+}
+
 // GetProviderDocIndexByVersion fetches version-specific documentation metadata
 // from the upstream registry's v2 provider-docs API. It pages through all
 // results (page[size]=100) and returns them as a flat slice. Only HCL-language
 // entries are requested.
 func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, namespace, providerName, version string) ([]ProviderDocEntry, error) {
+	versionID, err := u.resolveProviderVersionID(ctx, namespace, providerName, version)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve v2 version ID for %s/%s@%s: %w", namespace, providerName, version, err)
+	}
+
 	base := strings.TrimSuffix(u.BaseURL, "/")
 	var all []ProviderDocEntry
 	pageNum := 1
 
 	for {
 		reqURL := fmt.Sprintf(
-			"%s/v2/provider-docs?filter[namespace]=%s&filter[provider-name]=%s&filter[provider-version]=%s&filter[language]=hcl&page[size]=100&page[number]=%d",
+			"%s/v2/provider-docs?filter[provider-version]=%s&filter[language]=hcl&page[size]=100&page[number]=%d",
 			base,
-			url.QueryEscape(namespace),
-			url.QueryEscape(providerName),
-			url.QueryEscape(version),
+			url.QueryEscape(versionID),
 			pageNum,
 		)
 

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -271,8 +271,21 @@ func TestDownloadFile_ContextCancelled(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetProviderDocIndexByVersion
+// resolveProviderVersionID + GetProviderDocIndexByVersion helpers
 // ---------------------------------------------------------------------------
+
+func makeVersionListPage(entries []providerVersionEntryV2, nextPage *int) providerVersionListV2 {
+	p := providerVersionListV2{}
+	p.Data = entries
+	p.Meta.Pagination.NextPage = nextPage
+	return p
+}
+
+func makeVersionEntry(id, version string) providerVersionEntryV2 {
+	e := providerVersionEntryV2{ID: id}
+	e.Attributes.Version = version
+	return e
+}
 
 func makeDocListPage(docs []providerDocEntryV2, nextPage *int) providerDocListV2 {
 	p := providerDocListV2{}
@@ -290,22 +303,82 @@ func makeDocEntry(id, slug, category, language string) providerDocEntryV2 {
 	return e
 }
 
-func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
+// ---------------------------------------------------------------------------
+// resolveProviderVersionID
+// ---------------------------------------------------------------------------
+
+func TestResolveProviderVersionID_NotFound(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/provider-docs" {
+		if r.URL.Path == "/v2/providers/hashicorp/aws/versions" {
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("1", "4.0.0"),
+				makeVersionEntry("2", "4.1.0"),
+			}, nil))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	_, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "5.0.0")
+	if err == nil {
+		t.Error("expected error when version is not in the list")
+	}
+}
+
+func TestResolveProviderVersionID_Pagination(t *testing.T) {
+	two := 2
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/providers/hashicorp/aws/versions" {
 			http.NotFound(w, r)
 			return
 		}
-		q := r.URL.Query()
-		if q.Get("filter[namespace]") != "hashicorp" || q.Get("filter[provider-name]") != "aws" ||
-			q.Get("filter[provider-version]") != "5.0.0" || q.Get("filter[language]") != "hcl" {
-			http.Error(w, "unexpected query params", http.StatusBadRequest)
-			return
+		switch r.URL.Query().Get("page[number]") {
+		case "1", "":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("10", "4.0.0"),
+			}, &two))
+		case "2":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("20", "5.0.0"),
+			}, nil))
+		default:
+			http.Error(w, "unexpected page", http.StatusBadRequest)
 		}
-		json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-			makeDocEntry("100", "index", "overview", "hcl"),
-			makeDocEntry("101", "aws_s3_bucket", "resources", "hcl"),
-		}, nil))
+	}))
+
+	id, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "5.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "20" {
+		t.Errorf("got id %q, want %q", id, "20")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetProviderDocIndexByVersion
+// ---------------------------------------------------------------------------
+
+func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws/versions":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("999", "5.0.0"),
+			}, nil))
+		case "/v2/provider-docs":
+			q := r.URL.Query()
+			if q.Get("filter[provider-version]") != "999" || q.Get("filter[language]") != "hcl" {
+				http.Error(w, "unexpected query params", http.StatusBadRequest)
+				return
+			}
+			json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
+				makeDocEntry("100", "index", "overview", "hcl"),
+				makeDocEntry("101", "aws_s3_bucket", "resources", "hcl"),
+			}, nil))
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 
 	docs, err := u.GetProviderDocIndexByVersion(context.Background(), "hashicorp", "aws", "5.0.0")
@@ -326,22 +399,27 @@ func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
 func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 	two := 2
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/provider-docs" {
-			http.NotFound(w, r)
-			return
-		}
-		switch r.URL.Query().Get("page[number]") {
-		case "1", "":
-			json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-				makeDocEntry("1", "index", "overview", "hcl"),
-			}, &two))
-		case "2":
-			json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-				makeDocEntry("2", "aws_instance", "resources", "hcl"),
-				makeDocEntry("3", "aws_vpc", "resources", "hcl"),
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws/versions":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("777", "5.0.0"),
 			}, nil))
+		case "/v2/provider-docs":
+			switch r.URL.Query().Get("page[number]") {
+			case "1", "":
+				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
+					makeDocEntry("1", "index", "overview", "hcl"),
+				}, &two))
+			case "2":
+				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
+					makeDocEntry("2", "aws_instance", "resources", "hcl"),
+					makeDocEntry("3", "aws_vpc", "resources", "hcl"),
+				}, nil))
+			default:
+				http.Error(w, "unexpected page", http.StatusBadRequest)
+			}
 		default:
-			http.Error(w, "unexpected page", http.StatusBadRequest)
+			http.NotFound(w, r)
 		}
 	}))
 
@@ -370,11 +448,16 @@ func TestGetProviderDocIndexByVersion_HTTPError(t *testing.T) {
 
 func TestGetProviderDocIndexByVersion_Empty(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/provider-docs" {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/null/versions":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("555", "1.0.0"),
+			}, nil))
+		case "/v2/provider-docs":
+			json.NewEncoder(w).Encode(makeDocListPage(nil, nil))
+		default:
 			http.NotFound(w, r)
-			return
 		}
-		json.NewEncoder(w).Encode(makeDocListPage(nil, nil))
 	}))
 
 	docs, err := u.GetProviderDocIndexByVersion(context.Background(), "hashicorp", "null", "1.0.0")


### PR DESCRIPTION
## Summary

Fixes the provider documentation tab regression introduced in v0.2.26 (#112). The upstream registry's v2 `provider-docs` API requires `filter[provider-version]` to be the numeric JSON:API provider-version ID, not the semver string. Passing the semver caused HTTP 400 errors for some versions during mirror sync, leaving doc index entries empty and the Documentation tab blank in the UI.

**Root cause:** `GetProviderDocIndexByVersion` in `upstream.go` was sending `filter[provider-version]=4.63.0` where the API expects `filter[provider-version]=<numeric-id>`.

**Fix:** Added `resolveProviderVersionID` which pages `GET /v2/providers/{namespace}/{name}/versions` to find the numeric ID for a given semver, then passes that ID to the doc index filter.

## Changelog

- fix: resolve numeric v2 provider-version ID before fetching doc index — `GetProviderDocIndexByVersion` was passing the semver string as `filter[provider-version]` to the upstream registry's v2 `provider-docs` API, which requires the numeric JSON:API provider-version ID; this caused HTTP 400 errors during mirror sync, leaving doc index entries empty and the provider documentation tab blank in the UI