### PR TITLE
feat: upgrade to SLSA Level 3 build provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         run: docker build -t terraform-registry-backend:ci backend/
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e0f18c8ea63fd80e # v0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: backend/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,11 @@ jobs:
     name: GoReleaser — binaries + GitHub Release
     runs-on: ubuntu-latest
     needs: ci
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write # required to create releases and upload assets
-      id-token: write # required for SLSA provenance attestation
-      attestations: write
+      id-token: write # required for Sigstore OIDC
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -96,14 +97,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload deployment configs to release
-        run: gh release upload "${GITHUB_REF_NAME}" "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz"
+        run: gh release upload "${GITHUB_REF_NAME}"
+          "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attest build provenance for release artifacts (SLSA)
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
-        with:
-          subject-path: dist/checksums.txt
+      - name: Generate subject hashes for SLSA provenance
+        id: hash
+        run: |
+          cd dist
+          # base64-encode the checksums file for the SLSA provenance generator
+          echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Publish draft release
         run: gh release edit "${GITHUB_REF_NAME}" --draft=false
@@ -115,11 +119,13 @@ jobs:
     name: Publish Docker image
     runs-on: ubuntu-latest
     needs: ci
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write # required to push to ghcr.io
       id-token: write # required for Sigstore OIDC (cosign keyless signing)
-      attestations: write # required for SLSA provenance attestation
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -160,12 +166,9 @@ jobs:
             VERSION=${{ github.ref_name }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
 
-      - name: Attest build provenance (SLSA)
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
+      - name: Output image reference
+        id: image
+        run: echo "image=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
@@ -181,13 +184,39 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Verify the image signature" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "cosign verify \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate-identity-regexp 'https://github\.com/${{ github.repository_owner }}/terraform-registry-backend/' \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\" >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-identity-regexp 'https://github\\.com/${{ github.repository_owner }}/terraform-registry-backend/' \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Search Rekor for this image" >> $GITHUB_STEP_SUMMARY
-          echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "rekor-cli search --sha ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  # ── SLSA Level 3 provenance — binary artifacts ──────────────────────────
+  # Runs in an isolated, tamper-resistant reusable workflow provided by the
+  # SLSA framework.  The caller cannot influence the provenance content.
+  binary-provenance:
+    name: SLSA L3 provenance — binaries
+    needs: goreleaser
+    permissions:
+      actions: read   # for detecting workflow path
+      id-token: write # for signing the provenance
+      contents: write # for uploading provenance to the release
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
+      upload-assets: true
+
+  # ── SLSA Level 3 provenance — container image ───────────────────────────
+  container-provenance:
+    name: SLSA L3 provenance — container
+    needs: docker
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.docker.outputs.image }}
+      digest: ${{ needs.docker.outputs.digest }}
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,7 +149,7 @@ The following items require coordinated work with `terraform-registry-frontend`:
 - **Files:** `.github/workflows/release.yml`, `docs/deployment.md`
 - **AC:** Rekor entry URL printed in release notes.
 
-#### A1.2 · SLSA Level 3 build provenance · [P1/M]
+#### A1.2 · SLSA Level 3 build provenance · [P1/M] ✅
 
 - Upgrade from basic attestation to SLSA L3 via `slsa-framework/slsa-github-generator`.
 - Isolated builder, non-falsifiable provenance, signed.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -9,6 +9,7 @@
 docs/
 !docs/embed.go
 !docs/swagger.json
+!docs/swagger-ui/
 
 # Development files
 .vscode/


### PR DESCRIPTION
Upgrade release workflow from SLSA Level 2 (inline attest-build-provenance) to SLSA Level 3 (isolated slsa-github-generator reusable workflows).

**Changes:**
- Replace \ctions/attest-build-provenance\ with \slsa-framework/slsa-github-generator\ reusable workflows
- Binary provenance via \generator_generic_slsa3.yml\ (attests checksums from GoReleaser)
- Container provenance via \generator_container_slsa3.yml\ (attests image digest)
- Add job outputs for hash subjects and image references
- Provenance runs in isolated, tamper-resistant runner (L3 requirement)

Also includes CI fixes: trivy-action SHA correction and swagger-ui .dockerignore inclusion.

## Changelog
- feat: upgrade to SLSA Level 3 build provenance via slsa-github-generator