### PR TITLE
fix: correct cosign SHA and SLSA subject-path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Attest build provenance for release artifacts (SLSA)
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
         with:
-          subject-path: dist/terraform-registry-*
+          subject-path: dist/checksums.txt
 
       - name: Publish draft release
         run: gh release edit "${GITHUB_REF_NAME}" --draft=false
@@ -168,7 +168,7 @@ jobs:
           push-to-registry: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372be428fad9c35427ed1bb7bafb18260451 # v3.8.2
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Sign image with cosign (keyless)
         run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
Two fixes for `release.yml`:

1. **Cosign SHA typo**: `3454372be428fad9c35427ed1bb7bafb18260451` is not a valid commit for
   `sigstore/cosign-installer@v3.8.2`. Correct SHA: `3454372f43399081ed03b604cb2d021dabca52bb`.
   This caused the Docker job to fail at "Set up job".

2. **SLSA subject-path mismatch**: `dist/terraform-registry-*` didn't match any files because
   GoReleaser places binaries in subdirectories (e.g. `dist/terraform-registry_linux_amd64_v1/`).
   Changed to `dist/checksums.txt` which is always present and covers all release artifacts.

## Changelog
- fix: correct cosign SHA and SLSA subject-path in release workflow