### PR TITLE
fix: scanning setup wizard leaves scanning disabled after config save

### DIFF
--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -685,6 +686,28 @@ func (h *Handlers) SaveScanningConfig(c *gin.Context) {
 		return
 	}
 
+	// Validate binary_path is within the managed install directory.
+	// This prevents arbitrary executables from being registered as scanners.
+	if h.cfg.Scanning.InstallDir != "" {
+		cleanBinary := filepath.Clean(input.BinaryPath)
+		cleanInstall := filepath.Clean(h.cfg.Scanning.InstallDir)
+		if !strings.HasPrefix(cleanBinary, cleanInstall+string(filepath.Separator)) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "binary_path must be within the scanner install directory"})
+			return
+		}
+	}
+
+	// Verify the binary exists on disk before saving.
+	if _, err := os.Stat(input.BinaryPath); err != nil {
+		if os.IsNotExist(err) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "binary_path does not exist"})
+		} else {
+			slog.Error("setup: failed to stat binary_path", "path", input.BinaryPath, "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify binary_path"})
+		}
+		return
+	}
+
 	ctx := c.Request.Context()
 
 	// Serialize the input to JSON for storage
@@ -700,6 +723,19 @@ func (h *Handlers) SaveScanningConfig(c *gin.Context) {
 		slog.Error("setup: failed to save scanning config", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save scanning configuration"})
 		return
+	}
+
+	// Update the in-memory config so the scanner job and config endpoint reflect
+	// the new settings immediately, without requiring a pod restart.
+	h.cfg.Scanning.Enabled = input.Enabled
+	h.cfg.Scanning.Tool = input.Tool
+	h.cfg.Scanning.BinaryPath = input.BinaryPath
+	h.cfg.Scanning.ExpectedVersion = input.ExpectedVersion
+	if input.TimeoutSecs > 0 {
+		h.cfg.Scanning.Timeout = time.Duration(input.TimeoutSecs) * time.Second
+	}
+	if input.WorkerCount > 0 {
+		h.cfg.Scanning.WorkerCount = input.WorkerCount
 	}
 
 	slog.Info("setup: scanning configuration saved", "tool", input.Tool, "enabled", input.Enabled)

--- a/backend/internal/api/setup/scanning_test.go
+++ b/backend/internal/api/setup/scanning_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
 // ---------------------------------------------------------------------------
@@ -175,13 +179,20 @@ func TestSaveScanningConfig_MissingBinaryPath(t *testing.T) {
 func TestSaveScanningConfig_Success(t *testing.T) {
 	env := newTestEnv(t)
 
+	// Create a real temp file to pass the os.Stat existence check.
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
 	r := gin.New()
 	r.POST("/scanning", env.h.SaveScanningConfig)
 
 	body := jsonBody(map[string]interface{}{
 		"enabled":      true,
 		"tool":         "trivy",
-		"binary_path":  "/usr/bin/trivy",
+		"binary_path":  binaryPath,
 		"timeout_secs": 60,
 	})
 
@@ -205,13 +216,19 @@ func TestSaveScanningConfig_Success(t *testing.T) {
 func TestSaveScanningConfig_DBError(t *testing.T) {
 	env := newTestEnv(t)
 
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
 	r := gin.New()
 	r.POST("/scanning", env.h.SaveScanningConfig)
 
 	body := jsonBody(map[string]interface{}{
 		"enabled":     true,
 		"tool":        "trivy",
-		"binary_path": "/usr/bin/trivy",
+		"binary_path": binaryPath,
 	})
 
 	// SetScanningConfig fails
@@ -223,5 +240,205 @@ func TestSaveScanningConfig_DBError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SaveScanningConfig — binary_path validation
+// ---------------------------------------------------------------------------
+
+func TestSaveScanningConfig_BinaryPathOutsideInstallDir(t *testing.T) {
+	env := newTestEnv(t)
+	env.h.cfg.Scanning.InstallDir = "/app/scanners"
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": "/usr/bin/trivy", // outside /app/scanners
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for binary_path outside install_dir", w.Code)
+	}
+	resp := getJSON(w)
+	if resp["error"] != "binary_path must be within the scanner install directory" {
+		t.Errorf("error = %v", resp["error"])
+	}
+}
+
+func TestSaveScanningConfig_BinaryPathTraversalBlocked(t *testing.T) {
+	env := newTestEnv(t)
+	env.h.cfg.Scanning.InstallDir = "/app/scanners"
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": "/app/scanners/../../../etc/passwd",
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for path traversal attempt", w.Code)
+	}
+}
+
+func TestSaveScanningConfig_BinaryNotExistOnDisk(t *testing.T) {
+	env := newTestEnv(t)
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": "/nonexistent/path/to/trivy",
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for non-existent binary", w.Code)
+	}
+	resp := getJSON(w)
+	if resp["error"] != "binary_path does not exist" {
+		t.Errorf("error = %v", resp["error"])
+	}
+}
+
+func TestSaveScanningConfig_UpdatesInMemoryConfig(t *testing.T) {
+	env := newTestEnv(t)
+	// Start with scanning disabled in-memory.
+	env.h.cfg.Scanning = config.ScanningConfig{
+		Enabled:    false,
+		Tool:       "",
+		BinaryPath: "",
+	}
+
+	// Create a real temp file to pass the os.Stat check.
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":          true,
+		"tool":             "trivy",
+		"binary_path":      binaryPath,
+		"expected_version": "0.50.0",
+		"timeout_secs":     120,
+		"worker_count":     4,
+	})
+
+	env.oidcMock.ExpectExec("UPDATE system_settings SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify in-memory config was updated.
+	sc := env.h.cfg.Scanning
+	if !sc.Enabled {
+		t.Error("cfg.Scanning.Enabled = false, want true")
+	}
+	if sc.Tool != "trivy" {
+		t.Errorf("cfg.Scanning.Tool = %q, want trivy", sc.Tool)
+	}
+	if sc.BinaryPath != binaryPath {
+		t.Errorf("cfg.Scanning.BinaryPath = %q, want %q", sc.BinaryPath, binaryPath)
+	}
+	if sc.ExpectedVersion != "0.50.0" {
+		t.Errorf("cfg.Scanning.ExpectedVersion = %q, want 0.50.0", sc.ExpectedVersion)
+	}
+	if sc.Timeout != 120*time.Second {
+		t.Errorf("cfg.Scanning.Timeout = %v, want 120s", sc.Timeout)
+	}
+	if sc.WorkerCount != 4 {
+		t.Errorf("cfg.Scanning.WorkerCount = %d, want 4", sc.WorkerCount)
+	}
+}
+
+func TestSaveScanningConfig_InMemoryNotUpdatedOnDBError(t *testing.T) {
+	env := newTestEnv(t)
+	env.h.cfg.Scanning = config.ScanningConfig{Enabled: false}
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": binaryPath,
+	})
+
+	env.oidcMock.ExpectExec("UPDATE system_settings SET").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+
+	// In-memory config must not have changed on DB failure.
+	if env.h.cfg.Scanning.Enabled {
+		t.Error("cfg.Scanning.Enabled updated on DB error, want unchanged (false)")
+	}
+}
+
+func TestSaveScanningConfig_NoInstallDirSkipsPathValidation(t *testing.T) {
+	env := newTestEnv(t)
+	// InstallDir is empty — path validation is skipped; only existence is checked.
+	env.h.cfg.Scanning.InstallDir = ""
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": binaryPath,
+	})
+
+	env.oidcMock.ExpectExec("UPDATE system_settings SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 when install_dir is empty", w.Code)
 	}
 }

