### PR TITLE
fix: resolve remaining lint and gosec CI failures

### DIFF
--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -75,8 +75,8 @@
 			"rule_id": "G201",
 			"details": "SQL string formatting",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\db\\repositories\\module_repository.go",
-			"code": "503: \t// Count total results\n504: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM modules %s\", whereClause)\n505: \tvar total int\n",
-			"line": "504",
+			"code": "513: \t// Count total results\n514: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM modules %s\", whereClause)\n515: \tvar total int\n",
+			"line": "514",
 			"column": "16",
 			"nosec": false,
 			"suppressions": null
@@ -91,8 +91,8 @@
 			"rule_id": "G304",
 			"details": "Potential file inclusion via variable",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\storage\\local\\local.go",
-			"code": "186: \tsidecarPath := fullPath + \".sha256\"\n187: \tif data, err := os.ReadFile(sidecarPath); err == nil { //nolint:gosec -- G304: sidecarPath derived from validated internal storage path, not user input\n188: \t\tchecksum := strings.TrimSpace(string(data))\n",
-			"line": "187",
+			"code": "214: \tsidecarPath := fullPath + \".sha256\"\n215: \tif data, err := os.ReadFile(sidecarPath); err == nil { //nolint:gosec -- G304: sidecarPath derived from validated internal storage path, not user input\n216: \t\tchecksum := strings.TrimSpace(string(data))\n",
+			"line": "215",
 			"column": "18",
 			"nosec": false,
 			"suppressions": null,
@@ -108,8 +108,8 @@
 			"rule_id": "G304",
 			"details": "Potential file inclusion via variable",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\services\\scm_publisher.go",
-			"code": "550: \tif p.moduleDocsRepo != nil {\n551: \t\tif f, err := os.Open(archivePath); err == nil { // G304: archivePath is a temp file created by this process\n552: \t\t\tdefer f.Close()\n",
-			"line": "551",
+			"code": "555: \tif p.moduleDocsRepo != nil {\n556: \t\tif f, err := os.Open(archivePath); err == nil { // G304: archivePath is a temp file created by this process\n557: \t\t\tdefer f.Close()\n",
+			"line": "556",
 			"column": "16",
 			"nosec": false,
 			"suppressions": null,
@@ -389,9 +389,9 @@
 		}
 	],
 	"Stats": {
-		"files": 143,
-		"lines": 40467,
-		"nosec": 106,
+		"files": 155,
+		"lines": 43929,
+		"nosec": 111,
 		"found": 24
 	},
 	"GosecVersion": "dev"

--- a/backend/internal/api/admin/audit_export_test.go
+++ b/backend/internal/api/admin/audit_export_test.go
@@ -172,7 +172,7 @@ func TestExportAuditLogs_Success(t *testing.T) {
 
 	// Body should contain valid JSON line(s)
 	var entry map[string]interface{}
-	if err := json.Unmarshal([]byte(w.Body.String()), &entry); err != nil {
+	if err := json.Unmarshal(w.Body.Bytes(), &entry); err != nil {
 		t.Fatalf("failed to parse NDJSON line: %v\nbody: %s", err, w.Body.String())
 	}
 	if entry["id"] != "entry-1" {
@@ -203,7 +203,7 @@ func TestExportAuditLogs_WithMetadata(t *testing.T) {
 	}
 
 	var entry map[string]interface{}
-	if err := json.Unmarshal([]byte(w.Body.String()), &entry); err != nil {
+	if err := json.Unmarshal(w.Body.Bytes(), &entry); err != nil {
 		t.Fatalf("failed to parse NDJSON line: %v", err)
 	}
 	meta, ok := entry["metadata"].(map[string]interface{})

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -134,7 +134,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 	}
 
 	// Read the initial secret
-	data, err := os.ReadFile(secretFilePath)
+	data, err := os.ReadFile(secretFilePath) // #nosec G304 -- path comes from server config, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to read JWT secret file %q: %w", secretFilePath, err)
 	}
@@ -147,7 +147,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 		return nil, fmt.Errorf("failed to create fsnotify watcher: %w", err)
 	}
 	if err := watcher.Add(secretFilePath); err != nil {
-		watcher.Close()
+		watcher.Close() // #nosec G104 -- cleanup during error return; main error is returned below
 		return nil, fmt.Errorf("failed to watch JWT secret file %q: %w", secretFilePath, err)
 	}
 
@@ -161,7 +161,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 					return
 				}
 				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
-					newData, readErr := os.ReadFile(secretFilePath)
+					newData, readErr := os.ReadFile(secretFilePath) // #nosec G304 -- path comes from server config, not user input
 					if readErr != nil {
 						slog.Error("failed to read updated JWT secret file", "path", secretFilePath, "error", readErr)
 						continue
@@ -198,7 +198,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 				}
 				slog.Error("JWT secret file watcher error", "error", watchErr)
 			case <-stopCh:
-				watcher.Close()
+				watcher.Close() // #nosec G104 -- best-effort cleanup on shutdown
 				return
 			}
 		}

--- a/backend/internal/jobs/webhook_retry_job.go
+++ b/backend/internal/jobs/webhook_retry_job.go
@@ -223,5 +223,5 @@ func (j *WebhookRetryJob) failRetry(ctx context.Context, event *scm.SCMWebhookLo
 // calculateBackoff returns the backoff duration for the given retry count.
 // The formula is 2^retryCount minutes: 1m, 2m, 4m, 8m, ...
 func calculateBackoff(retryCount int) time.Duration {
-	return time.Minute * time.Duration(1<<uint(retryCount))
+	return time.Minute * time.Duration(1<<uint(retryCount)) // #nosec G115 -- retryCount is bounded by maxRetries (5)
 }


### PR DESCRIPTION
Hotfix for v0.6.0 release CI.

- Use w.Body.Bytes() in audit export tests (gosimple S1030)
- Add #nosec annotations for false positive gosec findings
- Update gosec baseline

## Changelog
- fix: resolve remaining lint and gosec CI failures for v0.6.0 release