### PR TITLE
release: v0.2.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       contents: write # needed to push auto-generated swagger.json back to the branch
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.26"
           cache-dependency-path: backend/go.sum
@@ -100,7 +100,7 @@ jobs:
           }'
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: go-coverage
           path: backend/coverage.out
@@ -130,7 +130,7 @@ jobs:
         # Once set, the action writes / overwrites 'coverage.json' in that gist, which the
         # shields.io endpoint badge in README.md reads.
         if: github.event_name == 'push'
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: ${{ vars.COVERAGE_GIST_ID }}
@@ -149,10 +149,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.26"
           cache-dependency-path: backend/go.sum
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload gosec results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: gosec-results
           path: backend/gosec-results.json
@@ -225,9 +225,11 @@ jobs:
   docker-build:
     name: Docker Build Smoke Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build backend Docker image
         run: docker build -t terraform-registry-backend:ci backend/
@@ -256,9 +258,11 @@ jobs:
   deployment-validate:
     name: Deployment Config Validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate Docker Compose configs
         working-directory: deployments
@@ -271,7 +275,7 @@ jobs:
           docker compose -f docker-compose.test.yml config --quiet
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: "latest"
 
@@ -290,7 +294,7 @@ jobs:
         run: kubectl kustomize deployments/kubernetes/overlays/production > /dev/null
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
         with:
           terraform_version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0   # need full history to walk ancestry
 
@@ -65,11 +67,11 @@ jobs:
       contents: write   # required to create releases and upload assets
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0   # GoReleaser needs full history to resolve previous tag
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
@@ -78,7 +80,7 @@ jobs:
         run: tar -czf "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -88,6 +90,11 @@ jobs:
 
       - name: Upload deployment configs to release
         run: gh release upload "${GITHUB_REF_NAME}" "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish draft release
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -101,10 +108,10 @@ jobs:
       packages: write   # required to push to ghcr.io
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -112,7 +119,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -122,10 +129,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build and push image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: backend/
           file: backend/Dockerfile

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -15,13 +15,15 @@ jobs:
   full-build:
     name: Full Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: '1.26'
           cache-dependency-path: backend/go.sum
@@ -59,7 +61,7 @@ jobs:
       # ── Artifacts ────────────────────────────────────────────────────────
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         if: always()
         with:
           name: scheduled-coverage-${{ github.run_id }}
@@ -72,9 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: full-build
     if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
     steps:
       - name: Create failure issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,7 @@ checksum:
   algorithm: sha256
 
 release:
+  draft: true
   github:
     owner: sethbacon
     name: terraform-registry-backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- fix: switch doc-index and provider-version pagination from next-page sentinel to length-based detection — the registry v2 API never populates meta.pagination.next-page, so GetProviderDocIndexByVersion now fetches all pages (1,500+ entries for large providers like azurerm) and resolveProviderVersionID pages through all versions to handle providers with more than 100 releases
+---
+
+## [0.2.30] - 2026-03-25
+
+### Fixed
+- fix: switch doc-index and provider-version pagination from next-page sentinel to length-based detection — the registry v2 API never populates `meta.pagination.next-page`; `GetProviderDocIndexByVersion` now fetches all pages (1,500+ entries for large providers like azurerm) and `resolveProviderVersionID` pages through all provider-version pages to handle providers with more than 100 releases
 
 ---
 
