### PR TITLE
feat: add registry-import CLI for bulk namespace import

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,26 @@ builds:
       - -X main.BuildDate={{ .Date }}
     mod_timestamp: "{{ .CommitTimestamp }}"
 
+  - id: registry-import
+    dir: backend
+    main: ./cmd/registry-import
+    binary: registry-import
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
 archives:
   - id: terraform-registry-binaries
     formats: [ binary ]

--- a/backend/cmd/registry-import/main.go
+++ b/backend/cmd/registry-import/main.go
@@ -425,7 +425,7 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 		if !info.IsDir() {
 			const maxEntryBytes = 500 * 1024 * 1024 // 500 MB per-entry limit — prevents decompression bombs
 			if _, err := io.Copy(tw, io.LimitReader(rc, maxEntryBytes)); err != nil { // #nosec G110
-				rc.Close() // #nosec G104 -- nolint:errcheck, closing reader on error path
+				_ = rc.Close() // explicitly discard — already returning the io.Copy error
 				return nil, err
 			}
 		}

--- a/backend/cmd/registry-import/main.go
+++ b/backend/cmd/registry-import/main.go
@@ -414,22 +414,22 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 		info := f.FileInfo()
 		header, err := tar.FileInfoHeader(info, "")
 		if err != nil {
-			rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
+			rc.Close() // #nosec G104 -- nolint:errcheck, closing reader on error path
 			return nil, err
 		}
 		header.Name = f.Name
 		if err := tw.WriteHeader(header); err != nil {
-			rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
+			rc.Close() // #nosec G104 -- nolint:errcheck, closing reader on error path
 			return nil, err
 		}
 		if !info.IsDir() {
 			const maxEntryBytes = 500 * 1024 * 1024 // 500 MB per-entry limit — prevents decompression bombs
 			if _, err := io.Copy(tw, io.LimitReader(rc, maxEntryBytes)); err != nil { // #nosec G110
-				rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
+				rc.Close() // #nosec G104 -- nolint:errcheck, closing reader on error path
 				return nil, err
 			}
 		}
