### PR TITLE
feat: add security scanning admin APIs and sort swagger UI tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,8 +483,8 @@ The backend generates OpenAPI 2.0 (Swagger) documentation using [swaggo/swag](ht
 - Use `{param}` in `@Router` paths (swag style), not `:param` (Gin style).
 - All `@Tags` values must be title-cased and drawn from the established vocabulary:
   `Authentication`, `API Keys`, `Users`, `Organizations`, `Modules`, `Providers`,
-  `Storage`, `SCM Providers`, `SCM OAuth`, `SCM Linking`, `Mirror`, `Mirror Protocol`,
-  `RBAC`, `Stats`, `System`, `Webhooks`
+  `Security Scanning`, `Storage`, `SCM Providers`, `SCM OAuth`, `SCM Linking`,
+  `Mirror`, `Mirror Protocol`, `RBAC`, `Stats`, `System`, `Webhooks`
 - After adding or changing any annotation, run `swag init` and update `docs/SWAGGER_ANNOTATION_CHECKLIST.md`.
 
 **Annotation template:**

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,6 +15,9 @@
 // @tag.name         System
 // @tag.description  Health, readiness, and service-discovery endpoints.
 //
+// @tag.name         Security Scanning
+// @tag.description  Module security scanning configuration, status, and scan results.
+//
 // @tag.name         Observability
 // @tag.description  Prometheus metrics and profiling are served on a dedicated side-channel port (default: 9090) that is separate from the main API server. This keeps the scrape path off the public ingress and avoids rate-limiting middleware. Configure the port with TFR_TELEMETRY_METRICS_PROMETHEUS_PORT. The endpoint path is always GET /metrics. pprof (if enabled via TFR_TELEMETRY_PROFILING_ENABLED=true) is served on TFR_TELEMETRY_PROFILING_PORT (default: 6060) at the standard /debug/pprof/ paths. Neither endpoint is part of the OpenAPI spec because they are not served by the Gin router.
 

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2559,6 +2559,77 @@
                 }
             }
         },
+        "/api/v1/admin/scanning/config": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the current security scanning configuration (read-only). Sensitive fields like binary_path are excluded. Requires admin scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Security Scanning"
+                ],
+                "summary": "Get scanning configuration",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ScanningConfigResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/scanning/stats": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns aggregate scan counts by status and a list of recent scans. Requires admin scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Security Scanning"
+                ],
+                "summary": "Get scanning statistics",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ScanningStatsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/stats/dashboard": {
             "get": {
                 "security": [
@@ -4574,7 +4645,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "System"
+                    "Security Scanning"
                 ],
                 "summary": "Get module version scan result",
                 "parameters": [
@@ -9443,6 +9514,29 @@
                 }
             }
         },
