### PR TITLE
fix: add missing scanning and audit columns to SystemSettings model

### DIFF
--- a/backend/internal/auth/statestore_test.go
+++ b/backend/internal/auth/statestore_test.go
@@ -128,3 +128,46 @@ func TestMemoryStateStore_CleanupRemovesExpired(t *testing.T) {
 		t.Error("expired entry still present after cleanup")
 	}
 }
+
+func TestMemoryStateStore_DefaultCleanupInterval(t *testing.T) {
+	// Zero interval should default to 5 minutes internally
+	store := NewMemoryStateStore(0)
+	defer store.Close()
+	ctx := context.Background()
+
+	data := &SessionState{State: "default-test", ProviderType: "oidc", CreatedAt: time.Now()}
+	if err := store.Save(ctx, "default-test", data, time.Hour); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, "default-test")
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load() returned nil, want non-nil")
+	}
+	if loaded.State != "default-test" {
+		t.Errorf("Load().State = %q, want %q", loaded.State, "default-test")
+	}
+}
+
+func TestMemoryStateStore_NegativeCleanupInterval(t *testing.T) {
+	// Negative interval should also default to 5 minutes
+	store := NewMemoryStateStore(-1 * time.Second)
+	defer store.Close()
+	ctx := context.Background()
+
+	data := &SessionState{State: "neg-test", ProviderType: "azuread", CreatedAt: time.Now()}
+	if err := store.Save(ctx, "neg-test", data, time.Hour); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := store.Load(ctx, "neg-test")
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load() returned nil, want non-nil")
+	}
+}

--- a/backend/internal/db/models/storage_config.go
+++ b/backend/internal/db/models/storage_config.go
@@ -19,8 +19,14 @@ type SystemSettings struct {
 	SetupTokenHash      sql.NullString `db:"setup_token_hash" json:"-"` // Never expose
 	OIDCConfigured      bool           `db:"oidc_configured" json:"oidc_configured"`
 	PendingAdminEmail   sql.NullString `db:"pending_admin_email" json:"pending_admin_email,omitempty"`
-	CreatedAt           time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt           time.Time      `db:"updated_at" json:"updated_at"`
+	// Scanning setup (migration 000021)
+	ScanningConfigured   bool         `db:"scanning_configured" json:"scanning_configured"`
+	ScanningConfiguredAt sql.NullTime `db:"scanning_configured_at" json:"scanning_configured_at,omitempty"`
+	ScanningConfig       []byte       `db:"scanning_config" json:"scanning_config,omitempty"`
+	// Audit retention (migration 000023)
+	AuditRetentionDays int       `db:"audit_retention_days" json:"audit_retention_days"`
+	CreatedAt          time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt          time.Time `db:"updated_at" json:"updated_at"`
 }
 
 // StorageConfig holds storage backend configuration

--- a/backend/scripts/check_package_coverage.sh
+++ b/backend/scripts/check_package_coverage.sh
@@ -7,7 +7,7 @@ PACKAGES=(
   "github.com/terraform-registry/terraform-registry/internal/auth"
   "github.com/terraform-registry/terraform-registry/internal/middleware"
 )
-MIN=79
+MIN=80
 for pkg in "${PACKAGES[@]}"; do
   # Test the exact package only (not sub-packages) and discard stdout/stderr.
   go test -coverprofile=/tmp/pkg-coverage.out "${pkg}" >/dev/null 2>&1 || true


### PR DESCRIPTION
Closes #186

## Summary
- Add 4 missing fields to `SystemSettings` struct (`scanning_configured`, `scanning_configured_at`, `scanning_config`, `audit_retention_days`) to match DB schema after migrations 000021 and 000023
- Restore per-package auth coverage threshold from 79% to 80%
- Add tests for `NewMemoryStateStore` zero/negative cleanup interval default branch

## Changelog
- fix: add missing scanning and audit columns to SystemSettings model, fixing HTTP 500 on setup status endpoint
- fix: restore per-package auth coverage threshold to 80%