### PR TITLE
fix: audit log resource_type 'unknown' for /api/v1/organizations routes

### DIFF
--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -178,6 +178,8 @@ func getResourceType(c *gin.Context) string {
 		return "api_key"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/organizations"):
 		return "organization"
+	case strings.HasPrefix(fullPath, "/api/v1/organizations"):
+		return "organization"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/storage"):
 		return "storage"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/roles"):

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -173,6 +173,8 @@ func TestAuditMiddleware_ResourceTypeDetection(t *testing.T) {
 		{"/api/v1/admin/users/baz", "user"},
 		{"/api/v1/admin/apikeys/1", "api_key"},
 		{"/api/v1/admin/organizations/x", "organization"},
+		{"/api/v1/organizations/some-id", "organization"},
+		{"/api/v1/organizations/some-id/members", "organization"},
 		{"/api/v1/admin/mirrors/y", "mirror"},
 		{"/other/z", "unknown"},
 	}


### PR DESCRIPTION
Closes #235

`getResourceType()` matched `/api/v1/admin/organizations` but not the non-admin `/api/v1/organizations` group (router.go:816), which handles org CRUD (POST/PUT/DELETE) and member management (POST/PUT/DELETE `/:id/members`).

Two new test cases added covering org and member paths.

Historical rows have been backfilled directly in the AKS cluster via `kubectl exec`.

## Changelog
- fix: audit log resource_type now correctly shows "organization" for /api/v1/organizations routes (org CRUD and member management)