### PR TITLE
release: v0.2.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries
+- fix: resolve provider-version numeric ID via correct v2 API endpoints — `resolveProviderVersionID` now calls `GET /v2/providers/{namespace}/{name}` to obtain the provider's numeric ID, then `GET /v2/providers/{id}/provider-versions` to find the matching semver entry; the previous `/v2/providers/{namespace}/{name}/versions` path returned 404
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- fix: add `/version` proxy location to Helm nginx ConfigMap — the ConfigMap was missing the location block, causing the SPA fallback to intercept backend API requests in Kubernetes deployments
-- fix: remove `go mod tidy` and swag doc generation from Dockerfile — both steps fail in environments with corporate TLS interception; `swagger.json` is committed to the repo by CI and `go.sum` already pins all dependencies
+---
 
-### Maintenance
-- chore: add PR template, CI changelog enforcement, and collection script — `.github/PULL_REQUEST_TEMPLATE.md` pre-fills the changelog section; `pr-checks.yml` fails PRs without a valid entry; `collect-changelog.sh` automates release-time changelog collection
+## [0.2.29] - 2026-03-25
+
+### Fixed
+- fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries
 
 ---
 

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -107,8 +107,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "483: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n484: \t\tresp.Body.Close()\n485: \t\tif decodeErr != nil {\n",
-			"line": "484",
+			"code": "509: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n510: \t\tresp.Body.Close()\n511: \t\tif decodeErr != nil {\n",
+			"line": "510",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -123,8 +123,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "477: \t\t\tbody, _ := io.ReadAll(resp.Body)\n478: \t\t\tresp.Body.Close()\n479: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "478",
+			"code": "503: \t\t\tbody, _ := io.ReadAll(resp.Body)\n504: \t\t\tresp.Body.Close()\n505: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "504",
 			"column": "4",
 			"nosec": false,
 			"suppressions": null
@@ -139,8 +139,24 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "423: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n424: \t\tresp.Body.Close()\n425: \t\tif decodeErr != nil {\n",
-			"line": "424",
+			"code": "455: \tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n456: \tresp.Body.Close()\n457: \tif decodeErr != nil {\n",
+			"line": "456",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "450: \t\tbody, _ := io.ReadAll(resp.Body)\n451: \t\tresp.Body.Close()\n452: \t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "451",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -155,9 +171,25 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "417: \t\t\tbody, _ := io.ReadAll(resp.Body)\n418: \t\t\tresp.Body.Close()\n419: \t\t\treturn \"\", fmt.Errorf(\"v2 provider versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "418",
-			"column": "4",
+			"code": "427: \tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026provResp)\n428: \tresp.Body.Close()\n429: \tif decodeErr != nil {\n",
+			"line": "428",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "422: \t\tbody, _ := io.ReadAll(resp.Body)\n423: \t\tresp.Body.Close()\n424: \t\treturn \"\", fmt.Errorf(\"v2 provider lookup failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "423",
+			"column": "3",
 			"nosec": false,
 			"suppressions": null
 		},
@@ -283,8 +315,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "1001: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n1002: \tstream.Body.Close()\n1003: \tif err != nil {\n",
-			"line": "1002",
+			"code": "1034: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n1035: \tstream.Body.Close()\n1036: \tif err != nil {\n",
+			"line": "1035",
 			"column": "2",
 			"nosec": false,
 			"suppressions": null
@@ -299,8 +331,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "995: \t\ttmpFile.Close()\n996: \t\tos.Remove(tmpFile.Name())\n997: \t}()\n",
-			"line": "996",
+			"code": "1028: \t\ttmpFile.Close()\n1029: \t\tos.Remove(tmpFile.Name())\n1030: \t}()\n",
+			"line": "1029",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -315,8 +347,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "994: \tdefer func() {\n995: \t\ttmpFile.Close()\n996: \t\tos.Remove(tmpFile.Name())\n",
-			"line": "995",
+			"code": "1027: \tdefer func() {\n1028: \t\ttmpFile.Close()\n1029: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "1028",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -331,8 +363,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "990: \tif err != nil {\n991: \t\tstream.Body.Close()\n992: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
-			"line": "991",
+			"code": "1023: \tif err != nil {\n1024: \t\tstream.Body.Close()\n1025: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
+			"line": "1024",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -340,9 +372,9 @@
 	],
 	"Stats": {
 		"files": 124,
-		"lines": 37683,
-		"nosec": 94,
-		"found": 21
+		"lines": 37757,
+		"nosec": 95,
+		"found": 23
 	},
 	"GosecVersion": "dev"
 }

--- a/backend/internal/db/repositories/provider_docs_repository.go
+++ b/backend/internal/db/repositories/provider_docs_repository.go
@@ -134,3 +134,18 @@ func (r *ProviderDocsRepository) DeleteProviderVersionDocs(ctx context.Context, 
 	}
 	return nil
 }