+        "admin.DashboardScanning": {
+            "type": "object",
+            "properties": {
+                "clean": {
+                    "type": "integer"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "integer"
+                },
+                "findings": {
+                    "type": "integer"
+                },
+                "pending": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
         "admin.DashboardStats": {
             "type": "object",
             "properties": {
@@ -9469,6 +9563,9 @@
                     "items": {
                         "$ref": "#/definitions/admin.RecentSyncEntry"
                     }
+                },
+                "scanning": {
+                    "$ref": "#/definitions/admin.DashboardScanning"
                 },
                 "scm_providers": {
                     "type": "integer"
@@ -10036,6 +10133,50 @@
                 }
             }
         },
+        "admin.RecentScanEntry": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "critical_count": {
+                    "type": "integer"
+                },
+                "high_count": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "low_count": {
+                    "type": "integer"
+                },
+                "medium_count": {
+                    "type": "integer"
+                },
+                "module_name": {
+                    "type": "string"
+                },
+                "module_version": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "scanned_at": {
+                    "type": "string"
+                },
+                "scanner": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "system": {
+                    "type": "string"
+                }
+            }
+        },
         "admin.RecentSyncEntry": {
             "type": "object",
             "properties": {
@@ -10130,6 +10271,61 @@
                 },
                 "token_type": {
                     "type": "string"
+                }
+            }
+        },
+        "admin.ScanningConfigResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "expected_version": {
+                    "type": "string"
+                },
+                "scan_interval_mins": {
+                    "type": "integer"
+                },
+                "severity_threshold": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "string"
+                },
+                "tool": {
+                    "type": "string"
+                },
+                "worker_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "admin.ScanningStatsResponse": {
+            "type": "object",
+            "properties": {
+                "clean": {
+                    "type": "integer"
+                },
+                "error": {
+                    "type": "integer"
+                },
+                "findings": {
+                    "type": "integer"
+                },
+                "pending": {
+                    "type": "integer"
+                },
+                "recent_scans": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.RecentScanEntry"
+                    }
+                },
+                "scanning": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -1,0 +1,147 @@
+// scanning_admin.go implements admin endpoints for viewing scanning configuration and aggregate scan statistics.
+package admin
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// ScanningConfigResponse is the public view of the scanning config (no binary path).
+type ScanningConfigResponse struct {
+	Enabled           bool   `json:"enabled"`
+	Tool              string `json:"tool"`
+	ExpectedVersion   string `json:"expected_version,omitempty"`
+	SeverityThreshold string `json:"severity_threshold"`
+	Timeout           string `json:"timeout"`
+	WorkerCount       int    `json:"worker_count"`
+	ScanIntervalMins  int    `json:"scan_interval_mins"`
+}
+
+// ScanningStatsResponse aggregates scan counts by status and recent activity.
+type ScanningStatsResponse struct {
+	Total       int64             `json:"total"`
+	Pending     int64             `json:"pending"`
+	Scanning    int64             `json:"scanning"`
+	Clean       int64             `json:"clean"`
+	Findings    int64             `json:"findings"`
+	Error       int64             `json:"error"`
+	RecentScans []RecentScanEntry `json:"recent_scans"`
+}
+
+// RecentScanEntry summarises a single recent scan for the admin UI.
+type RecentScanEntry struct {
+	ID            string     `json:"id"`
+	ModuleVersion string     `json:"module_version"`
+	ModuleName    string     `json:"module_name"`
+	Namespace     string     `json:"namespace"`
+	System        string     `json:"system"`
+	Scanner       string     `json:"scanner"`
+	Status        string     `json:"status"`
+	Critical      int        `json:"critical_count"`
+	High          int        `json:"high_count"`
+	Medium        int        `json:"medium_count"`
+	Low           int        `json:"low_count"`
+	ScannedAt     *time.Time `json:"scanned_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+}
+
+// @Summary      Get scanning configuration
+// @Description  Returns the current security scanning configuration (read-only). Sensitive fields like binary_path are excluded. Requires admin scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Produce      json
+// @Success      200  {object}  ScanningConfigResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Router       /api/v1/admin/scanning/config [get]
+func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		resp := ScanningConfigResponse{
+			Enabled:           cfg.Enabled,
+			Tool:              cfg.Tool,
+			ExpectedVersion:   cfg.ExpectedVersion,
+			SeverityThreshold: cfg.SeverityThreshold,
+			Timeout:           cfg.Timeout.String(),
+			WorkerCount:       cfg.WorkerCount,
+			ScanIntervalMins:  cfg.ScanIntervalMins,
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
+// @Summary      Get scanning statistics
+// @Description  Returns aggregate scan counts by status and a list of recent scans. Requires admin scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Produce      json
+// @Success      200  {object}  ScanningStatsResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/scanning/stats [get]
+func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		var stats ScanningStatsResponse
+
+		// Aggregate counts by status.
+		err := db.QueryRowContext(ctx, `
+			SELECT
+				COUNT(*) AS total,
+				COUNT(*) FILTER (WHERE status = 'pending') AS pending,
+				COUNT(*) FILTER (WHERE status = 'scanning') AS scanning,
+				COUNT(*) FILTER (WHERE status = 'clean') AS clean,
+				COUNT(*) FILTER (WHERE status = 'findings') AS findings,
+				COUNT(*) FILTER (WHERE status = 'error') AS error_count
+			FROM module_version_scans
+		`).Scan(
+			&stats.Total,
+			&stats.Pending,
+			&stats.Scanning,
+			&stats.Clean,
+			&stats.Findings,
+			&stats.Error,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query scan statistics"})
+			return
+		}
+
+		// Recent scans — last 10, with module info joined.
+		rows, err := db.QueryContext(ctx, `
+			SELECT
+				s.id, mv.version, m.name, m.namespace, m.system,
+				s.scanner, s.status,
+				s.critical_count, s.high_count, s.medium_count, s.low_count,
+				s.scanned_at, s.created_at
+			FROM module_version_scans s
+			JOIN module_versions mv ON mv.id = s.module_version_id
+			JOIN modules m ON m.id = mv.module_id
+			ORDER BY s.updated_at DESC
+			LIMIT 10
+		`)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query recent scans"})
+			return
+		}
+		defer rows.Close()
+
+		stats.RecentScans = []RecentScanEntry{}
+		for rows.Next() {
+			var entry RecentScanEntry
+			if scanErr := rows.Scan(
+				&entry.ID, &entry.ModuleVersion, &entry.ModuleName, &entry.Namespace, &entry.System,
+				&entry.Scanner, &entry.Status,
+				&entry.Critical, &entry.High, &entry.Medium, &entry.Low,
+				&entry.ScannedAt, &entry.CreatedAt,
+			); scanErr == nil {
+				stats.RecentScans = append(stats.RecentScans, entry)
+			}
+		}
+
+		c.JSON(http.StatusOK, stats)
+	}
+}

--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -11,7 +11,7 @@ import (
 
 // @Summary      Get module version scan result
 // @Description  Returns the latest security scan for a module version, including tool name, version, severity counts, and raw output. Requires admin scope.
-// @Tags         System
+// @Tags         Security Scanning
 // @Security     Bearer
 // @Produce      json
 // @Param        namespace  path  string  true  "Module namespace"

--- a/backend/internal/api/admin/stats.go
+++ b/backend/internal/api/admin/stats.go
@@ -7,18 +7,24 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
 // StatsHandler handles stats-related API requests
 type StatsHandler struct {
-	db *sqlx.DB
+	db       *sqlx.DB
+	scanning *config.ScanningConfig
 }
 
 // NewStatsHandler creates a new stats handler
-func NewStatsHandler(database *sqlx.DB) *StatsHandler {
-	return &StatsHandler{
+func NewStatsHandler(database *sqlx.DB, scanning ...*config.ScanningConfig) *StatsHandler {
+	h := &StatsHandler{
 		db: database,
 	}
+	if len(scanning) > 0 {
+		h.scanning = scanning[0]
+	}
+	return h
 }
 
 // DashboardStats represents the response for dashboard statistics
@@ -31,7 +37,18 @@ type DashboardStats struct {
 	SCMProviders    int64               `json:"scm_providers"`
 	BinaryMirrors   BinaryMirrorStats   `json:"binary_mirrors"`
 	ProviderMirrors ProviderMirrorStats `json:"provider_mirrors"`
+	Scanning        DashboardScanning   `json:"scanning"`
 	RecentSyncs     []RecentSyncEntry   `json:"recent_syncs"`
+}
+
+// DashboardScanning summarises security scanning health for the dashboard.
+type DashboardScanning struct {
+	Enabled  bool  `json:"enabled"`
+	Total    int64 `json:"total"`
+	Pending  int64 `json:"pending"`
+	Clean    int64 `json:"clean"`
+	Findings int64 `json:"findings"`
+	Error    int64 `json:"error"`
 }
 
 // ModuleSystemCount is a count of modules for a single system (provider).
@@ -224,6 +241,26 @@ func (h *StatsHandler) GetDashboardStats(c *gin.Context) {
 		&stats.ProviderMirrors.Total,
 		&stats.ProviderMirrors.Healthy,
 		&stats.ProviderMirrors.Failed,
+	)
+
+	// Security scanning summary.
+	if h.scanning != nil {
+		stats.Scanning.Enabled = h.scanning.Enabled
+	}
+	_ = h.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE status = 'pending') AS pending,
+			COUNT(*) FILTER (WHERE status = 'clean') AS clean,
+			COUNT(*) FILTER (WHERE status = 'findings') AS findings,
+			COUNT(*) FILTER (WHERE status = 'error') AS error_count
+		FROM module_version_scans
+	`).Scan(
+		&stats.Scanning.Total,
+		&stats.Scanning.Pending,
+		&stats.Scanning.Clean,
+		&stats.Scanning.Findings,
+		&stats.Scanning.Error,
 	)
 
 	// Recent sync activity — last 8 entries unified across both mirror types.

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -269,7 +269,8 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 					SwaggerUIBundle.plugins.DownloadUrl
 				],
 				layout: "BaseLayout",