-		rc.Close() //nolint:errcheck // #nosec G104 -- closing entry reader, return value not actionable
+		rc.Close() // #nosec G104 -- nolint:errcheck, closing entry reader
 	}
 
 	if err := tw.Close(); err != nil {

--- a/backend/cmd/registry-import/main.go
+++ b/backend/cmd/registry-import/main.go
@@ -414,21 +414,22 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 		info := f.FileInfo()
 		header, err := tar.FileInfoHeader(info, "")
 		if err != nil {
-			rc.Close() //nolint:errcheck
+			rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
 			return nil, err
 		}
 		header.Name = f.Name
 		if err := tw.WriteHeader(header); err != nil {
-			rc.Close() //nolint:errcheck
+			rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
 			return nil, err
 		}
 		if !info.IsDir() {
-			if _, err := io.Copy(tw, rc); err != nil {
-				rc.Close() //nolint:errcheck
+			const maxEntryBytes = 500 * 1024 * 1024 // 500 MB per-entry limit — prevents decompression bombs
+			if _, err := io.Copy(tw, io.LimitReader(rc, maxEntryBytes)); err != nil { // #nosec G110
+				rc.Close() //nolint:errcheck // #nosec G104 -- closing on error path, return value not actionable
 				return nil, err
 			}
 		}
-		rc.Close() //nolint:errcheck
+		rc.Close() //nolint:errcheck // #nosec G104 -- closing entry reader, return value not actionable
 	}
 
 	if err := tw.Close(); err != nil {

--- a/backend/cmd/registry-import/main.go
+++ b/backend/cmd/registry-import/main.go
@@ -1,0 +1,441 @@
+// registry-import imports module versions from a public Terraform registry into a private
+// registry instance via its upload API.
+//
+// Usage:
+//
+//	registry-import \
+//	  --namespace=hashicorp \
+//	  --source-url=https://registry.terraform.io \
+//	  --org=myorg \
+//	  --registry-url=https://my-registry.example.com \
+//	  --api-key=<key>
+//
+// Flags:
+//   - --source-url     Base URL of the source registry (default: https://registry.terraform.io)
+//   - --namespace      Namespace (author) to import from the source registry (required)
+//   - --module         Specific module name within the namespace to import (optional; imports all when omitted)
+//   - --system         Filter by provider system, e.g. aws, azurerm (optional; imports all systems when omitted)
+//   - --org            Organisation slug in the target registry (required)
+//   - --registry-url   Base URL of the target registry (required)
+//   - --api-key        API key for the target registry (required)
+//   - --dry-run        Print planned actions without uploading anything
+//   - --concurrency    Maximum parallel uploads (default: 4)
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ─── source registry types ────────────────────────────────────────────────────
+
+type versionsResponse struct {
+	Modules []struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	} `json:"modules"`
+}
+
+type searchResponse struct {
+	Modules []sourceModule `json:"modules"`
+	Meta    struct {
+		NextOffset int `json:"next_offset"`
+		Limit      int `json:"limit"`
+		Total      int `json:"total"`
+	} `json:"meta"`
+}
+
+type sourceModule struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+}
+
+// ─── work item ────────────────────────────────────────────────────────────────
+
+type importJob struct {
+	namespace string
+	name      string
+	system    string
+	version   string
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+
+func main() {
+	sourceURL := flag.String("source-url", "https://registry.terraform.io", "Source registry base URL")
+	namespace := flag.String("namespace", "", "Namespace to import from source registry (required)")
+	module := flag.String("module", "", "Specific module name to import (default: all modules in namespace)")
+	system := flag.String("system", "", "Filter by provider/system (default: all)")
+	org := flag.String("org", "", "Organisation slug in the target registry (required)")
+	registryURL := flag.String("registry-url", "", "Target registry base URL (required)")
+	apiKey := flag.String("api-key", "", "API key for the target registry (required)")
+	dryRun := flag.Bool("dry-run", false, "Print planned actions without uploading")
+	concurrency := flag.Int("concurrency", 4, "Maximum parallel uploads")
+	flag.Parse()
+
+	if *namespace == "" {
+		log.Fatal("--namespace is required")
+	}
+	if *org == "" {
+		log.Fatal("--org is required")
+	}
+	if *registryURL == "" {
+		log.Fatal("--registry-url is required")
+	}
+	if *apiKey == "" {
+		log.Fatal("--api-key is required")
+	}
+
+	client := &http.Client{Timeout: 120 * time.Second}
+
+	// Collect all (module, system) pairs to import.
+	modules, err := listModules(client, *sourceURL, *namespace, *module, *system)
+	if err != nil {
+		log.Fatalf("listing modules: %v", err)
+	}
+	log.Printf("found %d module/system combinations in namespace %q", len(modules), *namespace)
+
+	// Build the full job list.
+	var jobs []importJob
+	for _, m := range modules {
+		versions, err := listVersions(client, *sourceURL, m.Namespace, m.Name, m.Provider)
+		if err != nil {
+			log.Printf("[warn] listing versions for %s/%s/%s: %v", m.Namespace, m.Name, m.Provider, err)
+			continue
+		}
+		for _, v := range versions {
+			jobs = append(jobs, importJob{
+				namespace: m.Namespace,
+				name:      m.Name,
+				system:    m.Provider,
+				version:   v,
+			})
+		}
+	}
+
+	log.Printf("planning to import %d module versions", len(jobs))
+
+	if *dryRun {
+		for _, j := range jobs {
+			fmt.Printf("  [dry-run] %s/%s/%s@%s\n", j.namespace, j.name, j.system, j.version)
+		}
+		return
+	}
+
+	// Execute imports with bounded concurrency.
+	sem := make(chan struct{}, *concurrency)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var succeeded, skipped, failed int
+
+	for _, j := range jobs {
+		j := j
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			result, err := importVersion(client, *sourceURL, *registryURL, *apiKey, *org, j)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil && result == "skipped":
+				skipped++
+				log.Printf("[skip]    %s/%s/%s@%s (already exists)", j.namespace, j.name, j.system, j.version)
+			case err == nil:
+				succeeded++
+				log.Printf("[ok]      %s/%s/%s@%s", j.namespace, j.name, j.system, j.version)
+			default:
+				failed++
+				log.Printf("[error]   %s/%s/%s@%s: %v", j.namespace, j.name, j.system, j.version, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+	log.Printf("done — imported: %d, skipped: %d, failed: %d", succeeded, skipped, failed)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// ─── source registry helpers ──────────────────────────────────────────────────
+
+// listModules returns all modules in the namespace. If moduleName or providerFilter is set
+// the results are filtered accordingly. Paginates automatically.
+func listModules(client *http.Client, sourceURL, namespace, moduleName, providerFilter string) ([]sourceModule, error) {
+	// If a specific module is given we can build the list directly.
+	if moduleName != "" {
+		if providerFilter != "" {
+			return []sourceModule{{Namespace: namespace, Name: moduleName, Provider: providerFilter}}, nil
+		}
+		// We still need to discover which systems exist for this module.
+		return listModuleSystems(client, sourceURL, namespace, moduleName)
+	}
+
+	// Otherwise page through the registry search API.
+	var all []sourceModule
+	offset := 0
+	for {
+		u := fmt.Sprintf("%s/v1/modules?namespace=%s&limit=50&offset=%d", sourceURL, namespace, offset)
+		var resp searchResponse
+		if err := getJSON(client, u, &resp); err != nil {
+			return nil, err
+		}
+		for _, m := range resp.Modules {
+			if providerFilter == "" || m.Provider == providerFilter {
+				all = append(all, m)
+			}
+		}
+		if offset+resp.Meta.Limit >= resp.Meta.Total {
+			break
+		}
+		offset += resp.Meta.Limit
+	}
+	return all, nil
+}
+
+// listModuleSystems returns all provider/system entries for a given namespace/module.
+func listModuleSystems(client *http.Client, sourceURL, namespace, moduleName string) ([]sourceModule, error) {
+	u := fmt.Sprintf("%s/v1/modules/%s/%s", sourceURL, namespace, moduleName)
+	// The module search endpoint returns multiple rows (one per provider) when provider is omitted.
+	var resp searchResponse
+	if err := getJSON(client, u, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Modules, nil
+}
+
+// listVersions returns all published version strings for a module.
+func listVersions(client *http.Client, sourceURL, namespace, name, provider string) ([]string, error) {
+	u := fmt.Sprintf("%s/v1/modules/%s/%s/%s/versions", sourceURL, namespace, name, provider)
+	var resp versionsResponse
+	if err := getJSON(client, u, &resp); err != nil {
+		return nil, err
+	}
+	if len(resp.Modules) == 0 {
+		return nil, nil
+	}
+	var versions []string
+	for _, v := range resp.Modules[0].Versions {
+		versions = append(versions, v.Version)
+	}
+	return versions, nil
+}
+
+// downloadURL retrieves the download URL for a specific module version via the
+// X-Terraform-Get redirect header.
+func downloadURL(client *http.Client, sourceURL, namespace, name, provider, version string) (string, error) {
+	u := fmt.Sprintf("%s/v1/modules/%s/%s/%s/%s/download", sourceURL, namespace, name, provider, version)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download redirect: unexpected status %d", resp.StatusCode)
+	}
+	location := resp.Header.Get("X-Terraform-Get")
+	if location == "" {
+		location = resp.Header.Get("Location")
+	}
+	if location == "" {
+		return "", errors.New("download redirect: no X-Terraform-Get or Location header")
+	}
+	return location, nil
+}
+
+// fetchArchive downloads a module archive from archiveURL and returns it as a .tar.gz byte
+// slice. If the upstream serves a .zip, it is converted on the fly.
+func fetchArchive(client *http.Client, archiveURL string) ([]byte, error) {
+	resp, err := client.Get(archiveURL) // #nosec G107 -- URL originates from public registry X-Terraform-Get header
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("archive download: status %d from %s", resp.StatusCode, archiveURL)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the upstream returned a .zip, re-pack it as .tar.gz.
+	if strings.HasSuffix(archiveURL, ".zip") || isZip(body) {
+		return zipToTarGz(body)
+	}
+	return body, nil
+}
+
+// ─── target registry upload ───────────────────────────────────────────────────
+
+// importVersion downloads a module version from source and uploads it to the target registry.
+// Returns "skipped" when the version already exists (HTTP 409), nil error on success.
+func importVersion(client *http.Client, sourceURL, registryURL, apiKey, org string, j importJob) (string, error) {
+	// 1. Resolve the download URL.
+	archiveURL, err := downloadURL(client, sourceURL, j.namespace, j.name, j.system, j.version)
+	if err != nil {
+		return "", fmt.Errorf("resolving download URL: %w", err)
+	}
+
+	// Resolve relative URLs against sourceURL.
+	if strings.HasPrefix(archiveURL, "/") {
+		archiveURL = sourceURL + archiveURL
+	}
+
+	// 2. Download the archive.
+	archive, err := fetchArchive(client, archiveURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching archive: %w", err)
+	}
+
+	// 3. Build the multipart upload request.
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+
+	writeField := func(k, v string) {
+		if fw, e := mw.CreateFormField(k); e == nil {
+			_, _ = fw.Write([]byte(v))
+		}
+	}
+	writeField("namespace", j.namespace)
+	writeField("name", j.name)
+	writeField("system", j.system)
+	writeField("version", j.version)
+	writeField("org", org)
+
+	fw, err := mw.CreateFormFile("file", path.Base(j.name)+"-"+j.version+".tar.gz")
+	if err != nil {
+		return "", err
+	}
+	if _, err := fw.Write(archive); err != nil {
+		return "", err
+	}
+	if err := mw.Close(); err != nil {
+		return "", err
+	}
+
+	// 4. POST to the target registry.
+	uploadURL := strings.TrimRight(registryURL, "/") + "/api/v1/modules"
+	req, err := http.NewRequest(http.MethodPost, uploadURL, &body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusOK:
+		return "ok", nil
+	case http.StatusConflict:
+		return "skipped", nil
+	default:
+		resBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("upload returned %d: %s", resp.StatusCode, strings.TrimSpace(string(resBody)))
+	}
+}
+
+// ─── utilities ────────────────────────────────────────────────────────────────
+
+func getJSON(client *http.Client, url string, dest interface{}) error {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(dest)
+}
+
+// isZip checks the first 4 bytes for the PK\x03\x04 magic header.
+func isZip(data []byte) bool {
+	return len(data) >= 4 &&
+		data[0] == 0x50 && data[1] == 0x4B && data[2] == 0x03 && data[3] == 0x04
+}
+
+// zipToTarGz converts a zip archive (in memory) to a .tar.gz stream.
+// Terraform module archives from the public registry are often zip files.
+func zipToTarGz(zipData []byte) ([]byte, error) {
+	r := bytes.NewReader(zipData)
+	zr, err := zip.NewReader(r, int64(len(zipData)))
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		info := f.FileInfo()
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			rc.Close() //nolint:errcheck
+			return nil, err
+		}
+		header.Name = f.Name
+		if err := tw.WriteHeader(header); err != nil {
+			rc.Close() //nolint:errcheck
+			return nil, err
+		}
+		if !info.IsDir() {
+			if _, err := io.Copy(tw, rc); err != nil {
+				rc.Close() //nolint:errcheck
+				return nil, err
+			}
+		}
+		rc.Close() //nolint:errcheck
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/backend/cmd/registry-import/main_test.go
+++ b/backend/cmd/registry-import/main_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ─── isZip ────────────────────────────────────────────────────────────────────
+
+func TestIsZip_Valid(t *testing.T) {
+	// Minimal valid zip header
+	data := []byte{0x50, 0x4B, 0x03, 0x04, 0x00, 0x00}
+	if !isZip(data) {
+		t.Error("expected true for zip magic header")
+	}
+}
+
+func TestIsZip_Invalid(t *testing.T) {
+	if isZip([]byte{0x1F, 0x8B, 0x00}) {
+		t.Error("expected false for gzip header")
+	}
+}
+
+func TestIsZip_Short(t *testing.T) {
+	if isZip([]byte{0x50, 0x4B}) {
+		t.Error("expected false for short slice")
+	}
+}
+
+// ─── zipToTarGz ───────────────────────────────────────────────────────────────
+
+func buildZip(files map[string]string) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := w.Write([]byte(content)); err != nil {
+			return nil, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestZipToTarGz_RoundTrip(t *testing.T) {
+	zipData, err := buildZip(map[string]string{
+		"main.tf": `resource "null_resource" "example" {}`,
+	})
+	if err != nil {
+		t.Fatalf("building zip: %v", err)
+	}
+
+	tgz, err := zipToTarGz(zipData)
+	if err != nil {
+		t.Fatalf("zipToTarGz: %v", err)
+	}
+
+	// Read back and verify the file is present.
+	gr, err := gzip.NewReader(bytes.NewReader(tgz))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	tr := tar.NewReader(gr)
+	found := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		if hdr.Name == "main.tf" {
+			found = true
+			content, _ := io.ReadAll(tr)
+			if !strings.Contains(string(content), "null_resource") {
+				t.Errorf("unexpected content: %s", content)
+			}
+		}
+	}
+	if !found {
+		t.Error("main.tf not found in converted tar.gz")
+	}
+}
+
+func TestZipToTarGz_InvalidZip(t *testing.T) {
+	_, err := zipToTarGz([]byte("not a zip"))
+	if err == nil {
+		t.Error("expected error for invalid zip data")
+	}
+}
+
+// ─── listVersions via HTTP mock ───────────────────────────────────────────────
+
+func TestListVersions_OK(t *testing.T) {
+	payload := versionsResponse{
+		Modules: []struct {
+			Versions []struct {
+				Version string `json:"version"`
+			} `json:"versions"`
+		}{
+			{Versions: []struct {
+				Version string `json:"version"`
+			}{{Version: "1.0.0"}, {Version: "1.1.0"}}},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	versions, err := listVersions(client, srv.URL, "hashicorp", "consul", "aws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(versions))
+	}
+}
+
+func TestListVersions_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"modules":[]}`))
+	}))
+	defer srv.Close()
+
+	versions, err := listVersions(srv.Client(), srv.URL, "ns", "name", "aws")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("expected 0 versions, got %d", len(versions))
+	}
+}
+
+func TestListVersions_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := listVersions(srv.Client(), srv.URL, "ns", "name", "aws")
+	if err == nil {
+		t.Error("expected error for 404")
+	}
+}
+
+// ─── downloadURL via HTTP mock ────────────────────────────────────────────────
+
+func TestDownloadURL_XTerraformGet(t *testing.T) {
+	const want = "https://example.com/archive.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Terraform-Get", want)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	got, err := downloadURL(srv.Client(), srv.URL, "ns", "name", "aws", "1.0.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDownloadURL_NoHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	_, err := downloadURL(srv.Client(), srv.URL, "ns", "name", "aws", "1.0.0")
+	if err == nil {
+		t.Error("expected error when no location header")
+	}
+}
+
+// ─── importVersion — skip on 409 ─────────────────────────────────────────────
+
+func TestImportVersion_SkipOn409(t *testing.T) {
+	// Source: serve download redirect + archive
+	archiveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/download"):
+			w.Header().Set("X-Terraform-Get", "http://"+r.Host+"/archive.tar.gz")
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(r.URL.Path, ".tar.gz"):
+			// Minimal valid tar.gz (empty)
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			_ = gw.Close()
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(buf.Bytes())
+		}
+	}))
+	defer archiveSrv.Close()
+
+	// Target: always return 409
+	targetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer targetSrv.Close()
+
+	result, err := importVersion(archiveSrv.Client(), archiveSrv.URL, targetSrv.URL, "key", "org",
+		importJob{namespace: "ns", name: "name", system: "aws", version: "1.0.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "skipped" {
+		t.Errorf("expected skipped, got %q", result)
+	}
+}


### PR DESCRIPTION
Closes #245

Adds a `registry-import` binary that fetches module versions from a source public Terraform registry and uploads them to a private registry instance using its existing upload API.

## Usage

```bash
registry-import \
  --namespace=hashicorp \
  --source-url=https://registry.terraform.io \
  --org=myorg \
  --registry-url=https://my-registry.example.com \
  --api-key=<key>

# Dry run to preview what would be imported
registry-import --namespace=hashicorp --module=consul --dry-run \
  --org=myorg --registry-url=https://my-registry.example.com --api-key=<key>
```

## Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--source-url` | `https://registry.terraform.io` | Source registry base URL |
| `--namespace` | — | Namespace to import (required) |
| `--module` | all | Specific module name to import |
| `--system` | all | Filter by provider/system |
| `--org` | — | Organisation in target registry (required) |
| `--registry-url` | — | Target registry base URL (required) |
| `--api-key` | — | API key for target registry (required) |
| `--dry-run` | false | Preview without uploading |
| `--concurrency` | 4 | Max parallel uploads |

## Details

- Idempotent: HTTP 409 responses from the target are treated as "already exists" and silently skipped
- Automatically converts `.zip` archives (format used by public registry) to `.tar.gz`
- Paginates through namespace search results to discover all modules
- Added to `.goreleaser.yml` as a second build target so release binaries ship for linux/darwin/windows (amd64+arm64, no windows/arm64)

## Changelog
- feat: add `registry-import` CLI tool for bulk importing module versions from a public Terraform registry namespace