### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.1] - 2026-04-09
+
+### Security
+
+- fix: reject path traversal sequences in `/v1/files/*filepath` handler and add `safeJoin` containment check to local storage backend — prevents arbitrary host file reads via `GET /v1/files/../../etc/passwd` when using local storage with `ServeDirectly: true` (public endpoint, no auth required)
+- fix: reject symlinks and hard links in module archive validation — prevents the registry from storing archives that would create path-escaping symlinks on Terraform client machines during `terraform init`
+- fix: require HTTPS for OIDC issuer URL — rejects `http://` issuers that would allow MITM substitution of JWKS signing keys to forge valid ID tokens
+
+---
+
 ## [0.3.0] - 2026-04-10
 
 ### Added

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -55,6 +55,16 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			filePath = filePath[1:]
 		}
 
+		// Reject path traversal sequences. The local storage backend uses
+		// filepath.Join which resolves ".." — block them here before any backend
+		// call so that GET /v1/files/../../etc/passwd cannot escape the storage root.
+		if strings.Contains(filePath, "..") || strings.Contains(filePath, "//") {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Invalid file path",
+			})
+			return
+		}
+
 		// Check if file exists
 		exists, err := storageBackend.Exists(c.Request.Context(), filePath)
 		if err != nil {

--- a/backend/internal/auth/oidc/provider.go
+++ b/backend/internal/auth/oidc/provider.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -43,6 +44,13 @@ func NewOIDCProviderWithContext(ctx context.Context, cfg *config.OIDCConfig) (*O
 
 	if cfg.ClientSecret == "" {
 		return nil, fmt.Errorf("OIDC client secret is required")
+	}
+
+	// Require HTTPS for the issuer URL. An HTTP issuer means discovery and JWKS
+	// key material are fetched over plaintext, allowing a MITM to substitute
+	// signing keys and forge valid ID tokens.
+	if !strings.HasPrefix(cfg.IssuerURL, "https://") {
+		return nil, fmt.Errorf("OIDC issuer URL must use HTTPS, got: %q", cfg.IssuerURL)
 	}
 
 	// Initialize OIDC provider

--- a/backend/internal/auth/oidc/provider_test.go
+++ b/backend/internal/auth/oidc/provider_test.go
@@ -85,6 +85,32 @@ func TestNewOIDCProvider_MissingClientSecret(t *testing.T) {
 	}
 }
 
+func TestNewOIDCProvider_HTTPIssuerRejected(t *testing.T) {
+	// An HTTP (non-TLS) issuer URL must be rejected: OIDC discovery and JWKS key
+	// material would be fetched over plaintext, enabling MITM to forge tokens.
+	httpIssuers := []string{
+		"http://example.com",
+		"http://localhost:8080",
+		"http://idp.internal/realms/myrealm",
+	}
+	for _, issuer := range httpIssuers {
+		t.Run(issuer, func(t *testing.T) {
+			_, err := NewOIDCProvider(&config.OIDCConfig{
+				Enabled:      true,
+				IssuerURL:    issuer,
+				ClientID:     "client",
+				ClientSecret: "secret",
+			})
+			if err == nil {
+				t.Errorf("NewOIDCProvider(%q) expected error for HTTP issuer, got nil", issuer)
+			}
+			if err != nil && !strings.Contains(err.Error(), "HTTPS") {
+				t.Errorf("error = %q, want to mention HTTPS", err.Error())
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetAuthURL
 // ---------------------------------------------------------------------------

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -48,6 +48,22 @@ func New(cfg *config.LocalStorageConfig, serverBaseURL string) (*LocalStorage, e
 	}, nil
 }
 
+// safeJoin constructs an absolute path by joining basePath and the caller-supplied
+// relative path, then verifies that the result is still inside basePath. This is a
+// defence-in-depth check: the primary traversal rejection lives in serve.go, but
+// this ensures the storage layer cannot be exploited even if a future code path
+// skips that check.
+func (s *LocalStorage) safeJoin(path string) (string, error) {
+	full := filepath.Join(s.basePath, filepath.FromSlash(path))
+	// filepath.Clean normalises the joined path (resolves any remaining ".." segments).
+	// We require the result to remain inside basePath by verifying the prefix.
+	base := filepath.Clean(s.basePath) + string(os.PathSeparator)
+	if !strings.HasPrefix(filepath.Clean(full)+string(os.PathSeparator), base) {
+		return "", fmt.Errorf("path escapes storage root: %s", path)
+	}
+	return full, nil
+}
+
 // Upload stores a file in the local filesystem
 func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
 	// Create full path
@@ -93,9 +109,12 @@ func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader
 
 // Download retrieves a file from the local filesystem
 func (s *LocalStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return nil, err
+	}
 
-	file, err := os.Open(fullPath) // #nosec G304 -- path is constructed from validated namespace/name/version components; path traversal is prevented at the API and archive-extraction layers
+	file, err := os.Open(fullPath) // #nosec G304 -- fullPath has been validated by safeJoin to remain within basePath
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("file not found: %s", path)
@@ -152,15 +171,21 @@ func (s *LocalStorage) GetURL(ctx context.Context, path string, ttl time.Duratio
 	}
 
 	// Return file:// URL for local access
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf("file://%s", fullPath), nil
 }
 
 // Exists checks if a file exists at the specified path
 func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return false, err
+	}
 
-	_, err := os.Stat(fullPath)
+	_, err = os.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -173,7 +198,10 @@ func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the file
 func (s *LocalStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return nil, err
+	}
 
 	stat, err := os.Stat(fullPath)
 	if err != nil {

--- a/backend/internal/storage/local/local_test.go
+++ b/backend/internal/storage/local/local_test.go
@@ -374,6 +374,55 @@ func TestGetMetadata_NoSidecar(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// safeJoin / path traversal
+// ---------------------------------------------------------------------------
+
+func TestSafeJoin_TraversalRejected(t *testing.T) {
+	s := newTestStorage(t, false, "")
+	ctx := context.Background()
+
+	traversalPaths := []string{
+		"../../etc/passwd",
+		"modules/../../../etc/shadow",
+		"a/b/c/../../../../secret",
+	}
+	for _, p := range traversalPaths {
+		t.Run(p, func(t *testing.T) {
+			_, err := s.Download(ctx, p)
+			if err == nil {
+				t.Errorf("Download(%q) expected error for traversal path, got nil", p)
+			}
+			_, err = s.Exists(ctx, p)
+			if err == nil {
+				t.Errorf("Exists(%q) expected error for traversal path, got nil", p)
+			}
+			_, err = s.GetMetadata(ctx, p)
+			if err == nil {
+				t.Errorf("GetMetadata(%q) expected error for traversal path, got nil", p)
+			}
+		})
+	}
+}
+
+func TestSafeJoin_NormalPathAllowed(t *testing.T) {
+	s := newTestStorage(t, false, "")
+	ctx := context.Background()
+
+	content := "hello"
+	if _, err := s.Upload(ctx, "modules/foo/1.0.0/archive.tar.gz", strings.NewReader(content), int64(len(content))); err != nil {
+		t.Fatal("Upload:", err)
+	}
+
+	ok, err := s.Exists(ctx, "modules/foo/1.0.0/archive.tar.gz")
+	if err != nil {
+		t.Fatalf("Exists() error: %v", err)
+	}
+	if !ok {
+		t.Error("Exists() = false for normal nested path, want true")
+	}
+}
+
 // TestNew_NewDirectory verifies New succeeds when the base path does not yet exist.
 func TestNew_NewDirectory(t *testing.T) {
 	parent, err := os.MkdirTemp("", "new-dir-test-*")

--- a/backend/internal/validation/archive.go
+++ b/backend/internal/validation/archive.go
@@ -57,6 +57,14 @@ func ValidateArchive(reader io.Reader, maxSize int64) error {
 			return fmt.Errorf("invalid file path in archive: %w", err)
 		}
 
+		// Reject symlinks and hard links. Server-side extraction ignores them, but
+		// an archive containing malicious symlinks (e.g. pointing to /etc/passwd)
+		// would be stored and later extracted by Terraform clients — creating a
+		// supply-chain vector. Reject at upload time so such archives never reach storage.
+		if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
+			return fmt.Errorf("symlinks and hard links are not allowed in module archives: %s", header.Name)
+		}
+
 		// Count actual decompressed bytes instead of trusting header.Size
 		// (header.Size is attacker-controlled and can be set to 0 while the
 		// entry contains arbitrary data).

--- a/backend/internal/validation/archive_test.go
+++ b/backend/internal/validation/archive_test.go
@@ -4,8 +4,37 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"strings"
 	"testing"
 )
+
+// makeTarGzWithHeaders creates an in-memory tar.gz archive from a slice of
+// pre-built tar.Header values. Callers set Typeflag, Linkname, etc. directly.
+// Only entries whose Typeflag is tar.TypeReg have body content written.
+func makeTarGzWithHeaders(t *testing.T, headers []*tar.Header) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, hdr := range headers {
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("tar WriteHeader: %v", err)
+		}
+		if hdr.Typeflag == tar.TypeReg && hdr.Size > 0 {
+			body := make([]byte, hdr.Size)
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("tar Write: %v", err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
 
 // makeGzipOf wraps raw bytes in a gzip stream (not a valid tar).
 func makeGzipOf(t *testing.T, data []byte) []byte {
@@ -114,6 +143,36 @@ func TestValidateArchive(t *testing.T) {
 			data:    makeGzipOf(t, []byte("not-tar-not-tar-not-tar-not-tar-not-tar-not-tar-not-tar-not-tar")),
 			wantErr: true,
 		},
+		{
+			// Symlink entries can escape the extraction directory on clients running
+			// terraform init. The registry must reject them at upload time.
+			name: "symlink entry rejected",
+			data: makeTarGzWithHeaders(t, []*tar.Header{
+				{
+					Typeflag: tar.TypeSymlink,
+					Name:     "link",
+					Linkname: "../../../etc/passwd",
+				},
+			}),
+			wantErr: true,
+			errMsg:  "symlinks and hard links are not allowed",
+		},
+		{
+			// Hard links share inodes and can reference files outside the module
+			// directory when the archive is extracted on a client machine.
+			name: "hard link entry rejected",
+			data: makeTarGzWithHeaders(t, []*tar.Header{
+				// Include a regular file first so the archive is non-empty before the link.
+				{Typeflag: tar.TypeReg, Name: "main.tf", Size: 4},
+				{
+					Typeflag: tar.TypeLink,
+					Name:     "hardlink",
+					Linkname: "main.tf",
+				},
+			}),
+			wantErr: true,
+			errMsg:  "symlinks and hard links are not allowed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,6 +180,9 @@ func TestValidateArchive(t *testing.T) {
 			err := ValidateArchive(bytes.NewReader(tt.data), tt.maxSize)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateArchive() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("ValidateArchive() error = %q, want to contain %q", err.Error(), tt.errMsg)
 			}
 		})
 	}


### PR DESCRIPTION
Security patch release. Three vulnerabilities identified during a full security audit and patched in #134, #135, #136.

## Changes since v0.3.0

### Security

- **HIGH** fix: reject path traversal in `/v1/files/*filepath` handler and local storage `safeJoin` (#134, closes #131)
- **MEDIUM** fix: reject symlinks and hard links in module archive validation (#135, closes #132)
- **LOW-MEDIUM** fix: require HTTPS for OIDC issuer URL (#136, closes #133)

## Changelog
- fix: reject path traversal sequences in /v1/files handler and add safeJoin containment to local storage backend
- fix: reject symlinks and hard links in module archive validation
- fix: require HTTPS for OIDC issuer URL