### PR TITLE
fix: increase auth rate limit burst to accommodate OIDC login flow

### DIFF
--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -33,11 +33,14 @@ func DefaultRateLimitConfig() RateLimitConfig {
 	}
 }
 
-// AuthRateLimitConfig returns stricter limits for auth endpoints
+// AuthRateLimitConfig returns stricter limits for auth endpoints.
+// The burst must be large enough to accommodate a full OIDC login cycle
+// (provider probe + redirect + callback + exchange-token = 4 minimum,
+// plus headroom for multi-provider probes and retries).
 func AuthRateLimitConfig() RateLimitConfig {
 	return RateLimitConfig{
-		RequestsPerMinute: 10, // 10 login attempts per minute
-		BurstSize:         5,
+		RequestsPerMinute: 20, // 20 auth requests per minute
+		BurstSize:         15,
 		CleanupInterval:   5 * time.Minute,
 	}
 }

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -30,11 +30,11 @@ func TestDefaultRateLimitConfig(t *testing.T) {
 
 func TestAuthRateLimitConfig(t *testing.T) {
 	cfg := AuthRateLimitConfig()
-	if cfg.RequestsPerMinute != 10 {
-		t.Errorf("RequestsPerMinute = %d, want 10", cfg.RequestsPerMinute)
+	if cfg.RequestsPerMinute != 20 {
+		t.Errorf("RequestsPerMinute = %d, want 20", cfg.RequestsPerMinute)
 	}
-	if cfg.BurstSize != 5 {
-		t.Errorf("BurstSize = %d, want 5", cfg.BurstSize)
+	if cfg.BurstSize != 15 {
+		t.Errorf("BurstSize = %d, want 15", cfg.BurstSize)
 	}
 }
 


### PR DESCRIPTION
Closes #193

## Summary
- Increased `AuthRateLimitConfig` from burst=5/10rpm to burst=15/20rpm
- The previous values were too low for a single OIDC login cycle (probes + redirect + callback + exchange-token = 5-6 requests)

## Changelog
- fix: increase auth rate limit burst from 5 to 15 to accommodate OIDC login flow

## Test plan
- [ ] `TestAuthRateLimitConfig` passes with updated values
- [ ] All middleware tests pass
- [ ] Manual test: OIDC login completes without 429 on exchange-token