### PR TITLE
fix: backfill doc index for existing provider versions with no docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- fix: add `/version` proxy location to Helm nginx ConfigMap — the ConfigMap was missing the location block, causing the SPA fallback to intercept backend API requests in Kubernetes deployments
-- fix: remove `go mod tidy` and swag doc generation from Dockerfile — both steps fail in environments with corporate TLS interception; `swagger.json` is committed to the repo by CI and `go.sum` already pins all dependencies
+---
 
-### Maintenance
-- chore: add PR template, CI changelog enforcement, and collection script — `.github/PULL_REQUEST_TEMPLATE.md` pre-fills the changelog section; `pr-checks.yml` fails PRs without a valid entry; `collect-changelog.sh` automates release-time changelog collection
+## [0.2.29] - 2026-03-25
+
+### Fixed
+- fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries
 
 ---
 

--- a/backend/internal/db/repositories/provider_docs_repository.go
+++ b/backend/internal/db/repositories/provider_docs_repository.go
@@ -134,3 +134,18 @@ func (r *ProviderDocsRepository) DeleteProviderVersionDocs(ctx context.Context, 
 	}
 	return nil
 }
+
+// CountProviderVersionDocs returns the number of doc index entries stored for a
+// provider version. A count of zero means the doc index was never populated (or
+// was cleared), allowing callers to decide whether a backfill is needed.
+func (r *ProviderDocsRepository) CountProviderVersionDocs(ctx context.Context, versionID string) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM provider_version_docs WHERE provider_version_id = $1`,
+		versionID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count provider version docs: %w", err)
+	}
+	return count, nil
+}

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -716,6 +716,39 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient *mirror
 			}
 
 			if len(missingPlatforms) == 0 {
+				// Backfill doc index if it was never populated for this already-complete
+				// version. This recovers from prior syncs where doc fetch failed (e.g.,
+				// upstream API change). Only one COUNT query is issued; the upstream fetch
+				// is skipped entirely when docs already exist.
+				if j.providerDocsRepo != nil {
+					docCount, countErr := j.providerDocsRepo.CountProviderVersionDocs(ctx, existingVersion.ID)
+					if countErr != nil {
+						log.Printf("Warning: failed to count docs for %s/%s@%s: %v", namespace, providerName, version.Version, countErr)
+					} else if docCount == 0 {
+						docEntries, docErr := upstreamClient.GetProviderDocIndexByVersion(ctx, namespace, providerName, version.Version)
+						if docErr != nil {
+							log.Printf("Warning: failed to backfill doc index for %s/%s@%s: %v", namespace, providerName, version.Version, docErr)
+						} else if len(docEntries) > 0 {
+							docModels := make([]models.ProviderVersionDoc, len(docEntries))
+							for i, d := range docEntries {
+								docModels[i] = models.ProviderVersionDoc{
+									UpstreamDocID: d.ID,
+									Title:         d.Title,
+									Slug:          d.Slug,
+									Category:      d.Category,
+									Subcategory:   d.Subcategory,
+									Path:          &d.Path,
+									Language:      d.Language,
+								}
+							}
+							if storeErr := j.providerDocsRepo.BulkCreateProviderVersionDocs(ctx, existingVersion.ID, docModels); storeErr != nil {
+								log.Printf("Warning: failed to store backfilled doc index for %s/%s@%s: %v", namespace, providerName, version.Version, storeErr)
+							} else {
+								log.Printf("Backfilled %d doc index entries for %s/%s@%s", len(docModels), namespace, providerName, version.Version)
+							}
+						}
+					}
+				}
 				log.Printf("Version %s of %s/%s already exists with all platforms, skipping", version.Version, namespace, providerName)
 				continue
 			}


### PR DESCRIPTION
## Summary

- Adds `CountProviderVersionDocs` repository method that returns the number of stored doc entries for a given provider version ID
- Modifies the mirror sync job's skip path (`len(missingPlatforms) == 0`) to check the doc count before continuing; if zero docs exist, fetches and stores the doc index from the upstream v2 API without re-downloading binaries

## Problem

After deploying v0.2.28 (which fixed the v2 API filter to use numeric version IDs), docs still did not populate for previously-synced provider versions. The sync job skips versions where all platforms already exist in the database, and the doc fetch code only runs for new versions — so any provider version synced while the v0.2.26/v0.2.27 bug was active has binaries but no docs.

## Fix

In the `len(missingPlatforms) == 0` skip branch, count existing docs for the version. If the count is zero, fetch the doc index and store it. All errors are non-fatal (logged as warnings) so a doc fetch failure does not prevent the sync job from continuing.

## Changelog

- fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries