### PR TITLE
feat: add OCI Distribution Spec v1.1 endpoints

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10816,6 +10816,260 @@
                 }
             }
         },
+        "/v2/": {
+            "get": {
+                "description": "Returns 200 to indicate OCI Distribution Spec v1.1 support.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "System"
+                ],
+                "summary": "OCI API ping",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/{namespace}/{name}/{system}/blobs/{digest}": {
+            "get": {
+                "description": "Streams the module archive (tar.gz) for the given digest.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Download module blob",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider/system",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Blob digest (sha256:...)",
+                        "name": "digest",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "head": {
+                "description": "Returns headers for the module archive blob identified by its digest.",
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Check module blob",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider/system",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Blob digest (sha256:...)",
+                        "name": "digest",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/v2/{namespace}/{name}/{system}/manifests/{reference}": {
+            "get": {
+                "description": "Returns the OCI manifest for a module version.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Get module manifest",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider/system",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Version tag or digest",
+                        "name": "reference",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/oci.ociManifest"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "OCI push is not supported; use POST /api/v1/modules to publish modules.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Push module manifest (not supported)",
+                "responses": {
+                    "405": {
+                        "description": "Method Not Allowed",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "head": {
+                "description": "Returns headers for the OCI manifest corresponding to a module version.",
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Check module manifest",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider/system",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Version tag or digest",
+                        "name": "reference",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/version": {
             "get": {
                 "description": "Returns the current API version and supported protocol versions.",
@@ -14202,6 +14456,40 @@
                     "type": "integer"
                 },
                 "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "oci.ociDescriptor": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string"
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                }
+            }
+        },
+        "oci.ociManifest": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/oci.ociDescriptor"
+                },
+                "layers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/oci.ociDescriptor"
+                    }
+                },
+                "mediaType": {
+                    "type": "string"
+                },
+                "schemaVersion": {
                     "type": "integer"
                 }
             }

--- a/backend/internal/api/oci/handler.go
+++ b/backend/internal/api/oci/handler.go
@@ -1,0 +1,306 @@
+// Package oci implements the OCI Distribution Spec v1.1 endpoints for the Terraform Registry.
+// It exposes module archives as OCI artifacts so that tools like `oras` can pull modules.
+//
+// Image naming convention:
+//
+//	/v2/<namespace>/<name>/<system>/manifests/<version>   — manifest (module metadata)
+//	/v2/<namespace>/<name>/<system>/blobs/sha256:<digest> — blob (tar.gz archive)
+//
+// Media types:
+//
+//	Config layer: application/vnd.oci.image.config.v1+json
+//	Module layer: application/vnd.opentofu.modulepkg.v1.tar+gzip
+//
+// Authentication:
+//
+//	Read operations (HEAD, GET): governed by the optional auth middleware in router.go.
+//	Write operations (PUT manifest): not supported — use POST /api/v1/modules.
+package oci
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
+)
+
+const (
+	mediaTypeConfig   = "application/vnd.oci.image.config.v1+json"
+	mediaTypeLayer    = "application/vnd.opentofu.modulepkg.v1.tar+gzip"
+	mediaTypeManifest = "application/vnd.oci.image.manifest.v1+json"
+	ociSpecVersion    = "2"
+)
+
+// Handler serves OCI Distribution Spec v1.1 endpoints backed by the registry's module store.
+type Handler struct {
+	moduleRepo *repositories.ModuleRepository
+	orgRepo    *repositories.OrganizationRepository
+	storage    storage.Storage
+}
+
+// NewHandler creates a new OCI Handler.
+func NewHandler(db *sql.DB, storageBackend storage.Storage) *Handler {
+	return &Handler{
+		moduleRepo: repositories.NewModuleRepository(db),
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		storage:    storageBackend,
+	}
+}
+
+// Ping handles GET /v2/ — OCI capability discovery.
+//
+// @Summary      OCI API ping
+// @Description  Returns 200 to indicate OCI Distribution Spec v1.1 support.
+// @Tags         System
+// @Produce      json
+// @Success      200  {object}  map[string]interface{}
+// @Router       /v2/ [get]
+func (h *Handler) Ping(c *gin.Context) {
+	c.Header("OCI-Distribution-Spec-Version", ociSpecVersion)
+	c.JSON(http.StatusOK, gin.H{})
+}
+
+// HeadManifest handles HEAD /v2/<namespace>/<name>/<system>/manifests/<reference>.
+//
+// @Summary      Check module manifest
+// @Description  Returns headers for the OCI manifest corresponding to a module version.
+// @Tags         Modules
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Provider/system"
+// @Param        reference  path  string  true  "Version tag or digest"
+// @Success      200
+// @Failure      404  {object}  map[string]interface{}
+// @Router       /v2/{namespace}/{name}/{system}/manifests/{reference} [head]
+func (h *Handler) HeadManifest(c *gin.Context) {
+	data, statusCode, err := h.buildManifestJSON(c)
+	if err != nil {
+		c.JSON(statusCode, ociErrors("MANIFEST_UNKNOWN", err.Error()))
+		return
+	}
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	c.Header("Content-Type", mediaTypeManifest)
+	c.Header("Docker-Content-Digest", digest)
+	c.Header("Content-Length", fmt.Sprintf("%d", len(data)))
+	c.Status(http.StatusOK)
+}
+
+// GetManifest handles GET /v2/<namespace>/<name>/<system>/manifests/<reference>.
+//
+// @Summary      Get module manifest
+// @Description  Returns the OCI manifest for a module version.
+// @Tags         Modules
+// @Produce      json
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Provider/system"
+// @Param        reference  path  string  true  "Version tag or digest"
+// @Success      200  {object}  ociManifest
+// @Failure      404  {object}  map[string]interface{}
+// @Router       /v2/{namespace}/{name}/{system}/manifests/{reference} [get]
+func (h *Handler) GetManifest(c *gin.Context) {
+	data, statusCode, err := h.buildManifestJSON(c)
+	if err != nil {
+		c.JSON(statusCode, ociErrors("MANIFEST_UNKNOWN", err.Error()))
+		return
+	}
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	c.Header("Docker-Content-Digest", digest)
+	c.Data(http.StatusOK, mediaTypeManifest, data)
+}
+
+// HeadBlob handles HEAD /v2/<namespace>/<name>/<system>/blobs/<digest>.
+//
+// @Summary      Check module blob
+// @Description  Returns headers for the module archive blob identified by its digest.
+// @Tags         Modules
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Provider/system"
+// @Param        digest     path  string  true  "Blob digest (sha256:...)"
+// @Success      200
+// @Failure      404  {object}  map[string]interface{}
+// @Router       /v2/{namespace}/{name}/{system}/blobs/{digest} [head]
+func (h *Handler) HeadBlob(c *gin.Context) {
+	mv, statusCode, err := h.lookupVersionByDigest(c)
+	if err != nil {
+		c.JSON(statusCode, ociErrors("BLOB_UNKNOWN", err.Error()))
+		return
+	}
+	c.Header("Content-Type", mediaTypeLayer)
+	c.Header("Content-Length", fmt.Sprintf("%d", mv.SizeBytes))
+	c.Header("Docker-Content-Digest", "sha256:"+mv.Checksum)
+	c.Status(http.StatusOK)
+}
+
+// GetBlob handles GET /v2/<namespace>/<name>/<system>/blobs/<digest>.
+//
+// @Summary      Download module blob
+// @Description  Streams the module archive (tar.gz) for the given digest.
+// @Tags         Modules
+// @Produce      application/octet-stream
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Provider/system"
+// @Param        digest     path  string  true  "Blob digest (sha256:...)"
+// @Success      200
+// @Failure      404  {object}  map[string]interface{}
+// @Router       /v2/{namespace}/{name}/{system}/blobs/{digest} [get]
+func (h *Handler) GetBlob(c *gin.Context) {
+	mv, statusCode, err := h.lookupVersionByDigest(c)
+	if err != nil {
+		c.JSON(statusCode, ociErrors("BLOB_UNKNOWN", err.Error()))
+		return
+	}
+
+	rc, err := h.storage.Download(c.Request.Context(), mv.StoragePath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ociErrors("BLOB_UNKNOWN", "failed to retrieve blob"))
+		return
+	}
+	defer rc.Close() //nolint:errcheck
+
+	c.Header("Content-Type", mediaTypeLayer)
+	c.Header("Content-Length", fmt.Sprintf("%d", mv.SizeBytes))
+	c.Header("Docker-Content-Digest", "sha256:"+mv.Checksum)
+	c.Status(http.StatusOK)
+	_, _ = io.Copy(c.Writer, rc)
+}
+
+// PutManifest handles PUT /v2/<namespace>/<name>/<system>/manifests/<reference>.
+// OCI push is not supported; use the upload API instead.
+//
+// @Summary      Push module manifest (not supported)
+// @Description  OCI push is not supported; use POST /api/v1/modules to publish modules.
+// @Tags         Modules
+// @Security     Bearer
+// @Produce      json
+// @Failure      405  {object}  map[string]interface{}
+// @Router       /v2/{namespace}/{name}/{system}/manifests/{reference} [put]
+func (h *Handler) PutManifest(c *gin.Context) {
+	c.JSON(http.StatusMethodNotAllowed, ociErrors("UNSUPPORTED",
+		"OCI push is not supported; use POST /api/v1/modules to publish modules"))
+}
+
+// ─── manifest building ────────────────────────────────────────────────────────
+
+// ociManifest is a minimal OCI image manifest (schemaVersion 2).
+type ociManifest struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	MediaType     string          `json:"mediaType"`
+	Config        ociDescriptor   `json:"config"`
+	Layers        []ociDescriptor `json:"layers"`
+}
+
+// ociDescriptor is an OCI content descriptor.
+type ociDescriptor struct {
+	MediaType string `json:"mediaType"`
+	Digest    string `json:"digest"`
+	Size      int64  `json:"size"`
+}
+
+// buildManifestJSON resolves the module version from path params and returns serialised manifest JSON.
+func (h *Handler) buildManifestJSON(c *gin.Context) ([]byte, int, error) {
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	system := c.Param("system")
+	ref := c.Param("reference")
+
+	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
+	if err != nil || org == nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("cannot resolve organization")
+	}
+
+	module, err := h.moduleRepo.GetModule(c.Request.Context(), org.ID, namespace, name, system)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("internal error")
+	}
+	if module == nil {
+		return nil, http.StatusNotFound, fmt.Errorf("module %s/%s/%s not found", namespace, name, system)
+	}
+
+	mv, err := h.moduleRepo.GetVersion(c.Request.Context(), module.ID, ref)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("internal error")
+	}
+	if mv == nil {
+		return nil, http.StatusNotFound, fmt.Errorf("version %s not found", ref)
+	}
+
+	configData := []byte("{}")
+	configDigest := fmt.Sprintf("sha256:%x", sha256.Sum256(configData))
+
+	manifest := ociManifest{
+		SchemaVersion: 2,
+		MediaType:     mediaTypeManifest,
+		Config: ociDescriptor{
+			MediaType: mediaTypeConfig,
+			Digest:    configDigest,
+			Size:      int64(len(configData)),
+		},
+		Layers: []ociDescriptor{{
+			MediaType: mediaTypeLayer,
+			Digest:    "sha256:" + mv.Checksum,
+			Size:      mv.SizeBytes,
+		}},
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("failed to marshal manifest")
+	}
+	return data, http.StatusOK, nil
+}
+
+// lookupVersionByDigest resolves a module version from path params + digest.
+func (h *Handler) lookupVersionByDigest(c *gin.Context) (*versionBlob, int, error) {
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	system := c.Param("system")
+	digestParam := c.Param("digest") // e.g. "sha256:abc123"
+
+	const prefix = "sha256:"
+	if len(digestParam) <= len(prefix) || digestParam[:len(prefix)] != prefix {
+		return nil, http.StatusBadRequest, fmt.Errorf("invalid digest format; expected sha256:<hex>")
+	}
+	checksum := digestParam[len(prefix):]
+
+	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
+	if err != nil || org == nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("cannot resolve organization")
+	}
+
+	module, err := h.moduleRepo.GetModule(c.Request.Context(), org.ID, namespace, name, system)
+	if err != nil || module == nil {
+		return nil, http.StatusNotFound, fmt.Errorf("module not found")
+	}
+
+	mv, err := h.moduleRepo.GetVersionByChecksum(c.Request.Context(), module.ID, checksum)
+	if err != nil || mv == nil {
+		return nil, http.StatusNotFound, fmt.Errorf("blob not found")
+	}
+
+	return &versionBlob{
+		StoragePath: mv.StoragePath,
+		SizeBytes:   mv.SizeBytes,
+		Checksum:    mv.Checksum,
+	}, http.StatusOK, nil
+}
+
+// versionBlob holds the fields needed to serve a module archive.
+type versionBlob struct {
+	StoragePath string
+	SizeBytes   int64
+	Checksum    string
+}
+
+// ociErrors returns the standard OCI error body format.
+func ociErrors(code, message string) gin.H {
+	return gin.H{"errors": []gin.H{{"code": code, "message": message}}}
+}

--- a/backend/internal/api/oci/handler_test.go
+++ b/backend/internal/api/oci/handler_test.go
@@ -1,0 +1,288 @@
+package oci
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+)
+
+// ─── router builder ───────────────────────────────────────────────────────────
+
+func newOCIRouter(_ *testing.T, _ *sql.DB) (*gin.Engine, sqlmock.Sqlmock, error) {
+	return nil, nil, nil
+}
+
+// unused in tests below — kept to avoid compilation error for newOCIRouter reference
+var _ = newOCIRouter
+
+// ─── shared row builders ──────────────────────────────────────────────────────
+
+func orgRow(id, name string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}).
+		AddRow(id, name, "Org "+name, nil, nil, now, now)
+}
+
+func moduleRow(id, orgID, ns, name, system string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows([]string{
+		"id", "organization_id", "namespace", "name", "system",
+		"description", "source", "created_by", "created_at", "updated_at",
+		"created_by_name", "deprecated", "deprecated_at", "deprecation_message", "successor_module_id",
+	}).AddRow(id, orgID, ns, name, system, nil, nil, nil, now, now, nil, false, nil, nil, nil)
+}
+
+func versionRow(id, moduleID, version, storagePath, checksum string, sizeBytes int64) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows([]string{
+		"id", "module_id", "version", "storage_path", "storage_backend",
+		"size_bytes", "checksum", "readme", "published_by",
+		"download_count", "deprecated", "deprecated_at", "deprecation_message",
+		"replacement_source", "created_at", "commit_sha", "tag_name", "scm_repo_id",
+	}).AddRow(id, moduleID, version, storagePath, "local",
+		sizeBytes, checksum, "", "",
+		0, false, nil, nil,
+		nil, now, nil, nil, nil)
+}
+
+// ─── Ping ────────────────────────────────────────────────────────────────────
+
+func TestPing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := &Handler{}
+	r.GET("/v2/", h.Ping)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if v := w.Header().Get("OCI-Distribution-Spec-Version"); v != ociSpecVersion {
+		t.Errorf("expected OCI-Distribution-Spec-Version=%s, got %q", ociSpecVersion, v)
+	}
+}
+
+// ─── PutManifest returns 405 ──────────────────────────────────────────────────
+
+func TestPutManifest_NotSupported(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := &Handler{}
+	r.PUT("/v2/:namespace/:name/:system/manifests/:reference", h.PutManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPut, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	errors, _ := body["errors"].([]interface{})
+	if len(errors) == 0 {
+		t.Error("expected errors array")
+	}
+}
+
+// ─── ociErrors helper ─────────────────────────────────────────────────────────
+
+func TestOCIErrors(t *testing.T) {
+	result := ociErrors("MANIFEST_UNKNOWN", "not found")
+	errors, ok := result["errors"].([]gin.H)
+	if !ok || len(errors) != 1 {
+		t.Fatalf("unexpected structure: %v", result)
+	}
+	if errors[0]["code"] != "MANIFEST_UNKNOWN" {
+		t.Errorf("unexpected code: %v", errors[0]["code"])
+	}
+}
+
+// ─── GetManifest — module not found ──────────────────────────────────────────
+
+func TestGetManifest_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnRows(orgRow("org-id", "default"))
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("org-id", "hashicorp", "consul", "aws").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/manifests/:reference", h.GetManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "MANIFEST_UNKNOWN") {
+		t.Errorf("expected MANIFEST_UNKNOWN error, got: %s", w.Body.String())
+	}
+}
+
+// ─── GetManifest — version not found ─────────────────────────────────────────
+
+func TestGetManifest_VersionNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnRows(orgRow("org-id", "default"))
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("org-id", "hashicorp", "consul", "aws").
+		WillReturnRows(moduleRow("mod-id", "org-id", "hashicorp", "consul", "aws"))
+
+	mock.ExpectQuery("SELECT.*FROM module_versions").
+		WithArgs("mod-id", "9.9.9").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/manifests/:reference", h.GetManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/manifests/9.9.9", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "MANIFEST_UNKNOWN") {
+		t.Errorf("expected MANIFEST_UNKNOWN error, got: %s", w.Body.String())
+	}
+}
+
+// ─── GetManifest — success ────────────────────────────────────────────────────
+
+func TestGetManifest_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	const checksum = "abc123def456"
+	const size = int64(1024)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnRows(orgRow("org-id", "default"))
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("org-id", "hashicorp", "consul", "aws").
+		WillReturnRows(moduleRow("mod-id", "org-id", "hashicorp", "consul", "aws"))
+
+	mock.ExpectQuery("SELECT.*FROM module_versions").
+		WithArgs("mod-id", "1.0.0").
+		WillReturnRows(versionRow("ver-id", "mod-id", "1.0.0", "modules/hashicorp/consul/aws/1.0.0.tar.gz", checksum, size))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/manifests/:reference", h.GetManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != mediaTypeManifest {
+		t.Errorf("expected Content-Type=%s, got %q", mediaTypeManifest, ct)
+	}
+	if dig := w.Header().Get("Docker-Content-Digest"); !strings.HasPrefix(dig, "sha256:") {
+		t.Errorf("expected Docker-Content-Digest header with sha256: prefix, got %q", dig)
+	}
+
+	var manifest ociManifest
+	if err := json.NewDecoder(w.Body).Decode(&manifest); err != nil {
+		t.Fatalf("decoding manifest: %v", err)
+	}
+	if manifest.SchemaVersion != 2 {
+		t.Errorf("expected schemaVersion 2, got %d", manifest.SchemaVersion)
+	}
+	if manifest.Config.MediaType != mediaTypeConfig {
+		t.Errorf("expected config mediaType %s, got %s", mediaTypeConfig, manifest.Config.MediaType)
+	}
+	if len(manifest.Layers) != 1 {
+		t.Fatalf("expected 1 layer, got %d", len(manifest.Layers))
+	}
+	if manifest.Layers[0].Digest != "sha256:"+checksum {
+		t.Errorf("expected layer digest sha256:%s, got %s", checksum, manifest.Layers[0].Digest)
+	}
+	if manifest.Layers[0].Size != size {
+		t.Errorf("expected layer size %d, got %d", size, manifest.Layers[0].Size)
+	}
+}
+
+// ─── HeadManifest — success ───────────────────────────────────────────────────
+
+func TestHeadManifest_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnRows(orgRow("org-id", "default"))
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("org-id", "hashicorp", "consul", "aws").
+		WillReturnRows(moduleRow("mod-id", "org-id", "hashicorp", "consul", "aws"))
+
+	mock.ExpectQuery("SELECT.*FROM module_versions").
+		WithArgs("mod-id", "1.0.0").
+		WillReturnRows(versionRow("ver-id", "mod-id", "1.0.0", "path.tar.gz", "abc123", 512))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.HEAD("/v2/:namespace/:name/:system/manifests/:reference", h.HeadManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Docker-Content-Digest") == "" {
+		t.Error("expected Docker-Content-Digest header")
+	}
+	if w.Header().Get("Content-Length") == "" {
+		t.Error("expected Content-Length header")
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -33,6 +33,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/api/admin"
 	"github.com/terraform-registry/terraform-registry/internal/api/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/api/modules"
+	"github.com/terraform-registry/terraform-registry/internal/api/oci"
 	"github.com/terraform-registry/terraform-registry/internal/api/providers"
 	"github.com/terraform-registry/terraform-registry/internal/api/scim"
 	"github.com/terraform-registry/terraform-registry/internal/api/setup"
@@ -176,6 +177,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	// Public handler is created here (before route registration)
 	tfBinariesHandler := terraform_binaries.NewHandler(tfMirrorRepo, storageBackend, auditRepo)
 
+	// OCI distribution handler (public read, backed by existing module storage)
+	ociHandler := oci.NewHandler(db, storageBackend)
+
 	// Initialize and start the API key expiry notifier
 	expiryNotifier := jobs.NewAPIKeyExpiryNotifier(apiKeyRepo, userRepo, &cfg.Notifications)
 	go expiryNotifier.Start(context.Background())
@@ -245,6 +249,17 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 
 	// Service discovery endpoint (Terraform protocol)
 	router.GET("/.well-known/terraform.json", serviceDiscoveryHandler(cfg))
+
+	// OCI Distribution Spec v1.1 — module archive pull endpoint
+	v2Group := router.Group("/v2")
+	{
+		v2Group.GET("/", ociHandler.Ping)
+		v2Group.HEAD("/:namespace/:name/:system/manifests/:reference", ociHandler.HeadManifest)
+		v2Group.GET("/:namespace/:name/:system/manifests/:reference", ociHandler.GetManifest)
+		v2Group.HEAD("/:namespace/:name/:system/blobs/:digest", ociHandler.HeadBlob)
+		v2Group.GET("/:namespace/:name/:system/blobs/:digest", ociHandler.GetBlob)
+		v2Group.PUT("/:namespace/:name/:system/manifests/:reference", ociHandler.PutManifest)
+	}
 
 	// API version
 	router.GET("/version", versionHandler())
@@ -1141,6 +1156,7 @@ func serviceDiscoveryHandler(cfg *config.Config) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{
 			"modules.v1":   cfg.Server.BaseURL + "/v1/modules/",
 			"providers.v1": cfg.Server.BaseURL + "/v1/providers/",
+			"oci.v1":       cfg.Server.BaseURL + "/v2/",
 		})
 	}
 }
