### PR TITLE
chore: update deployment configs to backend v0.4.2 / frontend v0.5.4

### DIFF
--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.3.5"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.4.3"
+    tag: "v0.5.4"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.3.5"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.4.3"
+    tag: "v0.5.4"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.3.5"
+    tag: "v0.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.4.3"
+    tag: "v0.5.4"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -51,7 +51,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.4.3"
+    tag: "0.5.4"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.3.5
+    newTag: v0.4.2
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.4.3
+    newTag: v0.5.4

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.3.5
+    newTag: v0.4.2
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.4.3
+    newTag: v0.5.4


### PR DESCRIPTION
## Summary
- Update frontend image tags from v0.4.3 to v0.5.4 across all Helm values and Kustomize overlays
- Update backend image tags from v0.3.5 to v0.4.2 in cloud-specific Helm values and Kustomize overlays

## Changelog
- chore: update deployment configs to backend v0.4.2 / frontend v0.5.4

## Test plan
- [ ] Verify image tags are correct in all deployment configs