### PR TITLE
fix: move module scan route to /modules/ prefix to resolve gin wildcard conflict

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1569,82 +1569,6 @@
                 }
             }
         },
-        "/api/v1/admin/modules/{namespace}/{name}/{system}/versions/{version}/scan": {
-            "get": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "Returns the latest security scan for a module version, including tool name, version, severity counts, and raw output. Requires admin scope.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "System"
-                ],
-                "summary": "Get module version scan result",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Module namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Module name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Provider system (e.g. aws)",
-                        "name": "system",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Module version",
-                        "name": "version",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.ModuleScan"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "404": {
-                        "description": "Module version or scan not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/admin/oidc/config": {
             "get": {
                 "security": [
@@ -4593,6 +4517,82 @@
                     },
                     "404": {
                         "description": "Module or version not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/scan": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the latest security scan for a module version, including tool name, version, severity counts, and raw output. Requires admin scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "Get module version scan result",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider system (e.g. aws)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ModuleScan"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Module version or scan not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -22,7 +22,7 @@ import (
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Module version or scan not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
-// @Router       /api/v1/admin/modules/{namespace}/{name}/{system}/versions/{version}/scan [get]
+// @Router       /api/v1/modules/{namespace}/{name}/{system}/versions/{version}/scan [get]
 func GetModuleScanHandler(db *sql.DB) gin.HandlerFunc {
 	moduleRepo := repositories.NewModuleRepository(db)
 	scanRepo := repositories.NewModuleScanRepository(db)

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -38,7 +38,7 @@ func newScanAdminRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	}
 	t.Cleanup(func() { db.Close() })
 	r := gin.New()
-	r.GET("/admin/modules/:namespace/:name/:system/versions/:version/scan",
+	r.GET("/modules/:namespace/:name/:system/versions/:version/scan",
 		GetModuleScanHandler(db))
 	return mock, r
 }
@@ -94,7 +94,7 @@ func TestGetModuleScan_Success(t *testing.T) {
 		WithArgs("ver-1").
 		WillReturnRows(sampleScanResultRow())
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -105,7 +105,7 @@ func TestGetModuleScan_OrgError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
 		WillReturnError(errors.New("db error"))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -116,7 +116,7 @@ func TestGetModuleScan_OrgNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
 		WillReturnRows(sqlmock.NewRows(orgColsScan))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -127,7 +127,7 @@ func TestGetModuleScan_ModuleDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRowScan())
 	mock.ExpectQuery("SELECT.*FROM modules.*WHERE").WillReturnError(errors.New("db error"))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -139,7 +139,7 @@ func TestGetModuleScan_ModuleNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM modules.*WHERE").
 		WillReturnRows(sqlmock.NewRows(moduleColsScan))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
@@ -152,7 +152,7 @@ func TestGetModuleScan_VersionDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
 		WillReturnError(errors.New("db error"))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -165,7 +165,7 @@ func TestGetModuleScan_VersionNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
 		WillReturnRows(sqlmock.NewRows(modVersionGetColsScan))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/9.9.9/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/9.9.9/scan")
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
@@ -180,7 +180,7 @@ func TestGetModuleScan_ScanDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
 		WillReturnError(errors.New("db error"))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -195,7 +195,7 @@ func TestGetModuleScan_ScanNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
 		WillReturnRows(sqlmock.NewRows(scanAdminCols))
 
-	w := doScanGET(r, "/admin/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
+	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -581,7 +581,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UndeprecateVersion)
-			authenticatedGroup.GET("/admin/modules/:namespace/:name/:system/versions/:version/scan",
+			authenticatedGroup.GET("/modules/:namespace/:name/:system/versions/:version/scan",
 				middleware.RequireScope(auth.ScopeAdmin),
 				admin.GetModuleScanHandler(db))
 


### PR DESCRIPTION
Closes #147

The module scan endpoint was registered under `/admin/modules/:namespace/...` which panics at startup because gin's radix tree sees a conflict with `/admin/modules/:id` (different wildcard name at the same position).

Moved to `/modules/:namespace/:name/:system/versions/:version/scan`, consistent with the existing deprecate/undeprecate routes.

## Changelog
- fix: move module scan route from `/admin/modules/` to `/modules/` prefix to resolve gin wildcard panic on startup