### PR TITLE
feat: SLO dashboards, recording rules, and exemplar wiring (F4.1)

### DIFF
--- a/backend/internal/middleware/metrics.go
+++ b/backend/internal/middleware/metrics.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
@@ -22,6 +23,11 @@ import (
 // (e.g. /v1/modules/:namespace/:name/:system/:version/download) rather than the raw URL.
 // Requests that do not match any registered route (404/405) use the literal string
 // "<no-route>" so unhandled paths do not inflate label cardinality.
+//
+// Prometheus exemplars are attached to the duration histogram using the X-Request-ID
+// as the trace_id label. This links individual histogram observations to specific
+// requests, enabling Grafana Tempo or other trace backends to correlate metrics with
+// traces when the same request ID is propagated through the tracing pipeline.
 //
 // This middleware must be registered AFTER gin.Recovery() and RequestIDMiddleware so that
 // the response status set by error handlers is captured correctly:
@@ -49,6 +55,17 @@ func MetricsMiddleware() gin.HandlerFunc {
 		status := fmt.Sprintf("%d", c.Writer.Status())
 
 		telemetry.HTTPRequestsTotal.WithLabelValues(method, path, status).Inc()
-		telemetry.HTTPRequestDuration.WithLabelValues(method, path).Observe(duration)
+
+		// Attach the request ID as an exemplar on the duration histogram so operators
+		// can navigate from a slow histogram bucket directly to the offending request's
+		// trace or log entry.
+		obs := telemetry.HTTPRequestDuration.WithLabelValues(method, path)
+		if eo, ok := obs.(prometheus.ExemplarObserver); ok {
+			if requestID := c.GetString(RequestIDKey); requestID != "" {
+				eo.ObserveWithExemplar(duration, prometheus.Labels{"trace_id": requestID})
+				return
+			}
+		}
+		obs.Observe(duration)
 	}
 }

--- a/deployments/observability/alert-rules.yml
+++ b/deployments/observability/alert-rules.yml
@@ -1,0 +1,104 @@
+# Terraform Registry — Prometheus Alert Rules
+#
+# These rules fire when the registry is violating latency or error-rate SLOs.
+#
+# Load into Prometheus by referencing this file in your prometheus.yml:
+#
+#   rule_files:
+#     - /etc/prometheus/terraform-registry-alerts.yml
+#
+# Validate with: promtool check rules alert-rules.yml
+#
+# Prerequisites: recording-rules.yml must also be loaded so that
+# job:http_request_duration_p95:rate5m and job:http_errors_ratio:rate5m
+# are available.
+
+groups:
+  - name: terraform_registry_slo_alerts
+    rules:
+
+      # -----------------------------------------------------------------------
+      # Latency SLO: p95 must be ≤ 2 s (5-minute window)
+      # -----------------------------------------------------------------------
+      - alert: RegistryHighLatency
+        expr: job:http_request_duration_p95:rate5m > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Terraform Registry p95 latency above 2 s"
+          description: >
+            The 95th-percentile HTTP request duration has been above 2 seconds
+            for 5 consecutive minutes.
+            Current p95: {{ printf "%.2f" $value }}s.
+            Check slow queries, storage backend latency, or upstream registry
+            timeouts.
+
+      - alert: RegistryCriticalLatency
+        expr: job:http_request_duration_p95:rate5m > 5
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Terraform Registry p95 latency above 5 s — SLO violation"
+          description: >
+            The 95th-percentile HTTP request duration has exceeded 5 seconds
+            for 2 consecutive minutes. SLO is in violation.
+            Current p95: {{ printf "%.2f" $value }}s.
+
+      # -----------------------------------------------------------------------
+      # Error rate SLO: 5xx rate must be < 1% (5-minute window)
+      # -----------------------------------------------------------------------
+      - alert: RegistryHighErrorRate
+        expr: job:http_errors_ratio:rate5m > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Terraform Registry 5xx error rate above 1%"
+          description: >
+            The fraction of HTTP responses with 5xx status codes has been
+            above 1% for 5 consecutive minutes.
+            Current rate: {{ printf "%.2f%%" (mul $value 100) }}.
+            Check application logs and database connectivity.
+
+      - alert: RegistryCriticalErrorRate
+        expr: job:http_errors_ratio:rate5m > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Terraform Registry 5xx error rate above 5% — SLO violation"
+          description: >
+            The fraction of HTTP responses with 5xx status codes has exceeded
+            5% for 2 consecutive minutes. SLO is in violation.
+            Current rate: {{ printf "%.2f%%" (mul $value 100) }}.
+
+      # -----------------------------------------------------------------------
+      # Fast burn: SLO burn rate > 14.4x for 1 hour (depletes 2% of monthly budget)
+      # -----------------------------------------------------------------------
+      - alert: RegistrySLOFastBurn
+        expr: job:slo_burn_rate:rate5m > 14.4
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Terraform Registry SLO fast-burn — monthly error budget at risk"
+          description: >
+            The SLO burn rate has been above 14.4x the steady-state for 1 hour,
+            meaning 2% of the monthly error budget (assuming 1% target) has been
+            consumed. Immediate investigation is required.
+            Current burn rate: {{ printf "%.1f" $value }}x.
+
+      # -----------------------------------------------------------------------
+      # Mirror sync health
+      # -----------------------------------------------------------------------
+      - alert: RegistryMirrorSyncErrors
+        expr: increase(mirror_sync_errors_total[30m]) > 3
+        labels:
+          severity: warning
+        annotations:
+          summary: "Terraform Registry mirror sync failing repeatedly"
+          description: >
+            Mirror {{ $labels.mirror_id }} has had more than 3 sync errors in
+            the last 30 minutes. Check upstream registry availability.

