### PR TITLE
fix: resolve lint errors blocking release CI

### DIFF
--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -135,14 +135,6 @@ func sampleModuleVersionGetRow() *sqlmock.Rows {
 			nil, nil, nil)
 }
 
-func sampleModuleSearchRow() *sqlmock.Rows {
-	return sqlmock.NewRows(moduleSearchCols).
-		AddRow("mod-1", "org-1", "hashicorp", "consul", "aws",
-			nil, "hashicorp/consul/aws", nil, nil, time.Now(), time.Now(),
-			false, nil, nil, nil,
-			nil, int64(0))
-}
-
 func sampleModuleSearchRowFTS() *sqlmock.Rows {
 	return sqlmock.NewRows(moduleSearchColsFTS).
 		AddRow("mod-1", "org-1", "hashicorp", "consul", "aws",

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -147,14 +147,6 @@ func samplePlatformRow() *sqlmock.Rows {
 			"local", int64(1024000), "sha256abc", nil, int64(0))
 }
 
-func sampleProviderSearchRow() *sqlmock.Rows {
-	return sqlmock.NewRows(providerSearchCols).
-		AddRow("prov-1", nil, "hashicorp", "aws",
-			nil, "hashicorp/provider-aws",
-			nil, nil, time.Now(), time.Now(),
-			nil, int64(0))
-}
-
 func sampleProviderSearchRowFTS() *sqlmock.Rows {
 	return sqlmock.NewRows(providerSearchColsFTS).
 		AddRow("prov-1", nil, "hashicorp", "aws",

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -193,7 +193,11 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 
 	// Initialize and start the audit log cleanup job (no-op when retention_days=0)
 	auditCleanupJob := jobs.NewAuditCleanupJob(&cfg.AuditRetention, auditRepo)
-	go auditCleanupJob.Start(context.Background())
+	go func() {
+		if err := auditCleanupJob.Start(context.Background()); err != nil {
+			log.Printf("Audit cleanup job failed: %v", err)
+		}
+	}()
 	log.Println("Audit log cleanup job started")
 
 	// Get encryption key from environment for OAuth token encryption

--- a/backend/internal/db/repositories/module_repository_test.go
+++ b/backend/internal/db/repositories/module_repository_test.go
@@ -734,13 +734,6 @@ var moduleSearchWithStatsColsFTS = []string{
 	"rank",
 }
 
-func sampleModuleSearchWithStatsRow() *sqlmock.Rows {
-	latestVersion := "1.0.0"
-	return sqlmock.NewRows(moduleSearchWithStatsCols).
-		AddRow("mod-1", "org-1", "hashicorp", "vpc", "aws", nil, nil, nil, nil,
-			time.Now(), time.Now(), false, nil, nil, nil, &latestVersion, int64(42))
-}
-
 func sampleModuleSearchWithStatsRowFTS() *sqlmock.Rows {
 	latestVersion := "1.0.0"
 	return sqlmock.NewRows(moduleSearchWithStatsColsFTS).

--- a/backend/internal/db/repositories/provider_repository_test.go
+++ b/backend/internal/db/repositories/provider_repository_test.go
@@ -703,12 +703,6 @@ var providerSearchWithStatsColsFTS = []string{
 	"rank",
 }
 
-func sampleProviderSearchWithStatsRow() *sqlmock.Rows {
-	latestVer := "2.1.0"
-	return sqlmock.NewRows(providerSearchWithStatsCols).
-		AddRow("prov-1", "org-1", "hashicorp", "aws", nil, nil, nil, nil, time.Now(), time.Now(), &latestVer, int64(100))
-}
-
 func sampleProviderSearchWithStatsRowFTS() *sqlmock.Rows {
 	latestVer := "2.1.0"
 	return sqlmock.NewRows(providerSearchWithStatsColsFTS).


### PR DESCRIPTION
Hotfix for v0.6.0 release CI failures.

- Handle `auditCleanupJob.Start()` error return value (errcheck)
- Remove 4 unused test helper functions replaced by FTS variants

## Changelog
- fix: resolve lint errors blocking v0.6.0 release CI