### PR TITLE
fix: SSO token delivery via cookie exchange + health version info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,26 @@ When a release is called for:
    The workflow will: run CI → build multi-platform binaries → push Docker image to
    `ghcr.io/sethbacon/terraform-registry-backend:vX.Y.Z` → create a GitHub Release.
 
+8. **Update deployment configs to reference the new version.** The following files contain
+   hardcoded image tags that must be bumped after every release. Backend and frontend
+   versions are independent — update only the component that was released.
+
+   **Helm chart** (in `deployments/helm/`):
+   - `Chart.yaml` — bump `appVersion` to the new backend version (used as default backend image tag)
+   - `values.yaml` — update `frontend.image.tag` when releasing a new frontend version
+   - `values-aks.yaml`, `values-eks.yaml`, `values-gke.yaml` — update `backend.image.tag`
+     and/or `frontend.image.tag` to the new version
+
+   **Kustomize overlays** (in `deployments/kubernetes/overlays/`):
+   - `eks/kustomization.yaml` — update `newTag` for backend and/or frontend
+   - `gke/kustomization.yaml` — update `newTag` for backend and/or frontend
+   - `production/kustomization.yaml` and `aks/kustomization.yaml` use `<IMAGE_TAG>`
+     placeholders filled at deploy time — no update needed
+
+   > **Why not automate this?** These files are example/reference configs with
+   > cloud-specific placeholders (`<ACR_NAME>`, `<ACCOUNT_ID>`, etc.) that users copy and
+   > customise. Automated updates would create noise in diffs for users tracking upstream.
+
 ---
 
 ## Project Overview

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -361,7 +361,9 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Set HttpOnly cookie — prevents JS access, logging, and Referer leakage
+		// Set HttpOnly cookie — prevents JS access, logging, and Referer leakage.
+		// SameSite=Lax allows the cookie to survive the top-level redirect from
+		// the identity provider back to the frontend; Strict would block it.
 		http.SetCookie(c.Writer, &http.Cookie{
 			Name:     "tfr_auth_token",
 			Value:    jwtToken,
@@ -369,7 +371,7 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			MaxAge:   86400, // 24 hours
 			Secure:   true,
 			HttpOnly: true,
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 		})
 		redirectTarget := fmt.Sprintf("%s/auth/callback", frontendBase)
 		c.Redirect(http.StatusFound, redirectTarget)
@@ -441,6 +443,44 @@ func (h *AuthHandlers) LogoutHandler() gin.HandlerFunc {
 
 		// No OIDC end_session_endpoint available — redirect to the frontend home page.
 		c.Redirect(http.StatusFound, postLogoutRedirect)
+	}
+}
+
+// @Summary      Exchange auth cookie for JWT
+// @Description  Reads the HttpOnly `tfr_auth_token` cookie set during the OIDC callback, validates it, returns the JWT in the response body, and clears the cookie. The frontend calls this endpoint on the /auth/callback page to move the token from the cookie into localStorage.
+// @Tags         Authentication
+// @Produce      json
+// @Success      200  {object}  map[string]string  "token"
+// @Failure      401  {object}  map[string]interface{}  "No cookie or invalid token"
+// @Router       /api/v1/auth/exchange-token [get]
+// ExchangeTokenHandler returns the JWT from the HttpOnly auth cookie.
+// GET /api/v1/auth/exchange-token
+func (h *AuthHandlers) ExchangeTokenHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		cookie, err := c.Cookie("tfr_auth_token")
+		if err != nil || cookie == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "No authentication cookie found"})
+			return
+		}
+
+		// Validate the JWT to ensure the cookie isn't stale or tampered with
+		if _, err := auth.ValidateJWT(cookie); err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid authentication token"})
+			return
+		}
+
+		// Clear the cookie — the frontend will store the token in localStorage
+		http.SetCookie(c.Writer, &http.Cookie{
+			Name:     "tfr_auth_token",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+
+		c.JSON(http.StatusOK, gin.H{"token": cookie})
 	}
 }
 

--- a/backend/internal/api/responses.go
+++ b/backend/internal/api/responses.go
@@ -2,9 +2,11 @@ package api
 
 // HealthResponse is returned by GET /health.
 type HealthResponse struct {
-	Status string `json:"status"`
-	Time   string `json:"time,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Status    string `json:"status"`
+	Time      string `json:"time,omitempty"`
+	Version   string `json:"version,omitempty"`
+	BuildDate string `json:"build_date,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 // ReadinessChecks contains individual subsystem health results.

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -500,6 +500,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 		{
 			authGroup.GET("/login", authHandlers.LoginHandler())
 			authGroup.GET("/callback", authHandlers.CallbackHandler())
+			authGroup.GET("/exchange-token", authHandlers.ExchangeTokenHandler())
 			authGroup.GET("/logout", authHandlers.LogoutHandler())
 		}
 
@@ -846,8 +847,10 @@ func healthCheckHandler(db *sql.DB) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{
-			"status": "healthy",
-			"time":   time.Now().UTC().Format(time.RFC3339),
+			"status":     "healthy",
+			"time":       time.Now().UTC().Format(time.RFC3339),
+			"version":    AppVersion,
+			"build_date": AppBuildDate,
 		})
 	}
 }

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -82,6 +82,12 @@ func TestHealthCheckHandler_Healthy(t *testing.T) {
 	if body["status"] != "healthy" {
 		t.Errorf("status = %v, want healthy", body["status"])
 	}
+	if body["version"] == nil {
+		t.Error("version field missing from healthy response")
+	}
+	if body["build_date"] == nil {
+		t.Error("build_date field missing from healthy response")
+	}
 }
 
 func TestHealthCheckHandler_Unhealthy(t *testing.T) {

--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: terraform-registry
 description: A Helm chart for deploying the Enterprise Terraform Registry
 type: application
 version: 0.2.0
-appVersion: "0.2.0"
+appVersion: "0.3.4"
 keywords:
   - terraform
   - registry

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v1.0.0"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v1.0.0"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v1.0.0"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v1.0.0"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v1.0.0"
+    tag: "v0.3.4"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v1.0.0"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -51,7 +51,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: ""
+    tag: "0.4.2"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v1.0.0
+    newTag: v0.3.4
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v1.0.0
+    newTag: v0.4.2

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v1.0.0
+    newTag: v0.3.4
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v1.0.0
+    newTag: v0.4.2


### PR DESCRIPTION
## Summary
- Add `GET /auth/exchange-token` endpoint that reads the HttpOnly `tfr_auth_token` cookie, validates the JWT, returns it in the response body, and clears the cookie
- Change SSO callback cookie `SameSite` from `Strict` to `Lax` so it survives the cross-site redirect from the identity provider
- Include `version` and `build_date` in the `/health` response for deployment verification
- Update stale deployment config image tags to v0.3.4/v0.4.2 and document release steps in CLAUDE.md

## Changelog
- fix: add /auth/exchange-token endpoint so the frontend can securely receive the SSO JWT from the HttpOnly cookie instead of URL query params
- fix: change callback cookie SameSite to Lax for cross-site redirect compatibility
- feat: include version and build_date in /health response
- chore: update deployment configs to current releases and document update steps

## Test plan
- [x] `go build ./...` — compiles clean
- [x] `go test ./internal/api/...` — all tests pass
- [ ] Deploy to AKS, test SSO login end-to-end
- [ ] Verify `/health` returns version and build_date fields
- [ ] Verify `tfr_auth_token` cookie is cleared after exchange