@@ -17,7 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix: backfill doc index for existing provider versions with no docs — the mirror sync job now checks the doc count when skipping already-complete versions; if zero docs exist (due to a prior failed doc fetch), it fetches and stores the doc index without re-downloading binaries
-- fix: resolve provider-version numeric ID via correct v2 API endpoints — `resolveProviderVersionID` now calls `GET /v2/providers/{namespace}/{name}` to obtain the provider's numeric ID, then `GET /v2/providers/{id}/provider-versions` to find the matching semver entry; the previous `/v2/providers/{namespace}/{name}/versions` path returned 404
+
+---
+
+## [0.2.28] - 2026-03-25
+
+### Fixed
+- fix: resolve numeric v2 provider-version ID before fetching doc index — `resolveProviderVersionID` now calls `GET /v2/providers/{namespace}/{name}` to obtain the provider's numeric ID then `GET /v2/providers/{id}/provider-versions` to find the matching semver entry
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix: switch doc-index and provider-version pagination from next-page sentinel to length-based detection — the registry v2 API never populates meta.pagination.next-page, so GetProviderDocIndexByVersion now fetches all pages (1,500+ entries for large providers like azurerm) and resolveProviderVersionID pages through all versions to handle providers with more than 100 releases
+
 ---
 
 ## [0.2.29] - 2026-03-25

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -107,8 +107,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "509: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n510: \t\tresp.Body.Close()\n511: \t\tif decodeErr != nil {\n",
-			"line": "510",
+			"code": "522: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n523: \t\tresp.Body.Close()\n524: \t\tif decodeErr != nil {\n",
+			"line": "523",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -123,8 +123,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "503: \t\t\tbody, _ := io.ReadAll(resp.Body)\n504: \t\t\tresp.Body.Close()\n505: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "504",
+			"code": "516: \t\t\tbody, _ := io.ReadAll(resp.Body)\n517: \t\t\tresp.Body.Close()\n518: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "517",
 			"column": "4",
 			"nosec": false,
 			"suppressions": null
@@ -139,9 +139,9 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "455: \tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n456: \tresp.Body.Close()\n457: \tif decodeErr != nil {\n",
-			"line": "456",
-			"column": "2",
+			"code": "462: \t\tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n463: \t\tresp.Body.Close()\n464: \t\tif decodeErr != nil {\n",
+			"line": "463",
+			"column": "3",
 			"nosec": false,
 			"suppressions": null
 		},
@@ -155,9 +155,9 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "450: \t\tbody, _ := io.ReadAll(resp.Body)\n451: \t\tresp.Body.Close()\n452: \t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "451",
-			"column": "3",
+			"code": "457: \t\t\tbody, _ := io.ReadAll(resp.Body)\n458: \t\t\tresp.Body.Close()\n459: \t\t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "458",
+			"column": "4",
 			"nosec": false,
 			"suppressions": null
 		},
@@ -372,7 +372,7 @@
 	],
 	"Stats": {
 		"files": 124,
-		"lines": 37757,
+		"lines": 37773,
 		"nosec": 95,
 		"found": 23
 	},

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -433,34 +433,47 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 		return "", fmt.Errorf("v2 provider lookup returned empty ID for %s/%s", namespace, providerName)
 	}
 
-	// Step 2: list all provider-versions under that provider ID.
-	versionsURL := fmt.Sprintf("%s/v2/providers/%s/provider-versions",
-		base,
-		provResp.Data.ID,
-	)
-	req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
-	if err != nil {
-		return "", fmt.Errorf("failed to create v2 provider-versions request: %w", err)
-	}
-	resp, err = u.HTTPClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch v2 provider-versions: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+	// Step 2: list all provider-versions under that provider ID, paging until
+	// the target semver is found or all pages are exhausted.  The upstream API
+	// sorts versions newest-first and does not populate meta.pagination; we stop
+	// when a page returns fewer entries than requested (last page reached).
+	const versionPageSize = 100
+	for versionPage := 1; ; versionPage++ {
+		versionsURL := fmt.Sprintf("%s/v2/providers/%s/provider-versions?page[size]=%d&page[number]=%d",
+			base,
+			provResp.Data.ID,
+			versionPageSize,
+			versionPage,
+		)
+		req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+		if err != nil {
+			return "", fmt.Errorf("failed to create v2 provider-versions request (page %d): %w", versionPage, err)
+		}
+		resp, err = u.HTTPClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch v2 provider-versions (page %d): %w", versionPage, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
+		}
+		var versionsResp providerVersionListV2
+		decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
 		resp.Body.Close()
-		return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-	var versionsResp providerVersionListV2
-	decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
-	resp.Body.Close()
-	if decodeErr != nil {
-		return "", fmt.Errorf("failed to decode v2 provider-versions response: %w", decodeErr)
-	}
+		if decodeErr != nil {
+			return "", fmt.Errorf("failed to decode v2 provider-versions response (page %d): %w", versionPage, decodeErr)
+		}
 
-	for _, entry := range versionsResp.Data {
-		if entry.Attributes.Version == semver {
-			return entry.ID, nil
+		for _, entry := range versionsResp.Data {
+			if entry.Attributes.Version == semver {
+				return entry.ID, nil
+			}
+		}
+
+		// Stop when we receive a partial page — no more pages available.
+		if len(versionsResp.Data) < versionPageSize {
+			break
 		}
 	}
 
@@ -529,7 +542,10 @@ func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, nam
 			})
 		}
 
