### PR TITLE
fix: skip swagger auto-commit on tag refs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # On tag refs (release builds) skip swagger validation — it was already
+          # checked when the release PR CI ran.  Tags are immutable so we cannot
+          # auto-commit anyway.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "Running on tag ${{ github.ref_name }} — skipping swagger auto-commit check"
+            exit 0
+          fi
+
           swag init -g cmd/server/main.go --outputTypes json
           if ! git diff --exit-code docs/swagger.json; then
             echo "swagger.json changed — committing updated docs"


### PR DESCRIPTION
## Summary
- Skip the swagger generation + auto-commit step entirely when CI runs on a tag ref
- Tags are immutable — auto-commit is impossible, and the `git rebase "origin/${TAG}"` command fails with `fatal: invalid upstream`
- Swagger was already validated when the release PR CI ran on the branch

## Context
This fixes the v0.6.0 release CI failure (runs 24482852659, 24483091798, 24483554222, 24483843214) where the swagger step tried to `git fetch origin "v0.6.0"` and `git rebase "origin/v0.6.0"` — treating the tag as a branch.

## Changelog
- fix: skip swagger auto-commit on tag refs in CI workflow