### PR TITLE
chore: bump frontend image tag to v0.10.2

### DIFF
--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.10.1"
+    tag: "v0.10.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.10.1"
+    tag: "v0.10.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.10.1"
+    tag: "v0.10.2"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -61,7 +61,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.10.1"
+    tag: "0.10.2"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -72,4 +72,4 @@ images:
     newTag: v0.10.2
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.10.1
+    newTag: v0.10.2

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -80,4 +80,4 @@ images:
     newTag: v0.10.2
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.10.1
+    newTag: v0.10.2


### PR DESCRIPTION
Closes #224

Bumps `frontend.image.tag` across Helm values files and Kustomize overlays to pick up frontend v0.10.2 (Modules default view/sort UX improvements).

Frontend release: https://github.com/sethbacon/terraform-registry-frontend/releases/tag/v0.10.2

## Changelog
- chore: bump frontend image tag to v0.10.2 across Helm values and Kustomize overlays