### PR TITLE
fix: bump deployment configs to v0.8.0 and wire scanning/redis env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ An enterprise-grade private Terraform Registry implementing all three HashiCorp 
 - **Provider Registry Protocol** (`/v1/providers/`)
 - **Provider Network Mirror Protocol** (`/v1/mirror/`)
 
-Current version: **v1.0.0**. All phases 1–6 complete; Phase 7 (testing & documentation) in progress.
+Current version: **v0.8.0**. All phases 1–6 complete; Phase 7 (testing & documentation) in progress.
 
 Frontend UI lives in a separate repository: [terraform-registry-frontend](https://github.com/sethbacon/terraform-registry-frontend)
 

--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -80,6 +80,19 @@ data:
   TFR_JWT_SECRET_FILE: {{ .Values.security.jwtSecretFile | quote }}
   {{- end }}
 
+  # Module security scanning
+  TFR_SCANNING_ENABLED: {{ .Values.scanning.enabled | quote }}
+  {{- if .Values.scanning.enabled }}
+  TFR_SCANNING_TOOL: {{ .Values.scanning.tool | quote }}
+  TFR_SCANNING_BINARY_PATH: {{ .Values.scanning.binaryPath | quote }}
+  {{- if .Values.scanning.expectedVersion }}
+  TFR_SCANNING_EXPECTED_VERSION: {{ .Values.scanning.expectedVersion | quote }}
+  {{- end }}
+  TFR_SCANNING_TIMEOUT: {{ .Values.scanning.timeout | quote }}
+  TFR_SCANNING_WORKER_COUNT: {{ .Values.scanning.workerCount | quote }}
+  TFR_SCANNING_SCAN_INTERVAL_MINS: {{ .Values.scanning.scanIntervalMins | quote }}
+  {{- end }}
+
   # Redis (optional, enables HA rate limiting and session store)
   {{- if .Values.redis.host }}
   TFR_REDIS_HOST: {{ .Values.redis.host | quote }}

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.7.1"
+    tag: "v0.8.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -61,7 +61,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.7.1"
+    tag: "0.8.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/base/configmap.yaml
+++ b/deployments/kubernetes/base/configmap.yaml
@@ -52,6 +52,26 @@ data:
   TFR_SECURITY_TLS_ENABLED: "false"
   TFR_SECURITY_RATE_LIMITING_ENABLED: "true"
 
+  # Redis (optional — enables HA rate limiting and session store).
+  # Leave TFR_REDIS_HOST empty to disable. When set, Redis must be reachable
+  # from the backend pod (e.g. an in-cluster service FQDN or managed endpoint).
+  TFR_REDIS_HOST: ""
+  TFR_REDIS_PORT: "6379"
+  TFR_REDIS_DB: "0"
+  TFR_REDIS_TLS: "false"
+  TFR_REDIS_POOL_SIZE: "10"
+
+  # Module security scanning (optional).
+  # Set TFR_SCANNING_ENABLED=true and override TFR_SCANNING_BINARY_PATH to
+  # a scanner binary present in the container image. Supported tools:
+  # trivy | terrascan | snyk | checkov | custom.
+  TFR_SCANNING_ENABLED: "false"
+  TFR_SCANNING_TOOL: "trivy"
+  TFR_SCANNING_BINARY_PATH: "/usr/local/bin/trivy"
+  TFR_SCANNING_TIMEOUT: "5m"
+  TFR_SCANNING_WORKER_COUNT: "2"
+  TFR_SCANNING_SCAN_INTERVAL_MINS: "5"
+
   # Logging
   TFR_LOGGING_LEVEL: "info"
   TFR_LOGGING_FORMAT: "json"

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.7.1
+    newTag: v0.8.0
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.7.1
+    newTag: v0.8.0

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.7.1
+    newTag: v0.8.0
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.7.1
+    newTag: v0.8.0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -570,19 +570,19 @@ Complete Infrastructure-as-Code configurations are provided for AWS, Azure, and 
 # AWS
 cd deployments/terraform/aws
 terraform init
-terraform plan -var="domain=registry.example.com" -var="image_tag=1.0.0"
+terraform plan -var="domain=registry.example.com" -var="image_tag=0.8.0"
 terraform apply
 
 # Azure
 cd deployments/terraform/azure
 terraform init
-terraform plan -var="location=eastus" -var="image_tag=1.0.0"
+terraform plan -var="location=eastus" -var="image_tag=0.8.0"
 terraform apply
 
 # GCP
 cd deployments/terraform/gcp
 terraform init
-terraform plan -var="project_id=my-project" -var="image_tag=1.0.0"
+terraform plan -var="project_id=my-project" -var="image_tag=0.8.0"
 terraform apply
 ```
 

--- a/docs/deployment/aks-new-cluster.md
+++ b/docs/deployment/aks-new-cluster.md
@@ -47,7 +47,7 @@ ALB_IDENTITY_NAME="alb-controller-identity"
 # Application
 HOSTNAME="registry.company.com"          # Replace with your domain
 OPS_EMAIL="ops@company.com"
-IMAGE_TAG="v1.0.0"
+IMAGE_TAG="v0.8.0"
 ```
 
 ---

--- a/docs/deployment/aks-operations.md
+++ b/docs/deployment/aks-operations.md
@@ -16,8 +16,8 @@ git pull
 helm upgrade terraform-registry ./deployments/helm \
   --namespace terraform-registry \
   --reuse-values \
-  --set backend.image.tag=v1.1.0 \
-  --set frontend.image.tag=v1.1.0
+  --set backend.image.tag=v0.8.0 \
+  --set frontend.image.tag=v0.8.0
 
 # Monitor rollout
 kubectl rollout status deployment/terraform-registry-backend -n terraform-registry

--- a/docs/deployment/aks-prerequisites.md
+++ b/docs/deployment/aks-prerequisites.md
@@ -35,8 +35,8 @@ az acr create \
 
 # Push images (see build instructions in the backend and frontend repos)
 az acr login --name <ACR_NAME>
-docker push <ACR_NAME>.azurecr.io/terraform-registry-backend:v1.0.0
-docker push <ACR_NAME>.azurecr.io/terraform-registry-frontend:v1.0.0
+docker push <ACR_NAME>.azurecr.io/terraform-registry-backend:v0.8.0
+docker push <ACR_NAME>.azurecr.io/terraform-registry-frontend:v0.8.0
 ```
 
 ### 3. Azure Database for PostgreSQL Flexible Server

--- a/docs/deployment/eks-deployment.md
+++ b/docs/deployment/eks-deployment.md
@@ -17,7 +17,7 @@ Collect the values you captured during prerequisites:
 | `<IRSA_ROLE_NAME>` | `terraform-registry-irsa`                                                                                                              |
 | `<HOSTNAME>`       | Your public DNS name                                                                                                                   |
 | `<EMAIL>`          | Your ops email                                                                                                                         |
-| `<IMAGE_TAG>`      | `v1.0.0`                                                                                                                               |
+| `<IMAGE_TAG>`      | `v0.8.0`                                                                                                                               |
 
 ---
 

--- a/docs/deployment/eks-prerequisites.md
+++ b/docs/deployment/eks-prerequisites.md
@@ -39,12 +39,12 @@ aws ecr get-login-password --region <AWS_REGION> | \
   --password-stdin <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
 
 docker tag terraform-registry-backend:latest \
-  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
-docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v0.8.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v0.8.0
 
 docker tag terraform-registry-frontend:latest \
-  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
-docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v0.8.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v0.8.0
 ```
 
 ### 2b. Amazon RDS for PostgreSQL

--- a/docs/deployment/gke-deployment.md
+++ b/docs/deployment/gke-deployment.md
@@ -66,7 +66,7 @@ patches:
 | `<HOSTNAME>`        | Your public DNS name                        |
 | `<EMAIL>`           | Your ops email                              |
 | `<INSTANCE_NAME>`   | `terraform-registry-db`                     |
-| `<IMAGE_TAG>`       | `v1.0.0`                                    |
+| `<IMAGE_TAG>`       | `v0.8.0`                                    |
 
 ---
 

--- a/docs/deployment/gke-prerequisites.md
+++ b/docs/deployment/gke-prerequisites.md
@@ -50,12 +50,12 @@ gcloud artifacts repositories create terraform-registry \
 gcloud auth configure-docker <REGION>-docker.pkg.dev
 
 docker tag terraform-registry-backend:latest \
-  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v1.0.0
-docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v1.0.0
+  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v0.8.0
+docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-backend:v0.8.0
 
 docker tag terraform-registry-frontend:latest \
-  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v1.0.0
-docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v1.0.0
+  <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v0.8.0
+docker push <REGION>-docker.pkg.dev/<PROJECT_ID>/terraform-registry/terraform-registry-frontend:v0.8.0
 ```
 
 ### 3b. Cloud SQL for PostgreSQL


### PR DESCRIPTION
Release v0.8.0 did not include the deployment-config tag-bump commit (previously done for v0.7.1 in #196), leaving Helm values files, env-specific overlays, and deployment docs pointing at v0.7.1 or older `v1.x` example tags.

This PR also closes two long-standing gaps where config keys were defined in `values.yaml` but never emitted by the chart template, and the Kustomize base was missing Redis/scanning env-vars entirely — so plain `kubectl` users could not enable either feature without a custom overlay.

## Changes

**Image tag drift (v0.7.1 → v0.8.0)**
- `deployments/helm/values.yaml` — frontend tag
- `deployments/helm/values-aks.yaml`, `values-eks.yaml`, `values-gke.yaml` — backend + frontend tags
- `deployments/kubernetes/overlays/eks/kustomization.yaml`, `gke/kustomization.yaml` — `newTag`
- AKS and `production` overlays continue to use the `<IMAGE_TAG>` placeholder filled at deploy time (unchanged)

**Config wiring gaps**
- `deployments/helm/templates/configmap.yaml` — wired `TFR_SCANNING_*` env vars (gated on `scanning.enabled`)
- `deployments/kubernetes/base/configmap.yaml` — added `TFR_SCANNING_*` and `TFR_REDIS_*` stubs

**Stale doc version strings (→ v0.8.0)**
- `CLAUDE.md` "Current version" line
- `docs/deployment.md`, `docs/deployment/aks-operations.md`, `aks-new-cluster.md`, `aks-prerequisites.md`, `eks-deployment.md`, `eks-prerequisites.md`, `gke-deployment.md`, `gke-prerequisites.md`

## Validation

- `helm lint deployments/helm` → no failures
- `helm template` with `scanning.enabled=true` + `redis.host=...` renders all 6 `TFR_SCANNING_*` and 6 `TFR_REDIS_*` env vars
- `kubectl kustomize deployments/kubernetes/overlays/eks` renders scanning/redis stubs from base configmap
- `go fmt ./...` and `go vet ./...` clean (no Go changes)

## Out of scope / follow-ups

- Exposing `TFR_SCANNING_*` in AWS ECS task-def JSON, Azure Container Apps bicep, Cloud Run YAML, and Terraform IaC modules — larger change across multiple IaC surfaces, belongs in its own PR
- Frontend repo deployment configs — no drift detected

## Changelog
- fix: bump deployment configs from v0.7.1 to v0.8.0 in Helm values, Kustomize overlays, and deployment docs
- fix: wire TFR_SCANNING_* env vars into Helm configmap so `scanning.enabled` actually takes effect
- fix: add TFR_SCANNING_* and TFR_REDIS_* stubs to Kustomize base configmap