### PR TITLE
chore: bump backend image tag to v0.10.5

### DIFF
--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.10.4"
+    tag: "v0.10.5"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.10.4"
+    tag: "v0.10.5"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.10.4"
+    tag: "v0.10.5"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.10.4
+    newTag: v0.10.5
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
     newTag: v0.10.3

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.10.4
+    newTag: v0.10.5
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
     newTag: v0.10.3


### PR DESCRIPTION
Updates deployment reference configs: backend v0.10.4 → v0.10.5. Frontend stays at v0.10.3.

## Changelog
- chore: bump backend deployment reference image tag to v0.10.5