### PR TITLE
fix: reject path traversal in /v1/files handler and local storage backend

### DIFF
--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -55,6 +55,16 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			filePath = filePath[1:]
 		}
 
+		// Reject path traversal sequences. The local storage backend uses
+		// filepath.Join which resolves ".." — block them here before any backend
+		// call so that GET /v1/files/../../etc/passwd cannot escape the storage root.
+		if strings.Contains(filePath, "..") || strings.Contains(filePath, "//") {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Invalid file path",
+			})
+			return
+		}
+
 		// Check if file exists
 		exists, err := storageBackend.Exists(c.Request.Context(), filePath)
 		if err != nil {

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -48,6 +48,22 @@ func New(cfg *config.LocalStorageConfig, serverBaseURL string) (*LocalStorage, e
 	}, nil
 }
 
+// safeJoin constructs an absolute path by joining basePath and the caller-supplied
+// relative path, then verifies that the result is still inside basePath. This is a
+// defence-in-depth check: the primary traversal rejection lives in serve.go, but
+// this ensures the storage layer cannot be exploited even if a future code path
+// skips that check.
+func (s *LocalStorage) safeJoin(path string) (string, error) {
+	full := filepath.Join(s.basePath, filepath.FromSlash(path))
+	// filepath.Clean normalises the joined path (resolves any remaining ".." segments).
+	// We require the result to remain inside basePath by verifying the prefix.
+	base := filepath.Clean(s.basePath) + string(os.PathSeparator)
+	if !strings.HasPrefix(filepath.Clean(full)+string(os.PathSeparator), base) {
+		return "", fmt.Errorf("path escapes storage root: %s", path)
+	}
+	return full, nil
+}
+
 // Upload stores a file in the local filesystem
 func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
 	// Create full path
@@ -93,9 +109,12 @@ func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader
 
 // Download retrieves a file from the local filesystem
 func (s *LocalStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return nil, err
+	}
 
-	file, err := os.Open(fullPath) // #nosec G304 -- path is constructed from validated namespace/name/version components; path traversal is prevented at the API and archive-extraction layers
+	file, err := os.Open(fullPath) // #nosec G304 -- fullPath has been validated by safeJoin to remain within basePath
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("file not found: %s", path)
@@ -152,15 +171,21 @@ func (s *LocalStorage) GetURL(ctx context.Context, path string, ttl time.Duratio
 	}
 
 	// Return file:// URL for local access
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf("file://%s", fullPath), nil
 }
 
 // Exists checks if a file exists at the specified path
 func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return false, err
+	}
 
-	_, err := os.Stat(fullPath)
+	_, err = os.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -173,7 +198,10 @@ func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the file
 func (s *LocalStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return nil, err
+	}
 
 	stat, err := os.Stat(fullPath)
 	if err != nil {

--- a/backend/internal/storage/local/local_test.go
+++ b/backend/internal/storage/local/local_test.go
@@ -374,6 +374,55 @@ func TestGetMetadata_NoSidecar(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// safeJoin / path traversal
+// ---------------------------------------------------------------------------
+
+func TestSafeJoin_TraversalRejected(t *testing.T) {
+	s := newTestStorage(t, false, "")
+	ctx := context.Background()
+
+	traversalPaths := []string{
+		"../../etc/passwd",
+		"modules/../../../etc/shadow",
+		"a/b/c/../../../../secret",
+	}
+	for _, p := range traversalPaths {
+		t.Run(p, func(t *testing.T) {
+			_, err := s.Download(ctx, p)
+			if err == nil {
+				t.Errorf("Download(%q) expected error for traversal path, got nil", p)
+			}
+			_, err = s.Exists(ctx, p)
+			if err == nil {
+				t.Errorf("Exists(%q) expected error for traversal path, got nil", p)
+			}
+			_, err = s.GetMetadata(ctx, p)
+			if err == nil {
+				t.Errorf("GetMetadata(%q) expected error for traversal path, got nil", p)
+			}
+		})
+	}
+}
+
+func TestSafeJoin_NormalPathAllowed(t *testing.T) {
+	s := newTestStorage(t, false, "")
+	ctx := context.Background()
+
+	content := "hello"
+	if _, err := s.Upload(ctx, "modules/foo/1.0.0/archive.tar.gz", strings.NewReader(content), int64(len(content))); err != nil {
+		t.Fatal("Upload:", err)
+	}
+
+	ok, err := s.Exists(ctx, "modules/foo/1.0.0/archive.tar.gz")
+	if err != nil {
+		t.Fatalf("Exists() error: %v", err)
+	}
+	if !ok {
+		t.Error("Exists() = false for normal nested path, want true")
+	}
+}
+
 // TestNew_NewDirectory verifies New succeeds when the base path does not yet exist.
 func TestNew_NewDirectory(t *testing.T) {
 	parent, err := os.MkdirTemp("", "new-dir-test-*")


### PR DESCRIPTION
Closes #131

Rejects path traversal attempts in the public `/v1/files/*filepath` handler and adds a defence-in-depth containment check to the local storage backend.

**serve.go:** Rejects any `filepath` parameter containing `..` or `//` before it reaches the storage backend. Without this, `GET /v1/files/../../etc/passwd` resolves to the host's `/etc/passwd` via `filepath.Join`.

**local.go:** Adds `safeJoin()` which verifies `filepath.Join(basePath, path)` is still prefixed by `basePath` after resolution. Applied to `Download`, `Exists`, `GetMetadata`, and `GetURL`. The previous `#nosec G304` comments incorrectly stated traversal was handled at the API layer — now it is, at both layers.

**local_test.go:** Adds `TestSafeJoin_TraversalRejected` (3 traversal paths across 3 methods) and `TestSafeJoin_NormalPathAllowed`.

## Changelog
- fix: reject path traversal sequences in /v1/files handler and local storage safeJoin