### PR TITLE
feat: Phase 0 quick wins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,27 @@ updates:
     # Ignore major-version bumps for infrastructure libs that require manual review.
     ignore:
       - dependency-name: "github.com/gin-gonic/gin"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
       - dependency-name: "github.com/golang-migrate/migrate/v4"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
+
+  # ---------------------------------------------------------------------------
+  # Docker (backend/)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: biweekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    reviewers:
+      - maintainers
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: "chore(deps)"
 
   # ---------------------------------------------------------------------------
   # GitHub Actions

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -91,6 +91,14 @@ jobs:
             fi
           fi
 
+      - name: Bump Helm chart appVersion
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Update appVersion in Chart.yaml to match the release version.
+          # Also bump the chart version patch component so Helm detects a change.
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" deployments/helm/Chart.yaml
+          echo "Updated deployments/helm/Chart.yaml appVersion to ${VERSION}"
+
       - name: Create release branch, commit, and push
         run: |
           VERSION="${{ inputs.version }}"
@@ -98,9 +106,13 @@ jobs:
           git checkout -b "$BRANCH"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet && echo "No CHANGELOG changes to commit" && exit 0
+          git add CHANGELOG.md deployments/helm/Chart.yaml
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "chore: release v${VERSION}"
+          # Rebase onto latest main to avoid merge conflicts from concurrent
+          # feature merges landing between branch creation and PR merge.
+          git fetch origin main
+          git rebase origin/main
           git push origin "$BRANCH"
 
       - name: Open release PR
@@ -120,6 +132,7 @@ jobs:
 
           ### Checklist
           - [ ] CHANGELOG.md updated with collected entries
+          - [ ] Helm \`Chart.yaml\` appVersion matches \`${VERSION}\`
           - [ ] CI passes
           - [ ] UAT: local Docker Compose build validated
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ builds:
 
 archives:
   - id: terraform-registry-binaries
-    formats: [binary]
+    formats: [ binary ]
     name_template: "terraform-registry-{{ .Os }}-{{ .Arch }}"
 
 checksum:
@@ -45,6 +45,27 @@ release:
     ```
     docker pull ghcr.io/sethbacon/terraform-registry-backend:{{ .Tag }}
     ```
+
+sboms:
+  - artifacts: archive
+    cmd: syft
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    args:
+      - sign-blob
+      - --yes
+      - --output-signature=${signature}
+      - ${artifact}
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    args:
+      - sign
+      - --yes
+      - ${artifact}
 
 changelog:
   use: github-native

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Frontend UI lives in a separate repository: [terraform-registry-frontend](https:
 
 ```txt
 terraform-registry-backend/
-├── backend/                  # Go 1.24 backend service
+├── backend/                  # Go 1.26 backend service
 │   ├── cmd/                  # Entry points (server, check-db, fix-migration, hash, test-api)
 │   ├── internal/
 │   │   ├── api/              # Gin HTTP handlers (modules, providers, mirror, admin, webhooks)
@@ -229,7 +229,7 @@ terraform-registry-backend/
 │   │   └── audit/            # Audit logging
 │   ├── pkg/checksum/         # Public checksum utilities
 │   ├── Dockerfile            # Multi-stage Go build
-│   ├── go.mod                # Go 1.24.0
+│   ├── go.mod                # Go 1.26.1
 │   └── config.example.yaml   # Configuration template
 ├── deployments/              # Docker Compose, Kubernetes, Helm, Bicep, CloudFormation, Terraform IaC
 ├── docs/                     # API quick reference, authentication guide, architecture, etc.
@@ -248,10 +248,10 @@ terraform-registry-backend/
 
 | Concern        | Technology                                                         |
 | -------------- | ------------------------------------------------------------------ |
-| Language       | Go 1.24.0                                                          |
+| Language       | Go 1.26.1                                                          |
 | HTTP Framework | Gin                                                                |
 | Database       | PostgreSQL 14+ via sqlx                                            |
-| Migrations     | golang-migrate (18 migrations (000001–000018))                     |
+| Migrations     | golang-migrate (24 migrations (000001–000024))                     |
 | Auth           | JWT (golang-jwt/jwt v5), API keys, OIDC (coreos/go-oidc), Azure AD |
 | Config         | Viper (`TFR_` env prefix overrides YAML)                           |
 | Storage        | Local filesystem, Azure Blob, S3-compatible, GCS                   |
@@ -384,7 +384,7 @@ HTTP Handler (api/)
 
 ### Database
 
-- 18 migrations (000001–000018) in `backend/internal/db/migrations/`.
+- 24 migrations (000001–000024) in `backend/internal/db/migrations/`.
 - Migrations run automatically at startup; use `migrate up/down` for manual control.
 - Always add a new migration file rather than editing existing ones.
 
