### PR TITLE
fix: allow pre-release versions in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Validate version format
         run: |
           VERSION="${{ inputs.version }}"
-          if ! echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+$'; then
+          if ! echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$'; then
             echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,3 +546,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2026-03-04
 
 - Initial commit
+


### PR DESCRIPTION
Fixes version validation regex to accept semver pre-release suffixes (e.g. 0.4.0-rc.1).