### PR TITLE
fix: prepare-release workflow uses release branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,8 +3,7 @@ name: Prepare Release
 # Automates the release preparation steps:
 #   1. Collects changelog entries from merged PR bodies
 #   2. Updates CHANGELOG.md (promotes [Unreleased] to new version)
-#   3. Commits on development and pushes
-#   4. Opens a release PR from development → main
+#   3. Pushes to a release branch and opens a PR to main
 #
 # Usage: dispatch manually with the desired version (e.g., 0.4.0).
 on:
@@ -35,7 +34,7 @@ jobs:
         run: |
           VERSION="${{ inputs.version }}"
           if ! echo "$VERSION" | grep -qP '^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Invalid version format: $VERSION (expected X.Y.Z)"
+            echo "::error::Invalid version format: $VERSION (expected X.Y.Z or X.Y.Z-pre.N)"
             exit 1
           fi
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
@@ -64,14 +63,12 @@ jobs:
             exit 1
           fi
 
-          # Replace [Unreleased] header with the new version, and add a fresh [Unreleased] above it
           if grep -q '## \[Unreleased\]' CHANGELOG.md; then
             sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $TODAY/" CHANGELOG.md
           else
             sed -i "1a\\\\n## [Unreleased]\\n\\n## [$VERSION] - $TODAY" CHANGELOG.md
           fi
 
-          # If collect-changelog produced entries, insert them after the version header
           if [ -s /tmp/changelog-block.md ]; then
             CONTENT=$(tail -n +2 /tmp/changelog-block.md)
             if [ -n "$CONTENT" ]; then
@@ -94,36 +91,40 @@ jobs:
             fi
           fi
 
-      - name: Commit and push
+      - name: Create release branch, commit, and push
         run: |
+          VERSION="${{ inputs.version }}"
+          BRANCH="release/v${VERSION}"
+          git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git diff --cached --quiet && echo "No CHANGELOG changes to commit" && exit 0
-          git commit -m "chore: release v${{ inputs.version }}"
-          git push origin development
+          git commit -m "chore: release v${VERSION}"
+          git push origin "$BRANCH"
 
       - name: Open release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ inputs.version }}"
+          BRANCH="release/v${VERSION}"
           gh pr create \
             --base main \
-            --head development \
+            --head "$BRANCH" \
             --title "chore: release v${VERSION}" \
             --body "$(cat <<EOF
           ## Release v${VERSION}
 
-          This PR merges the \`development\` branch into \`main\` for release v${VERSION}.
+          This PR merges release preparation into \`main\` for release v${VERSION}.
 
           ### Checklist
           - [ ] CHANGELOG.md updated with collected entries
           - [ ] CI passes
           - [ ] UAT: local Docker Compose build validated
 
-          > **Merge this PR using a merge commit** (not squash) to preserve commit ancestry
-          > between \`development\` and \`main\`. After merge, \`auto-tag.yml\` will
-          > automatically create and push the \`v${VERSION}\` tag, triggering the release workflow.
+          > **Merge this PR using a merge commit** (not squash). After merge, \`auto-tag.yml\`
+          > will automatically create and push the \`v${VERSION}\` tag, triggering the release
+          > workflow. Then merge \`main\` back into \`development\` to sync the version bump.
           EOF
           )"


### PR DESCRIPTION
Fixes branch protection issue by using release/vX.Y.Z branch instead of pushing to development.