### PR TITLE
fix(release): stage curated assets to avoid HTTP 400 on Content-Length 0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,34 @@ jobs:
           # base64-encode the checksums file for the SLSA provenance generator
           echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Stage curated release assets
+        # GoReleaser's `format: binary` archive entries don't actually create a
+        # renamed file on disk — the artifacts.json entry just points back at
+        # the binary inside the per-target build dir (e.g.
+        # dist/terraform-registry_linux_amd64_v1/terraform-registry). We must
+        # copy each binary to its published name explicitly. We also exclude
+        # GoReleaser internals (artifacts.json, metadata.json, config.yaml,
+        # digests.txt, CHANGELOG.md, the per-target build subdirs) so they
+        # don't end up as release assets and so empty files don't trip the
+        # release-create upload (HTTP 400 on Content-Length: 0).
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          # Copy renamed binaries by reading the goreleaser artifacts manifest.
+          jq -r '.[] | select(.type=="Binary" and .extra.Format=="binary") | "\(.path)\t\(.name)"' \
+            dist/artifacts.json | while IFS=$'\t' read -r src name; do
+              cp "$src" "release/$name"
+          done
+          cp dist/checksums.txt release/
+          cp dist/checksums.txt.sig release/
+          cp "dist/deployment-configs-${GITHUB_REF_NAME}.tar.gz" release/
+          ls -la release/
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-artifacts
-          path: dist/
+          path: release/
           retention-days: 1
           if-no-files-found: error
 
@@ -243,20 +266,20 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download release artifacts (binaries, checksums, sigs, SBOMs, deployment configs)
+      - name: Download release artifacts (binaries, checksums, sigs, deployment configs)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-artifacts
-          path: dist/
+          path: release/
 
       - name: Download SLSA L3 binary provenance
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ needs.binary-provenance.outputs.provenance-name }}
-          path: dist/
+          path: release/
 
       - name: List release assets
-        run: ls -la dist/
+        run: ls -la release/
 
       - name: Create GitHub Release with all assets
         run: |
@@ -274,6 +297,6 @@ jobs:
           - Binaries: SLSA Level 3 provenance (\`multiple.intoto.jsonl\`) attached.
           - Container image: SLSA Level 3 provenance attached as an OCI artifact at \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}\`.
           - Checksums signed with cosign keyless signing (Sigstore + Rekor)." \
-            dist/*
+            release/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(release): stage curated release assets in `release.yml` so the publish step uploads only renamed binaries (`terraform-registry-<os>-<arch>`), `checksums.txt`, `checksums.txt.sig`, the deployment-configs tarball, and `multiple.intoto.jsonl` — avoiding HTTP 400 Bad Content-Length on GoReleaser's empty `digests.txt` and skipping internal files (`artifacts.json`, `metadata.json`, `config.yaml`, per-target build subdirs)
+
 ## [0.8.2] - 2026-04-19
 
 ### Fixed


### PR DESCRIPTION
## Problem

The v0.8.3 release run (24632640062) failed at the `Publish GitHub Release` step with:

`HTTP 400: Bad Content-Length (https://uploads.github.com/.../assets?label=&name=digests.txt)`

Two root causes:

1. **Empty file**: GoReleaser produced an empty `digests.txt` (0 bytes), which caused `gh release create` to send `Content-Length: 0` for that asset upload, which the GitHub uploads API rejects.
2. **Missing renamed binaries**: GoReleaser's archives `format: binary` entries don't create renamed files on disk. The `artifacts.json` `Format: binary` entries (e.g. `terraform-registry-linux-amd64`) just point back at the source binary inside the per-target build subdir (`dist/terraform-registry_linux_amd64_v1/terraform-registry`). `actions/upload-artifact` therefore only captured the unrenamed copies, and the renamed names referenced in `checksums.txt` were never present in the workflow artifact.
3. **Goreleaser internals leaking into the release**: `dist/*` was uploading `artifacts.json`, `metadata.json`, `config.yaml`, `CHANGELOG.md` (already in the repo), and the per-target build subdirs as release assets.

## Fix

Add a `Stage curated release assets` step after GoReleaser that:

- Reads `dist/artifacts.json` and copies each `type==Binary && extra.Format==binary` entry to `release/<published-name>`.
- Copies only `checksums.txt`, `checksums.txt.sig`, and `deployment-configs-<version>.tar.gz`.
- Uploads `release/` (not `dist/`) as the workflow artifact.

The `publish-release` job now downloads `release/` plus the SLSA provenance and creates the GitHub Release atomically with only the curated, non-empty assets.

## Changelog

- fix(release): stage curated release assets so publish step uploads only renamed binaries, checksums, sigs, deployment configs, and SLSA provenance — avoiding HTTP 400 Bad Content-Length on empty `digests.txt` and skipping GoReleaser internals

## Verification

Will be verified by re-tagging v0.8.3 (delete & re-create) and re-dispatching the Release workflow.