@@ -571,7 +571,8 @@ func (h *Handler) MethodName(c *gin.Context) {
 - All GitHub Actions pinned to full commit SHAs
 - Scheduled weekly builds with auto-issue on failure
 - **SLSA provenance attestation** on Docker images and GoReleaser binaries via `actions/attest-build-provenance`
-- **Cosign keyless signing** on Docker images via Sigstore (verify with `cosign verify`)
+- **SBOM generation** via syft in GoReleaser (`sboms:` block)
+- **Cosign keyless signing** on Docker images and checksum files via Sigstore (verify with `cosign verify`)
 
 ### Repository Topics
 
@@ -579,7 +580,6 @@ func (h *Handler) MethodName(c *gin.Context) {
 
 ### Remaining Recommendations (not yet applied)
 
-- **Add SECURITY.md** — currently only referenced in CONTRIBUTING.md; a dedicated file enables GitHub's security advisory features
 - **Enable secret scanning non-provider patterns and validity checks** for broader secret detection
 - **Add a tag protection rule** to prevent deletion of release tags (`v*.*.*`)
 - **Consider CodeQL code scanning** for Go static analysis beyond gosec

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers responsible for enforcement via the
+repository's contact channels.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A fully-featured, enterprise-grade Terraform registry implementing all three HashiCorp protocols with multi-tenancy support.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go)](https://go.dev/)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/sethbacon/59239e8575b4f784f875647e2b344b41/raw/coverage.json)](https://github.com/sethbacon/terraform-registry-backend/actions/workflows/ci.yml)
 
 - [Features](#features)
@@ -108,7 +108,7 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 
 ### Observability & CI/CD
 
-- **Prometheus Metrics** - Nine named application metrics on a dedicated scrape port (default 9090)
+- **Prometheus Metrics** - Eleven named application metrics on a dedicated scrape port (default 9090)
 - **Structured Logging** - stdlib `slog` with JSON (production) and text (development) formats
 - **pprof Profiling** - Opt-in profiling server on a configurable port
 - **GitHub Actions CI/CD** - Build, vet, race-detector tests, gosec security scan, Docker build, multi-platform releases
@@ -123,7 +123,7 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 └──────────────────┬─────────────────────────────────┘
                    │ REST API / Protocol Endpoints
 ┌──────────────────▼─────────────────────────────────┐
-│              Go 1.24 Backend (Gin)                 │
+│              Go 1.26 Backend (Gin)                 │
 │  Modules API │ Providers API │ Mirror │ Admin      │
 │  Terraform Binary Mirror                           │
 │  Auth: JWT │ API Keys │ OIDC │ Azure AD │ RBAC     │
@@ -140,7 +140,7 @@ A fully-featured, enterprise-grade Terraform registry implementing all three Has
 
 ### Prerequisites
 
-- Go 1.24 or later
+- Go 1.26 or later
 - PostgreSQL 14+
 - Docker & Docker Compose (for containerized deployment)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,616 +1,483 @@
-# Terraform Registry Backend -- Roadmap
+# Terraform Registry Backend — Roadmap
 
-> **Goal**: Raise all review scores to 9/10 or 10/10.
-> **Out of scope**: v1.0 API stability (deferred), state management, runtime execution (plan/apply).
-> **Structure**: Phases are ordered by impact. Work items within each phase are **independent** and can be worked on by separate agents in parallel unless noted otherwise.
+**Baseline:** v0.7.0 (2026-04-17)
+**Goal:** Close enterprise-adoption gaps identified in the 2026-04-17 independent evaluation and reach verifiable parity with Terraform Enterprise, Artifactory, and Spacelift for the registry surface area.
 
----
-
-## Phase 1: High-Availability & Security Hardening (Security 8→9, Enterprise 7→9)
-
-### 1.1 Redis-Backed Rate Limiter
-
-**Why**: The in-memory token bucket (`internal/middleware/ratelimit.go:52-222`) is the single biggest HA blocker. Each instance maintains independent state; clients bypass limits by rotating across pods. The code itself documents this at line 58-61.
-
-**Current state**:
-- `RateLimiter` struct (line 62-67) is a concrete type with no interface.
-- `RateLimitMiddleware` (line 168) accepts `*RateLimiter` pointer; nil = disabled.
-- Three hardcoded presets: `DefaultRateLimitConfig()` (200/min), `AuthRateLimitConfig()` (10/min), `UploadRateLimitConfig()` (30/min). Config values from `config.go` lines 255-259 (`security.rate_limiting.requests_per_minute`, `burst`) are **never wired** to these presets -- only `Enabled` is used (router.go line 470).
-- `BackgroundServices` (router.go line 67-96) owns rate limiter lifecycle and calls `rl.Stop()` on shutdown.
-
-**Work items**:
-
-1. **Extract `RateLimiterBackend` interface** in `internal/middleware/ratelimit.go`:
-   ```go
-   type RateLimiterBackend interface {
-       Allow(ctx context.Context, key string) (bool, error)
-       RemainingTokens(ctx context.Context, key string) (int, error)
-       Close() error
-   }
-   ```
-   Refactor the existing in-memory implementation to satisfy this interface. Update `RateLimitMiddleware` to accept the interface instead of `*RateLimiter`.
-
-2. **Implement Redis backend** in new package `internal/middleware/ratelimit_redis.go`:
-   - Use `go-redis/redis_rate` with the GCRA algorithm (as recommended in the existing code comment at line 60).
-   - Accept `RedisConfig` for connection details.
-   - Implement `Allow()` using `redis_rate.Limiter.Allow()`.
-   - Implement `Close()` to close the Redis connection.
-
-3. **Add Redis configuration** to `internal/config/config.go`:
-   - New `RedisConfig` struct under `Config`: `Host`, `Port`, `Password`, `DB`, `TLS`, `PoolSize`, `DialTimeout`.
-   - Bind env vars: `TFR_REDIS_HOST`, `TFR_REDIS_PORT`, etc.
-   - Add to `setDefaults()` and `Validate()`.
-
-4. **Wire config values to rate limiter presets** in `router.go`:
-   - Use `cfg.Security.RateLimiting.RequestsPerMinute` and `Burst` from config instead of hardcoded `DefaultRateLimitConfig()` when custom values are provided.
-   - Fall back to presets when config values are zero/default.
-
-5. **Factory logic** in `router.go` (around line 469): If `cfg.Redis.Host != ""`, create Redis-backed limiters; otherwise fall back to in-memory with a startup warning log.
-
-6. **Tests**: Unit tests for both backends. Integration test with a real Redis container (use `testcontainers-go` or Docker Compose in CI).
-
-7. **Metrics**: Add `rate_limit_rejections_total` CounterVec (labels: `tier`, `key_type`) to `internal/telemetry/metrics.go`. Increment in `RateLimitMiddleware` on 429 responses.
-
-**Affected files**: `internal/middleware/ratelimit.go`, `internal/middleware/ratelimit_redis.go` (new), `internal/config/config.go`, `internal/api/router.go`, `internal/telemetry/metrics.go`, `config.example.yaml`, `docs/configuration.md`, `deployments/helm/values.yaml`
-
-**Acceptance criteria**: Rate limiting works correctly across multiple pods with Redis. Falls back gracefully to in-memory when Redis is unavailable. Config values are respected. Metrics track rejections.
+This roadmap is organized into **phases** (sequencing) and **tracks** (parallel workstreams). Multiple agents may claim tracks concurrently. Items marked `↔` have a cross-repo dependency with `terraform-registry-frontend`.
 
 ---
 
-### 1.2 Redis-Backed OIDC Session Store
+## Cross-repo dependency summary
 
-**Why**: The in-memory OIDC state store (`internal/api/admin/auth.go:36-95`) causes 100% OIDC login failure behind a load balancer without sticky sessions. The code documents this at lines 36-38.
+The following items require coordinated work with `terraform-registry-frontend`:
 
-**Current state**:
-- `AuthHandlers.sessionStore` is `map[string]*SessionState` protected by `sync.Mutex`.
-- `SessionState` (line 44-49): `State`, `CreatedAt`, `RedirectURL`, `ProviderType`.
-- Created in `LoginHandler` (line 147), consumed + deleted in `CallbackHandler` (lines 229-245).
-- Cleanup goroutine (lines 82-95) runs every 5 min, removes entries >10 min old.
-
-**Work items**:
-
-1. **Extract `StateStore` interface** in `internal/auth/statestore.go` (new file):
-   ```go
-   type StateStore interface {
-       Save(ctx context.Context, state string, data *SessionState, ttl time.Duration) error
-       Load(ctx context.Context, state string) (*SessionState, error)
-       Delete(ctx context.Context, state string) error
-       Close() error
-   }
-   ```
-
-2. **Refactor in-memory implementation** into `internal/auth/statestore_memory.go` satisfying the interface.
-
-3. **Implement Redis backend** in `internal/auth/statestore_redis.go`:
-   - Use Redis `SET` with `EX` for TTL (auto-expiry, no cleanup goroutine needed).
-   - Serialize `SessionState` as JSON.
-   - `Load` uses `GET` + `DEL` atomically (Lua script or pipeline) for single-use.
-
-4. **Wire into `AuthHandlers`**: Accept `StateStore` interface in constructor. Factory in `router.go` selects backend based on `cfg.Redis.Host`.
-
-5. **Tests**: Unit tests with mock store. Integration test for login flow across two instances (test that callback works on a different instance than login).
-
-**Affected files**: `internal/auth/statestore.go` (new), `internal/auth/statestore_memory.go` (new), `internal/auth/statestore_redis.go` (new), `internal/api/admin/auth.go`, `internal/api/router.go`
-
-**Acceptance criteria**: OIDC login works without sticky sessions in multi-pod deployment. In-memory mode still works for single-instance deployments.
+| Backend item                     | Frontend item                   | Topic                |
+| -------------------------------- | ------------------------------- | -------------------- |
+| B2.1 (SAML connector)            | B2.1 (SAML login picker)        | SAML login flow      |
+| B2.2 (LDAP connector)            | B2.2 (LDAP login form)          | LDAP login flow      |
+| B2.3 (SCIM endpoints)            | B2.3 (SCIM admin page)          | SCIM provisioning    |
+| B2.4 (OIDC refresh)              | A1.1 (httpOnly cookie auth)     | Auth token migration |
+| D3.4 (Per-org quotas)            | E4.4 (Quota dashboard)          | Org quota management |
+| E4.1 (Module deprecation API)    | E4.1 (Deprecation banner)       | Module deprecation   |
+| E4.3 (OPA/Rego policy)           | E4.2 (Policy results in upload) | Policy evaluation    |
+| E4.4 (Module test orchestration) | E4.3 (Test results UI)          | Module test display  |
+| E4.2 (OCI endpoint)              | E4.5 (OCI pull snippet)         | OCI distribution     |
+| E0.2 (Module resync re-analysis) | — (uses existing detail page)   | Module metadata      |
+| H0.2 (Release workflow)          | H0.3 (Release workflow)         | CI/CD streamlining   |
 
 ---
 
-### 1.3 Per-Organization Rate Limiting
+## Legend
 
-**Why**: Currently rate limiting is per-user/per-API-key/per-IP only (`ratelimit.go:201-222`). An organization with many users has uncapped aggregate throughput.
-
-**Current state**:
-- `getRateLimitKey()` checks `user_id`, then `api_key_id`, then `c.ClientIP()`. No `organization_id` path exists (despite org context being available in Gin context from auth middleware at `auth.go:157`).
-
-**Work items**:
-
-1. **Add `OrgRateLimitConfig`** to `config.go`: `org_requests_per_minute`, `org_burst`.
-
-2. **Add composite rate limiting** in `ratelimit.go`: After individual key check passes, also check org-level key `org:<orgID>` with the org config. Both must pass.
-
-3. **Propagate org ID** to rate limiter: The org ID is already set in Gin context by auth middleware. The rate limiter just needs to read it.
-
-4. **Tests**: Verify that individual limits + org limits both apply. Verify that users without an org context (e.g., public endpoints) are unaffected.
-
-**Affected files**: `internal/middleware/ratelimit.go`, `internal/config/config.go`, `config.example.yaml`
-
-**Depends on**: 1.1 (should use the same `RateLimiterBackend` interface).
+- **Size:** S (<1d), M (1–3d), L (1–2w), XL (>2w)
+- **Priority:** P0 (adoption blocker), P1 (high), P2 (medium), P3 (nice-to-have)
+- **Track:** A = Supply chain / SecOps · B = Enterprise identity · C = Compliance / crypto · D = Operability · E = Protocol / features · F = Observability · G = Data layer · H = CI/CD
 
 ---
 
-### 1.4 Secrets Rotation Support
+## Phase 0 — Quick wins (all parallel; target: 1 sprint)
 
-**Why**: JWT secret and encryption key are loaded once via `sync.Once` (`internal/auth/jwt.go:59`) with no hot-reload. Rotating requires a full restart, and changing `ENCRYPTION_KEY` makes all previously encrypted SCM tokens unreadable.
+### A0.1 · Add `SECURITY.md` at repo root · [P0/S]
 
-**Work items**:
+- Disclosure policy, supported-versions matrix, PGP contact, CVE acknowledgment SLAs (48h / 7d / 30d).
+- Template: mirror frontend `SECURITY.md` structure.
+- **Files:** `SECURITY.md`, `README.md` (add link), `.github/SECURITY_CONTACTS`
+- **AC:** File present; linked from README; referenced in `.github/SECURITY_CONTACTS`.
 
-1. **Dual-key decryption for `TokenCipher`** (`internal/crypto/tokencipher.go`):
-   - Accept `ENCRYPTION_KEY` (current) and `ENCRYPTION_KEY_PREVIOUS` (optional).
-   - Encrypt always uses the current key.
-   - Decrypt tries current key first; on GCM auth failure, tries previous key.
-   - This allows zero-downtime rotation: set new key as current, old key as previous, restart pods, then re-encrypt all tokens in a background job.
+### A0.2 · Add `CODE_OF_CONDUCT.md` · [P0/S]
 
-2. **JWT secret reload via file-watch** (`internal/auth/jwt.go`):
-   - Add `TFR_JWT_SECRET_FILE` config option (alternative to env var).
-   - Use `fsnotify` to watch the file for changes.
-   - On change, atomically swap the signing key (use `atomic.Pointer[[]byte]`).
-   - New tokens use the new key; validation tries both keys (current and previous) for a configurable overlap period.
+- Contributor Covenant 2.1.
+- **Files:** `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` (add link)
+- **AC:** File present; linked from CONTRIBUTING.md.
 
-3. **Documentation**: Add `docs/secrets-rotation.md` with step-by-step rotation procedures for JWT secret, encryption key, and OIDC client secrets.
+### A0.3 · Pin Docker base-image digests · [P0/S]
 
-4. **Helm integration**: Update `deployments/helm/values.yaml` to support `ENCRYPTION_KEY_PREVIOUS` and `TFR_JWT_SECRET_FILE`.
+- `backend/Dockerfile`: replace `golang:1.26-alpine` and `alpine:3.19` tags with `@sha256:<digest>`.
+- Add Dependabot entry for `docker` ecosystem.
+- **Files:** `backend/Dockerfile`, `.github/dependabot.yml`
+- **AC:** Digests pinned; Dependabot config updated.
 
-**Affected files**: `internal/crypto/tokencipher.go`, `internal/auth/jwt.go`, `internal/config/config.go`, `config.example.yaml`, `docs/secrets-rotation.md` (new), `deployments/helm/values.yaml`, `deployments/helm/templates/secret.yaml`
+### A0.4 · Add SBOM generation to GoReleaser · [P0/S]
 
----
+- `.goreleaser.yml`: add `sboms:` block using `syft`.
+- Generate CycloneDX + SPDX JSON per artifact.
+- Attach to GitHub release.
+- **Files:** `.goreleaser.yml`, `.github/workflows/release.yml`
+- **AC:** `make release` dry-run produces `*.sbom.cdx.json` and `*.sbom.spdx.json`.
 
-## Phase 2: Feature Completeness (Features 8→9, Ease of Use 7→9)
+### A0.5 · Add cosign keyless signing · [P0/S]
 
-### 2.1 Webhook Retry with Exponential Backoff
+- `.goreleaser.yml`: add `signs:` block using `cosign sign-blob --yes` with GitHub OIDC.
+- Sign container images in `.github/workflows/release.yml` via `cosign sign --yes <image>@<digest>`.
+- Publish signature verification one-liner in README.
+- **Files:** `.goreleaser.yml`, `.github/workflows/release.yml`, `README.md`
+- **AC:** `cosign verify-blob` + `cosign verify` succeed for a tagged release.
 
-**Why**: Webhook processing is fire-and-forget (`internal/api/webhooks/scm_webhook.go:177-188`). Failed `ProcessTagPush` calls are logged but never retried. If the SCM is temporarily unavailable or the storage backend hiccups, module versions are silently lost.
+### C0.1 · Document Go minimum toolchain · [P1/S]
 
-**Current state**:
-- `safego.Go()` spawns a background goroutine with 10-min timeout.
-- Webhook log tracks state: `processing` → `completed` / `failed` / `skipped`.
-- The `scm_webhook_events` table (migration 000001, lines 275-299) has `processed` boolean and `error` text columns but no retry tracking.
-- `SCMPublisher.ProcessTagPush` (scm_publisher.go:72-140) does the actual work.
+- Add to README: "Minimum Go: 1.26. Tested against 1.26.1."
+- Add `go` directive in `go.mod` pinning minor version.
+- **Files:** `README.md`, `backend/go.mod`
+- **AC:** README + go.mod aligned.
 
-**Work items**:
+### D0.1 · Remove `continue-on-error: true` on E2E job · [P1/S]
 
-1. **Database migration** (`000019_webhook_retry.up.sql`):
-   ```sql
-   ALTER TABLE scm_webhook_events
-     ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0,
-     ADD COLUMN max_retries INTEGER NOT NULL DEFAULT 3,
-     ADD COLUMN next_retry_at TIMESTAMP WITH TIME ZONE,
-     ADD COLUMN last_error TEXT;
-   CREATE INDEX idx_webhook_events_retry
-     ON scm_webhook_events(next_retry_at)
-     WHERE processed = false AND retry_count < max_retries;
-   ```
+- `.github/workflows/ci.yml`: make E2E a required gate on `main`; schedule nightly full matrix separately.
+- **Files:** `.github/workflows/ci.yml`
+- **AC:** `main` branch protection includes E2E job.
 
-2. **Webhook retry job** in `internal/jobs/webhook_retry_job.go` (new file):
-   - Polling loop similar to `ModuleScannerJob` pattern.
-   - Query: `SELECT * FROM scm_webhook_events WHERE processed = false AND retry_count < max_retries AND next_retry_at <= NOW() ORDER BY next_retry_at LIMIT ?`.
-   - For each event: re-derive connector from `module_scm_repo_id` → `scm_provider` → `BuildConnector()`, re-run `ProcessTagPush`.
-   - On success: mark `processed = true`.
-   - On failure: increment `retry_count`, set `next_retry_at` with exponential backoff (1min, 5min, 30min), update `last_error`.
-   - Configurable: `TFR_WEBHOOKS_MAX_RETRIES` (default 3), `TFR_WEBHOOKS_RETRY_INTERVAL_MINS` (poll interval, default 2).
+### H0.1 · Publish gosec baseline drift gate · [P1/S]
 
-3. **Update `scm_webhook.go`**: On initial failure, set `next_retry_at = NOW() + 1 minute` instead of leaving in terminal failed state.
+- Add PR check comparing `gosec-results.json` vs `gosec-baseline.json`.
+- Fail PR if new findings exceed baseline.
+- Script: `backend/scripts/gosec-compare.py` (already exists — wire into CI).
+- **Files:** `.github/workflows/ci.yml`, `.github/workflows/pr-checks.yml`
+- **AC:** PR comments show diff; CI fails on net-new HIGH findings.
 
-4. **Metrics**: Add `webhook_retries_total` CounterVec (labels: `outcome`: success/failure/exhausted) to `telemetry/metrics.go`.
+### E0.1 · Fix audit log "unknown" resource type · [P1/S]
 
-5. **Config**: Add `WebhooksConfig` to `config.go` with `MaxRetries`, `RetryIntervalMins`.
+- `backend/internal/middleware/audit.go` `getResourceType()` returns `"unknown"` for endpoints not matching known prefixes (`/api/v1/storage/*`, `/api/v1/setup/*`, admin endpoints).
+- Add mappings for all current API route prefixes: `storage`, `setup`, `roles`, `scm-providers`, `webhooks`, `scanning`, `approvals`, `terraform-mirrors`, `binary-mirrors`.
+- Ensure future route additions have a corresponding audit resource type (add CI lint or table-driven test).
+- **Files:** `backend/internal/middleware/audit.go`, `backend/internal/middleware/audit_test.go`
+- **AC:** No audit log entry produced with `resource_type = "unknown"` for any documented API route; regression test covers all route prefixes.
+- **Source:** UAT
 
-6. **Tests**: Unit test for backoff calculation. Integration test for retry flow with a mock SCM connector that fails then succeeds.
+### E0.2 · Module resync must re-run HCL analyzer · [P1/M]
 
-**Affected files**: `internal/db/migrations/000019_*.sql` (new), `internal/jobs/webhook_retry_job.go` (new), `internal/api/webhooks/scm_webhook.go`, `internal/services/scm_publisher.go`, `internal/config/config.go`, `internal/telemetry/metrics.go`, `internal/api/router.go` (register job), `config.example.yaml`
+- Currently, module resync only re-downloads the archive but does **not** re-run the HCL analyzer. Modules uploaded before the analyzer was improved (or with analyzer bugs) are stuck with stale/missing inputs/outputs metadata.
+- On resync (or a new "re-analyze" action), re-extract inputs, outputs, provider requirements, and version constraints from the module archive using `backend/internal/analyzer/`.
+- Store updated metadata; surface via existing module-version detail API.
+- Consider a bulk re-analyze admin endpoint for all versions of a module (or all modules).
+- **Files:** `backend/internal/services/module_service.go`, `backend/internal/analyzer/`, `backend/internal/api/module_routes.go`
+- **AC:** After resync, previously-missing inputs/outputs appear on the module version detail endpoint; E2E test confirms.
+- **Source:** UAT
+- **↔ Frontend:** existing ModuleDetailPage already renders inputs/outputs — no frontend change needed if API contract unchanged.
 
----
+### H0.2 · Streamline release workflow · [P1/M]
 
-### 2.2 Advanced Search with PostgreSQL Full-Text Search
+- **Problem (from UAT):** Current `CLAUDE.md` release process has high friction — merge conflicts between `prepare-release.yml` output and concurrent feature merges, redundant CI runs (full CI on release branch + again on tag), manual `release.yml` dispatch due to `GITHUB_TOKEN` limitations, and manual Helm/Kustomize image-tag bumps across multiple files (`values-aks.yaml`, `values-eks.yaml`, `values-gke.yaml`, `eks/kustomization.yaml`, `gke/kustomization.yaml`).
+- Evaluate and implement best-practice improvements:
+  1. **Single-commit release:** `prepare-release.yml` should produce a single atomic commit (CHANGELOG + version bump) directly on `main` via rebase, not a merge-commit PR, to eliminate merge conflicts.
+  2. **Tag-triggered release:** Auto-tag on version-bump commit detection (skip manual dispatch); `release.yml` triggers on `v*` tag push.
+  3. **Skip redundant CI:** Release workflow should use the CI artifacts from the tag-triggering commit (not re-run lint/test/build). Use `workflow_call` with artifact passthrough or `actions/download-artifact`.
+  4. **Auto-bump deployment manifests:** `prepare-release.yml` bumps Helm `Chart.yaml` `appVersion` in the same release commit. Kustomize overlays keep `<IMAGE_TAG>` placeholders (substituted by per-environment CD pipelines via `kustomize edit set image`). Post-release job in `release.yml` opens a cross-repo PR to bump frontend image tag when the backend tag is known.
+  5. **Document streamlined flow** in `CLAUDE.md` and `CONTRIBUTING.md`.
+- **Files:** `.github/workflows/prepare-release.yml`, `.github/workflows/release.yml`, `.github/workflows/auto-tag.yml`, `CLAUDE.md`, `CONTRIBUTING.md`
+- **AC:** Release from merge-to-main to published GitHub Release + pushed Docker image requires ≤1 manual step (approve the auto-PR or click "merge"); no merge conflicts on CHANGELOG; deployment manifests auto-updated.
+- **Source:** UAT
+- **↔ Frontend H0.3:** Coordinate release cadence and shared deployment-manifest updates.
 
-**Why**: Current search uses `ILIKE '%query%'` across namespace, name, description (`module_repository.go:562-655`, `provider_repository.go:751+`). This has no relevance ranking, no stemming, and forces sequential scans on large registries (no GIN indexes exist).
+### F0.1 · Emit business-event Prometheus metrics · [P2/S]
 
-**Work items**:
-
-1. **Database migration** (`000020_search_indexes.up.sql`):
-   ```sql
-   -- Add tsvector columns for full-text search
-   ALTER TABLE modules ADD COLUMN search_vector tsvector;
-   ALTER TABLE providers ADD COLUMN search_vector tsvector;
-
-   -- Populate
-   UPDATE modules SET search_vector =
-     setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-     setweight(to_tsvector('english', coalesce(namespace, '')), 'B') ||
-     setweight(to_tsvector('english', coalesce(description, '')), 'C') ||
-     setweight(to_tsvector('english', coalesce(system, '')), 'B');
-
-   UPDATE providers SET search_vector =
-     setweight(to_tsvector('english', coalesce(type, '')), 'A') ||
-     setweight(to_tsvector('english', coalesce(namespace, '')), 'B') ||
-     setweight(to_tsvector('english', coalesce(description, '')), 'C');
-
-   -- GIN indexes
-   CREATE INDEX idx_modules_search ON modules USING GIN(search_vector);
-   CREATE INDEX idx_providers_search ON providers USING GIN(search_vector);
-
-   -- Triggers to maintain on INSERT/UPDATE
-   CREATE OR REPLACE FUNCTION modules_search_vector_update() RETURNS trigger AS $$
-   BEGIN
-     NEW.search_vector :=
-       setweight(to_tsvector('english', coalesce(NEW.name, '')), 'A') ||
-       setweight(to_tsvector('english', coalesce(NEW.namespace, '')), 'B') ||
-       setweight(to_tsvector('english', coalesce(NEW.description, '')), 'C') ||
-       setweight(to_tsvector('english', coalesce(NEW.system, '')), 'B');
-     RETURN NEW;
-   END $$ LANGUAGE plpgsql;
-
-   CREATE TRIGGER trg_modules_search BEFORE INSERT OR UPDATE ON modules
-     FOR EACH ROW EXECUTE FUNCTION modules_search_vector_update();
-   -- (Same pattern for providers)
-   ```
-
-2. **Update search repository methods** (`module_repository.go`, `provider_repository.go`):
-   - Replace `ILIKE` with `search_vector @@ plainto_tsquery('english', $query)` for ranked results.
-   - Add `ts_rank(search_vector, query)` to ORDER BY for relevance scoring.
-   - Keep `ILIKE` as fallback when query is a single short token (prefix matching).
-
-3. **Add sort parameter** to search API: `sort=relevance|name|downloads|created|updated`, `order=asc|desc`.
-
-4. **Add namespace and system/type filters** as explicit query parameters (currently only `namespace` and `system` exist for modules; add `organization` filter).
-
-5. **Tests**: Unit tests for search ranking (name match ranks higher than description match). Performance test with 1000+ modules.
-
-**Affected files**: `internal/db/migrations/000020_*.sql` (new), `internal/db/repositories/module_repository.go`, `internal/db/repositories/provider_repository.go`, `internal/api/modules/search.go`, `internal/api/providers/search.go`
+- Add counters: `registry_module_publishes_total{org}`, `registry_provider_publishes_total{org}`, `registry_storage_bytes{org,kind}`, `registry_downloads_total{org,kind}`.
+- Wire into existing handlers in `backend/internal/api/`.
+- Publish sample Grafana dashboard JSON.
+- **Files:** `backend/internal/api/*.go` (handlers), `backend/internal/telemetry/metrics.go`, `docs/observability.md`
+- **AC:** Metrics visible on `/metrics`; sample Grafana dashboard JSON in `docs/observability.md`.
 
 ---
 
-### 2.3 Security Scanning in Setup Wizard
+## Phase 1 — Supply chain + security hardening (parallel tracks)
 
-**Why**: The setup wizard configures OIDC, storage, and admin user but does not configure security scanning. Users must manually configure scanning via environment variables after setup. Adding scanning to the wizard improves first-run experience.
+### Track A — Supply chain
 
-**Current state**:
-- Setup wizard: 5 endpoints in `internal/api/setup/handlers.go` (status, validate-token, OIDC, storage, admin, complete).
-- Scanning config: `ScanningConfig` in `config.go` lines 42-68. Fields: `Enabled`, `Tool`, `BinaryPath`, `ExpectedVersion`, `Timeout`, `WorkerCount`, `ScanIntervalMins`, `VersionArgs`, `ScanArgs`, `OutputFormat`.
-- Scanner factory: `scanner/scanner.go:43-67` creates scanners by tool name.
-- Scanner validation: each scanner has a `Version()` method that runs `<binary> --version`.
-- Setup status (`GetSetupStatus` in handlers.go) checks `oidc_configured`, `storage_configured`, `admin_configured`. No `scanning_configured` field.
+#### A1.1 · Rekor transparency log integration · [P0/M]
 
-**Work items**:
+- Ensure cosign signatures pushed to public Rekor.
+- Document `cosign verify --certificate-identity-regexp` pattern.
+- **Files:** `.github/workflows/release.yml`, `docs/deployment.md`
+- **AC:** Rekor entry URL printed in release notes.
 
-1. **New setup endpoint** `POST /api/v1/setup/scanning/test` in `internal/api/setup/handlers.go`:
-   - Accept: `{ tool: string, binary_path: string, expected_version?: string }`.
-   - Validate that the binary exists at the given path.
-   - Call `scanner.NewScanner(tool, binaryPath, ...)` then `s.Version(ctx)`.
-   - If `expected_version` set, compare with actual version.
-   - Return `{ success: bool, detected_version: string, error?: string }`.
+#### A1.2 · SLSA Level 3 build provenance · [P1/M]
 
-2. **New setup endpoint** `POST /api/v1/setup/scanning` in `internal/api/setup/handlers.go`:
-   - Accept: `{ enabled: bool, tool: string, binary_path: string, expected_version: string, timeout_secs: int, worker_count: int }`.
-   - Persist to `system_settings` table (key: `scanning_config`, value: JSON).
-   - Update runtime config (similar to how OIDC provider is swapped at runtime).
+- Upgrade from basic attestation to SLSA L3 via `slsa-framework/slsa-github-generator`.
+- Isolated builder, non-falsifiable provenance, signed.
+- **Files:** `.github/workflows/release.yml`
+- **AC:** `slsa-verifier verify-artifact` passes.
 
-3. **Update `GetSetupStatus`** to include `scanning_configured` field (read from `system_settings`).
+#### A1.3 · Vendor ReDoc + Swagger UI locally · [P1/M]
 
-4. **Register routes** in `router.go` under the setup group with `SetupTokenMiddleware`.
+- Remove CDN dependency (`cdn.jsdelivr.net`) that leaks into air-gapped installs.
+- Bundle assets into `backend/docs/embed.go`.
+- **Files:** `backend/docs/embed.go`, `backend/cmd/server/main.go`
+- **AC:** Air-gap install serves API docs with no external calls.
 
-5. **Migration** (`000021_setup_scanning.up.sql`): Add `scanning_config` row to `system_settings` if not exists.
+### Track C — Crypto / FIPS
 
-6. **Runtime integration**: On startup, if `system_settings.scanning_config` exists and no env-var override, use the DB-stored config for the scanner job.
+#### C1.1 · FIPS-140-3 build variant · [P0/L]
 
-7. **Tests**: E2E test for test/save endpoints. Unit test for scanner validation with mock binary.
+- Add `make build-fips` target using Go `GOEXPERIMENT=boringcrypto` (or go-fips toolchain).
+- Publish separate `*-fips` binaries and `fips` container tag.
+- `/version` endpoint reports `"crypto_mode": "fips" | "standard"`.
+- **Files:** `Makefile`, `backend/Dockerfile.fips`, `.goreleaser.yml`, `backend/cmd/server/main.go`
+- **AC:** `goversion -m bin/registry-fips` shows boringcrypto; FIPS image tagged and signed.
 
-**Affected files**: `internal/api/setup/handlers.go`, `internal/api/setup/responses.go`, `internal/api/router.go`, `internal/config/config.go`, `internal/db/migrations/000021_*.sql` (new), `cmd/server/main.go` (config merge logic)
+#### C1.2 · Rotate bcrypt cost + document rationale · [P1/M]
 
----
+- Confirm bcrypt cost ≥ 12; add ADR `docs/adr/0011-password-hashing.md`.
+- Add migration path for upgrading existing hashes on next login.
+- **Files:** `backend/internal/auth/apikey.go`, `docs/adr/0011-password-hashing.md`
+- **AC:** ADR merged; upgrade path tested.
 
-### 2.4 Storage Migration Wizard
+### Track H — CI hardening
 
-**Why**: The `StoragePage` warns "Changing storage backends may result in data loss" but provides no migration path. The `storage_backend` column on `module_versions` and `provider_platforms` tracks where each artifact lives, and the `Storage` interface (`internal/storage/storage.go:26-46`) already exposes `Upload/Download/Delete/Exists` -- all the primitives needed for migration.
+#### H1.1 · Dependency review action + OSV scan on PR · [P1/M]
 
-**Current state**:
-- `module_versions.storage_backend` (VARCHAR(50)) records backend per version.
-- `provider_platforms` has similar storage tracking.
-- API methods `activateStorageConfig`, `updateStorageConfig` exist in the frontend `api.ts` but are **not wired** to any UI on the StoragePage.
-- The runtime only initializes one storage backend from config (`NewStorage(cfg)` based on `DefaultBackend`).
+- Add `actions/dependency-review-action` on PRs.
+- Add `osv-scanner` nightly scan of `go.sum`.
+- **Files:** `.github/workflows/pr-checks.yml`, `.github/workflows/scheduled-build.yml`
+- **AC:** Alerts file new GitHub issues automatically.
 
-**Work items**:
+#### H1.2 · Add `trivy fs` scan of final image in CI · [P2/S]
 
-1. **Database migration** (`000022_storage_migration.up.sql`):
-   ```sql
-   CREATE TABLE storage_migrations (
-     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-     source_config_id UUID NOT NULL REFERENCES storage_config(id),
-     target_config_id UUID NOT NULL REFERENCES storage_config(id),
-     status VARCHAR(20) NOT NULL DEFAULT 'pending', -- pending/running/completed/failed/cancelled
-     total_artifacts INTEGER NOT NULL DEFAULT 0,
-     migrated_artifacts INTEGER NOT NULL DEFAULT 0,
-     failed_artifacts INTEGER NOT NULL DEFAULT 0,
-     error_message TEXT,
-     started_at TIMESTAMP WITH TIME ZONE,
-     completed_at TIMESTAMP WITH TIME ZONE,
-     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-     created_by UUID REFERENCES users(id)
-   );
-
-   CREATE TABLE storage_migration_items (
-     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-     migration_id UUID NOT NULL REFERENCES storage_migrations(id) ON DELETE CASCADE,
-     artifact_type VARCHAR(20) NOT NULL, -- 'module' or 'provider'
-     artifact_id UUID NOT NULL,
-     source_path VARCHAR(500) NOT NULL,
-     status VARCHAR(20) NOT NULL DEFAULT 'pending', -- pending/migrated/failed/skipped
-     error_message TEXT,
-     migrated_at TIMESTAMP WITH TIME ZONE
-   );
-   CREATE INDEX idx_migration_items_status ON storage_migration_items(migration_id, status);
-   ```
-
-2. **Storage migration service** in `internal/services/storage_migration.go` (new):
-   - `PlanMigration(sourceConfigID, targetConfigID)`: Query all `module_versions` and `provider_platforms` on the source backend. Return artifact count and estimated size.
-   - `ExecuteMigration(migrationID)`: Background job that iterates `storage_migration_items`, for each: Download from source → Upload to target → Update `storage_backend` column → Mark migrated. Uses worker pool (configurable concurrency). Tracks progress in `storage_migrations.migrated_artifacts`.
-   - `GetMigrationStatus(migrationID)`: Returns current progress.
-   - `CancelMigration(migrationID)`: Sets cancellation flag, workers check before each item.
-   - Both source and target `Storage` instances initialized simultaneously from their respective `storage_config` rows.
-
-3. **API endpoints** in `internal/api/admin/storage_migration.go` (new):
-   - `POST /api/v1/admin/storage/migrations/plan`: Plan a migration (returns artifact count).
-   - `POST /api/v1/admin/storage/migrations`: Start a migration.
-   - `GET /api/v1/admin/storage/migrations/:id`: Get migration status.
-   - `POST /api/v1/admin/storage/migrations/:id/cancel`: Cancel a running migration.
-   - `GET /api/v1/admin/storage/migrations`: List migrations.
-   - Scope required: `admin`.
-
-4. **Register routes** in `router.go`.
-
-5. **Tests**: Unit tests for plan/execute/cancel. Integration test with local→local migration (different base paths).
-
-**Affected files**: `internal/db/migrations/000022_*.sql` (new), `internal/services/storage_migration.go` (new), `internal/api/admin/storage_migration.go` (new), `internal/db/repositories/storage_migration_repository.go` (new), `internal/db/models/storage_migration.go` (new), `internal/api/router.go`
+- Scan SBOM for CVE >= HIGH; fail build.
+- **Files:** `.github/workflows/ci.yml`
+- **AC:** CI log shows Trivy summary; gate active.
 
 ---
 
-### 2.5 Audit Log Retention & Cleanup
+## Phase 2 — Enterprise identity (↔ frontend Track B)
 
-**Why**: The `audit_logs` table has no cleanup mechanism (`audit_repository.go` has no `Delete` method). The table will grow unboundedly. No partitioning exists (migration 000001). The review flagged this explicitly.
+### Track B — Identity
 
-**Work items**:
+#### B2.1 · SAML 2.0 IdP connector · [P0/L]
 
-1. **Database migration** (`000023_audit_retention.up.sql`):
-   - Add `retention_days` to `system_settings` (default 90).
-   - Add partial index: `CREATE INDEX idx_audit_logs_created ON audit_logs(created_at)`.
+- New package `backend/internal/auth/saml/` using `crewjam/saml`.
+- Support SP-initiated + IdP-initiated flows.
+- Metadata endpoint `/auth/saml/metadata`; ACS at `/auth/saml/acs`.
+- Group claim → scope mapping reusing existing role-template model.
+- Config: multiple IdPs per deployment; per-org IdP binding optional.
+- **Files:** `backend/internal/auth/saml/*.go`, `backend/internal/config/config.go`, `backend/internal/api/auth_routes.go`
+- **AC:** Tested against Okta, Entra ID SAML, ADFS, Ping; integration test in `cmd/api-test`.
+- **↔ Frontend B2.1:** Login page provider-picker must list SAML IdPs.
 
-2. **Cleanup job** in `internal/jobs/audit_cleanup_job.go` (new):
-   - Similar pattern to the existing JWT revocation cleanup goroutine (`main.go:218-227`).
-   - Runs daily at configurable time.
-   - Deletes audit logs older than `retention_days` in batches (1000 per batch to avoid long locks).
-   - Config: `TFR_AUDIT_RETENTION_DAYS` (default 90), `TFR_AUDIT_CLEANUP_BATCH_SIZE` (default 1000).
+#### B2.2 · LDAP / Active Directory connector · [P0/L]
 
-3. **Archive before delete** (optional): If audit shipper is configured (webhook/file), ship logs before deletion.
+- New package `backend/internal/auth/ldap/` using `go-ldap/ldap`.
+- Simple bind + StartTLS/LDAPS; group lookup via `memberOf` or nested-group search.
+- Connection pooling + failover across multiple DCs.
+- Group-DN → scope mapping.
+- **Files:** `backend/internal/auth/ldap/*.go`, `backend/internal/config/config.go`, `backend/internal/api/auth_routes.go`
+- **AC:** Tested against OpenLDAP + Active Directory; CI integration test with `osixia/docker-openldap`.
 
-4. **API endpoint** `GET /api/v1/admin/audit-logs/export` with date range filter for bulk export before cleanup.
+#### B2.3 · SCIM 2.0 provisioning endpoints · [P0/L]
 
-5. **Metrics**: Add `audit_logs_cleaned_total` counter to `telemetry/metrics.go`.
+- Implement `/scim/v2/Users`, `/scim/v2/Groups` per RFC 7644.
+- Token-authenticated per-IdP; scope `admin` or new `scim:provision`.
+- JIT deprovisioning (deactivate on SCIM delete; soft-delete users).
+- **Files:** `backend/internal/api/scim/*.go`, `backend/internal/auth/scopes.go`, `backend/internal/db/models/user.go`
+- **AC:** Okta + Entra SCIM connectors successfully provision/deprovision; integration test in CI.
+- **↔ Frontend B2.3:** SCIM admin page.
 
-6. **Config**: Add `AuditRetentionConfig` to `config.go`.
+#### B2.4 · OIDC refresh token + silent renew · [P1/M]
 
-**Affected files**: `internal/db/migrations/000023_*.sql` (new), `internal/jobs/audit_cleanup_job.go` (new), `internal/config/config.go`, `internal/telemetry/metrics.go`, `internal/api/router.go`, `config.example.yaml`
+- Implement refresh-token rotation in `internal/auth/oidc/`.
+- Add `/auth/refresh` endpoint.
+- Set auth token as `HttpOnly; Secure; SameSite=Strict` cookie.
+- Add double-submit CSRF pattern: non-HttpOnly `csrf` cookie + `X-CSRF-Token` header validation on mutating requests.
+- **Files:** `backend/internal/auth/oidc/provider.go`, `backend/internal/middleware/csrf.go`, `backend/internal/api/auth_routes.go`
+- **AC:** Token auto-refreshes before expiry; compatible with Entra, Okta, Auth0, Keycloak. Frontend httpOnly migration unblocked.
+- **↔ Frontend A1.1:** httpOnly cookie auth migration.
 
----
+#### B2.5 · Per-principal rate limiting · [P1/M]
 
-## Phase 3: Operational Maturity (Maturity 7→9, Enterprise 7→9)
+- Extend `middleware/ratelimit.go` with token bucket keyed by `user_id` or `api_key_id`.
+- Allow admin override per org.
+- **Files:** `backend/internal/middleware/ratelimit.go`, `backend/internal/config/config.go`
+- **AC:** Compromised API key cannot DoS; new metric `registry_ratelimit_exceeded_total{principal_type}`.
 
-### 3.1 Fix Helm Chart Issues
+#### B2.6 · mTLS client authentication · [P2/M]
 
-**Why**: Several concrete bugs found in the Helm chart during review.
-
-**Work items** (each is independent):
-
-1. **Fix readinessProbe**: `deployments/helm/templates/deployment-backend.yaml` line 79 points to `/health` but should point to `/ready`. The `/ready` endpoint (router.go line 877) checks both database AND storage, while `/health` only checks database.
-
-2. **Create ServiceMonitor template**: `deployments/helm/values.yaml` defines `serviceMonitor.enabled` (line 233) but no `templates/servicemonitor.yaml` exists. Create the template:
-   ```yaml
-   {{- if .Values.serviceMonitor.enabled }}
-   apiVersion: monitoring.coreos.com/v1
-   kind: ServiceMonitor
-   metadata:
-     name: {{ include "terraform-registry.fullname" . }}
-     labels: {{ include "terraform-registry.labels" . | nindent 4 }}
-   spec:
-     selector:
-       matchLabels: {{ include "terraform-registry.selectorLabels" . | nindent 6 }}
-     endpoints:
-       - port: metrics
-         interval: {{ .Values.serviceMonitor.interval | default "30s" }}
-         path: /metrics
-   {{- end }}
-   ```
-
-3. **Add scanning config to values.yaml**: The `ScanningConfig` struct in `config.go` has 10+ fields but none are exposed in the Helm chart.
-
-4. **Add audit config to values.yaml**: The `AuditConfig` / `AuditShipperConfig` structs exist but are not parameterized in Helm.
-
-5. **Add PrometheusRule template** for alerting: High error rate, rate limiter exhaustion, mirror sync failure, scan failure.
-
-6. **Add topologySpreadConstraints** to the backend deployment template (currently only in the Kustomize production overlay).
-
-**Affected files**: `deployments/helm/templates/deployment-backend.yaml`, `deployments/helm/templates/servicemonitor.yaml` (new), `deployments/helm/templates/prometheusrule.yaml` (new), `deployments/helm/values.yaml`
+- Optional mTLS mode for machine-to-machine callers.
+- Cert-subject → scope mapping via config.
+- **Files:** `backend/internal/auth/mtls/*.go`, `backend/internal/config/config.go`
+- **AC:** `terraform init` with `--client-cert` succeeds end-to-end.
 
 ---
 
-### 3.2 Disaster Recovery Documentation
+## Phase 3 — Compliance + operability (parallel tracks)
 
-**Why**: No DR runbook, no RTO/RPO guidance, no backup procedures documented. This is a key enterprise readiness gap.
+### Track C — Compliance
 
-**Work items**:
+#### C3.1 · Air-gapped install guide · [P0/L]
 
-1. **Create `docs/disaster-recovery.md`**:
-   - **Backup procedures**: PostgreSQL `pg_dump` / `pg_basebackup` with recommended schedule (daily full, hourly WAL archiving). Storage backend backup per cloud (S3 versioning, Azure soft-delete, GCS object versioning).
-   - **Restore procedures**: Step-by-step for each scenario: database restore, storage restore, full-cluster recovery.
-   - **RTO/RPO targets**: Document recommended targets (e.g., RPO 1hr with WAL shipping, RTO 30min with warm standby).
-   - **Failover playbook**: PostgreSQL failover (streaming replication + pgBouncer), storage backend failover (cloud-native HA), application pod recovery (Kubernetes self-healing).
-   - **Testing procedures**: Quarterly DR drill checklist.
+- New `docs/air-gap-install.md`: offline image bundle via `docker save`, scanner-DB pre-seeding (Trivy offline DB, Checkov rules), internal CA trust, private module upstream config.
+- `make airgap-bundle` target producing tarball.
+- **Files:** `docs/air-gap-install.md`, `Makefile`, `scripts/airgap-bundle.sh`
+- **AC:** Clean-room test on an egress-blocked VM; success recorded.
 
-2. **Create `docs/capacity-planning.md`**:
-   - Database sizing: rows per module/version, audit log growth rate formula.
-   - Storage sizing: average module archive size, mirror size estimation.
-   - Compute: pod resource recommendations by registry size (small/medium/large).
-   - Network: bandwidth estimation for mirror syncs.
+#### C3.2 · Published threat model (STRIDE) · [P0/M]
 
-3. **Kubernetes CronJob for backups** in `deployments/helm/templates/cronjob-backup.yaml`:
-   - Optional `pg_dump` CronJob with S3/Azure/GCS upload.
-   - Parameterized in `values.yaml` under `backup.enabled`, `backup.schedule`, `backup.destination`.
+- Create `docs/threat-model.md` with DFD, trust boundaries, mitigations per STRIDE category.
+- Include assumptions + residual risks.
+- **Files:** `docs/threat-model.md`, `SECURITY.md` (add link)
+- **AC:** Reviewed by external security reviewer; linked from SECURITY.md.
 
-**Affected files**: `docs/disaster-recovery.md` (new), `docs/capacity-planning.md` (new), `deployments/helm/templates/cronjob-backup.yaml` (new), `deployments/helm/values.yaml`
+#### C3.3 · SOC2 / ISO27001 control mapping · [P1/L]
 
----
+- `docs/compliance/soc2-mapping.md` + `docs/compliance/iso27001-mapping.md` with control → feature → evidence source.
+- Audit log immutability (append-only; periodic hash-chain export).
+- Legal-hold API to prevent cleanup job from deleting flagged logs.
+- Audit-log export endpoint: NDJSON or OCSF format.
+- **Files:** `docs/compliance/*.md`, `backend/internal/audit/export.go`, `backend/internal/audit/legal_hold.go`, `backend/internal/api/audit_routes.go`
+- **AC:** Mapping reviewed; immutability test in CI.
 
-### 3.3 Architecture Decision Records
+#### C3.4 · GDPR / data-subject tooling · [P1/M]
 
-**Why**: No ADR directory exists (`docs/adr/` was checked and not found). Key design decisions are undocumented -- why scope-based RBAC instead of role-based, why PostgreSQL not SQLite, why in-memory rate limiting was chosen initially, etc.
+- `/admin/users/:id/export` (JSON data export).
+- `/admin/users/:id/erase` (tombstone user records, preserve audit trail per regulation).
+- **Files:** `backend/internal/api/user_routes.go`, `backend/internal/services/user_service.go`
+- **AC:** Integration tests confirm behavior.
 
-**Work items**:
+#### C3.5 · Data residency + multi-region DR documentation · [P2/M]
 
-1. **Create `docs/adr/` directory** with `README.md` explaining the ADR format (use Michael Nygard's template: Title, Status, Context, Decision, Consequences).
+- Document: single-region, multi-region-active-passive, multi-region-active-active storage strategies.
+- Add example Terraform for cross-region PG replica + S3 CRR.
+- **Files:** `docs/data-residency.md`, `deployments/terraform/aws/multi-region/`
+- **AC:** `deployments/terraform/aws/multi-region/` sample.
 
-2. **Backfill key ADRs** (each is a separate file, can be written in parallel):
-   - `001-scope-based-rbac.md`: Why fine-grained scopes instead of coarse roles.
-   - `002-postgresql-as-primary-store.md`: Why PostgreSQL, not SQLite or embedded DB.
-   - `003-storage-backend-abstraction.md`: Factory pattern, pluggable backends.
-   - `004-jwt-plus-apikey-dual-auth.md`: Why both JWT and API key auth.
-   - `005-fire-and-forget-webhooks.md`: Trade-offs, why retry was deferred, migration plan to retry queue.
-   - `006-in-memory-rate-limiting.md`: Initial trade-off, Redis migration plan.
-   - `007-setup-wizard-one-time-token.md`: Security model for first-run setup.
-   - `008-module-scanning-architecture.md`: Scanner interface, SARIF support, worker pool.
-   - `009-network-mirror-protocol.md`: Why implement the provider network mirror protocol.
-   - `010-binary-mirror-custom-protocol.md`: Why a custom protocol for Terraform/OpenTofu binaries.
+### Track D — Operability
 
-**Affected files**: `docs/adr/README.md` (new), `docs/adr/001-*.md` through `docs/adr/010-*.md` (new)
+#### D3.1 · Version upgrade runbook · [P0/M]
 
----
+- `docs/upgrade-guide.md`: per-version breaking changes, migration behavior, rollback strategy, pre-flight checks.
+- Add `registry upgrade preflight` CLI subcommand that validates DB state before a version jump.
+- **Files:** `docs/upgrade-guide.md`, `backend/cmd/server/upgrade.go`
+- **AC:** Dry-run upgrade from 0.6.x → 0.7.x documented + tested.
 
-### 3.4 Getting Started Tutorial
+#### D3.2 · Validated DR drill runbook with RPO/RTO numbers · [P0/M]
 
-**Why**: No end-to-end tutorial exists walking through deploy → publish → consume. Documentation is comprehensive but lacks a guided "happy path."
+- Execute timed restore from pg_dump + object-store snapshot.
+- Record RPO (target: <15min) / RTO (target: <2h).
+- Publish results in `docs/disaster-recovery.md`.
+- **Files:** `docs/disaster-recovery.md`, `scripts/dr-drill.sh`
+- **AC:** Drill log appended; automation script in `scripts/dr-drill.sh`.
 
-**Work items**:
+#### D3.3 · Chaos / soak test suite · [P1/L]
 
-1. **Create `docs/getting-started.md`**:
-   - **Part 1: Deploy** (Docker Compose quickstart, 5 minutes to running).
-   - **Part 2: Configure** (Navigate setup wizard, configure local storage + dev OIDC or dev mode).
-   - **Part 3: Publish a module** (Upload via UI, upload via `curl`, publish from GitHub via SCM integration with a sample repo).
-   - **Part 4: Consume in Terraform** (Configure `~/.terraformrc`, write a `module {}` block, run `terraform init`).
-   - **Part 5: Publish a provider** (Upload via UI, verify with `terraform providers mirror`).
-   - **Part 6: Set up a mirror** (Configure a provider mirror, sync, verify with `terraform init` using network mirror protocol).
-   - Each section includes expected output/screenshots descriptions.
+- New `cmd/chaos-test/` binary that injects failures: Redis down, S3 5xx, PG connection storm.
+- Nightly workflow `.github/workflows/chaos.yml`.
+- **Files:** `cmd/chaos-test/*.go`, `.github/workflows/chaos.yml`
+- **AC:** Pass rate > 95% for 24h soak on a canary environment.
 
-2. **Create `examples/` directory** with sample Terraform configurations:
-   - `examples/module-consumer/main.tf`: Consumes a module from the local registry.
-   - `examples/terraformrc-example`: Sample `.terraformrc` with `credentials` block.
+#### D3.4 · Per-org quotas + chargeback metrics · [P1/M]
 
-**Affected files**: `docs/getting-started.md` (new), `examples/module-consumer/main.tf` (new), `examples/terraformrc-example` (new)
+- New table `org_quotas` (storage_bytes_limit, publishes_per_day, downloads_per_day).
+- Soft-warn at 80%, hard-deny at 100%.
+- Prometheus: `registry_quota_utilization_ratio{org,resource}`.
+- **Files:** `backend/internal/db/models/org_quota.go`, `backend/internal/db/migrations/025_*.up.sql`, `backend/internal/middleware/quota.go`, `backend/internal/api/admin_routes.go`
+- **AC:** E2E test: quota breach returns 429 with `X-Quota-Reset` header.
+- **↔ Frontend E4.4:** Quota dashboard.
 
----
+#### D3.5 · Backup-to-object-store automation · [P2/M]
 
-### 3.5 Observability Improvements
+- Scheduled job inside registry (or separate sidecar) performing `pg_dump` to S3/Blob/GCS with lifecycle retention.
+- Encryption with KMS key.
+- **Files:** `backend/internal/jobs/backup_job.go`, `backend/internal/config/config.go`
+- **AC:** Scheduled backup tested; restore validated.
 
-**Why**: Several specific gaps identified during review.
+### Track G — Data layer
 
-**Work items** (each is independent):
+#### G3.1 · Optional MySQL support · [P2/L]
 
-1. **Add `app_info` metric** to `telemetry/metrics.go`:
-   ```go
-   var AppInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
-       Name: "terraform_registry_info",
-       Help: "Application build information",
-   }, []string{"version", "go_version", "build_date"})
-   ```
-   Set to 1 on startup in `main.go`.
+- Abstract queries in `backend/internal/db/` behind dialect interface.
+- Add MySQL migrations (parallel to PG set).
+- Publish `values-mysql.yaml` Helm variant.
+- **Files:** `backend/internal/db/dialect_*.go`, `backend/internal/db/migrations_mysql/`, `deployments/helm/values-mysql.yaml`
+- **AC:** CI matrix includes MySQL; all tests pass.
 
-2. **Add `mirror_sync_duration_seconds` labels**: Currently has no labels (`telemetry/metrics.go:155`). Add `mirror_id` and `mirror_type` labels.
+#### G3.2 · Migration rollback documentation · [P1/M]
 
-3. **Add scanner job metrics**: `module_scan_queue_depth` gauge, `module_scan_duration_seconds` histogram.
-
-4. **Add revoked token cleanup metric**: `jwt_revoked_tokens_cleaned_total` counter.
-
-5. **Grafana dashboard ConfigMap**: Create `deployments/helm/templates/grafana-dashboard.yaml` with a pre-built JSON dashboard covering: request rate, error rate, p99 latency, mirror sync health, scan queue depth, rate limiter rejections, DB connection pool.
-
-**Affected files**: `internal/telemetry/metrics.go`, `cmd/server/main.go`, `internal/jobs/module_scanner_job.go`, `deployments/helm/templates/grafana-dashboard.yaml` (new)
+- For each of 24 migrations, document whether reversible + rollback steps.
+- **Files:** `backend/internal/db/migrations/README.md`
+- **AC:** Doc merged; referenced from upgrade-guide.
 
 ---
 
-## Phase 4: Documentation Excellence (Documentation 9→10)
+## Phase 4 — Feature expansion (parallel tracks)
 
-### 4.1 Module Deprecation UX Improvement
+### Track E — Protocol & features
 
-**Why**: Deprecation exists (repository lines 699-747, API routes at router.go:594-599) but the workflow is basic. No module-level deprecation (only version-level), no migration guidance field.
+#### E4.1 · Module deprecation API · [P0/L]
 
-**Work items**:
+- Per Terraform CLI ≥1.10 spec: registry returns `deprecation` block on module versions.
+- New fields on `modules_versions`: `deprecated`, `deprecation_reason`, `replacement_source`.
+- Admin API endpoints for deprecation CRUD.
+- `terraform init` surfaces warning.
+- **Files:** `backend/internal/db/models/module_version.go`, `backend/internal/db/migrations/026_*.up.sql`, `backend/internal/api/module_routes.go`
+- **AC:** `terraform init` prints deprecation notice; API conformance test.
+- **↔ Frontend E4.1:** Deprecation banner on module detail page; admin toggle.
 
-1. **Database migration** (`000024_module_deprecation.up.sql`):
-   ```sql
-   ALTER TABLE modules
-     ADD COLUMN deprecated BOOLEAN NOT NULL DEFAULT FALSE,
-     ADD COLUMN deprecated_at TIMESTAMP WITH TIME ZONE,
-     ADD COLUMN deprecation_message TEXT,
-     ADD COLUMN successor_module_id UUID REFERENCES modules(id);
-   ```
+#### E4.2 · OCI distribution endpoint for modules · [P1/L]
 
-2. **Repository methods** in `module_repository.go`: `DeprecateModule(moduleID, message, successorID)`, `UndeprecateModule(moduleID)`.
+- Add `backend/internal/api/oci/` implementing OCI distribution spec v1.1.
+- Modules mirror-pushable/pullable as OCI artifacts (media type `application/vnd.opentofu.modulepkg`).
+- **Files:** `backend/internal/api/oci/*.go`, `backend/internal/api/routes.go`
+- **AC:** `oras push` + `oras pull` round-trip succeeds; Harbor federation tested.
+- **↔ Frontend E4.5:** OCI pull snippet on module detail.
 
-3. **API endpoints**:
-   - `POST /api/v1/modules/:ns/:name/:sys/deprecate` with body `{ message: string, successor?: { namespace, name, system } }`.
-   - `DELETE /api/v1/modules/:ns/:name/:sys/deprecate`.
+#### E4.3 · Policy engine integration (OPA/Rego + Conftest) · [P1/L]
 
-4. **Search integration**: Deprecated modules shown with lower priority in search results (sort by `deprecated ASC, relevance DESC`).
+- New `backend/internal/policy/` evaluates Rego bundles on module publish + on consumer metadata endpoint.
+- Admin-configurable bundle sources (OCI, HTTP, S3).
+- Block/warn modes per policy.
+- **Files:** `backend/internal/policy/*.go`, `backend/internal/config/config.go`, `backend/internal/api/module_routes.go`
+- **AC:** Example "no public S3 buckets" policy blocks non-compliant upload.
+- **↔ Frontend E4.2:** Policy results in upload flow.
 
-5. **Terraform protocol**: Return a deprecation warning in the module versions list response (protocol allows additional metadata).
+#### E4.4 · Module test orchestration on publish · [P1/L]
 
-6. **Tests**: Unit test for deprecation/undeprecation flow. E2E test for search result ordering.
+- Trigger ephemeral `terraform init && terraform validate && terraform test` sandbox against declared examples on upload.
+- Store results alongside version metadata.
+- Sandbox: ephemeral container with no cloud credentials (validate-only) OR optional cloud-creds runner per org.
+- **Files:** `backend/internal/jobs/module_test_job.go`, `backend/internal/services/module_service.go`
+- **AC:** Malformed example blocks publish with clear error.
+- **↔ Frontend E4.3:** Test results UI.
 
-**Affected files**: `internal/db/migrations/000024_*.sql` (new), `internal/db/repositories/module_repository.go`, `internal/db/models/module.go`, `internal/api/modules/deprecation.go` (new), `internal/api/router.go`
+#### E4.5 · Inbound webhook / run-task approval surface · [P2/M]
+
+- Add `/webhooks/approvals/:token` endpoint for external CI systems to approve pending publishes.
+- Signed tokens, single-use.
+- **Files:** `backend/internal/api/webhook_routes.go`, `backend/internal/services/approval_service.go`
+- **AC:** Jenkins/GitHub Actions approval round-trip tested.
+
+#### E4.6 · Optional mTLS / IP allowlist on binary mirror · [P2/M]
+
+- `config.yaml`: `binary_mirror.auth: none|allowlist|mtls`.
+- **Files:** `backend/internal/config/config.go`, `backend/internal/middleware/binary_mirror_auth.go`
+- **AC:** Locked-down mode rejects anonymous; open mode preserves protocol compliance.
+
+#### E4.7 · Bulk namespace import tooling · [P2/M]
+
+- New `cmd/registry-import/` CLI: given a public namespace, mirror all modules/versions into the registry.
+- Respects pull-through cache.
+- **Files:** `backend/cmd/registry-import/*.go`
+- **AC:** Import `terraform-aws-modules` end-to-end; idempotent reruns.
+
+### Track F — Observability extensions
+
+#### F4.1 · Trace-based SLO dashboards · [P1/M]
+
+- Exemplar wiring between metrics and OTel traces.
+- Publish Grafana dashboard + Prometheus recording rules.
+- **Files:** `deployments/observability/grafana-dashboard.json`, `deployments/observability/recording-rules.yml`
+- **AC:** Dashboards render; p95 latency alert rule firing tested.
+
+#### F4.2 · Structured audit log export (OCSF) · [P2/M]
+
+- Convert audit events to OCSF JSON on export endpoint.
+- **Files:** `backend/internal/audit/ocsf_exporter.go`, `backend/internal/api/audit_routes.go`
+- **AC:** Splunk/Elastic-ingestible sample verified.
 
 ---
 
-### 4.2 Documentation Polish
+## Phase 5 — Continuous hardening (ongoing)
 
-**Work items** (each is independent, can be written in parallel):
+### H5.1 · Fuzz testing on parsers · [P2/M]
 
-1. **Update `docs/observability.md`** with all Prometheus metrics (current list + new ones from 3.5), Grafana dashboard import instructions, alerting recommendations.
+- `go test -fuzz` targets for HCL parser, provider-binary unpacker, SCM webhook payload parsers.
+- Nightly workflow.
+- **Files:** `backend/internal/analyzer/*_fuzz_test.go`, `backend/internal/scm/*_fuzz_test.go`, `.github/workflows/fuzz.yml`
+- **AC:** Corpus committed; CI runs 10min fuzz per target.
 
-2. **Update `docs/configuration.md`** with all new config options (Redis, webhook retry, audit retention, per-org rate limiting, scanning setup, storage migration).
+### H5.2 · Coverage floor raise · [P2/M]
 
-3. **Update `docs/deployment.md`** with Helm ServiceMonitor, Grafana dashboard, backup CronJob instructions.
+- Raise backend coverage floor from 80% → 85% over two minor versions.
+- **Files:** `.github/workflows/ci.yml`
+- **AC:** CI threshold updated; deltas tracked.
 
-4. **Update README.md** with links to Getting Started tutorial, DR runbook, ADRs.
+### H5.3 · `CODEOWNERS` auto-request on ADR/docs changes · [P3/S]
 
-5. **Create `docs/api-migration-guide.md`** documenting breaking changes between minor versions and migration steps.
-
-**Affected files**: `docs/observability.md`, `docs/configuration.md`, `docs/deployment.md`, `README.md`, `docs/api-migration-guide.md` (new)
-
----
-
-## Summary: Score Impact Projection
-
-| Category                 | Before | After | Key Drivers                                                                                    |
-| ------------------------ | ------ | ----- | ---------------------------------------------------------------------------------------------- |
-| **Security**             | 8      | 9     | Redis rate limiter, OIDC session HA, per-org rate limiting, secrets rotation                   |
-| **Ease of Use**          | 7      | 9     | Getting Started tutorial, scanning setup wizard, storage migration wizard, advanced search     |
-| **Documentation**        | 9      | 10    | ADRs, DR runbook, capacity planning, Getting Started, API migration guide                      |
-| **Maturity**             | 8      | 9     | Helm fixes, ServiceMonitor, Grafana dashboard, webhook retry, audit cleanup                    |
-| **Feature Completeness** | 9      | 10    | Advanced search (FTS), webhook retry, module deprecation, storage migration, scanning setup    |
-| **Enterprise Readiness** | 7      | 9     | Redis HA, DR runbook, secrets rotation, audit retention, backup CronJob, per-org rate limiting |
+- Ensure security-sensitive paths require security team review.
+- **Files:** `.github/CODEOWNERS`
+- **AC:** Test PR blocked until security approver reviews.
 
 ---
 
-## Dependency Graph
+## Milestones
 
-```
-Phase 1 (parallel):
-  1.1 Redis Rate Limiter ─────┐
-  1.2 Redis OIDC Sessions ────┤── share Redis config (1.1 creates RedisConfig, 1.2 reuses)
-  1.3 Per-Org Rate Limiting ──┘── depends on 1.1 (interface)
-  1.4 Secrets Rotation ──────── independent
+| Version    | Target content                                                           |
+| ---------- | ------------------------------------------------------------------------ |
+| **0.8.0**  | Phase 0 complete + Phase 1 Tracks A, C, H                                |
+| **0.9.0**  | Phase 2 (SAML + LDAP + SCIM + refresh tokens + httpOnly cookies)         |
+| **0.10.0** | Phase 3 (compliance + operability + migration rollback docs)             |
+| **0.11.0** | Phase 4 Track E items E4.1, E4.3, E4.4                                   |
+| **1.0.0**  | All P0/P1 items complete; FIPS variant published; SOC2 mapping published |
 
-Phase 2 (parallel, after Phase 1 Redis config exists):
-  2.1 Webhook Retry ──────── independent
-  2.2 Advanced Search ────── independent
-  2.3 Scanning Setup Wizard ── independent
-  2.4 Storage Migration ──── independent
-  2.5 Audit Retention ────── independent
+---
 
-Phase 3 (parallel):
-  3.1 Helm Fixes ─────────── independent
-  3.2 DR Documentation ───── independent
-  3.3 ADRs ───────────────── independent
-  3.4 Getting Started ────── independent
-  3.5 Observability ──────── independent
+## Scope boundaries
 
-Phase 4 (after Phase 2-3):
-  4.1 Module Deprecation UX ── depends on 2.2 (search integration)
-  4.2 Documentation Polish ─── depends on all prior phases (documents new features)
-```
+**Included:** Backend server, protocol implementations, deployment artifacts under this repo.
+
+**Explicitly excluded:** Frontend UI changes (see `terraform-registry-frontend/ROADMAP.md`), terraform-pipeline-templates changes, third-party scanner internals.
+
+---
+
+## How to contribute to this roadmap
+
+1. Pick an item by ID (e.g., `B2.1`).
+2. Open an issue titled `[roadmap:B2.1] <short title>`; link the roadmap line.
+3. Submit PR referencing the issue and update this file's checkbox when merged.
+4. Cross-repo items (`↔`) must coordinate via linked issues to `terraform-registry-frontend`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report them privately using one of these methods:
+
+1. **GitHub Security Advisories** — Use the "Report a vulnerability" button on the
+   [Security tab](../../security/advisories) of this repository.
+2. **Email** — Send details to the repository maintainers listed in `CODEOWNERS`.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce (proof of concept if possible)
+- Affected versions
+- Potential impact
+
+### Response Timeline
+
+- **Acknowledgement:** within 48 hours
+- **Initial assessment:** within 5 business days
+- **Fix or mitigation:** targeting 30 days for critical/high severity
+
+### Disclosure Policy
+
+We follow [coordinated disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
+We will credit reporters in the release notes unless anonymity is requested.
+
+## Security Practices
+
+- All releases include SHA-256 checksums and SLSA provenance attestations
+- Container images are signed with [cosign](https://github.com/sigstore/cosign)
+- Dependencies are monitored by Dependabot (Go modules, GitHub Actions, Docker)
+- Static analysis via `gosec` runs on every PR with baseline drift detection
+- The application follows OWASP Top 10 mitigations (parameterised queries,
+  input validation, CSRF protection, rate limiting, audit logging)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Terraform Registry Backend
 
 # Stage 1: Build the Go application
-FROM golang:alpine AS builder
+FROM golang:alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata
@@ -34,7 +34,7 @@ RUN CLEAN_VERSION="${VERSION#v}" && \
     ./cmd/server
 
 # Stage 2: Create minimal production image
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5162,6 +5162,76 @@
                 }
             }
         },
+        "/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/reanalyze": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Re-download the module archive from storage and re-run the HCL analyzer to refresh terraform-docs metadata. Optionally re-queues a security scan. Requires modules:publish scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Re-analyze module version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target system (e.g. aws, azurerm)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Semantic version (e.g. 1.2.3)",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Module or version not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/scan": {
             "get": {
                 "security": [

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -2,10 +2,13 @@
 package admin
 
 import (
+	"bytes"
 	"database/sql"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/analyzer"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -18,6 +21,8 @@ type ModuleAdminHandlers struct {
 	orgRepo        *repositories.OrganizationRepository
 	storageBackend storage.Storage
 	cfg            *config.Config
+	moduleDocsRepo *repositories.ModuleDocsRepository
+	scanRepo       *repositories.ModuleScanRepository
 }
 
 // NewModuleAdminHandlers creates a new module admin handlers instance
@@ -28,6 +33,18 @@ func NewModuleAdminHandlers(db *sql.DB, storageBackend storage.Storage, cfg *con
 		storageBackend: storageBackend,
 		cfg:            cfg,
 	}
+}
+
+// WithModuleDocs sets the module docs repository for re-analysis support.
+func (h *ModuleAdminHandlers) WithModuleDocs(repo *repositories.ModuleDocsRepository) *ModuleAdminHandlers {
+	h.moduleDocsRepo = repo
+	return h
+}
+
+// WithScanQueue sets the scan repository for re-scan support.
+func (h *ModuleAdminHandlers) WithScanQueue(repo *repositories.ModuleScanRepository) *ModuleAdminHandlers {
+	h.scanRepo = repo
+	return h
 }
 
 // @Summary      Create module record
@@ -725,4 +742,126 @@ func (h *ModuleAdminHandlers) UndeprecateModule(c *gin.Context) {
 		"name":      name,
 		"system":    system,
 	})
+}
+
+// @Summary      Re-analyze module version
+// @Description  Re-download the module archive from storage and re-run the HCL analyzer to refresh terraform-docs metadata. Optionally re-queues a security scan. Requires modules:publish scope.
+// @Tags         Modules
+// @Security     Bearer
+// @Produce      json
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Target system (e.g. aws, azurerm)"
+// @Param        version    path  string  true  "Semantic version (e.g. 1.2.3)"
+// @Success      200  {object}  map[string]interface{}
+// @Failure      404  {object}  map[string]interface{}  "Module or version not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/modules/{namespace}/{name}/{system}/versions/{version}/reanalyze [post]
+// ReanalyzeVersion re-runs the HCL analyzer on an existing module version's archive.
+func (h *ModuleAdminHandlers) ReanalyzeVersion(c *gin.Context) {
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	system := c.Param("system")
+	version := c.Param("version")
+
+	// Get organization context
+	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get organization context"})
+		return
+	}
+
+	var orgID string
+	if org != nil {
+		orgID = org.ID
+	}
+
+	// Get module
+	module, err := h.moduleRepo.GetModule(c.Request.Context(), orgID, namespace, name, system)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get module"})
+		return
+	}
+	if module == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Module not found"})
+		return
+	}
+
+	// Get the specific version
+	versionRecord, err := h.moduleRepo.GetVersion(c.Request.Context(), module.ID, version)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get version"})
+		return
+	}
+	if versionRecord == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	if versionRecord.StoragePath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Version has no stored archive"})
+		return
+	}
+
+	result := gin.H{
+		"namespace": namespace,
+		"name":      name,
+		"system":    system,
+		"version":   version,
+	}
+
+	// Re-run HCL analyzer if docs repo is configured
+	if h.moduleDocsRepo != nil {
+		reader, err := h.storageBackend.Download(c.Request.Context(), versionRecord.StoragePath)
+		if err != nil {
+			slog.Error("reanalyze: failed to download archive from storage",
+				"version_id", versionRecord.ID, "path", versionRecord.StoragePath, "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to download archive from storage"})
+			return
+		}
+		defer reader.Close()
+
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(reader); err != nil {
+			slog.Error("reanalyze: failed to read archive",
+				"version_id", versionRecord.ID, "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read archive"})
+			return
+		}
+
+		doc, err := analyzer.AnalyzeArchive(bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			slog.Warn("reanalyze: HCL analysis failed",
+				"version_id", versionRecord.ID, "error", err)
+			result["docs"] = "analysis_failed"
+		} else if doc != nil {
+			if err := h.moduleDocsRepo.UpsertModuleDocs(c.Request.Context(), versionRecord.ID, doc); err != nil {
+				slog.Warn("reanalyze: failed to store docs",
+					"version_id", versionRecord.ID, "error", err)
+				result["docs"] = "store_failed"
+			} else {
+				result["docs"] = "updated"
+				result["inputs"] = len(doc.Inputs)
+				result["outputs"] = len(doc.Outputs)
+			}
+		} else {
+			result["docs"] = "no_terraform_files"
+		}
+	} else {
+		result["docs"] = "skipped_no_docs_repo"
+	}
+
+	// Re-queue security scan if configured
+	if h.scanRepo != nil && h.cfg.Scanning.Enabled && h.cfg.Scanning.BinaryPath != "" {
+		if err := h.scanRepo.CreatePendingScan(c.Request.Context(), versionRecord.ID); err != nil {
+			slog.Warn("reanalyze: failed to queue security scan",
+				"version_id", versionRecord.ID, "error", err)
+			result["scan"] = "queue_failed"
+		} else {
+			result["scan"] = "queued"
+		}
+	}
+
+	result["message"] = "Re-analysis complete"
+	c.JSON(http.StatusOK, result)
 }

--- a/backend/internal/api/modules/upload.go
+++ b/backend/internal/api/modules/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
@@ -285,6 +286,9 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 				}
 			}
 		}
+
+		// Emit publish metric
+		telemetry.ModulePublishesTotal.WithLabelValues(namespace, system).Inc()
 
 		// Return success response with module metadata
 		c.JSON(http.StatusCreated, gin.H{

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 	"github.com/terraform-registry/terraform-registry/pkg/checksum"
 )
@@ -380,6 +381,9 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			})
 			return
 		}
+
+		// Emit publish metric
+		telemetry.ProviderPublishesTotal.WithLabelValues(provider.Namespace, provider.Type).Inc()
 
 		// Return success response with provider metadata
 		c.JSON(http.StatusCreated, gin.H{

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -486,7 +486,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	tfMirrorAdminHandler := admin.NewTerraformMirrorHandler(tfMirrorRepo)
 	tfMirrorAdminHandler.SetSyncJob(tfMirrorSyncJob)
 	providerAdminHandlers := admin.NewProviderAdminHandlers(db, storageBackend, cfg)
-	moduleAdminHandlers := admin.NewModuleAdminHandlers(db, storageBackend, cfg)
+	moduleAdminHandlers := admin.NewModuleAdminHandlers(db, storageBackend, cfg).
+		WithModuleDocs(moduleDocsRepo).
+		WithScanQueue(scanRepo)
 
 	// Initialize RBAC handlers
 	rbacRepo := repositories.NewRBACRepository(sqlxDB)
@@ -721,6 +723,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UndeprecateVersion)
+			authenticatedGroup.POST("/modules/:namespace/:name/:system/versions/:version/reanalyze",
+				middleware.RequireScope(auth.ScopeModulesWrite),
+				moduleAdminHandlers.ReanalyzeVersion)
 
 			// Module-level deprecation
 			authenticatedGroup.POST("/modules/:namespace/:name/:system/deprecate",

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -172,6 +172,30 @@ func getResourceType(c *gin.Context) string {
 		return "api_key"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/organizations"):
 		return "organization"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/storage"):
+		return "storage"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/roles"):
+		return "role"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/scm-providers"):
+		return "scm_provider"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/webhooks"):
+		return "webhook"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/scanning"),
+		strings.HasPrefix(fullPath, "/api/v1/admin/security-scanning"):
+		return "scanning"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/approvals"):
+		return "approval"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/terraform-mirror"):
+		return "terraform_mirror"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/binary-mirror"):
+		return "binary_mirror"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/policies"):
+		return "policy"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/setup"),
+		strings.HasPrefix(fullPath, "/api/v1/setup"):
+		return "setup"
+	case strings.HasPrefix(fullPath, "/api/v1/auth"):
+		return "auth"
 	default:
 		return "unknown"
 	}

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -137,6 +137,37 @@ var (
 
 // Mirror sync metrics — recorded by the mirror sync background job.
 //
+// Business-event publish metrics — incremented by upload handlers on successful publish.
+//
+// ModulePublishesTotal is a CounterVec with labels {namespace, system} incremented
+// when a new module version is successfully published (uploaded or ingested via SCM).
+//
+// ProviderPublishesTotal is a CounterVec with labels {namespace, type} incremented
+// when a new provider version is published.
+//
+// Example PromQL queries:
+//   - Publish rate by namespace:  sum by (namespace) (rate(registry_module_publishes_total[1h]))
+//   - Provider publishes/day:     increase(registry_provider_publishes_total[24h])
+var (
+	ModulePublishesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "registry_module_publishes_total",
+			Help: "Total number of module versions published, by namespace and system.",
+		},
+		[]string{"namespace", "system"},
+	)
+
+	ProviderPublishesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "registry_provider_publishes_total",
+			Help: "Total number of provider versions published, by namespace and type.",
+		},
+		[]string{"namespace", "type"},
+	)
+)
+
+// Mirror sync metrics — recorded by the mirror sync background job.
+//
 // MirrorSyncDuration is a HistogramVec with labels {mirror_id, mirror_type}.
 // Each observation represents one complete sync cycle for a single mirror configuration.
 // The mirror_id label is the UUID of the mirror configuration record and mirror_type


### PR DESCRIPTION
## Summary

Implements all Phase 0 items from the backend ROADMAP.md (9 items across security, supply chain, observability, and DX tracks).

## Changes

### Security & Supply Chain (A0.1–A0.5)
- **SECURITY.md** — Vulnerability disclosure policy, supported-versions matrix, response SLAs (48h/7d/30d)
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **Docker digest pins** — Both `golang:alpine` and `alpine:3.21` pinned to SHA256; Dependabot docker ecosystem added
- **SBOM generation** — `syft` via GoReleaser `sboms:` block
- **Cosign signing** — Keyless signing on container images and checksum files via Sigstore

### Observability (F0.1)
- **Prometheus counters** — `registry_module_publishes_total` and `registry_provider_publishes_total` with namespace/system/type labels

### Enterprise Features (E0.1–E0.2)
- **Audit log** — Expanded `getResourceType()` from 6 to 18 route-prefix mappings
- **Module re-analysis** — New `POST /admin/modules/:ns/:name/:sys/versions/:ver/reanalyze` endpoint

### CI/CD (H0.2)
- **Release workflow** — `prepare-release.yml` rebases onto `origin/main` and auto-bumps Helm `Chart.yaml` `appVersion`

### Documentation
- Updated CLAUDE.md (Go 1.26.1, 24 migrations, SBOM in security features, removed resolved recommendation)
- Updated README.md (Go 1.26+ badge, 11 metrics, architecture diagram)

## Changelog
- feat: add SECURITY.md with vulnerability disclosure policy
- feat: add CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- feat: pin Docker base images to SHA256 digests
- feat: add SBOM generation and cosign keyless signing to GoReleaser
- feat: expand audit log resource type mappings
- feat: add module version re-analysis endpoint
- feat: add module/provider publish Prometheus counters
- feat: streamline release workflow with rebase and Helm appVersion bump