### PR TITLE
fix: respect security.rate_limiting.enabled config for all rate limiters

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -95,6 +95,17 @@ func (bg *BackgroundServices) Shutdown() {
 	slog.Info("all background services stopped")
 }
 
+// collectRateLimiters returns a slice of non-nil rate limiters for shutdown tracking.
+func collectRateLimiters(limiters ...*middleware.RateLimiter) []*middleware.RateLimiter {
+	var out []*middleware.RateLimiter
+	for _, rl := range limiters {
+		if rl != nil {
+			out = append(out, rl)
+		}
+	}
+	return out
+}
+
 // AppVersion and AppBuildDate are set by main before NewRouter is called.
 // They are populated from ldflags injected by GoReleaser at release time.
 var AppVersion = "dev"
@@ -453,10 +464,13 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	// Initialize SCM webhook handler
 	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher)
 
-	// Initialize rate limiters
-	authRateLimiter := middleware.NewRateLimiter(middleware.AuthRateLimitConfig())
-	generalRateLimiter := middleware.NewRateLimiter(middleware.DefaultRateLimitConfig())
-	uploadRateLimiter := middleware.NewRateLimiter(middleware.UploadRateLimitConfig())
+	// Initialize rate limiters (conditionally, based on config)
+	var authRateLimiter, generalRateLimiter, uploadRateLimiter *middleware.RateLimiter
+	if cfg.Security.RateLimiting.Enabled {
+		authRateLimiter = middleware.NewRateLimiter(middleware.AuthRateLimitConfig())
+		generalRateLimiter = middleware.NewRateLimiter(middleware.DefaultRateLimitConfig())
+		uploadRateLimiter = middleware.NewRateLimiter(middleware.UploadRateLimitConfig())
+	}
 
 	// Admin API endpoints
 	apiV1 := router.Group("/api/v1")
@@ -806,7 +820,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 		tfMirrorSyncJob:  tfMirrorSyncJob,
 		expiryNotifier:   expiryNotifier,
 		moduleScannerJob: moduleScannerJob,
-		rateLimiters:     []*middleware.RateLimiter{authRateLimiter, generalRateLimiter, uploadRateLimiter},
+		rateLimiters:     collectRateLimiters(authRateLimiter, generalRateLimiter, uploadRateLimiter),
 	}
 
 	return router, bg

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -163,9 +163,16 @@ func (rl *RateLimiter) RemainingTokens(key string) int {
 	return int(currentTokens)
 }
 
-// RateLimitMiddleware creates a Gin middleware that rate limits requests
+// RateLimitMiddleware creates a Gin middleware that rate limits requests.
+// If limiter is nil (rate limiting disabled), requests pass through unchanged.
 func RateLimitMiddleware(limiter *RateLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// When rate limiting is disabled, pass through
+		if limiter == nil {
+			c.Next()
+			return
+		}
+
 		// Determine the rate limit key
 		key := getRateLimitKey(c)
 


### PR DESCRIPTION
Closes #150

The `security.rate_limiting.enabled` config field was defined but never checked — all three rate limiters (auth, general, upload) were unconditionally created and applied. Setting `TFR_SECURITY_RATE_LIMITING_ENABLED=false` had no effect.

This caused E2E test failures in the frontend repo where the strict auth rate limiter (10 req/min, burst 5) blocked the logout endpoint after ~40 tests worth of page navigations exhausted the auth bucket.

**Changes:**
- `router.go`: conditionally create rate limiters only when `cfg.Security.RateLimiting.Enabled` is true
- `ratelimit.go`: `RateLimitMiddleware` passes through when limiter is nil (disabled)
- `router.go`: `collectRateLimiters` helper filters nil entries for shutdown tracking

## Changelog
- fix: respect `security.rate_limiting.enabled` config — all rate limiters (auth, general, upload) were unconditionally applied, ignoring the config flag