### PR TITLE
feat: OCSF audit log export format (F4.2)

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -402,14 +402,14 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Streams audit log entries as newline-delimited JSON (NDJSON) for archival.",
+                "description": "Streams audit log entries as newline-delimited JSON (NDJSON) or OCSF 1.1 API",
                 "produces": [
                     "application/x-ndjson"
                 ],
                 "tags": [
                     "Audit"
                 ],
-                "summary": "Export audit logs as NDJSON",
+                "summary": "Export audit logs",
                 "parameters": [
                     {
                         "type": "string",
@@ -422,6 +422,16 @@
                         "description": "End date in RFC3339 format (default: now)",
                         "name": "end_date",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "ndjson",
+                            "ocsf"
+                        ],
+                        "type": "string",
+                        "description": "Output format: ndjson (default) or ocsf",
+                        "name": "format",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -432,7 +442,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid date parameters",
+                        "description": "Invalid date or format parameters",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/audit_export.go
+++ b/backend/internal/api/admin/audit_export.go
@@ -1,4 +1,4 @@
-// audit_export.go implements the NDJSON export endpoint for audit logs.
+// audit_export.go implements the NDJSON and OCSF export endpoints for audit logs.
 package admin
 
 import (
@@ -7,28 +7,31 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/audit"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
-// @Summary      Export audit logs as NDJSON
-// @Description  Streams audit log entries as newline-delimited JSON (NDJSON) for archival.
+// @Summary      Export audit logs
+// @Description  Streams audit log entries as newline-delimited JSON (NDJSON) or OCSF 1.1 API
 //
-//	Accepts optional start_date and end_date query parameters in RFC3339 format.
-//	Defaults to the last 30 days when no dates are provided.
+//	Activity events for SIEM ingestion. Accepts optional start_date and end_date query
+//	parameters in RFC3339 format. Defaults to the last 30 days when no dates are provided.
+//	Use format=ocsf to receive OCSF-formatted events (class_uid 6003); default is format=ndjson.
 //
 // @Tags         Audit
 // @Security     Bearer
 // @Produce      application/x-ndjson
 // @Param        start_date  query  string  false  "Start date in RFC3339 format (default: 30 days ago)"
 // @Param        end_date    query  string  false  "End date in RFC3339 format (default: now)"
+// @Param        format      query  string  false  "Output format: ndjson (default) or ocsf"  Enums(ndjson, ocsf)
 // @Success      200  {string}  string  "NDJSON stream of audit log entries"
-// @Failure      400  {object}  map[string]interface{}  "Invalid date parameters"
+// @Failure      400  {object}  map[string]interface{}  "Invalid date or format parameters"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      403  {object}  map[string]interface{}  "Forbidden — audit:read scope required"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/audit-logs/export [get]
 // coverage:skip:requires-database
-func ExportAuditLogs(auditRepo *repositories.AuditRepository) gin.HandlerFunc {
+func ExportAuditLogs(auditRepo *repositories.AuditRepository, appVersion string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		now := time.Now().UTC()
 		startDate := now.AddDate(0, 0, -30)
@@ -52,6 +55,12 @@ func ExportAuditLogs(auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 			endDate = t
 		}
 
+		format := c.DefaultQuery("format", "ndjson")
+		if format != "ndjson" && format != "ocsf" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "format must be ndjson or ocsf"})
+			return
+		}
+
 		rows, err := auditRepo.StreamAuditLogs(c.Request.Context(), startDate, endDate)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query audit logs for export"})
@@ -59,7 +68,11 @@ func ExportAuditLogs(auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 		}
 		defer rows.Close()
 
-		filename := "audit-logs-" + now.Format("2006-01-02") + ".ndjson"
+		ext := "ndjson"
+		if format == "ocsf" {
+			ext = "ocsf.ndjson"
+		}
+		filename := "audit-logs-" + now.Format("2006-01-02") + "." + ext
 		c.Header("Content-Type", "application/x-ndjson")
 		c.Header("Content-Disposition", "attachment; filename="+filename)
 		c.Status(http.StatusOK)
@@ -90,7 +103,24 @@ func ExportAuditLogs(auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 				_ = json.Unmarshal(metadataJSON, &entry.Metadata)
 			}
 
-			_ = enc.Encode(entry) // writes JSON + "\n"
+			if format == "ocsf" {
+				ev := audit.ToOCSF(entry.toLogEntry(), appVersion)
+				// Supplement user name/email from the export row (not in LogEntry).
+				if ev.Actor.User != nil {
+					if entry.UserName != nil {
+						ev.Actor.User.Name = *entry.UserName
+					}
+					if entry.UserEmail != nil {
+						if ev.Unmapped == nil {
+							ev.Unmapped = make(map[string]interface{})
+						}
+						ev.Unmapped["user_email"] = *entry.UserEmail
+					}
+				}
+				_ = enc.Encode(ev)
+			} else {
+				_ = enc.Encode(entry) // writes JSON + "\n"
+			}
 			c.Writer.Flush()
 		}
 	}