--- a/deployments/observability/grafana-dashboard.json
+++ b/deployments/observability/grafana-dashboard.json
@@ -1,0 +1,352 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source connected to your Terraform Registry",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "description": "SLO overview for the Terraform Registry: latency percentiles, error rate, download and publish volumes, and SLO burn rate. Requires recording-rules.yml and alert-rules.yml to be loaded in Prometheus.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP p95 Latency (all routes)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:http_request_duration_p95:rate5m",
+          "legendFormat": "p95",
+          "exemplar": true
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:http_request_duration_p99:rate5m",
+          "legendFormat": "p99",
+          "exemplar": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "p95 Latency by Route",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s", "custom": { "lineWidth": 1, "fillOpacity": 5 } }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "path:http_request_duration_p95:rate5m",
+          "legendFormat": "{{ path }}",
+          "exemplar": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP 5xx Error Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "lineWidth": 2, "fillOpacity": 20 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "max": 0.1
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:http_errors_ratio:rate5m",
+          "legendFormat": "5xx rate"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "0.01",
+          "legendFormat": "SLO target (1%)"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "SLO Burn Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 15 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "orange", "value": 6 },
+              { "color": "red", "value": 14.4 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:slo_burn_rate:rate5m",
+          "legendFormat": "burn rate"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "14.4",
+          "legendFormat": "fast-burn threshold"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "1",
+          "legendFormat": "steady-state (1x)"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Module Download Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:module_downloads:rate5m",
+          "legendFormat": "modules/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:provider_downloads:rate5m",
+          "legendFormat": "providers/s"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Module Publish Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:module_publishes:rate5m",
+          "legendFormat": "modules published/s"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Current p95 Latency",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "colorMode": "background" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:http_request_duration_p95:rate5m",
+          "legendFormat": "p95 latency",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Current Error Rate",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "colorMode": "background" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:http_errors_ratio:rate5m",
+          "legendFormat": "5xx rate",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "SLO Burn Rate (current)",
+      "type": "gauge",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "max": 20,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "orange", "value": 6 },
+              { "color": "red", "value": 14.4 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "job:slo_burn_rate:rate5m",
+          "legendFormat": "",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "DB Open Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 15 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "colorMode": "background" },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "db_open_connections",
+          "legendFormat": "connections",
+          "instant": true
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["terraform", "registry", "slo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Terraform Registry — SLO Dashboard",
+  "uid": "terraform-registry-slo",
+  "version": 1
+}

--- a/deployments/observability/recording-rules.yml
+++ b/deployments/observability/recording-rules.yml
@@ -1,0 +1,77 @@
+# Terraform Registry — Prometheus Recording Rules
+#
+# These rules pre-compute expensive PromQL expressions so dashboards and
+# alert rules can query cheap counters instead of repeating heavy aggregations.
+#
+# Load into Prometheus by referencing this file in your prometheus.yml:
+#
+#   rule_files:
+#     - /etc/prometheus/terraform-registry-rules.yml
+#
+# Validate with: promtool check rules recording-rules.yml
+
+groups:
+  - name: terraform_registry_slo
+    interval: 60s
+    rules:
+      # p95 HTTP request latency across all routes (5-minute window)
+      - record: job:http_request_duration_p95:rate5m
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le) (
+              rate(http_request_duration_seconds_bucket[5m])
+            )
+          )
+
+      # p99 HTTP request latency across all routes (5-minute window)
+      - record: job:http_request_duration_p99:rate5m
+        expr: |
+          histogram_quantile(0.99,
+            sum by (le) (
+              rate(http_request_duration_seconds_bucket[5m])
+            )
+          )
+
+      # Per-route p95 latency (5-minute window) — labelled by path
+      - record: path:http_request_duration_p95:rate5m
+        expr: |
+          histogram_quantile(0.95,
+            sum by (path, le) (
+              rate(http_request_duration_seconds_bucket[5m])
+            )
+          )
+
+      # HTTP error ratio: 5xx / total (5-minute window)
+      - record: job:http_errors_ratio:rate5m
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+
+      # HTTP client error ratio: 4xx / total (5-minute window)
+      - record: job:http_client_errors_ratio:rate5m
+        expr: |
+          sum(rate(http_requests_total{status=~"4.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+
+      # Module download rate (per second, 5-minute window)
+      - record: job:module_downloads:rate5m
+        expr: sum(rate(module_downloads_total[5m]))
+
+      # Provider download rate (per second, 5-minute window)
+      - record: job:provider_downloads:rate5m
+        expr: sum(rate(provider_downloads_total[5m]))
+
+      # Module publish rate (per second, 5-minute window)
+      - record: job:module_publishes:rate5m
+        expr: sum(rate(registry_module_publishes_total[5m]))
+
+      # SLO burn rate: how fast we are consuming the 1% monthly error budget.
+      # A value > 1 means we are burning faster than steady-state; > 14.4 triggers
+      # the 1-hour fast-burn alert window.
+      - record: job:slo_burn_rate:rate5m
+        expr: |
+          job:http_errors_ratio:rate5m
+          /
+          0.01


### PR DESCRIPTION
Closes #246

Adds the complete observability layer for SLO tracking.

**New files in `deployments/observability/`:**
- `grafana-dashboard.json` — 10-panel dashboard: p95/p99 latency (global + per-route), 5xx error rate vs SLO target, SLO burn rate, module/provider download rate, module publish rate, and summary stat/gauge panels. Import via Grafana UI or `grafana-cli dashboards import`.
- `recording-rules.yml` — Pre-computed recording rules for dashboard and alert efficiency. Load via `rule_files:` in `prometheus.yml`. Validate with `promtool check rules recording-rules.yml`.
- `alert-rules.yml` — Five alert rules: `RegistryHighLatency` (p95 >2s), `RegistryCriticalLatency` (p95 >5s), `RegistryHighErrorRate` (5xx >1%), `RegistryCriticalErrorRate` (5xx >5%), `RegistrySLOFastBurn` (burn rate >14.4x for 1h), `RegistryMirrorSyncErrors`.

**Code change in `backend/internal/middleware/metrics.go`:**
- `MetricsMiddleware` now attaches a `trace_id` exemplar to each `http_request_duration_seconds` histogram observation using the `X-Request-ID` value. Enables Grafana Exemplar scatter overlay to link slow buckets to specific requests.

## Changelog
- feat: add Grafana SLO dashboard with p95/p99 latency, error rate, burn rate, and download panels
- feat: add Prometheus recording rules and alert rules for latency and error-rate SLOs
- feat: wire Prometheus exemplars (trace_id=X-Request-ID) into HTTP duration histogram