### PR TITLE
feat: add scanning:read RBAC scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ terraform-registry-backend/
 | Language       | Go 1.24.0                                                          |
 | HTTP Framework | Gin                                                                |
 | Database       | PostgreSQL 14+ via sqlx                                            |
-| Migrations     | golang-migrate (14 migrations (000001–000014))                     |
+| Migrations     | golang-migrate (18 migrations (000001–000018))                     |
 | Auth           | JWT (golang-jwt/jwt v5), API keys, OIDC (coreos/go-oidc), Azure AD |
 | Config         | Viper (`TFR_` env prefix overrides YAML)                           |
 | Storage        | Local filesystem, Azure Blob, S3-compatible, GCS                   |
@@ -384,7 +384,7 @@ HTTP Handler (api/)
 
 ### Database
 
-- 14 migrations (000001–000014) in `backend/internal/db/migrations/`.
+- 18 migrations (000001–000018) in `backend/internal/db/migrations/`.
 - Migrations run automatically at startup; use `migrate up/down` for manual control.
 - Always add a new migration file rather than editing existing ones.
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -598,7 +598,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UndeprecateVersion)
 			authenticatedGroup.GET("/modules/:namespace/:name/:system/versions/:version/scan",
-				middleware.RequireScope(auth.ScopeAdmin),
+				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetModuleScanHandler(db))
 
 			// Security scanning admin endpoints
@@ -606,7 +606,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 				middleware.RequireScope(auth.ScopeAdmin),
 				admin.GetScanningConfigHandler(&cfg.Scanning))
 			authenticatedGroup.GET("/admin/scanning/stats",
-				middleware.RequireScope(auth.ScopeAdmin),
+				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScanningStatsHandler(sqlxDB))
 
 			// API Keys management - self-service for own keys

--- a/backend/internal/auth/scopes.go
+++ b/backend/internal/auth/scopes.go
@@ -41,6 +41,9 @@ const (
 	// Audit log scopes
 	ScopeAuditRead Scope = "audit:read"
 
+	// Security scanning scopes
+	ScopeScanningRead Scope = "scanning:read" // View scan results, config, and stats
+
 	// Admin scope (wildcard - all permissions)
 	ScopeAdmin Scope = "admin"
 )
@@ -62,6 +65,7 @@ func AllScopes() []Scope {
 		ScopeSCMManage,
 		ScopeAPIKeysManage,
 		ScopeAuditRead,
+		ScopeScanningRead,
 		ScopeAdmin,
 	}
 }

--- a/backend/internal/auth/scopes_test.go
+++ b/backend/internal/auth/scopes_test.go
@@ -63,6 +63,10 @@ func TestHasScope(t *testing.T) {
 		{"read does not imply write", []string{"modules:read"}, ScopeModulesWrite, false},
 		// Multiple scopes, one matches
 		{"one of many matches", []string{"providers:read", "modules:read"}, ScopeModulesRead, true},
+		// Scanning scope
+		{"exact match scanning:read", []string{"scanning:read"}, ScopeScanningRead, true},
+		{"admin grants scanning:read", []string{"admin"}, ScopeScanningRead, true},
+		{"scanning:read does not grant admin", []string{"scanning:read"}, ScopeAdmin, false},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/db/migrations/000018_add_scanning_read_scope.down.sql
+++ b/backend/internal/db/migrations/000018_add_scanning_read_scope.down.sql
@@ -1,0 +1,10 @@
+-- 000018_add_scanning_read_scope.down.sql
+-- Remove scanning:read scope from devops and auditor system role templates.
+
+UPDATE role_templates
+SET scopes = scopes - 'scanning:read'
+WHERE name = 'devops' AND is_system = true;
+
+UPDATE role_templates
+SET scopes = scopes - 'scanning:read'
+WHERE name = 'auditor' AND is_system = true;

--- a/backend/internal/db/migrations/000018_add_scanning_read_scope.up.sql
+++ b/backend/internal/db/migrations/000018_add_scanning_read_scope.up.sql
@@ -1,0 +1,11 @@
+-- 000018_add_scanning_read_scope.up.sql
+-- Add scanning:read scope to devops and auditor system role templates
+-- so they can view scan results and stats without full admin access.
+
+UPDATE role_templates
+SET scopes = scopes || '["scanning:read"]'::jsonb
+WHERE name = 'devops' AND is_system = true;
+
+UPDATE role_templates
+SET scopes = scopes || '["scanning:read"]'::jsonb
+WHERE name = 'auditor' AND is_system = true;


### PR DESCRIPTION
Adds a granular `scanning:read` permission scope so devops and auditor roles can
view security scan results and statistics without requiring full admin access.

**Changes:**
- New `scanning:read` scope in `auth/scopes.go`
- `GET .../versions/:version/scan` → `scanning:read` (was `admin`)
- `GET /admin/scanning/stats` → `scanning:read` (was `admin`)
- `GET /admin/scanning/config` → remains `admin` (exposes server config)
- Migration 000018 adds `scanning:read` to devops and auditor role templates
- Test coverage for the new scope in `scopes_test.go`

## Changelog
- feat: add scanning:read RBAC scope granting devops and auditor roles access to scan results and stats