-				docExpansion: "list"
+				docExpansion: "list",
+				tagsSorter: "alpha"
 			})
 			window.ui = ui
 		}
@@ -423,7 +424,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, db)
 	userHandlers := admin.NewUserHandlers(cfg, db)
 	orgHandlers := admin.NewOrganizationHandlers(cfg, db)
-	statsHandlers := admin.NewStatsHandler(sqlxDB)
+	statsHandlers := admin.NewStatsHandler(sqlxDB, &cfg.Scanning)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers
 
@@ -599,6 +600,14 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.GET("/modules/:namespace/:name/:system/versions/:version/scan",
 				middleware.RequireScope(auth.ScopeAdmin),
 				admin.GetModuleScanHandler(db))
+
+			// Security scanning admin endpoints
+			authenticatedGroup.GET("/admin/scanning/config",
+				middleware.RequireScope(auth.ScopeAdmin),
+				admin.GetScanningConfigHandler(&cfg.Scanning))
+			authenticatedGroup.GET("/admin/scanning/stats",
+				middleware.RequireScope(auth.ScopeAdmin),
+				admin.GetScanningStatsHandler(sqlxDB))
 
 			// API Keys management - self-service for own keys
 			// Users can manage their own API keys without api_keys:manage scope

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -6,7 +6,7 @@ This checklist tracks Swagger/OpenAPI annotation progress for all API endpoints 
 
 **Target**: 100% API coverage with Swagger annotations
 
