### PR TITLE
fix: reject symlinks and hard links in archive validation

### DIFF
--- a/backend/internal/validation/archive.go
+++ b/backend/internal/validation/archive.go
@@ -57,6 +57,14 @@ func ValidateArchive(reader io.Reader, maxSize int64) error {
 			return fmt.Errorf("invalid file path in archive: %w", err)
 		}
 
+		// Reject symlinks and hard links. Server-side extraction ignores them, but
+		// an archive containing malicious symlinks (e.g. pointing to /etc/passwd)
+		// would be stored and later extracted by Terraform clients — creating a
+		// supply-chain vector. Reject at upload time so such archives never reach storage.
+		if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
+			return fmt.Errorf("symlinks and hard links are not allowed in module archives: %s", header.Name)
+		}
+
 		// Count actual decompressed bytes instead of trusting header.Size
 		// (header.Size is attacker-controlled and can be set to 0 while the
 		// entry contains arbitrary data).

--- a/backend/internal/validation/archive_test.go
+++ b/backend/internal/validation/archive_test.go
@@ -4,8 +4,37 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"strings"
 	"testing"
 )
+
+// makeTarGzWithHeaders creates an in-memory tar.gz archive from a slice of
+// pre-built tar.Header values. Callers set Typeflag, Linkname, etc. directly.
+// Only entries whose Typeflag is tar.TypeReg have body content written.
+func makeTarGzWithHeaders(t *testing.T, headers []*tar.Header) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, hdr := range headers {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar WriteHeader: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeReg && hdr.Size > 0 {
+			body := make([]byte, hdr.Size)
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("tar Write: %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
 
 // makeGzipOf wraps raw bytes in a gzip stream (not a valid tar).
 func makeGzipOf(t *testing.T, data []byte) []byte {
@@ -114,6 +143,36 @@ func TestValidateArchive(t *testing.T) {
 			data:    makeGzipOf(t, []byte("not-tar-not-tar-not-tar-not-tar-not-tar-not-tar-not-tar-not-tar")),
 			wantErr: true,
 		},
+		{
+			// Symlink entries can escape the extraction directory on clients running
+			// terraform init. The registry must reject them at upload time.
+			name: "symlink entry rejected",
+			data: makeTarGzWithHeaders(t, []*tar.Header{
+				{
+					Typeflag: tar.TypeSymlink,
+					Name:     "link",
+					Linkname: "../../../etc/passwd",
+				},
+			}),
+			wantErr: true,
+			errMsg:  "symlinks and hard links are not allowed",
+		},
+		{
+			// Hard links share inodes and can reference files outside the module
+			// directory when the archive is extracted on a client machine.
+			name: "hard link entry rejected",
+			data: makeTarGzWithHeaders(t, []*tar.Header{
+				// Include a regular file first so the archive is non-empty before the link.
+				{Typeflag: tar.TypeReg, Name: "main.tf", Size: 4},
+				{
+					Typeflag: tar.TypeLink,
+					Name:     "hardlink",
+					Linkname: "main.tf",
+				},
+			}),
+			wantErr: true,
+			errMsg:  "symlinks and hard links are not allowed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,6 +180,9 @@ func TestValidateArchive(t *testing.T) {
 			err := ValidateArchive(bytes.NewReader(tt.data), tt.maxSize)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateArchive() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("ValidateArchive() error = %q, want to contain %q", err.Error(), tt.errMsg)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #132

`ValidateArchive` validated path names but never checked `header.Typeflag`. Symlink and hard link tar entries passed validation and were stored in the registry.

Server-side extraction (`archiver/tarball.go`) only processes `TypeDir` and `TypeReg`, so the registry itself is not affected. However, a stored archive containing a symlink like `link -> ../../../../etc/shadow` is extracted verbatim by `terraform init` on the user's machine — making the registry a supply-chain vector for distributing malicious archives to module consumers.

**archive.go:** Adds a `Typeflag` check immediately after `validatePath` inside the iteration loop, returning an error for `tar.TypeSymlink` and `tar.TypeLink`.

**archive_test.go:** Adds `makeTarGzWithHeaders` helper for building archives with arbitrary tar headers. Adds `symlink_entry_rejected` and `hard_link_entry_rejected` table test cases, both with `errMsg` assertions.

## Changelog
- fix: reject symlinks and hard links in module archive validation to prevent supply-chain path-traversal on client machines