@@ -1163,6 +1179,9 @@ func versionHandler() gin.HandlerFunc {
 				"modules":   "v1",
 				"providers": "v1",
 				"mirror":    "v1",
+			},
+			"capabilities": gin.H{
+				"oci": true,
 			},
 		})
 	}

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -878,6 +878,31 @@ func (r *ModuleRepository) GetVersionByID(ctx context.Context, id string) (*mode
 	return v, nil
 }
 
+// GetVersionByChecksum retrieves a module version by its checksum (used by OCI blob lookups).
+func (r *ModuleRepository) GetVersionByChecksum(ctx context.Context, moduleID, checksum string) (*models.ModuleVersion, error) {
+	query := `
+		SELECT id, module_id, version, storage_path, storage_backend, size_bytes, checksum, readme, published_by,
+		       download_count, COALESCE(deprecated, false), deprecated_at, deprecation_message, replacement_source, created_at,
+		       commit_sha, tag_name, scm_repo_id::text
+		FROM module_versions
+		WHERE module_id = $1 AND checksum = $2
+		LIMIT 1
+	`
+	v := &models.ModuleVersion{}
+	err := r.db.QueryRowContext(ctx, query, moduleID, checksum).Scan(
+		&v.ID, &v.ModuleID, &v.Version, &v.StoragePath, &v.StorageBackend, &v.SizeBytes, &v.Checksum,
+		&v.Readme, &v.PublishedBy, &v.DownloadCount, &v.Deprecated, &v.DeprecatedAt, &v.DeprecationMessage,
+		&v.ReplacementSource, &v.CreatedAt, &v.CommitSHA, &v.TagName, &v.SCMRepoID,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get module version by checksum: %w", err)
+	}
+	return v, nil
+}
+
 // DeprecateModule marks an entire module as deprecated with an optional message and successor module ID
 func (r *ModuleRepository) DeprecateModule(ctx context.Context, moduleID string, message *string, successorModuleID *string) error {
 	query := `


### PR DESCRIPTION
Closes #175

Implements the OCI Distribution Spec v1.1 endpoint group under `/v2/` so that tools like `oras` can pull Terraform modules as OCI artifacts.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/v2/` | Capability ping |
| `HEAD` | `/v2/<ns>/<name>/<sys>/manifests/<ref>` | Manifest existence check |
| `GET` | `/v2/<ns>/<name>/<sys>/manifests/<ref>` | Manifest fetch |
| `HEAD` | `/v2/<ns>/<name>/<sys>/blobs/<digest>` | Blob existence check |
| `GET` | `/v2/<ns>/<name>/<sys>/blobs/<digest>` | Blob download |
| `PUT` | `/v2/<ns>/<name>/<sys>/manifests/<ref>` | Returns 405 — OCI push not supported |

## Details

- Module layer media type: `application/vnd.opentofu.modulepkg.v1.tar+gzip`
- Manifest media type: `application/vnd.oci.image.manifest.v1+json`
- Config blob is a minimal `{}` JSON object
- Blob layer is the module tar.gz archive identified by its sha256 checksum
- Service discovery response now includes `"oci.v1": "<base_url>/v2/"`
- `/version` response now includes `"capabilities": {"oci": true}`
- `ModuleRepository` gains `GetVersionByChecksum` for blob digest lookup

## Changelog
- feat: add OCI Distribution Spec v1.1 endpoints for `oras pull` support