### PR TITLE
fix: switch doc-index and version pagination to length-based detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: switch doc-index and provider-version pagination from next-page sentinel to length-based detection — the registry v2 API never populates meta.pagination.next-page, so GetProviderDocIndexByVersion now fetches all pages (1,500+ entries for large providers like azurerm) and resolveProviderVersionID pages through all versions to handle providers with more than 100 releases
+
 ---
 
 ## [0.2.29] - 2026-03-25

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -107,8 +107,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "509: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n510: \t\tresp.Body.Close()\n511: \t\tif decodeErr != nil {\n",
-			"line": "510",
+			"code": "522: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n523: \t\tresp.Body.Close()\n524: \t\tif decodeErr != nil {\n",
+			"line": "523",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -123,8 +123,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "503: \t\t\tbody, _ := io.ReadAll(resp.Body)\n504: \t\t\tresp.Body.Close()\n505: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "504",
+			"code": "516: \t\t\tbody, _ := io.ReadAll(resp.Body)\n517: \t\t\tresp.Body.Close()\n518: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "517",
 			"column": "4",
 			"nosec": false,
 			"suppressions": null
@@ -139,9 +139,9 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "455: \tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n456: \tresp.Body.Close()\n457: \tif decodeErr != nil {\n",
-			"line": "456",
-			"column": "2",
+			"code": "462: \t\tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n463: \t\tresp.Body.Close()\n464: \t\tif decodeErr != nil {\n",
+			"line": "463",
+			"column": "3",
 			"nosec": false,
 			"suppressions": null
 		},
@@ -155,9 +155,9 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "450: \t\tbody, _ := io.ReadAll(resp.Body)\n451: \t\tresp.Body.Close()\n452: \t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "451",
-			"column": "3",
+			"code": "457: \t\t\tbody, _ := io.ReadAll(resp.Body)\n458: \t\t\tresp.Body.Close()\n459: \t\t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "458",
+			"column": "4",
 			"nosec": false,
 			"suppressions": null
 		},
@@ -372,7 +372,7 @@
 	],
 	"Stats": {
 		"files": 124,
-		"lines": 37757,
+		"lines": 37773,
 		"nosec": 95,
 		"found": 23
 	},

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -433,34 +433,47 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 		return "", fmt.Errorf("v2 provider lookup returned empty ID for %s/%s", namespace, providerName)
 	}
 
-	// Step 2: list all provider-versions under that provider ID.
-	versionsURL := fmt.Sprintf("%s/v2/providers/%s/provider-versions",
-		base,
-		provResp.Data.ID,
-	)
-	req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
-	if err != nil {
-		return "", fmt.Errorf("failed to create v2 provider-versions request: %w", err)
-	}
-	resp, err = u.HTTPClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch v2 provider-versions: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+	// Step 2: list all provider-versions under that provider ID, paging until
+	// the target semver is found or all pages are exhausted.  The upstream API
+	// sorts versions newest-first and does not populate meta.pagination; we stop
+	// when a page returns fewer entries than requested (last page reached).
+	const versionPageSize = 100
+	for versionPage := 1; ; versionPage++ {
+		versionsURL := fmt.Sprintf("%s/v2/providers/%s/provider-versions?page[size]=%d&page[number]=%d",
+			base,
+			provResp.Data.ID,
+			versionPageSize,
+			versionPage,
+		)
+		req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+		if err != nil {
+			return "", fmt.Errorf("failed to create v2 provider-versions request (page %d): %w", versionPage, err)
+		}
+		resp, err = u.HTTPClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch v2 provider-versions (page %d): %w", versionPage, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+		var versionsResp providerVersionListV2
+		decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
 		resp.Body.Close()
-		return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-	var versionsResp providerVersionListV2
-	decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
-	resp.Body.Close()
-	if decodeErr != nil {
-		return "", fmt.Errorf("failed to decode v2 provider-versions response: %w", decodeErr)
-	}
+		if decodeErr != nil {
+			return "", fmt.Errorf("failed to decode v2 provider-versions response (page %d): %w", versionPage, decodeErr)
+		}
 
-	for _, entry := range versionsResp.Data {
-		if entry.Attributes.Version == semver {
-			return entry.ID, nil
+		for _, entry := range versionsResp.Data {
+			if entry.Attributes.Version == semver {
+				return entry.ID, nil
+			}
+		}
+
+		// Stop when we receive a partial page — no more pages available.
+		if len(versionsResp.Data) < versionPageSize {
+			break
 		}
 	}
 
@@ -529,7 +542,10 @@ func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, nam
 			})
 		}
 
