### PR TITLE
fix(setup): detect unconfigured features added after initial setup and re-trigger wizard

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -297,7 +297,15 @@ func handleSetupToken(repo *repositories.OIDCConfigRepository) error {
 		return fmt.Errorf("failed to check setup status: %w", err)
 	}
 	if completed {
-		return nil // Setup already done, nothing to do
+		// Check if there are unconfigured features added in later releases
+		hasPending, pendingErr := repo.HasPendingFeatureSetup(ctx)
+		if pendingErr != nil {
+			return fmt.Errorf("failed to check pending feature setup: %w", pendingErr)
+		}
+		if !hasPending {
+			return nil // Setup fully done, nothing to do
+		}
+		log.Println("Detected unconfigured features added after initial setup.")
 	}
 
 	// Check if a token hash already exists (server restarted before setup completed)

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12884,6 +12884,12 @@
                 "oidc_configured": {
                     "type": "boolean"
                 },
+                "pending_feature_setup": {
+                    "type": "boolean"
+                },
+                "scanning_configured": {
+                    "type": "boolean"
+                },
                 "setup_completed": {
                     "type": "boolean"
                 },

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -78,12 +78,13 @@ func (h *Handlers) GetSetupStatus(c *gin.Context) {
 	scanningConfigured, _ := h.oidcConfigRepo.GetScanningConfigured(ctx)
 
 	response := gin.H{
-		"setup_completed":     status.SetupCompleted,
-		"storage_configured":  status.StorageConfigured,
-		"oidc_configured":     status.OIDCConfigured,
-		"admin_configured":    status.AdminConfigured,
-		"setup_required":      status.SetupRequired,
-		"scanning_configured": scanningConfigured,
+		"setup_completed":       status.SetupCompleted,
+		"storage_configured":    status.StorageConfigured,
+		"oidc_configured":       status.OIDCConfigured,
+		"admin_configured":      status.AdminConfigured,
+		"setup_required":        status.SetupRequired,
+		"scanning_configured":   scanningConfigured,
+		"pending_feature_setup": status.PendingFeatureSetup,
 	}
 
 	if status.StorageConfiguredAt != nil {
@@ -484,6 +485,34 @@ func (h *Handlers) CompleteSetup(c *gin.Context) {
 	status, err := h.oidcConfigRepo.GetEnhancedSetupStatus(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check setup status"})
+		return
+	}
+
+	scanningConfigured, _ := h.oidcConfigRepo.GetScanningConfigured(ctx)
+
+	// If this is a pending-feature completion (initial setup was already done),
+	// only verify the pending features are now configured.
+	if status.PendingFeatureSetup {
+		if !scanningConfigured {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   "Feature setup is incomplete. The following components must be configured: security scanning",
+				"missing": []string{"security scanning"},
+			})
+			return
+		}
+
+		// Clear the setup token hash to re-disable setup endpoints
+		if err := h.oidcConfigRepo.SetSetupCompleted(ctx); err != nil {
+			slog.Error("setup: failed to complete feature setup", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete feature setup"})
+			return
+		}
+
+		slog.Info("setup: pending feature setup completed successfully")
+		c.JSON(http.StatusOK, gin.H{
+			"message":         "Feature setup completed successfully.",
+			"setup_completed": true,
+		})
 		return
 	}
 

--- a/backend/internal/db/models/oidc_config.go
+++ b/backend/internal/db/models/oidc_config.go
@@ -172,7 +172,9 @@ type SetupStatus struct {
 	StorageConfigured   bool           `json:"storage_configured"`
 	OIDCConfigured      bool           `json:"oidc_configured"`
 	AdminConfigured     bool           `json:"admin_configured"`
+	ScanningConfigured  bool           `json:"scanning_configured"`
 	SetupRequired       bool           `json:"setup_required"`
+	PendingFeatureSetup bool           `json:"pending_feature_setup"`
 	StorageConfiguredAt *time.Time     `json:"storage_configured_at,omitempty"`
 	AdminEmail          sql.NullString `json:"-"`
 }

--- a/backend/internal/db/repositories/oidc_config_repository.go
+++ b/backend/internal/db/repositories/oidc_config_repository.go
@@ -139,24 +139,34 @@ func (r *OIDCConfigRepository) GetEnhancedSetupStatus(ctx context.Context) (*mod
 	if err == sql.ErrNoRows {
 		// Fresh database with no settings row yet
 		return &models.SetupStatus{
-			SetupCompleted:    false,
-			StorageConfigured: false,
-			OIDCConfigured:    false,
-			AdminConfigured:   false,
-			SetupRequired:     true,
+			SetupCompleted:      false,
+			StorageConfigured:   false,
+			OIDCConfigured:      false,
+			AdminConfigured:     false,
+			ScanningConfigured:  false,
+			SetupRequired:       true,
+			PendingFeatureSetup: false,
 		}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 
+	adminConfigured := settings.PendingAdminEmail.Valid && settings.PendingAdminEmail.String != ""
+
+	// Detect features that were added after initial setup completed but haven't
+	// been configured yet (e.g. scanning added in a newer release).
+	pendingFeatureSetup := settings.SetupCompleted && !settings.ScanningConfigured
+
 	status := &models.SetupStatus{
-		SetupCompleted:    settings.SetupCompleted,
-		StorageConfigured: settings.StorageConfigured,
-		OIDCConfigured:    settings.OIDCConfigured,
-		AdminConfigured:   settings.PendingAdminEmail.Valid && settings.PendingAdminEmail.String != "",
-		SetupRequired:     !settings.SetupCompleted,
-		AdminEmail:        settings.PendingAdminEmail,
+		SetupCompleted:      settings.SetupCompleted,
+		StorageConfigured:   settings.StorageConfigured,
+		OIDCConfigured:      settings.OIDCConfigured,
+		AdminConfigured:     adminConfigured,
+		ScanningConfigured:  settings.ScanningConfigured,
+		SetupRequired:       !settings.SetupCompleted || pendingFeatureSetup,
+		PendingFeatureSetup: pendingFeatureSetup,
+		AdminEmail:          settings.PendingAdminEmail,
 	}
 
 	if settings.StorageConfiguredAt.Valid {
@@ -165,6 +175,18 @@ func (r *OIDCConfigRepository) GetEnhancedSetupStatus(ctx context.Context) (*mod
 	}
 
 	return status, nil
+}
+
+// HasPendingFeatureSetup returns true when initial setup is completed but one
+// or more features added in later releases have not been configured yet.
+func (r *OIDCConfigRepository) HasPendingFeatureSetup(ctx context.Context) (bool, error) {
+	var pending bool
+	query := `SELECT setup_completed AND NOT scanning_configured FROM system_settings WHERE id = 1`
+	err := r.db.GetContext(ctx, &pending, query)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return pending, err
 }
 
 // GetScanningConfigured checks if scanning has been configured via the setup wizard

--- a/backend/internal/db/repositories/oidc_config_repository_test.go
+++ b/backend/internal/db/repositories/oidc_config_repository_test.go
@@ -320,6 +320,8 @@ func TestGetEnhancedSetupStatus_Configured(t *testing.T) {
 	settingsCols := []string{
 		"id", "storage_configured", "storage_configured_at", "storage_configured_by",
 		"setup_completed", "setup_token_hash", "oidc_configured", "pending_admin_email",
+		"scanning_configured", "scanning_configured_at", "scanning_config",
+		"audit_retention_days",
 		"created_at", "updated_at",
 	}
 	now := time.Now()
@@ -327,6 +329,8 @@ func TestGetEnhancedSetupStatus_Configured(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(settingsCols).AddRow(
 			1, true, now, nil,
 			true, nil, true, "admin@example.com",
+			true, now, nil,
+			30,
 			now, now,
 		))
 
@@ -349,8 +353,52 @@ func TestGetEnhancedSetupStatus_Configured(t *testing.T) {
 	if status.SetupRequired {
 		t.Error("expected SetupRequired = false")
 	}
+	if !status.ScanningConfigured {
+		t.Error("expected ScanningConfigured = true")
+	}
+	if status.PendingFeatureSetup {
+		t.Error("expected PendingFeatureSetup = false")
+	}
 	if status.StorageConfiguredAt == nil {
 		t.Error("expected StorageConfiguredAt to be set")
+	}
+}
+
+func TestGetEnhancedSetupStatus_PendingFeature(t *testing.T) {
+	repo, mock := newOIDCConfigRepo(t)
+
+	settingsCols := []string{
+		"id", "storage_configured", "storage_configured_at", "storage_configured_by",
+		"setup_completed", "setup_token_hash", "oidc_configured", "pending_admin_email",
+		"scanning_configured", "scanning_configured_at", "scanning_config",
+		"audit_retention_days",
+		"created_at", "updated_at",
+	}
+	now := time.Now()
+	mock.ExpectQuery("SELECT.*FROM system_settings").
+		WillReturnRows(sqlmock.NewRows(settingsCols).AddRow(
+			1, true, now, nil,
+			true, nil, true, "admin@example.com",
+			false, nil, nil, // scanning NOT configured
+			30,
+			now, now,
+		))
+
+	status, err := repo.GetEnhancedSetupStatus(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !status.SetupCompleted {
+		t.Error("expected SetupCompleted = true")
+	}
+	if !status.SetupRequired {
+		t.Error("expected SetupRequired = true (pending features)")
+	}
+	if !status.PendingFeatureSetup {
+		t.Error("expected PendingFeatureSetup = true")
+	}
+	if status.ScanningConfigured {
+		t.Error("expected ScanningConfigured = false")
 	}
 }
 

--- a/backend/internal/middleware/setup.go
+++ b/backend/internal/middleware/setup.go
@@ -75,7 +75,7 @@ func SetupTokenMiddleware(oidcConfigRepo *repositories.OIDCConfigRepository) gin
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
-		// 1. Check if setup is already completed — permanently block all setup endpoints
+		// 1. Check if setup is already completed — block unless there are pending features
 		completed, err := oidcConfigRepo.IsSetupCompleted(ctx)
 		if err != nil {
 			slog.Error("setup middleware: failed to check setup status", "error", err)
@@ -85,10 +85,21 @@ func SetupTokenMiddleware(oidcConfigRepo *repositories.OIDCConfigRepository) gin
 			return
 		}
 		if completed {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "Setup has already been completed. These endpoints are permanently disabled.",
-			})
-			return
+			// Allow through if there are unconfigured features added in later releases
+			hasPending, pendingErr := oidcConfigRepo.HasPendingFeatureSetup(ctx)
+			if pendingErr != nil {
+				slog.Error("setup middleware: failed to check pending features", "error", pendingErr)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to check setup status",
+				})
+				return
+			}
+			if !hasPending {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+					"error": "Setup has already been completed. These endpoints are permanently disabled.",
+				})
+				return
+			}
 		}
 
 		// 2. Rate limit check before doing any bcrypt work

