### PR TITLE
chore: release v0.8.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,34 @@ jobs:
           # base64-encode the checksums file for the SLSA provenance generator
           echo "hashes=$(cat checksums.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Stage curated release assets
+        # GoReleaser's `format: binary` archive entries don't actually create a
+        # renamed file on disk — the artifacts.json entry just points back at
+        # the binary inside the per-target build dir (e.g.
+        # dist/terraform-registry_linux_amd64_v1/terraform-registry). We must
+        # copy each binary to its published name explicitly. We also exclude
+        # GoReleaser internals (artifacts.json, metadata.json, config.yaml,
+        # digests.txt, CHANGELOG.md, the per-target build subdirs) so they
+        # don't end up as release assets and so empty files don't trip the
+        # release-create upload (HTTP 400 on Content-Length: 0).
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          # Copy renamed binaries by reading the goreleaser artifacts manifest.
+          jq -r '.[] | select(.type=="Binary" and .extra.Format=="binary") | "\(.path)\t\(.name)"' \
+            dist/artifacts.json | while IFS=$'\t' read -r src name; do
+              cp "$src" "release/$name"
+          done
+          cp dist/checksums.txt release/
+          cp dist/checksums.txt.sig release/
+          cp "dist/deployment-configs-${GITHUB_REF_NAME}.tar.gz" release/
+          ls -la release/
+
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-artifacts
-          path: dist/
+          path: release/
           retention-days: 1
           if-no-files-found: error
 
@@ -243,20 +266,20 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download release artifacts (binaries, checksums, sigs, SBOMs, deployment configs)
+      - name: Download release artifacts (binaries, checksums, sigs, deployment configs)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-artifacts
-          path: dist/
+          path: release/
 
       - name: Download SLSA L3 binary provenance
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ needs.binary-provenance.outputs.provenance-name }}
-          path: dist/
+          path: release/
 
       - name: List release assets
-        run: ls -la dist/
+        run: ls -la release/
 
       - name: Create GitHub Release with all assets
         run: |
@@ -274,6 +297,6 @@ jobs:
           - Binaries: SLSA Level 3 provenance (\`multiple.intoto.jsonl\`) attached.
           - Container image: SLSA Level 3 provenance attached as an OCI artifact at \`ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}\`.
           - Checksums signed with cosign keyless signing (Sigstore + Rekor)." \
-            dist/*
+            release/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-04-20
+
 ### Fixed
 
-- fix(release): stage curated release assets in `release.yml` so the publish step uploads only renamed binaries (`terraform-registry-<os>-<arch>`), `checksums.txt`, `checksums.txt.sig`, the deployment-configs tarball, and `multiple.intoto.jsonl` — avoiding HTTP 400 Bad Content-Length on GoReleaser's empty `digests.txt` and skipping internal files (`artifacts.json`, `metadata.json`, `config.yaml`, per-target build subdirs)
+- fix(release): stage curated release assets in `release.yml` so the publish step uploads only renamed binaries (`terraform-registry-<os>-<arch>`), `checksums.txt`, `checksums.txt.sig`, the deployment-configs tarball, and `multiple.intoto.jsonl` — avoiding HTTP 400 Bad Content-Length on GoReleaser's empty `digests.txt` and skipping internal files (`artifacts.json`, `metadata.json`, `config.yaml`, per-target build subdirs) (#210)
+
+### Changed
+
+- chore: bump Helm chart `appVersion`, cloud values files (`values-aks`, `values-eks`, `values-gke`), and Kustomize overlay tags (`eks`, `gke`) to `v0.8.4`
 
 ## [0.8.3] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(release): stage curated release assets in `release.yml` so the publish step uploads only renamed binaries (`terraform-registry-<os>-<arch>`), `checksums.txt`, `checksums.txt.sig`, the deployment-configs tarball, and `multiple.intoto.jsonl` — avoiding HTTP 400 Bad Content-Length on GoReleaser's empty `digests.txt` and skipping internal files (`artifacts.json`, `metadata.json`, `config.yaml`, per-target build subdirs)
+
 ## [0.8.2] - 2026-04-19
 
 ### Fixed

--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: terraform-registry
 description: A Helm chart for deploying the Enterprise Terraform Registry
 type: application
 version: 0.2.0
-appVersion: "0.8.3"
+appVersion: "0.8.4"
 keywords:
   - terraform
   - registry

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.8.3"
+    tag: "v0.8.4"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.8.3"
+    tag: "v0.8.4"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.8.3"
+    tag: "v0.8.4"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.8.3
+    newTag: v0.8.4
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
     newTag: v0.8.2

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.8.3
+    newTag: v0.8.4
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
     newTag: v0.8.2


### PR DESCRIPTION
## Release v0.8.4

Patch release for the curated-assets release-workflow fix.

## Background

v0.8.3 had a partial release:

- ✅ Container image `ghcr.io/sethbacon/terraform-registry-backend:0.8.3` was published with cosign keyless signature and SLSA L3 attestation (immutable artifact on GHCR).
- ❌ GitHub Release was never created because the `Publish GitHub Release` step failed with `HTTP 400: Bad Content-Length` on GoReleaser's empty `digests.txt` file.

Re-running the v0.8.3 release would overwrite the `0.8.3` / `0.8` / `latest` container tags and orphan the existing cosign signature / SLSA attestation. Bumping to v0.8.4 keeps a clean audit trail.

## Changes

- All of v0.8.3's changes (atomic GitHub Release creation to satisfy Immutable Releases) ship as part of v0.8.4.
- Plus the curated-assets fix from #210: the `Publish GitHub Release` step now uploads only renamed binaries, `checksums.txt`, `checksums.txt.sig`, the deployment-configs tarball, and `multiple.intoto.jsonl`. GoReleaser internals (`artifacts.json`, `metadata.json`, `config.yaml`, empty `digests.txt`, per-target build subdirs) are excluded.

## Version bumps

- `deployments/helm/Chart.yaml` `appVersion` → `0.8.4`
- `deployments/helm/values-{aks,eks,gke}.yaml` backend image tag → `v0.8.4`
- `deployments/kubernetes/overlays/{eks,gke}/kustomization.yaml` `newTag` → `v0.8.4`

## Changelog

- chore: release v0.8.4 — patch release shipping the curated-assets fix that prevented v0.8.3's GitHub Release from being created