-		if page.Meta.Pagination.NextPage == nil {
+		// The registry API does not populate meta.pagination.next-page, so we
+		// cannot rely on that field.  Instead, stop when the page is not full
+		// (i.e. fewer entries than requested means we have reached the last page).
+		if len(page.Data) < 100 {
 			break
 		}
 		pageNum++

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -352,6 +353,42 @@ func TestResolveProviderVersionID_Found(t *testing.T) {
 	}
 }
 
+func TestResolveProviderVersionID_Pagination(t *testing.T) {
+	// Page 1 returns a full page of 100 versions (not the target); page 2 returns
+	// a partial page that contains the target version.
+	page1Versions := make([]providerVersionEntryV2, 100)
+	for i := range page1Versions {
+		page1Versions[i] = makeVersionEntry(fmt.Sprintf("%d", i+1000), fmt.Sprintf("1.%d.0", i))
+	}
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "200"}})
+		case "/v2/providers/200/provider-versions":
+			switch r.URL.Query().Get("page[number]") {
+			case "1", "":
+				json.NewEncoder(w).Encode(makeVersionListPage(page1Versions, nil))
+			case "2":
+				json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+					makeVersionEntry("9999", "99.0.0"),
+				}, nil))
+			default:
+				http.Error(w, "unexpected page", http.StatusBadRequest)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	id, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "99.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "9999" {
+		t.Errorf("got id %q, want %q", id, "9999")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetProviderDocIndexByVersion
 // ---------------------------------------------------------------------------
@@ -396,7 +433,13 @@ func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
 }
 
 func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
-	two := 2
+	// The registry API does not populate meta.pagination; pagination is detected
+	// by receiving fewer entries than the requested page size (< 100).
+	// Page 1 returns a full page of 100 docs; page 2 returns 3 docs (partial → stop).
+	page1 := make([]providerDocEntryV2, 100)
+	for i := range page1 {
+		page1[i] = makeDocEntry(fmt.Sprintf("%d", i+1), fmt.Sprintf("resource_%d", i+1), "resources", "hcl")
+	}
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/providers/hashicorp/aws":
@@ -408,13 +451,12 @@ func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 		case "/v2/provider-docs":
 			switch r.URL.Query().Get("page[number]") {
 			case "1", "":
-				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-					makeDocEntry("1", "index", "overview", "hcl"),
-				}, &two))
+				json.NewEncoder(w).Encode(makeDocListPage(page1, nil))
 			case "2":
 				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-					makeDocEntry("2", "aws_instance", "resources", "hcl"),
-					makeDocEntry("3", "aws_vpc", "resources", "hcl"),
+					makeDocEntry("101", "index", "overview", "hcl"),
+					makeDocEntry("102", "aws_instance", "resources", "hcl"),
+					makeDocEntry("103", "aws_vpc", "resources", "hcl"),
 				}, nil))
 			default:
 				http.Error(w, "unexpected page", http.StatusBadRequest)
@@ -428,11 +470,11 @@ func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(docs) != 3 {
-		t.Fatalf("got %d docs across pages, want 3", len(docs))
+	if len(docs) != 103 {
+		t.Fatalf("got %d docs across pages, want 103", len(docs))
 	}
-	if docs[2].ID != "3" {
-		t.Errorf("last doc ID = %q, want 3", docs[2].ID)
+	if docs[102].ID != "103" {
+		t.Errorf("last doc ID = %q, want %q", docs[102].ID, "103")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `GetProviderDocIndexByVersion`: pagination now stops when a page returns fewer than 100 entries (partial page) rather than checking `meta.pagination.next-page`
- `resolveProviderVersionID`: same length-based pagination added so providers with more than 100 releases (e.g. azurerm with 400+) can resolve any version
- Tests updated: `TestGetProviderDocIndexByVersion_Pagination` now uses a full 100-entry first page; `TestResolveProviderVersionID_Pagination` added

## Problem

The registry.terraform.io v2 API **never populates `meta.pagination.next-page`**, so the previous `NextPage == nil` check always broke after the first page. Large providers like `azurerm` have 1,580 doc entries across 16 pages — only the first 100 were being stored.

## Fix

Stop when `len(page.Data) < 100` (partial page = last page). This matches the actual API behaviour confirmed by querying the live registry.

## Changelog

- fix: switch doc-index and version pagination from next-page sentinel to length-based detection — the registry v2 API never populates meta.pagination.next-page, so GetProviderDocIndexByVersion now fetches all pages (1,500+ entries for large providers like azurerm) and resolveProviderVersionID pages through all versions to handle providers with more than 100 releases