--- a/backend/internal/middleware/setup_test.go
+++ b/backend/internal/middleware/setup_test.go
@@ -56,6 +56,9 @@ func TestSetupMiddleware_SetupCompleted(t *testing.T) {
 	mock, r := newSetupRouter(t)
 	mock.ExpectQuery("SELECT setup_completed FROM system_settings").
 		WillReturnRows(sqlmock.NewRows([]string{"setup_completed"}).AddRow(true))
+	// HasPendingFeatureSetup check — no pending features
+	mock.ExpectQuery("SELECT setup_completed AND NOT scanning_configured FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"pending"}).AddRow(false))
 
 	w := doSetupRequest(r, "SetupToken valid-token")
 	if w.Code != http.StatusForbidden {


### PR DESCRIPTION
Registries that completed initial setup before scanning was added had `setup_completed=true` permanently, preventing the setup wizard from ever showing again. Five interconnected guards all blocked re-entry.

## Changelog
- fix(setup): detect unconfigured features added after initial setup and re-trigger the setup wizard — registries that completed setup before scanning was added now correctly show the setup banner and allow configuring scanning without requiring a full re-setup
- fix(setup): `SetupTokenMiddleware` now allows setup API requests when `setup_completed` is true but pending features remain unconfigured
- fix(setup): server startup generates a new setup token when pending feature setup is detected
- fix(setup): `CompleteSetup` handler supports pending-feature-only completion flow, validating only the unconfigured features