-		if page.Meta.Pagination.NextPage == nil {
+		// The registry API does not populate meta.pagination.next-page, so we
+		// cannot rely on that field.  Instead, stop when the page is not full
+		// (i.e. fewer entries than requested means we have reached the last page).
+		if len(page.Data) < 100 {
 			break
 		}
 		pageNum++

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -352,6 +353,42 @@ func TestResolveProviderVersionID_Found(t *testing.T) {
 	}
 }
 
+func TestResolveProviderVersionID_Pagination(t *testing.T) {
+	// Page 1 returns a full page of 100 versions (not the target); page 2 returns
+	// a partial page that contains the target version.
+	page1Versions := make([]providerVersionEntryV2, 100)
+	for i := range page1Versions {
+		page1Versions[i] = makeVersionEntry(fmt.Sprintf("%d", i+1000), fmt.Sprintf("1.%d.0", i))
+	}
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "200"}})
+		case "/v2/providers/200/provider-versions":
+			switch r.URL.Query().Get("page[number]") {
+			case "1", "":
+				json.NewEncoder(w).Encode(makeVersionListPage(page1Versions, nil))
+			case "2":
+				json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+					makeVersionEntry("9999", "99.0.0"),
+				}, nil))
+			default:
+				http.Error(w, "unexpected page", http.StatusBadRequest)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	id, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "99.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "9999" {
+		t.Errorf("got id %q, want %q", id, "9999")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetProviderDocIndexByVersion
 // ---------------------------------------------------------------------------
@@ -396,7 +433,13 @@ func TestGetProviderDocIndexByVersion_SinglePage(t *testing.T) {
 }
 
 func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
-	two := 2
+	// The registry API does not populate meta.pagination; pagination is detected
+	// by receiving fewer entries than the requested page size (< 100).
+	// Page 1 returns a full page of 100 docs; page 2 returns 3 docs (partial → stop).
+	page1 := make([]providerDocEntryV2, 100)
+	for i := range page1 {
+		page1[i] = makeDocEntry(fmt.Sprintf("%d", i+1), fmt.Sprintf("resource_%d", i+1), "resources", "hcl")
+	}
 	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v2/providers/hashicorp/aws":
@@ -408,13 +451,12 @@ func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 		case "/v2/provider-docs":
 			switch r.URL.Query().Get("page[number]") {
 			case "1", "":
-				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-					makeDocEntry("1", "index", "overview", "hcl"),
-				}, &two))
+				json.NewEncoder(w).Encode(makeDocListPage(page1, nil))
 			case "2":
 				json.NewEncoder(w).Encode(makeDocListPage([]providerDocEntryV2{
-					makeDocEntry("2", "aws_instance", "resources", "hcl"),
-					makeDocEntry("3", "aws_vpc", "resources", "hcl"),
+					makeDocEntry("101", "index", "overview", "hcl"),
+					makeDocEntry("102", "aws_instance", "resources", "hcl"),
+					makeDocEntry("103", "aws_vpc", "resources", "hcl"),
 				}, nil))
 			default:
 				http.Error(w, "unexpected page", http.StatusBadRequest)
@@ -428,11 +470,11 @@ func TestGetProviderDocIndexByVersion_Pagination(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(docs) != 3 {
-		t.Fatalf("got %d docs across pages, want 3", len(docs))
+	if len(docs) != 103 {
+		t.Fatalf("got %d docs across pages, want 103", len(docs))
 	}
-	if docs[2].ID != "3" {
-		t.Errorf("last doc ID = %q, want 3", docs[2].ID)
+	if docs[102].ID != "103" {
+		t.Errorf("last doc ID = %q, want %q", docs[102].ID, "103")
 	}
 }
 


### PR DESCRIPTION
Release v0.2.30.

## Changelog

- fix: switch doc-index and provider-version pagination from next-page sentinel to length-based detection — the registry v2 API never populates meta.pagination.next-page; GetProviderDocIndexByVersion now fetches all pages (1,500+ entries for large providers like azurerm) and resolveProviderVersionID pages through all provider-version pages to handle providers with more than 100 releases