@@ -109,4 +139,29 @@ type auditExportRow struct {
 	Metadata       map[string]interface{} `json:"metadata,omitempty"`
 	IPAddress      *string                `json:"ip_address,omitempty"`
 	CreatedAt      time.Time              `json:"created_at"`
+}
+
+// toLogEntry converts the export row into an audit.LogEntry for OCSF conversion.
+func (r *auditExportRow) toLogEntry() *audit.LogEntry {
+	entry := &audit.LogEntry{
+		Timestamp: r.CreatedAt,
+		Action:    r.Action,
+		Metadata:  r.Metadata,
+	}
+	if r.UserID != nil {
+		entry.UserID = *r.UserID
+	}
+	if r.OrganizationID != nil {
+		entry.OrganizationID = *r.OrganizationID
+	}
+	if r.ResourceType != nil {
+		entry.ResourceType = *r.ResourceType
+	}
+	if r.ResourceID != nil {
+		entry.ResourceID = *r.ResourceID
+	}
+	if r.IPAddress != nil {
+		entry.IPAddress = *r.IPAddress
+	}
+	return entry
 }

--- a/backend/internal/api/admin/audit_export_test.go
+++ b/backend/internal/api/admin/audit_export_test.go
@@ -27,7 +27,7 @@ func newAuditExportRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	auditRepo := repositories.NewAuditRepository(db)
 
 	r := gin.New()
-	r.GET("/audit-logs/export", ExportAuditLogs(auditRepo))
+	r.GET("/audit-logs/export", ExportAuditLogs(auditRepo, "test"))
 
 	return mock, r
 }
@@ -255,5 +255,97 @@ func TestExportAuditLogs_DefaultDateRange(t *testing.T) {
 	// Should succeed with 200 — no date params means default 30-day window
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExportAuditLogs — invalid format parameter
+// ---------------------------------------------------------------------------
+
+func TestExportAuditLogs_InvalidFormat(t *testing.T) {
+	_, r := newAuditExportRouter(t)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs/export?format=xml", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if _, ok := resp["error"]; !ok {
+		t.Error("expected 'error' key in response body")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ExportAuditLogs — OCSF format returns valid OCSF events
+// ---------------------------------------------------------------------------
+
+func TestExportAuditLogs_OCSFFormat(t *testing.T) {
+	mock, r := newAuditExportRouter(t)
+
+	email := "bob@example.com"
+	name := "Bob"
+	userID := "user-42"
+	orgID := "org-99"
+	resType := "module"
+	resID := "mod-7"
+	ip := "192.168.1.1"
+
+	rows := sqlmock.NewRows(auditExportCols).
+		AddRow("entry-ocsf", &userID, &orgID, "create_module", &resType, &resID,
+			nil, &ip, time.Now(), &email, &name)
+
+	mock.ExpectQuery("SELECT al\\.id").
+		WillReturnRows(rows)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs/export?format=ocsf", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", ct)
+	}
+
+	cd := w.Header().Get("Content-Disposition")
+	if cd == "" {
+		t.Error("expected Content-Disposition header")
+	}
+
+	// OCSF event must have class_uid 6003 and correct actor fields.
+	var ev map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &ev); err != nil {
+		t.Fatalf("failed to parse OCSF NDJSON line: %v\nbody: %s", err, w.Body.String())
+	}
+	if ev["class_uid"] != float64(6003) {
+		t.Errorf("class_uid = %v, want 6003", ev["class_uid"])
+	}
+	actor, ok := ev["actor"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("actor is not a map: %T", ev["actor"])
+	}
+	user, ok := actor["user"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("actor.user is not a map: %T", actor["user"])
+	}
+	if user["uid"] != "user-42" {
+		t.Errorf("actor.user.uid = %v, want user-42", user["uid"])
+	}
+	if user["name"] != "Bob" {
+		t.Errorf("actor.user.name = %v, want Bob", user["name"])
+	}
+	unmapped, ok := ev["unmapped"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("unmapped is not a map: %T", ev["unmapped"])
+	}
+	if unmapped["user_email"] != "bob@example.com" {
+		t.Errorf("unmapped.user_email = %v, want bob@example.com", unmapped["user_email"])
 	}
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -997,7 +997,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			auditLogsGroup := authenticatedGroup.Group("/admin/audit-logs")
 			{
 				auditLogsGroup.GET("", middleware.RequireScope(auth.ScopeAuditRead), auditLogHandlers.ListAuditLogsHandler())
-				auditLogsGroup.GET("/export", middleware.RequireScope(auth.ScopeAuditRead), admin.ExportAuditLogs(auditRepo))
+				auditLogsGroup.GET("/export", middleware.RequireScope(auth.ScopeAuditRead), admin.ExportAuditLogs(auditRepo, AppVersion))
 				auditLogsGroup.GET("/:id", middleware.RequireScope(auth.ScopeAuditRead), auditLogHandlers.GetAuditLogHandler())
 			}
 		}


### PR DESCRIPTION
Closes #247

Adds `?format=ocsf` to `GET /api/v1/admin/audit-logs/export`. When this parameter is set, each audit log entry is emitted as an OCSF 1.1 API Activity event (class_uid 6003) formatted as NDJSON. The default `format=ndjson` behavior is unchanged.

**Changes:**
- `internal/api/admin/audit_export.go`: added `format` query param validation, OCSF conversion path using `audit.ToOCSF`, user name/email supplementation in actor
- `internal/api/admin/audit_export_test.go`: added `TestExportAuditLogs_InvalidFormat` and `TestExportAuditLogs_OCSFFormat` tests; updated helper to pass `appVersion`
- `internal/api/router.go`: pass `AppVersion` to `ExportAuditLogs`
- The OCSF converter (`internal/audit/export.go`) was already fully implemented and tested in a prior commit

## Changelog
- feat: add OCSF 1.1 audit log export format via `?format=ocsf` query parameter on the export endpoint