### PR TITLE
chore: bump frontend image tags to v0.5.5

### DIFF
--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.5.4"
+    tag: "v0.5.5"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.5.4"
+    tag: "v0.5.5"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.5.4"
+    tag: "v0.5.5"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -51,7 +51,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.5.4"
+    tag: "0.5.5"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -72,4 +72,4 @@ images:
     newTag: v0.4.3
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.5.4
+    newTag: v0.5.5

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -80,4 +80,4 @@ images:
     newTag: v0.4.3
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.5.4
+    newTag: v0.5.5


### PR DESCRIPTION
Update deployment config frontend image tags to v0.5.5.

## Changelog
- chore: bump deployment config frontend image tags to v0.5.5