### PR TITLE
fix: audit log resource_type shows 'unknown' for admin module, provider, and storage routes

### DIFF
--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -160,10 +160,16 @@ func AuditMiddlewareWithShipper(auditRepo *repositories.AuditRepository, shipper
 func getResourceType(c *gin.Context) string {
 	fullPath := c.FullPath()
 	switch {
+	case strings.HasPrefix(fullPath, "/api/v1/admin/modules"):
+		return "module"
 	case strings.HasPrefix(fullPath, "/api/v1/modules"):
 		return "module"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/providers"):
+		return "provider"
 	case strings.HasPrefix(fullPath, "/api/v1/providers"):
 		return "provider"
+	case strings.HasPrefix(fullPath, "/api/v1/storage"):
+		return "storage"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/mirrors"):
 		return "mirror"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/users"):

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -162,7 +162,14 @@ func TestAuditMiddleware_ResourceTypeDetection(t *testing.T) {
 		wantRes string
 	}{
 		{"/api/v1/modules/foo", "module"},
+		{"/api/v1/admin/modules/create", "module"},
+		{"/api/v1/admin/modules/some-id", "module"},
 		{"/api/v1/providers/bar", "provider"},
+		{"/api/v1/admin/providers", "provider"},
+		{"/api/v1/admin/providers/some-id", "provider"},
+		{"/api/v1/storage/configs", "storage"},
+		{"/api/v1/storage/configs/some-id", "storage"},
+		{"/api/v1/admin/storage/migrations", "storage"},
 		{"/api/v1/admin/users/baz", "user"},
 		{"/api/v1/admin/apikeys/1", "api_key"},
 		{"/api/v1/admin/organizations/x", "organization"},


### PR DESCRIPTION
Closes #231

`getResourceType()` in `backend/internal/middleware/audit.go` was missing prefix cases for three route groups, causing their `resource_type` to fall through to `"unknown"` in audit logs:

| Route prefix | Was | Now |
|---|---|---|
| `/api/v1/admin/modules/...` | `unknown` | `module` |
| `/api/v1/admin/providers/...` | `unknown` | `provider` |
| `/api/v1/storage/configs/...` | `unknown` | `storage` |

Storage config CRUD is registered under `authenticatedGroup.Group("/storage")` (i.e. `/api/v1/storage/...`), not `/api/v1/admin/storage/` — the existing case for `admin/storage` only covered migration routes.

The test table in `audit_test.go` is extended with 7 new path cases.

## Changelog
- fix: audit log resource_type now correctly shows "module", "provider", and "storage" instead of "unknown" for admin module/provider CRUD and storage config routes