### PR TITLE
fix: require HTTPS for OIDC issuer URL

### DIFF
--- a/backend/internal/auth/oidc/provider.go
+++ b/backend/internal/auth/oidc/provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -43,6 +44,13 @@ func NewOIDCProviderWithContext(ctx context.Context, cfg *config.OIDCConfig) (*O
 
 	if cfg.ClientSecret == "" {
 		return nil, fmt.Errorf("OIDC client secret is required")
+	}
+
+	// Require HTTPS for the issuer URL. An HTTP issuer means discovery and JWKS
+	// key material are fetched over plaintext, allowing a MITM to substitute
+	// signing keys and forge valid ID tokens.
+	if !strings.HasPrefix(cfg.IssuerURL, "https://") {
+		return nil, fmt.Errorf("OIDC issuer URL must use HTTPS, got: %q", cfg.IssuerURL)
 	}
 
 	// Initialize OIDC provider

--- a/backend/internal/auth/oidc/provider_test.go
+++ b/backend/internal/auth/oidc/provider_test.go
@@ -85,6 +85,32 @@ func TestNewOIDCProvider_MissingClientSecret(t *testing.T) {
 	}
 }
 
+func TestNewOIDCProvider_HTTPIssuerRejected(t *testing.T) {
+	// An HTTP (non-TLS) issuer URL must be rejected: OIDC discovery and JWKS key
+	// material would be fetched over plaintext, enabling MITM to forge tokens.
+	httpIssuers := []string{
+		"http://example.com",
+		"http://localhost:8080",
+		"http://idp.internal/realms/myrealm",
+	}
+	for _, issuer := range httpIssuers {
+		t.Run(issuer, func(t *testing.T) {
+			_, err := NewOIDCProvider(&config.OIDCConfig{
+				Enabled:      true,
+				IssuerURL:    issuer,
+				ClientID:     "client",
+				ClientSecret: "secret",
+			})
+			if err == nil {
+				t.Errorf("NewOIDCProvider(%q) expected error for HTTP issuer, got nil", issuer)
+			}
+			if err != nil && !strings.Contains(err.Error(), "HTTPS") {
+				t.Errorf("error = %q, want to mention HTTPS", err.Error())
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetAuthURL
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #133

`NewOIDCProviderWithContext` accepted any `IssuerURL` without checking the URL scheme. An HTTP issuer means OIDC discovery (`.well-known/openid-configuration`) and JWKS key material are fetched over plaintext HTTP, allowing a network-path MITM to substitute signing keys and forge valid ID tokens for any user.

**provider.go:** Returns an error immediately if `IssuerURL` does not start with `https://`, before `oidc.NewProvider()` is called.

**provider_test.go:** Adds `TestNewOIDCProvider_HTTPIssuerRejected` covering three HTTP issuer URL variants (`http://example.com`, `http://localhost:8080`, `http://idp.internal/realms/myrealm`), asserting both that an error is returned and that the error message mentions "HTTPS".

## Changelog
- fix: reject non-HTTPS OIDC issuer URLs to prevent MITM key substitution