### PR TITLE
chore: sync workflow fixes to main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -29,7 +29,7 @@ jobs:
         id: version
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$TITLE" | grep -oP 'v\d+\.\d+\.\d+')
+          VERSION=$(echo "$TITLE" | grep -oP 'v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?')
           if [ -z "$VERSION" ]; then
             echo "::error::Could not extract semver from PR title: $TITLE"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Attest build provenance for release artifacts (SLSA)
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
         with:
-          subject-path: dist/terraform-registry-*
+          subject-path: dist/checksums.txt
 
       - name: Publish draft release
         run: gh release edit "${GITHUB_REF_NAME}" --draft=false
@@ -168,7 +168,7 @@ jobs:
           push-to-registry: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372be428fad9c35427ed1bb7bafb18260451 # v3.8.2
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
 
       - name: Sign image with cosign (keyless)
         run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
Syncs the following workflow fixes from development to main:

- **auto-tag.yml**: regex now captures pre-release suffixes (e.g. `v0.4.0-rc.1`)
- **release.yml**: corrected cosign-installer commit SHA for v3.8.2
- **release.yml**: fixed SLSA subject-path from `dist/terraform-registry-*` to `dist/checksums.txt`

These fixes are needed on main for the release pipeline to work correctly.

## Changelog
- fix: auto-tag regex captures pre-release version suffixes
- fix: correct cosign SHA and SLSA subject-path in release workflow