+
+// CountProviderVersionDocs returns the number of doc index entries stored for a
+// provider version. A count of zero means the doc index was never populated (or
+// was cleared), allowing callers to decide whether a backfill is needed.
+func (r *ProviderDocsRepository) CountProviderVersionDocs(ctx context.Context, versionID string) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM provider_version_docs WHERE provider_version_id = $1`,
+		versionID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count provider version docs: %w", err)
+	}
+	return count, nil
+}

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -716,6 +716,39 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient *mirror
 			}
 
 			if len(missingPlatforms) == 0 {
+				// Backfill doc index if it was never populated for this already-complete
+				// version. This recovers from prior syncs where doc fetch failed (e.g.,
+				// upstream API change). Only one COUNT query is issued; the upstream fetch
+				// is skipped entirely when docs already exist.
+				if j.providerDocsRepo != nil {
+					docCount, countErr := j.providerDocsRepo.CountProviderVersionDocs(ctx, existingVersion.ID)
+					if countErr != nil {
+						log.Printf("Warning: failed to count docs for %s/%s@%s: %v", namespace, providerName, version.Version, countErr)
+					} else if docCount == 0 {
+						docEntries, docErr := upstreamClient.GetProviderDocIndexByVersion(ctx, namespace, providerName, version.Version)
+						if docErr != nil {
+							log.Printf("Warning: failed to backfill doc index for %s/%s@%s: %v", namespace, providerName, version.Version, docErr)
+						} else if len(docEntries) > 0 {
+							docModels := make([]models.ProviderVersionDoc, len(docEntries))
+							for i, d := range docEntries {
+								docModels[i] = models.ProviderVersionDoc{
+									UpstreamDocID: d.ID,
+									Title:         d.Title,
+									Slug:          d.Slug,
+									Category:      d.Category,
+									Subcategory:   d.Subcategory,
+									Path:          &d.Path,
+									Language:      d.Language,
+								}
+							}
+							if storeErr := j.providerDocsRepo.BulkCreateProviderVersionDocs(ctx, existingVersion.ID, docModels); storeErr != nil {
+								log.Printf("Warning: failed to store backfilled doc index for %s/%s@%s: %v", namespace, providerName, version.Version, storeErr)
+							} else {
+								log.Printf("Backfilled %d doc index entries for %s/%s@%s", len(docModels), namespace, providerName, version.Version)
+							}
+						}
+					}
+				}
 				log.Printf("Version %s of %s/%s already exists with all platforms, skipping", version.Version, namespace, providerName)
 				continue
 			}

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -365,8 +365,15 @@ type providerDocContentV2 struct {
 	} `json:"data"`
 }
 
+// providerV2Response is the JSON:API envelope for GET /v2/providers/{namespace}/{name}.
+type providerV2Response struct {
+	Data struct {
+		ID string `json:"id"`
+	} `json:"data"`
+}
+
 // providerVersionListV2 is the JSON:API envelope for
-// GET /v2/providers/{namespace}/{name}/versions.
+// GET /v2/providers/{id}/provider-versions.
 type providerVersionListV2 struct {
 	Data []providerVersionEntryV2 `json:"data"`
 	Meta struct {
@@ -385,57 +392,76 @@ type providerVersionEntryV2 struct {
 	} `json:"attributes"`
 }
 
-// resolveProviderVersionID pages through the upstream v2
-// /v2/providers/{namespace}/{name}/versions endpoint to find the numeric
-// JSON:API ID for the given semver string. The v2 provider-docs API requires
-// this numeric ID as filter[provider-version]; passing the semver string
-// directly causes a 400 "provider-version filter is required" error.
+// resolveProviderVersionID returns the numeric JSON:API provider-version ID for
+// the given semver string using a two-step lookup:
+//
+//  1. GET /v2/providers/{namespace}/{name}        → the provider's numeric ID.
+//  2. GET /v2/providers/{id}/provider-versions    → flat list of all versions.
+//
+// The v2 provider-docs API requires this numeric ID as filter[provider-version];
+// passing the semver string directly causes a 400 "provider-version filter is
+// required" error.
 func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespace, providerName, semver string) (string, error) {
 	base := strings.TrimSuffix(u.BaseURL, "/")
-	pageNum := 1
 
-	for {
-		reqURL := fmt.Sprintf(
-			"%s/v2/providers/%s/%s/versions?page[size]=100&page[number]=%d",
-			base,
-			url.PathEscape(namespace),
-			url.PathEscape(providerName),
-			pageNum,
-		)
-
-		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
-		if err != nil {
-			return "", fmt.Errorf("failed to create v2 provider versions request (page %d): %w", pageNum, err)
-		}
-
-		resp, err := u.HTTPClient.Do(req)
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch v2 provider versions (page %d): %w", pageNum, err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			return "", fmt.Errorf("v2 provider versions request failed with status %d: %s", resp.StatusCode, string(body))
-		}
-
-		var page providerVersionListV2
-		decodeErr := json.NewDecoder(resp.Body).Decode(&page)
+	// Step 1: resolve the provider's numeric ID.
+	providerURL := fmt.Sprintf("%s/v2/providers/%s/%s",
+		base,
+		url.PathEscape(namespace),
+		url.PathEscape(providerName),
+	)
+	req, err := http.NewRequestWithContext(ctx, "GET", providerURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+	if err != nil {
+		return "", fmt.Errorf("failed to create v2 provider lookup request: %w", err)
+	}
+	resp, err := u.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch v2 provider: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		if decodeErr != nil {
-			return "", fmt.Errorf("failed to decode v2 provider versions response (page %d): %w", pageNum, decodeErr)
-		}
+		return "", fmt.Errorf("v2 provider lookup failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	var provResp providerV2Response
+	decodeErr := json.NewDecoder(resp.Body).Decode(&provResp)
+	resp.Body.Close()
+	if decodeErr != nil {
+		return "", fmt.Errorf("failed to decode v2 provider response: %w", decodeErr)
+	}
+	if provResp.Data.ID == "" {
+		return "", fmt.Errorf("v2 provider lookup returned empty ID for %s/%s", namespace, providerName)
+	}
 
-		for _, entry := range page.Data {
-			if entry.Attributes.Version == semver {
-				return entry.ID, nil
-			}
-		}
+	// Step 2: list all provider-versions under that provider ID.
+	versionsURL := fmt.Sprintf("%s/v2/providers/%s/provider-versions",
+		base,
+		provResp.Data.ID,
+	)
+	req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+	if err != nil {
+		return "", fmt.Errorf("failed to create v2 provider-versions request: %w", err)
+	}
+	resp, err = u.HTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch v2 provider-versions: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	var versionsResp providerVersionListV2
+	decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
+	resp.Body.Close()
+	if decodeErr != nil {
+		return "", fmt.Errorf("failed to decode v2 provider-versions response: %w", decodeErr)
+	}
 
-		if page.Meta.Pagination.NextPage == nil {
-			break
+	for _, entry := range versionsResp.Data {
+		if entry.Attributes.Version == semver {
+			return entry.ID, nil
 		}
-		pageNum++
 	}
 
 	return "", fmt.Errorf("provider version %s/%s@%s not found in upstream v2 versions API", namespace, providerName, semver)

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -309,14 +309,17 @@ func makeDocEntry(id, slug, category, language string) providerDocEntryV2 {
 
 func TestResolveProviderVersionID_NotFound(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/providers/hashicorp/aws/versions" {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "100"}})
+		case "/v2/providers/100/provider-versions":
 			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("1", "4.0.0"),
 				makeVersionEntry("2", "4.1.0"),
 			}, nil))
-			return
+		default:
+			http.NotFound(w, r)
 		}
-		http.NotFound(w, r)
 	}))
 
 	_, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "5.0.0")
@@ -325,24 +328,18 @@ func TestResolveProviderVersionID_NotFound(t *testing.T) {
 	}
 }
 
-func TestResolveProviderVersionID_Pagination(t *testing.T) {
-	two := 2
+func TestResolveProviderVersionID_Found(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v2/providers/hashicorp/aws/versions" {
-			http.NotFound(w, r)
-			return
-		}
-		switch r.URL.Query().Get("page[number]") {
-		case "1", "":
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "100"}})
+		case "/v2/providers/100/provider-versions":
 			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("10", "4.0.0"),
-			}, &two))
-		case "2":
-			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("20", "5.0.0"),
 			}, nil))
 		default:
-			http.Error(w, "unexpected page", http.StatusBadRequest)
+			http.NotFound(w, r)
 		}
 	}))
 
@@ -362,7 +359,9 @@ func TestResolveProviderVersionID_Pagination(t *testing.T) {
 func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v2/providers/hashicorp/aws/versions":
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "5000"}})
+		case "/v2/providers/5000/provider-versions":
 			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("999", "5.0.0"),
 			}, nil))
@@ -400,7 +399,9 @@ func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 	two := 2
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v2/providers/hashicorp/aws/versions":
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "5000"}})
+		case "/v2/providers/5000/provider-versions":
 			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("777", "5.0.0"),
 			}, nil))
@@ -449,7 +450,9 @@ func TestGetProviderDocIndexByVersion_HTTPError(t *testing.T) {
 func TestGetProviderDocIndexByVersion_Empty(t *testing.T) {
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v2/providers/hashicorp/null/versions":
+		case "/v2/providers/hashicorp/null":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "6000"}})
+		case "/v2/providers/6000/provider-versions":
 			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
 				makeVersionEntry("555", "1.0.0"),
 			}, nil))


### PR DESCRIPTION
Release v0.2.29.

## Changelog

- fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries