### PR TITLE
fix: correct trivy-action SHA in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         run: docker build -t terraform-registry-backend:ci backend/
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e0f18c8ea63fd80e # v0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: backend/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -9,6 +9,7 @@
 docs/
 !docs/embed.go
 !docs/swagger.json
+!docs/swagger-ui/
 
 # Development files
 .vscode/


### PR DESCRIPTION
Fix corrupted trivy-action SHA and include swagger-ui directory in Docker build context.

The trivy-action SHA \18f2510ee396bbf400402947e0f18c8ea63fd80e\ (labeled v0.28.0) was invalid — likely an LLM hallucination during Phase 1 PR generation. Updated to v0.35.0.

Also adds \!docs/swagger-ui/\ to \ackend/.dockerignore\ so the \//go:embed swagger-ui/*\ directive finds its assets during Docker builds.

## Changelog
- fix: correct trivy-action SHA to valid v0.35.0 commit
- fix: include swagger-ui/ in Docker build context (.dockerignore)