--- a/backend/internal/db/repositories/oidc_config_repository.go
+++ b/backend/internal/db/repositories/oidc_config_repository.go
@@ -189,9 +189,14 @@ func (r *OIDCConfigRepository) GetEnhancedSetupStatus(ctx context.Context) (*mod
 
 // HasPendingFeatureSetup returns true when initial setup is completed but one
 // or more features added in later releases have not been configured yet.
+//
+// To add a new feature check (e.g. for E4.3 policy engine or E4.4 module testing),
+// extend the boolean expression:
+//
+//	setup_completed AND (NOT scanning_configured OR NOT policy_configured OR NOT testing_configured)
 func (r *OIDCConfigRepository) HasPendingFeatureSetup(ctx context.Context) (bool, error) {
 	var pending bool
-	query := `SELECT setup_completed AND NOT scanning_configured FROM system_settings WHERE id = 1`
+	query := `SELECT setup_completed AND (NOT scanning_configured) FROM system_settings WHERE id = 1`
 	err := r.db.GetContext(ctx, &pending, query)
 	if err == sql.ErrNoRows {
 		return false, nil

--- a/backend/internal/middleware/setup_test.go
+++ b/backend/internal/middleware/setup_test.go
@@ -57,7 +57,7 @@ func TestSetupMiddleware_SetupCompleted(t *testing.T) {
 	mock.ExpectQuery("SELECT setup_completed FROM system_settings").
 		WillReturnRows(sqlmock.NewRows([]string{"setup_completed"}).AddRow(true))
 	// HasPendingFeatureSetup check — no pending features
-	mock.ExpectQuery("SELECT setup_completed AND NOT scanning_configured FROM system_settings").
+	mock.ExpectQuery(`SELECT setup_completed AND \(NOT scanning_configured\) FROM system_settings`).
 		WillReturnRows(sqlmock.NewRows([]string{"pending"}).AddRow(false))
 
 	w := doSetupRequest(r, "SetupToken valid-token")


### PR DESCRIPTION
Closes #228

## Changes

**`backend/internal/api/setup/handlers.go`**
- Added `binary_path` validation: when `cfg.Scanning.InstallDir` is set, rejects paths outside the install directory (path traversal protection)
- Added `os.Stat` existence check on `binary_path` before saving — returns 400 instead of silently accepting a broken config
- After successful DB save, updates `cfg.Scanning` fields in-place so the scanner job and `GetScanningConfigHandler` reflect new settings immediately without a pod restart

**`backend/internal/db/repositories/oidc_config_repository.go`**
- `HasPendingFeatureSetup`: explicit parentheses in SQL boolean expression + extension comment documenting how to add future feature checks (E4.3 policy engine, E4.4 module testing)

**Tests**
- Updated existing `TestSaveScanningConfig_Success` and `TestSaveScanningConfig_DBError` to use a real temp file (new `os.Stat` check requires the binary to exist)
- Added 6 new `SaveScanningConfig` tests: path outside install dir, path traversal attempt, non-existent binary, in-memory config updated on success, in-memory config unchanged on DB error, no-install-dir skips path check
- Updated `TestSetupMiddleware_SetupCompleted` sqlmock expectation to match new SQL query

## Changelog
- fix: scanning setup wizard leaves scanning disabled after config save — validate binary_path and update in-memory config on save