### PR TITLE
fix(release): create GitHub Release atomically to satisfy Immutable Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Package deployment configs
         run: tar -czf "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz" deployments/
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (build only — release creation deferred)
         id: goreleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
@@ -99,11 +99,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload deployment configs to release
-        run: gh release upload "${GITHUB_REF_NAME}"
-          "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stage deployment configs into dist/
+        run: cp "/tmp/deployment-configs-${GITHUB_REF_NAME}.tar.gz" dist/
 
       - name: Generate subject hashes for SLSA provenance
         id: hash
@@ -111,6 +108,14 @@ jobs:
           cd dist
           # base64-encode the checksums file for the SLSA provenance generator
           echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-artifacts
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
 
   # ── Build + push Docker image ────────────────────────────────────────────
   docker:
@@ -201,7 +206,12 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
-      upload-assets: true
+      # Do NOT upload to the GitHub Release here. The repository has GitHub's
+      # Immutable Releases feature enabled, which freezes a release (including
+      # drafts) the moment it is created. The publish-release job below creates
+      # the release atomically with all binaries + this provenance attached.
+      upload-assets: false
+      provenance-name: multiple.intoto.jsonl
 
   # ── SLSA Level 3 provenance — container image ───────────────────────────
   container-provenance:
@@ -219,18 +229,51 @@ jobs:
       registry-username: ${{ github.actor }}
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-  # ── Publish the draft release ────────────────────────────────────────────
-  # Must run AFTER binary-provenance uploads multiple.intoto.jsonl. Publishing
-  # flips the release from draft → published, at which point GitHub treats it
-  # as immutable and rejects further asset uploads.
+  # ── Create the GitHub Release atomically ─────────────────────────────────
+  # The repository enforces GitHub's Immutable Releases security feature: a
+  # release (including drafts) is frozen at creation time and cannot accept
+  # additional asset uploads later. We therefore wait until all artifacts
+  # (binaries, checksums, signatures, SBOMs, deployment configs, and SLSA L3
+  # binary provenance) are available, then create the release once with
+  # everything attached.
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [binary-provenance, container-provenance]
+    needs: [goreleaser, binary-provenance, container-provenance]
     permissions:
       contents: write
     steps:
-      - name: Flip draft → published
-        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --repo "${GITHUB_REPOSITORY}"
+      - name: Download release artifacts (binaries, checksums, sigs, SBOMs, deployment configs)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-artifacts
+          path: dist/
+
+      - name: Download SLSA L3 binary provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ needs.binary-provenance.outputs.provenance-name }}
+          path: dist/
+
+      - name: List release assets
+        run: ls -la dist/
+
+      - name: Create GitHub Release with all assets
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "Release ${GITHUB_REF_NAME}" \
+            --notes "## Docker Image
+
+          \`\`\`
+          docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}
+          \`\`\`
+
+          ## Supply-chain attestations
+
+          - Binaries: SLSA Level 3 provenance (\`multiple.intoto.jsonl\`) attached.
+          - Container image: SLSA Level 3 provenance attached as an OCI artifact at \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}\`.
+          - Checksums signed with cosign keyless signing (Sigstore + Rekor)." \
+            dist/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,18 +33,14 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
+# Release creation is disabled here because the repository has GitHub's
+# Immutable Releases feature enabled, which freezes a release (including
+# drafts) at the moment of creation. We need SLSA L3 binary provenance
+# (multiple.intoto.jsonl) attached at the same time as the binaries, so the
+# release is created atomically by the publish-release job in release.yml
+# AFTER all artifacts and provenance files are produced.
 release:
-  draft: true
-  github:
-    owner: sethbacon
-    name: terraform-registry-backend
-  name_template: "Release {{ .Tag }}"
-  footer: |
-    ## Docker Image
-
-    ```
-    docker pull ghcr.io/sethbacon/terraform-registry-backend:{{ .Tag }}
-    ```
+  disable: true
 
 sboms:
   - artifacts: archive


### PR DESCRIPTION
Closes #207

The repository has GitHub's Immutable Releases security feature enabled, which freezes a release (including drafts) at creation time. The previous release flow had GoReleaser create a draft release first and then SLSA's `upload-assets: true` step tried to attach `multiple.intoto.jsonl` later — failing with `Cannot upload assets to an immutable release` (observed on v0.8.1 and v0.8.2).

This change keeps Immutable Releases enabled and restructures the release flow so the GitHub Release is created exactly once, with every asset attached:

- `.goreleaser.yml`: `release.disable: true` — GoReleaser only builds artifacts to `dist/`.
- `release.yml` `goreleaser` job: stages the deployment-configs tarball into `dist/` and uploads `dist/` as a workflow artifact (`release-artifacts`).
- `release.yml` `binary-provenance` job: `upload-assets: false`, `provenance-name: multiple.intoto.jsonl` — provenance is emitted as a workflow artifact instead of a release asset.
- New `release.yml` `publish-release` job (depends on `goreleaser`, `binary-provenance`, `container-provenance`): downloads both artifacts into `dist/` and runs a single `gh release create vX.Y.Z dist/*` — atomic, immutability-compliant.

## Changelog
- fix: create GitHub Release atomically with all assets (binaries, checksums, sigs, SBOMs, deployment configs, and SLSA L3 binary provenance) in a single `gh release create` call to satisfy GitHub's Immutable Releases security feature
