### PR TITLE
fix(ci): repair scheduled build (closes #211)

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -8,8 +8,8 @@ name: Scheduled Build
 # scheduled failures do not block PR merges and vice-versa.
 on:
   schedule:
-    - cron: '0 8 * * 1'   # Every Monday 08:00 UTC
-  workflow_dispatch: {}    # Allow manual triggering from the Actions UI
+    - cron: "0 8 * * 1" # Every Monday 08:00 UTC
+  workflow_dispatch: {} # Allow manual triggering from the Actions UI
 
 jobs:
   full-build:
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.26'
+          go-version: "1.26"
           cache-dependency-path: backend/go.sum
 
       # ── Backend ──────────────────────────────────────────────────────────
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run OSV-Scanner
         id: osv
-        uses: google/osv-scanner-action/osv-scanner-action@19ec1316531e591c8578d1e05ceb30e5b935e3c5 # v2
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
         continue-on-error: true
         with:
           scan-args: |-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(coverfilter): make `pathSuffixMatches` normalize backslashes to forward slashes explicitly so the Windows-path test input passes on Linux runners — `filepath.ToSlash` is a no-op on Linux and left `\`-separated paths unchanged, causing `TestPathSuffixMatches` to fail in the weekly scheduled build (#211)
+- fix(ci): bump pinned `google/osv-scanner-action` SHA to v2.3.5 — the prior pin was removed upstream and caused the scheduled OSV scan to fail with `Unable to resolve action ... unable to find version` (#211)
+
 ## [0.8.4] - 2026-04-20
 
 ### Fixed

--- a/backend/scripts/coverfilter/main.go
+++ b/backend/scripts/coverfilter/main.go
@@ -213,7 +213,12 @@ func parseLine(s string) (int, error) {
 // false positives when two packages contain files with the same name
 // (e.g. both "internal/api/router.go" and "internal/mirror/router.go").
 func pathSuffixMatches(absPath, modPath string) bool {
-	abs := filepath.ToSlash(absPath)
+	// Normalize backslashes to forward slashes regardless of host OS.
+	// filepath.ToSlash is a no-op on Linux (separator is '/'), but we may
+	// receive Windows-style absolute paths (e.g. when this binary processes
+	// a coverage profile recorded on a Windows developer's machine), so we
+	// replace backslashes explicitly.
+	abs := strings.ReplaceAll(absPath, "\\", "/")
 	parts := strings.Split(modPath, "/")
 	// Require at least 2 trailing segments (package dir + file) so bare
 	// filenames can't cause cross-package false matches.


### PR DESCRIPTION
Closes #211.

## Problem

The 2026-04-20 weekly scheduled build (run 24660599688) had two independent failures:

### 1. `TestPathSuffixMatches` failed on Linux

`backend/scripts/coverfilter/main.go` used `filepath.ToSlash` to normalize paths before suffix matching. `filepath.ToSlash` is a **no-op on Linux** (where the separator is already `/`), so the Windows-style backslash path in the test fixture — `C:\dev\repo\backend\internal\auth\provider.go` — never got normalized, and the suffix comparison against `github.com/foo/bar/internal/auth/provider.go` returned `false` when `true` was expected.

This test only passed on Windows, so it slipped through until the Linux scheduled build ran it.

### 2. OSV Vulnerability Scan failed to resolve the pinned action

`Unable to resolve action google/osv-scanner-action/osv-scanner-action@19ec1316531e591c8578d1e05ceb30e5b935e3c5, unable to find version 19ec1316531e591c8578d1e05ceb30e5b935e3c5`

The SHA was previously tagged `v2` upstream but was removed/force-pushed. Latest release is v2.3.5.

## Fix

1. Replace `filepath.ToSlash(absPath)` with `strings.ReplaceAll(absPath, ""\\"", ""/"")` so backslash → forward-slash normalization happens regardless of host OS.
2. Bump pinned SHA to `c51854704019a247608d928f370c98740469d4b5` (v2.3.5) with updated comment.

## Verification

`go test ./scripts/coverfilter/ -run TestPathSuffixMatches -v` → PASS locally on Windows. The Linux CI run on this PR will confirm the fix there.

## Changelog

- fix(coverfilter): make `pathSuffixMatches` normalize backslashes to forward slashes explicitly so the Windows-path test input passes on Linux runners (#211)
- fix(ci): bump pinned `google/osv-scanner-action` SHA to v2.3.5 — the prior pin was removed upstream and caused the scheduled OSV scan to fail (#211)
