### PR TITLE
chore: release v0.3.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owner for all files
+* @sethbacon
+
+# CI/CD workflows require explicit review
+.github/ @sethbacon
+
+# Backend core
+backend/ @sethbacon
+
+# Deployment configurations
+deployments/ @sethbacon
+
+# Release configuration
+.goreleaser.yml @sethbacon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,3 +498,64 @@ func (h *Handler) MethodName(c *gin.Context) {
 - The `azure-devops-extension/` directory is deferred/work-in-progress.
 - `test-modules/`, `test-providers/`, and `test-terraform/` contain sample artifacts for local testing.
 - `CHANGELOG.md` tracks version history.
+
+---
+
+## Repository Security Hardening (applied 2026-04-09)
+
+### Branch Protection
+
+**`main` branch:**
+- Required status checks (strict — branch must be up-to-date): `Backend Tests & Quality`, `Security Scan (gosec)`, `Docker Build Smoke Test`, `Deployment Config Validation`
+- Required pull request reviews: 1 approving review, dismiss stale reviews, require code owner review
+- Enforce admins: no (admin/owner can bypass review requirements as sole maintainer)
+- Required linear history: yes (squash/rebase only, no merge commits)
+- Required conversation resolution: yes
+- Force pushes: blocked
+- Branch deletion: blocked
+
+**`development` branch:**
+- Required status checks (non-strict): `Backend Tests & Quality`, `Security Scan (gosec)`, `Docker Build Smoke Test`, `Deployment Config Validation`
+- Required linear history: yes
+- Required conversation resolution: yes
+- Force pushes: blocked
+- Branch deletion: blocked
+- Admin bypass: allowed (owner can push directly for admin tasks)
+
+### Merge Strategy
+
+- **Squash merge only** — merge commits and rebase merges are disabled
+- **Delete branch on merge** — enabled; feature/fix branches are cleaned up automatically
+- **Allow update branch** — enabled; PRs can pull in base branch changes via GitHub UI
+- **Web commit signoff required** — enabled; all web-based commits require DCO signoff
+
+### Dependency Management
+
+- **Dependabot vulnerability alerts** — enabled
+- **Dependabot automated security fixes** — enabled
+- **Dependabot version updates** — configured via `.github/dependabot.yml` for Go modules and GitHub Actions (biweekly)
+
+### Code Ownership
+
+- **CODEOWNERS** file at `.github/CODEOWNERS` — `@sethbacon` owns all files; `backend/`, `.github/`, `deployments/`, and `.goreleaser.yml` require explicit owner review
+
+### Security Features (GitHub)
+
+- Secret scanning: enabled
+- Secret scanning push protection: enabled
+- gosec security scanning in CI with baseline tracking
+- golangci-lint static analysis in CI
+- `go vet` and race-detector-enabled tests in CI
+- All GitHub Actions pinned to full commit SHAs
+- Scheduled weekly builds with auto-issue on failure
+
+### Repository Topics
+
+`terraform`, `terraform-registry`, `go`, `gin`, `postgresql`, `infrastructure-as-code`, `private-registry`
+
+### Remaining Recommendations (not yet applied)
+
+- **Add SECURITY.md** — currently only referenced in CONTRIBUTING.md; a dedicated file enables GitHub's security advisory features
+- **Enable secret scanning non-provider patterns and validity checks** for broader secret detection
+- **Add a tag protection rule** to prevent deletion of release tags (`v*.*.*`)
+- **Consider CodeQL code scanning** for Go static analysis beyond gosec

--- a/README.md
+++ b/README.md
@@ -7,71 +7,38 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 [![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://go.dev/)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sethbacon/59239e8575b4f784f875647e2b344b41/raw/coverage.json)](https://github.com/sethbacon/terraform-registry-backend/actions/workflows/ci.yml)
 
-- [Enterprise Terraform Registry — Backend](#enterprise-terraform-registry-%E2%80%94-backend)
-  - [Features](#features)
-    - [Terraform Protocol Support](#terraform-protocol-support)
-    - [Authentication \& Authorization](#authentication-%26-authorization)
-    - [Multi-Tenancy](#multi-tenancy)
-    - [Module Source Control (SCM) Integration](#module-source-control-(scm)-integration)
-    - [Storage Backends](#storage-backends)
-    - [Deployment Options](#deployment-options)
-    - [Terraform Binary Mirror](#terraform-binary-mirror)
-    - [Observability \& CI/CD](#observability-%26-ci%2Fcd)
-  - [Architecture](#architecture)
-  - [Installation](#installation)
-    - [Prerequisites](#prerequisites)
-    - [Quick Start with Docker Compose](#quick-start-with-docker-compose)
-    - [First-Run Setup](#first-run-setup)
-    - [Manual Setup](#manual-setup)
-  - [Configuration](#configuration)
-  - [Monitoring \& Observability](#monitoring-%26-observability)
-    - [Prometheus + Grafana Stack](#prometheus-%2B-grafana-stack)
-  - [Usage with Terraform](#usage-with-terraform)
-    - [Publishing Modules](#publishing-modules)
-    - [Publishing Providers](#publishing-providers)
-  - [Development](#development)
-    - [Running Tests](#running-tests)
-    - [Building](#building)
-  - [Documentation](#documentation)
-  - [References](#references)
-  - [Contributing](#contributing)
-  - [License](#license)
-  - [Disclaimer](#disclaimer)
-  - [Acknowledgments](#acknowledgments)
-    - [Trademark Notice](#trademark-notice)
-
-- [Enterprise Terraform Registry — Backend](#enterprise-terraform-registry-%E2%80%94-backend)
-  - [Features](#features)
-    - [Terraform Protocol Support](#terraform-protocol-support)
-    - [Authentication \& Authorization](#authentication-%26-authorization)
-    - [Multi-Tenancy](#multi-tenancy)
-    - [Module Source Control (SCM) Integration](#module-source-control-(scm)-integration)
-    - [Storage Backends](#storage-backends)
-    - [Deployment Options](#deployment-options)
-    - [Terraform Binary Mirror](#terraform-binary-mirror)
-    - [Observability \& CI/CD](#observability-%26-ci%2Fcd)
-  - [Architecture](#architecture)
-  - [Installation](#installation)
-    - [Prerequisites](#prerequisites)
-    - [Quick Start with Docker Compose](#quick-start-with-docker-compose)
-    - [First-Run Setup](#first-run-setup)
-    - [Manual Setup](#manual-setup)
-  - [Configuration](#configuration)
-  - [Monitoring \& Observability](#monitoring-%26-observability)
-    - [Prometheus + Grafana Stack](#prometheus-%2B-grafana-stack)
-  - [Usage with Terraform](#usage-with-terraform)
-    - [Publishing Modules](#publishing-modules)
-    - [Publishing Providers](#publishing-providers)
-  - [Development](#development)
-    - [Running Tests](#running-tests)
-    - [Building](#building)
-  - [Documentation](#documentation)
-  - [References](#references)
-  - [Contributing](#contributing)
-  - [License](#license)
-  - [Disclaimer](#disclaimer)
-  - [Acknowledgments](#acknowledgments)
-    - [Trademark Notice](#trademark-notice)
+- [Features](#features)
+  - [Terraform Protocol Support](#terraform-protocol-support)
+  - [Authentication & Authorization](#authentication--authorization)
+  - [Multi-Tenancy](#multi-tenancy)
+  - [Module Source Control (SCM) Integration](#module-source-control-scm-integration)
+  - [Storage Backends](#storage-backends)
+  - [Deployment Options](#deployment-options)
+  - [Terraform Binary Mirror](#terraform-binary-mirror)
+  - [Module Security Scanning](#module-security-scanning)
+  - [Observability & CI/CD](#observability--cicd)
+- [Architecture](#architecture)
+- [Installation](#installation)
+  - [Prerequisites](#prerequisites)
+  - [Quick Start with Docker Compose](#quick-start-with-docker-compose)
+  - [First-Run Setup](#first-run-setup)
+  - [Manual Setup](#manual-setup)
+- [Configuration](#configuration)
+- [Monitoring & Observability](#monitoring--observability)
+  - [Prometheus + Grafana Stack](#prometheus--grafana-stack)
+- [Usage with Terraform](#usage-with-terraform)
+  - [Publishing Modules](#publishing-modules)
+  - [Publishing Providers](#publishing-providers)
+- [Development](#development)
+  - [Running Tests](#running-tests)
+  - [Building](#building)
+- [Documentation](#documentation)
+- [References](#references)
+- [Contributing](#contributing)
+- [License](#license)
+- [Disclaimer](#disclaimer)
+- [Acknowledgments](#acknowledgments)
+  - [Trademark Notice](#trademark-notice)
 
 ## Features
 
@@ -130,6 +97,14 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 - **Platform Filtering** — Optionally restrict which `os/arch` combinations are downloaded and served
 - **Public Download API** — Unauthenticated endpoints at `/terraform/binaries/:name/versions/…` compatible with Terraform's [network mirror protocol](https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol)
 - **Prometheus Metric** — `terraform_binary_downloads_total` counter with `{version, os, arch}` labels
+
+### Module Security Scanning
+
+- **Automatic Scanning** - Every uploaded module version is automatically queued for a security scan
+- **Multiple Scanner Backends** - Trivy (recommended), Checkov, Terrascan, Snyk, or a custom binary
+- **Structured Results** - Severity counts (Critical/High/Medium/Low) and raw output stored per version
+- **Supply-Chain Protection** - Optional binary version pinning rejects mismatched scanner executables
+- **Module Documentation Extraction** - Inputs, outputs, provider requirements, and Terraform version constraints automatically extracted from uploaded modules at upload time — no `terraform-docs` binary required
 
 ### Observability & CI/CD
 
@@ -342,6 +317,8 @@ go build -o terraform-registry cmd/server/main.go
 - [API Reference](docs/api-reference.md) - API documentation guide
 - [Observability Reference](docs/observability.md) - Prometheus metrics catalogue
 - [Configuration Reference](docs/configuration.md) - All `TFR_*` environment variables
+- [Module Security Scanning](docs/module-scanning.md) - Scanner setup (Trivy, Checkov, Terrascan, Snyk, custom)
+- [Module Documentation Extraction](docs/module-documentation.md) - Automatic extraction of inputs, outputs, and provider requirements
 - [Deployment Guide](docs/deployment.md) - Production deployment for all platforms
 - [Troubleshooting](docs/troubleshooting.md) - Common issues and diagnostic tools
 - [Development Guide](docs/development.md) - Local development setup

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -112,3 +112,29 @@ telemetry:
   profiling:
     enabled: false
     port: 6060
+
+# Module security scanning — automatically scans uploaded module archives for
+# IaC misconfigurations and vulnerabilities. Disabled by default; requires a
+# supported scanner binary to be installed on the server.
+# See docs/module-scanning.md for full setup instructions.
+scanning:
+  enabled: false
+  # tool selects the scanner backend: trivy | checkov | terrascan | snyk | custom
+  tool: trivy
+  # binary_path is the absolute path to the scanner executable
+  binary_path: /usr/local/bin/trivy
+  # expected_version pins the binary version for supply-chain protection.
+  # The job refuses to run if the installed binary reports a different version.
+  # Leave blank to disable pinning.
+  expected_version: ""
+  # severity_threshold is a comma-separated list of severities to record.
+  # Leave blank to record all findings (CRITICAL, HIGH, MEDIUM, LOW).
+  severity_threshold: ""
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+  # version_args and scan_args are only used when tool is "custom".
+  # version_args: ["--version"]
+  # scan_args: ["scan", "--format", "json"]
+  # output_format is only used when tool is "custom": "sarif" or "json"
+  # output_format: sarif

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,3 +403,37 @@ Dev mode enables:
 
 **Never set `TFR_DEV_MODE=true` in production.** The dev login endpoint allows anyone
 to authenticate as any user without credentials.
+
+---
+
+## Module Security Scanning
+
+The registry can automatically scan every uploaded module version for IaC misconfigurations and vulnerabilities. Scanning is disabled by default and requires a supported scanner binary installed on the server.
+
+For full installation instructions per scanner tool, see [Module Security Scanning](module-scanning.md).
+
+```yaml
+scanning:
+  enabled: false          # set true to activate
+  tool: trivy             # trivy | checkov | terrascan | snyk | custom
+  binary_path: /usr/local/bin/trivy
+  expected_version: ""    # optional version pin (supply-chain protection)
+  severity_threshold: ""  # blank = record all; e.g. "CRITICAL,HIGH" to filter
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+```
+
+| Variable | Type | Default | Description |
+| --- | --- | --- | --- |
+| `TFR_SCANNING_ENABLED` | bool | `false` | Master toggle for the scanning feature. |
+| `TFR_SCANNING_TOOL` | string | — | Scanner backend: `trivy`, `checkov`, `terrascan`, `snyk`, or `custom`. |
+| `TFR_SCANNING_BINARY_PATH` | string | — | Absolute path to the scanner binary on the server. |
+| `TFR_SCANNING_EXPECTED_VERSION` | string | — | Exact version string the binary must report. The job refuses to start if it doesn't match. Leave blank to disable pinning. |
+| `TFR_SCANNING_SEVERITY_THRESHOLD` | string | (all) | Comma-separated severities to record: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Blank records all. |
+| `TFR_SCANNING_TIMEOUT` | duration | `5m` | Maximum time a single scan may run. |
+| `TFR_SCANNING_WORKER_COUNT` | int | `2` | Concurrent scan workers. |
+| `TFR_SCANNING_SCAN_INTERVAL_MINS` | int | `5` | How often the job polls for pending scans. |
+| `TFR_SCANNING_VERSION_ARGS` | string[] | — | **`custom` tool only.** Arguments to print the binary version. |
+| `TFR_SCANNING_SCAN_ARGS` | string[] | — | **`custom` tool only.** Arguments passed before the target directory. |
+| `TFR_SCANNING_OUTPUT_FORMAT` | string | — | **`custom` tool only.** Output parser: `sarif` or `json`. |

--- a/docs/module-documentation.md
+++ b/docs/module-documentation.md
@@ -1,0 +1,137 @@
+# Module Documentation Extraction
+
+When a module version is uploaded, the registry automatically parses its Terraform source files and extracts structured documentation: input variables, output values, provider requirements, and Terraform version constraints.
+
+No external tool or configuration is required. Extraction runs in-process at upload time using the [hashicorp/terraform-config-inspect](https://github.com/hashicorp/terraform-config-inspect) library.
+
+---
+
+## What Is Extracted
+
+| Field | Source in the module | Notes |
+|---|---|---|
+| **Inputs** | `variable` blocks | Name, type, description, default value, and whether the variable is required. |
+| **Outputs** | `output` blocks | Name, description, and whether the value is marked sensitive. |
+| **Providers** | `required_providers` block | Provider name, registry source address, and version constraints. |
+| **Terraform version** | `terraform { required_version = "..." }` block | The minimum / constraint on the Terraform CLI version. |
+
+Extraction is **best-effort**: the parser tolerates incomplete modules and missing provider schemas. If a module has no `.tf` files at the root, no documentation is stored and the endpoint returns `404`.
+
+---
+
+## API
+
+Retrieve extracted documentation for a specific version:
+
+```
+GET /api/v1/modules/{namespace}/{name}/{system}/versions/{version}/docs
+```
+
+No authentication is required.
+
+**Example:**
+```bash
+curl https://registry.example.com/api/v1/modules/myorg/vpc/aws/versions/1.0.0/docs
+```
+
+**Response:**
+```json
+{
+  "inputs": [
+    {
+      "name": "vpc_cidr",
+      "type": "string",
+      "description": "CIDR block for the VPC.",
+      "default": "10.0.0.0/16",
+      "required": false
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "Name prefix for all resources.",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "name": "vpc_id",
+      "description": "ID of the created VPC.",
+      "sensitive": false
+    },
+    {
+      "name": "nat_gateway_ips",
+      "description": "Elastic IP addresses of the NAT gateways.",
+      "sensitive": false
+    }
+  ],
+  "providers": [
+    {
+      "name": "aws",
+      "source": "hashicorp/aws",
+      "version_constraints": ">= 5.0"
+    }
+  ],
+  "requirements": {
+    "required_version": ">= 1.3"
+  }
+}
+```
+
+**Fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `inputs[].name` | string | Variable name as declared. |
+| `inputs[].type` | string | Type constraint expression (e.g. `string`, `list(string)`). Empty if not declared. |
+| `inputs[].description` | string | Description from the `description` argument. Empty if not set. |
+| `inputs[].default` | any | Default value, JSON-decoded. `null` if `required = true`. |
+| `inputs[].required` | bool | `true` when no `default` is set and the caller must supply a value. |
+| `outputs[].name` | string | Output name as declared. |
+| `outputs[].description` | string | Description from the `description` argument. Empty if not set. |
+| `outputs[].sensitive` | bool | `true` when the output is marked `sensitive = true`. |
+| `providers[].name` | string | Short provider name (the map key in `required_providers`). |
+| `providers[].source` | string | Registry source address, e.g. `hashicorp/aws`. Empty if not declared. |
+| `providers[].version_constraints` | string | Version constraint string, e.g. `>= 5.0, < 6.0`. Empty if not declared. |
+| `requirements.required_version` | string | Terraform version constraint from the `terraform` block. |
+
+---
+
+## Web UI
+
+On any module's detail page, select a version and scroll below the README to the **Module Documentation** section. It shows inputs, outputs, and provider requirements in structured tables, visible to all users. The section is omitted when no documentation was extracted (e.g. modules with no `.tf` files at the archive root).
+
+---
+
+## How It Works
+
+At upload time, the handler:
+
+1. Extracts the `.tar.gz` archive to a temporary directory.
+2. Calls `hashicorp/terraform-config-inspect` to parse all `.tf` files in the module root.
+3. Stores the extracted inputs, outputs, providers, and requirements in the `module_docs` table.
+4. Deletes the temporary directory.
+
+The parser is **tolerant of errors**: if Terraform files are present but reference undeclared providers or have partial syntax issues, extraction still succeeds for the well-formed portions. Parsing diagnostics are logged at `DEBUG` level.
+
+---
+
+## Module Archive Requirements
+
+For documentation to be extracted, the uploaded archive must:
+
+- Be a valid `.tar.gz` file.
+- Contain at least one `.tf` file at the **module root**. The root is defined as the top-level directory in the archive, or the first directory containing `.tf` files.
+
+Nested submodules (e.g. `modules/submodule/*.tf`) are not scanned — only the root is analysed.
+
+---
+
+## Configuration
+
+No configuration is required. Extraction is always enabled and runs as part of every module upload. There are no `TFR_*` environment variables or YAML keys to set.
+
+---
+
+## Differences from the `terraform-docs` CLI Tool
+
+The extraction is performed entirely in-process using the official HashiCorp `terraform-config-inspect` library — **the `terraform-docs` CLI binary is not used and does not need to be installed**. The extracted information is a subset of what the `terraform-docs` CLI produces; it covers the most commonly needed fields (variables, outputs, providers, version requirements) without requiring an external process.

--- a/docs/module-scanning.md
+++ b/docs/module-scanning.md
@@ -1,0 +1,419 @@
+# Module Security Scanning
+
+The registry can automatically scan every uploaded Terraform module for security misconfigurations and vulnerabilities. When enabled, a background job picks up each newly uploaded module version, runs the configured scanner against the extracted archive, and stores the results. Results are viewable in the web UI on the module detail page and via the admin API.
+
+Scanning is **disabled by default**. The scanner binary must be installed on the server before the feature is enabled.
+
+---
+
+## How It Works
+
+1. A module version is uploaded via the API or UI.
+2. The upload handler creates a `pending` scan record in the database.
+3. The `module-scanner` background job polls the database every `scan_interval_mins` minutes.
+4. For each pending record the job downloads the module archive from storage, extracts it to a temporary directory, and invokes the scanner binary.
+5. Results (severity counts and raw JSON output) are stored in the `module_scans` table.
+6. The temporary directory is deleted immediately after the scan completes.
+7. Results are visible in the UI (Security Scan panel on the module detail page) and via `GET /api/v1/admin/modules/{namespace}/{name}/{system}/versions/{version}/scan`.
+
+---
+
+## Supported Scanners
+
+| Tool | `tool` value | License | Notes |
+|---|---|---|---|
+| [Trivy](https://github.com/aquasecurity/trivy) | `trivy` | Apache 2.0 | Recommended. Scans vulnerabilities, secrets, and IaC misconfigurations. |
+| [Checkov](https://github.com/bridgecrewio/checkov) | `checkov` | Apache 2.0 | Broad Terraform policy coverage. Python-based. |
+| [Terrascan](https://github.com/tenable/terrascan) | `terrascan` | Apache 2.0 | Purpose-built for IaC. Single binary. |
+| [Snyk](https://snyk.io/) | `snyk` | Proprietary (free tier available) | Requires authentication (`snyk auth`). |
+| Custom binary | `custom` | — | Any tool that writes SARIF or JSON to stdout. |
+
+---
+
+## Quick Start (Trivy — Recommended)
+
+### 1. Install Trivy
+
+**Linux / macOS (official install script):**
+```bash
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+trivy --version
+```
+
+**Debian / Ubuntu:**
+```bash
+sudo apt-get install wget apt-transport-https gnupg lsb-release
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install trivy
+```
+
+**macOS (Homebrew):**
+```bash
+brew install trivy
+```
+
+**Docker-based (no install):**
+
+If you run the registry in a container, add Trivy to your Docker image:
+```dockerfile
+FROM ghcr.io/aquasecurity/trivy:latest AS trivy
+FROM your-registry-base-image
+COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
+```
+
+### 2. Configure the Registry
+
+```yaml
+# config.yaml
+scanning:
+  enabled: true
+  tool: trivy
+  binary_path: /usr/local/bin/trivy   # or wherever trivy is installed
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+```
+
+Or with environment variables:
+```bash
+export TFR_SCANNING_ENABLED=true
+export TFR_SCANNING_TOOL=trivy
+export TFR_SCANNING_BINARY_PATH=/usr/local/bin/trivy
+```
+
+### 3. Restart the Backend
+
+The scanner job starts automatically when the server starts. Confirm it started:
+```
+INFO module scanner: started tool=trivy version=0.58.0
+```
+
+If the binary is missing or misconfigured, the server logs a warning and continues running with scanning disabled — it does not crash:
+```
+INFO module scanner: disabled (scanning.binary_path not set)
+```
+or:
+```
+ERROR module scanner: failed to construct scanner error="scanner binary not accessible at ..."
+```
+
+---
+
+## Configuration Reference
+
+All options live under the `scanning:` key in `config.yaml` or use the `TFR_SCANNING_` environment variable prefix.
+
+| YAML key | Environment variable | Type | Default | Description |
+|---|---|---|---|---|
+| `enabled` | `TFR_SCANNING_ENABLED` | bool | `false` | Master toggle. Set to `true` to activate. |
+| `tool` | `TFR_SCANNING_TOOL` | string | — | Scanner backend: `trivy`, `checkov`, `terrascan`, `snyk`, or `custom`. |
+| `binary_path` | `TFR_SCANNING_BINARY_PATH` | string | — | Absolute path to the scanner executable on the server. |
+| `expected_version` | `TFR_SCANNING_EXPECTED_VERSION` | string | — | If set, the job refuses to run if the installed binary reports a different version. Supply-chain protection. |
+| `severity_threshold` | `TFR_SCANNING_SEVERITY_THRESHOLD` | string | (all) | Comma-separated list of severities to record, e.g. `CRITICAL,HIGH`. Findings below the threshold are omitted from counts. |
+| `timeout` | `TFR_SCANNING_TIMEOUT` | duration | `5m` | Maximum time a single scan may run before it is killed. |
+| `worker_count` | `TFR_SCANNING_WORKER_COUNT` | int | `2` | Number of scans to run concurrently. |
+| `scan_interval_mins` | `TFR_SCANNING_SCAN_INTERVAL_MINS` | int | `5` | How often (in minutes) the job polls for pending scans. |
+| `version_args` | `TFR_SCANNING_VERSION_ARGS` | string[] | — | **Custom tool only.** CLI arguments to retrieve the binary version, e.g. `["--version"]`. |
+| `scan_args` | `TFR_SCANNING_SCAN_ARGS` | string[] | — | **Custom tool only.** CLI arguments passed before the target directory, e.g. `["iac", "test", "--json"]`. |
+| `output_format` | `TFR_SCANNING_OUTPUT_FORMAT` | string | — | **Custom tool only.** How to parse the tool's output: `sarif` or `json`. |
+
+---
+
+## Scanner-Specific Setup
+
+### Trivy
+
+Trivy requires no authentication. The registry invokes:
+```
+trivy fs --format json --scanners vuln,secret,misconfig --exit-code 0 --quiet <dir>
+```
+
+**Air-gapped environments:** Trivy downloads its vulnerability database on first use. In air-gapped deployments, pre-populate the database:
+```bash
+# On a machine with internet access
+trivy image --download-db-only
+# Copy ~/.cache/trivy to the server's trivy cache directory
+```
+
+Or set `TRIVY_NO_PROGRESS=true` and `TRIVY_OFFLINE_SCAN=true` to disable network access.
+
+**Recommended config:**
+```yaml
+scanning:
+  enabled: true
+  tool: trivy
+  binary_path: /usr/local/bin/trivy
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+```
+
+---
+
+### Checkov
+
+Checkov is Python-based. Install via pip:
+```bash
+pip3 install checkov
+which checkov   # e.g. /usr/local/bin/checkov
+checkov --version
+```
+
+Or in a container:
+```dockerfile
+RUN pip3 install checkov
+```
+
+The registry invokes:
+```
+checkov -d <dir> -o json --quiet
+```
+
+**Note:** Checkov exits with code `1` when checks fail, which is normal. The registry handles this correctly.
+
+**Recommended config:**
+```yaml
+scanning:
+  enabled: true
+  tool: checkov
+  binary_path: /usr/local/bin/checkov
+  timeout: 10m   # checkov can be slower than trivy
+  worker_count: 1
+  scan_interval_mins: 5
+```
+
+---
+
+### Terrascan
+
+Install the single binary:
+```bash
+# Linux amd64
+curl -L "https://github.com/tenable/terrascan/releases/latest/download/terrascan_Linux_x86_64.tar.gz" | tar xz terrascan
+mv terrascan /usr/local/bin/
+terrascan version
+```
+
+The registry invokes:
+```
+terrascan scan -t terraform -d <dir> -o json
+```
+
+**Recommended config:**
+```yaml
+scanning:
+  enabled: true
+  tool: terrascan
+  binary_path: /usr/local/bin/terrascan
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+```
+
+---
+
+### Snyk
+
+Snyk requires authentication before it can scan. Install and authenticate:
+```bash
+npm install -g snyk
+snyk auth   # opens browser to authenticate with your Snyk account
+snyk --version
+```
+
+Or in a container using an API token:
+```bash
+snyk auth $SNYK_TOKEN
+```
+
+The registry invokes:
+```
+snyk iac test <dir> --json
+```
+
+**Note:** Snyk exits with code `1` when vulnerabilities are found, which is normal. The registry handles this correctly.
+
+**Recommended config:**
+```yaml
+scanning:
+  enabled: true
+  tool: snyk
+  binary_path: /usr/local/bin/snyk
+  timeout: 5m
+  worker_count: 1   # Snyk has rate limits on free tier
+  scan_interval_mins: 5
+```
+
+---
+
+### Custom Tool
+
+Use `custom` when you have an internal scanner or a tool not natively supported. The binary must:
+- Accept the target directory as its last argument
+- Write results to **stdout**
+- Output either **SARIF** (any conformant SARIF 2.1.0 JSON) or **JSON** with a `vulnerabilities` array where each entry has a `severity` field
+
+**Example — tfsec (SARIF output):**
+```yaml
+scanning:
+  enabled: true
+  tool: custom
+  binary_path: /usr/local/bin/tfsec
+  output_format: sarif
+  version_args: ["--version"]
+  scan_args: ["--format", "sarif"]
+  timeout: 5m
+  worker_count: 2
+  scan_interval_mins: 5
+```
+
+**Example — internal tool (JSON output):**
+```yaml
+scanning:
+  enabled: true
+  tool: custom
+  binary_path: /opt/internal/scanner
+  output_format: json
+  version_args: ["version"]
+  scan_args: ["scan", "--output", "json"]
+  timeout: 10m
+  worker_count: 1
+  scan_interval_mins: 10
+```
+
+For `output_format: json`, the expected output schema is:
+```json
+{
+  "vulnerabilities": [
+    { "severity": "CRITICAL" },
+    { "severity": "HIGH" },
+    { "severity": "MEDIUM" }
+  ]
+}
+```
+
+Severity values are matched case-insensitively to `critical`, `high`, `medium`, `low`.
+
+For `output_format: sarif`, any conformant SARIF 2.1.0 document is accepted. Severity is read from `result.properties.severity` or `rule.properties.security-severity`.
+
+---
+
+## Supply-Chain Version Pinning
+
+To prevent a compromised or unexpected scanner binary from being used, set `expected_version`. The job will refuse to run — and log an error — if the installed binary's reported version does not match exactly:
+
+```yaml
+scanning:
+  enabled: true
+  tool: trivy
+  binary_path: /usr/local/bin/trivy
+  expected_version: "0.58.0"   # must match exactly what `trivy --version` reports
+```
+
+When the version drifts (e.g. after a system package update), the scanner stops and logs:
+```
+ERROR module scanner: binary version mismatch — refusing to run
+  tool=trivy expected=0.58.0 actual=0.59.1
+  action=update scanning.expected_version in config or reinstall the expected binary
+```
+
+Update `expected_version` after deliberately upgrading the scanner binary.
+
+---
+
+## Kubernetes Deployment
+
+When running in Kubernetes, install the scanner binary in the same container as the registry backend. Example using Trivy in a Helm values override:
+
+```yaml
+# values-override.yaml
+extraInitContainers:
+  - name: install-trivy
+    image: aquasec/trivy:0.58.0
+    command: ["cp", "/usr/local/bin/trivy", "/shared/trivy"]
+    volumeMounts:
+      - name: scanner-bin
+        mountPath: /shared
+
+extraVolumes:
+  - name: scanner-bin
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: scanner-bin
+    mountPath: /opt/scanners
+
+env:
+  - name: TFR_SCANNING_ENABLED
+    value: "true"
+  - name: TFR_SCANNING_TOOL
+    value: "trivy"
+  - name: TFR_SCANNING_BINARY_PATH
+    value: "/opt/scanners/trivy"
+```
+
+---
+
+## Viewing Scan Results
+
+Results are available in two places:
+
+**Web UI:** Open any module's detail page, select a version, and the **Security Scan** panel appears in the right sidebar (visible to users with `admin` or `modules:write` scope).
+
+**API:**
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  https://registry.example.com/api/v1/admin/modules/myorg/vpc/aws/versions/1.0.0/scan
+```
+
+Response:
+```json
+{
+  "id": "...",
+  "scanner": "trivy",
+  "scanner_version": "0.58.0",
+  "status": "findings",
+  "scanned_at": "2025-04-09T12:00:00Z",
+  "critical_count": 0,
+  "high_count": 2,
+  "medium_count": 5,
+  "low_count": 3,
+  "raw_results": { ... }
+}
+```
+
+**Status values:**
+
+| Status | Meaning |
+|---|---|
+| `pending` | Scan is queued, not yet started. |
+| `scanning` | Scan is actively running. |
+| `clean` | Scan completed with zero findings. |
+| `findings` | Scan completed with one or more findings. |
+| `error` | Scan failed. Check `error_message` for details. |
+
+---
+
+## Troubleshooting
+
+**No scans are running:**
+- Check `scanning.enabled: true` is set.
+- Verify the binary path: `ls -la /usr/local/bin/trivy`.
+- Check server logs for `module scanner:` lines at startup.
+- Ensure the registry process has execute permission on the binary.
+
+**All scans show `error` status:**
+- Check the `error_message` field in the scan API response.
+- Common causes: binary path wrong, insufficient permissions, scanner requires authentication (Snyk), or timeout too short for large modules.
+
+**Scanner binary version mismatch:**
+- Update `expected_version` to match the installed binary, or reinstall the expected version.
+
+**Scans are slow / backing up:**
+- Increase `worker_count` (default: 2) to process more scans concurrently.
+- Reduce `timeout` if modules are small and scans are hanging.
+- Check available CPU on the server — scanner binaries are CPU-intensive.
+
+**`pending` scans left after a crash:**
+- The job automatically resets scan records stuck in `scanning` state for more than 30 minutes on startup. No manual intervention is needed for normal restarts.


### PR DESCRIPTION
## Summary

- docs: add `docs/module-scanning.md` — full setup guide for all five scanner backends (Trivy, Checkov, Terrascan, Snyk, custom) with install instructions, config reference, Kubernetes sidecar pattern, supply-chain pinning, and troubleshooting
- docs: add `docs/module-documentation.md` — covers automatic terraform-docs extraction, API endpoint, response schema, and web UI location
- docs: add `scanning:` block to `config.example.yaml` with all fields and inline comments
- docs: add `## Module Security Scanning` section to `docs/configuration.md` with full `TFR_SCANNING_*` variable table
- docs: update `README.md` — add Module Security Scanning to features list, link new docs, fix duplicate TOC, correct broken percent-encoded fragment anchors
- chore: document repository security hardening in `CLAUDE.md`, add `CODEOWNERS`

## Changelog

- docs: add module security scanning setup guide (Trivy, Checkov, Terrascan, Snyk, custom)
- docs: add module documentation extraction guide
- docs: add scanning: section to config.example.yaml and TFR_SCANNING_* variables to configuration reference
- chore: document repository security hardening in CLAUDE.md and add CODEOWNERS