-**Current Status**: ✅ 109/109 annotated (100%) — All Gin-router endpoints complete
+**Current Status**: ✅ 111/111 annotated (100%) — All Gin-router endpoints complete
 
 See the **Out-of-Band Endpoints** section at the bottom for observability endpoints that live
 on dedicated ports and are deliberately excluded from the OpenAPI spec.
@@ -220,7 +220,17 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 
 ---
 
-## Phase 8: Utilities
+## Phase 8: Security Scanning
+
+- [x] `GET /api/v1/admin/scanning/config` - Get scanning configuration
+- [x] `GET /api/v1/admin/scanning/stats` - Get scanning statistics and recent scans
+
+**File**: `backend/internal/api/admin/scanning_admin.go`
+**Progress**: 2/2 annotated ✅
+
+---
+
+## Phase 9: Utilities
 
 - [x] `GET /api/v1/admin/stats/dashboard` - Get dashboard statistics
 - [x] `POST /webhooks/scm/:module_source_repo_id/:secret` - SCM webhook (public)
@@ -276,8 +286,8 @@ complete operational coverage.
 ---
 
 ```txt
-Total Gin-router Endpoints: 109
-Annotated: 109
+Total Gin-router Endpoints: 111
+Annotated: 111
 Remaining: 0
 Completion: 100% ✅
 
@@ -293,13 +303,15 @@ Phase Breakdown:
   Phase 5 (SCM):                  18/18 (100%) ✅
   Phase 6 (Mirror):                9/9  (100%) ✅
   Phase 7 (RBAC):                 15/15 (100%) ✅
-  Phase 8 (Utilities):             6/6  (100%) ✅
+  Phase 8 (Security Scanning):     2/2  (100%) ✅
+  Phase 9 (Utilities):             6/6  (100%) ✅
 
 @Tags used (all title-cased):
   Authentication, API Keys, Users, Organizations,
-  Modules, Providers, Storage, SCM Providers,
-  SCM OAuth, SCM Linking, Mirror, Mirror Protocol,
-  RBAC, Stats, System, Observability, Webhooks
+  Modules, Providers, Security Scanning, Storage,
+  SCM Providers, SCM OAuth, SCM Linking, Mirror,
+  Mirror Protocol, RBAC, Stats, System, Observability,
+  Webhooks
 ```
 
 ---
@@ -315,5 +327,5 @@ Then visit `https://localhost/api-docs` to verify in the Swagger UI.
 
 ---
 
-**Last Updated**: 2026-03-21
-**Status**: ✅ All 109 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist
+**Last Updated**: 2026-04-14
+**Status**: ✅ All 111 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist


### PR DESCRIPTION
## Summary
- Add GET /admin/scanning/config and /admin/scanning/stats endpoints for the new frontend SecurityScanningPage
- Add Security Scanning swagger tag with full annotations on new and existing scan endpoints
- Sort swagger UI tags alphabetically via tagsSorter: alpha
- Extend dashboard stats handler with scanning health data for Dashboard HealthPill

## Changelog
- feat: add security scanning config and stats API endpoints
- feat: add Security Scanning swagger tag with full annotations
- feat: sort swagger UI tags alphabetically
- feat: extend dashboard stats with scanning health data

## Test plan
- [ ] Verify GET /admin/scanning/config returns config (requires admin scope)
- [ ] Verify GET /admin/scanning/stats returns aggregate counts and recent scans
- [ ] Verify dashboard stats include scanning field
- [ ] Verify swagger UI at /api-docs/ shows tags sorted alphabetically
- [ ] Run go test ./... — existing tests should pass