### PR TITLE
fix: security scanning broken when configured via setup wizard

### DIFF
--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -854,13 +854,15 @@ func (h *ModuleAdminHandlers) ReanalyzeVersion(c *gin.Context) {
 
 	// Re-queue security scan if configured
 	if h.scanRepo != nil && h.cfg.Scanning.Enabled && h.cfg.Scanning.BinaryPath != "" {
-		if err := h.scanRepo.CreatePendingScan(c.Request.Context(), versionRecord.ID); err != nil {
+		if err := h.scanRepo.UpsertPendingScan(c.Request.Context(), versionRecord.ID); err != nil {
 			slog.Warn("reanalyze: failed to queue security scan",
 				"version_id", versionRecord.ID, "error", err)
 			result["scan"] = "queue_failed"
 		} else {
 			result["scan"] = "queued"
 		}
+	} else {
+		result["scan"] = "not_configured"
 	}
 
 	result["message"] = "Re-analysis complete"

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -187,19 +187,48 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	log.Println("API key expiry notifier started")
 
 	// Initialize and start the module security scanner job (no-op when scanning is disabled)
-	// If scanning is not enabled via config file, check the database for setup wizard config
+	// If scanning is not enabled via config file, check the database for setup wizard config.
+	// The DB JSON was saved from SaveScanningConfigInput (snake_case json tags), so we decode
+	// into an anonymous struct with matching json tags rather than config.ScanningConfig which
+	// only carries mapstructure tags.
 	if !cfg.Scanning.Enabled {
 		if scanConfigJSON, err := oidcConfigRepo.GetScanningConfig(context.Background()); err == nil && scanConfigJSON != nil {
-			var dbScanCfg config.ScanningConfig
-			if json.Unmarshal(scanConfigJSON, &dbScanCfg) == nil && dbScanCfg.Enabled {
-				cfg.Scanning = dbScanCfg
+			var dbInput struct {
+				Enabled           bool   `json:"enabled"`
+				Tool              string `json:"tool"`
+				BinaryPath        string `json:"binary_path"`
+				ExpectedVersion   string `json:"expected_version"`
+				SeverityThreshold string `json:"severity_threshold"`
+				TimeoutSecs       int    `json:"timeout_secs"`
+				WorkerCount       int    `json:"worker_count"`
+				ScanIntervalMins  int    `json:"scan_interval_mins"`
+				InstallDir        string `json:"install_dir"`
+			}
+			if err := json.Unmarshal(scanConfigJSON, &dbInput); err == nil && dbInput.Enabled {
+				cfg.Scanning.Enabled = dbInput.Enabled
+				cfg.Scanning.Tool = dbInput.Tool
+				cfg.Scanning.BinaryPath = dbInput.BinaryPath
+				cfg.Scanning.ExpectedVersion = dbInput.ExpectedVersion
+				cfg.Scanning.SeverityThreshold = dbInput.SeverityThreshold
+				cfg.Scanning.WorkerCount = dbInput.WorkerCount
+				if dbInput.TimeoutSecs > 0 {
+					cfg.Scanning.Timeout = time.Duration(dbInput.TimeoutSecs) * time.Second
+				}
+				if dbInput.ScanIntervalMins > 0 {
+					cfg.Scanning.ScanIntervalMins = dbInput.ScanIntervalMins
+				}
+				if dbInput.InstallDir != "" {
+					cfg.Scanning.InstallDir = dbInput.InstallDir
+				}
 			}
 		}
 	}
 	moduleScannerJob := jobs.NewModuleScannerJob(&cfg.Scanning, scanRepo, moduleRepo, storageBackend)
-	if err := moduleScannerJob.Start(context.Background()); err != nil {
-		log.Printf("module scanner job failed to start: %v", err)
-	}
+	go func() {
+		if err := moduleScannerJob.Start(context.Background()); err != nil {
+			log.Printf("module scanner job failed to start: %v", err)
+		}
+	}()
 
 	// Initialize and start the audit log cleanup job (no-op when retention_days=0)
 	auditCleanupJob := jobs.NewAuditCleanupJob(&cfg.AuditRetention, auditRepo)
@@ -544,7 +573,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	// Initialize setup wizard handlers
 	setupHandlers := setup.NewHandlers(
 		cfg, tokenCipher, oidcConfigRepo, storageConfigRepo, userRepo, orgRepo, authHandlers,
-	)
+	).WithScannerJob(moduleScannerJob)
 
 	// Initialize policy engine (no-op when disabled).
 	policyEngineCfg := policy.Config{

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -40,6 +41,15 @@ type Handlers struct {
 	orgRepo           *repositories.OrganizationRepository
 	authHandlers      *admin.AuthHandlers // to swap OIDC provider at runtime
 	installFunc       installer.InstallFunc
+	scannerJob        *jobs.ModuleScannerJob
+}
+
+// WithScannerJob attaches the scanner job so that SaveScanningConfig can kick
+// it off immediately after enabling scanning at runtime, without requiring a
+// server restart.
+func (h *Handlers) WithScannerJob(job *jobs.ModuleScannerJob) *Handlers {
+	h.scannerJob = job
+	return h
 }
 
 // NewHandlers creates a new setup Handlers instance.
@@ -739,6 +749,16 @@ func (h *Handlers) SaveScanningConfig(c *gin.Context) {
 	}
 
 	slog.Info("setup: scanning configuration saved", "tool", input.Tool, "enabled", input.Enabled)
+
+	// If scanning was just enabled at runtime, kick off the scanner job so that
+	// pending scans are processed immediately without a server restart.
+	if input.Enabled && h.scannerJob != nil {
+		go func() {
+			if err := h.scannerJob.Start(context.Background()); err != nil {
+				slog.Warn("setup: scanner job failed to start after config save", "error", err)
+			}
+		}()
+	}
 
 	c.JSON(http.StatusOK, SaveScanningConfigResponse{
 		Message: "Scanning configuration saved",

--- a/backend/internal/api/setup/scanning_test.go
+++ b/backend/internal/api/setup/scanning_test.go
@@ -12,6 +12,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
 )
 
 // ---------------------------------------------------------------------------
@@ -409,6 +410,50 @@ func TestSaveScanningConfig_InMemoryNotUpdatedOnDBError(t *testing.T) {
 	// In-memory config must not have changed on DB failure.
 	if env.h.cfg.Scanning.Enabled {
 		t.Error("cfg.Scanning.Enabled updated on DB error, want unchanged (false)")
+	}
+}
+
+func TestWithScannerJob_SetsField(t *testing.T) {
+	env := newTestEnv(t)
+	scanJob := jobs.NewModuleScannerJob(&config.ScanningConfig{}, nil, nil, nil)
+	h := env.h.WithScannerJob(scanJob)
+	if h.scannerJob == nil {
+		t.Error("WithScannerJob: scannerJob field not set")
+	}
+}
+
+func TestSaveScanningConfig_WithScannerJobAttached(t *testing.T) {
+	// Verifies that SaveScanningConfig still returns 200 when a scanner job
+	// is attached and scanning is enabled — the goroutine fires but returns
+	// immediately because the job's binary path is empty.
+	env := newTestEnv(t)
+	scanJob := jobs.NewModuleScannerJob(&config.ScanningConfig{}, nil, nil, nil)
+	env.h.WithScannerJob(scanJob)
+
+	dir := t.TempDir()
+	binaryPath := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	env.h.cfg.Scanning.InstallDir = dir
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	body := jsonBody(map[string]interface{}{
+		"enabled":     true,
+		"tool":        "trivy",
+		"binary_path": binaryPath,
+	})
+
+	env.oidcMock.ExpectExec("UPDATE system_settings SET").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
 	}
 }
 

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -42,6 +42,27 @@ func (r *ModuleScanRepository) CreatePendingScan(ctx context.Context, moduleVers
 	return nil
 }
 
+// UpsertPendingScan inserts a new pending scan record, or resets an existing
+// completed/errored record back to pending so the worker will re-process it.
+// Records that are already pending or actively scanning are left untouched to
+// avoid interrupting an in-flight scan.
+func (r *ModuleScanRepository) UpsertPendingScan(ctx context.Context, moduleVersionID string) error {
+	const q = `
+		INSERT INTO module_version_scans (module_version_id, scanner, status)
+		VALUES ($1, 'pending', 'pending')
+		ON CONFLICT (module_version_id) DO UPDATE
+			SET status        = 'pending',
+			    error_message = NULL,
+			    updated_at    = NOW()
+			WHERE module_version_scans.status NOT IN ('pending', 'scanning')
+	`
+	_, err := r.db.ExecContext(ctx, q, moduleVersionID)
+	if err != nil {
+		return fmt.Errorf("upsert pending scan: %w", err)
+	}
+	return nil
+}
+
 // ListPendingScans returns up to limit scan records with status 'pending',
 // ordered by creation time ascending (FIFO).
 func (r *ModuleScanRepository) ListPendingScans(ctx context.Context, limit int) ([]*models.ModuleScan, error) {

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -278,6 +278,39 @@ func TestGetLatestScan_DBError(t *testing.T) {
 // ResetStaleScanningRecords
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// UpsertPendingScan
+// ---------------------------------------------------------------------------
+
+func TestUpsertPendingScan_Success(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectExec("INSERT INTO module_version_scans").
+		WithArgs("ver-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.UpsertPendingScan(context.Background(), "ver-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}
+
+func TestUpsertPendingScan_DBError(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectExec("INSERT INTO module_version_scans").
+		WithArgs("ver-1").
+		WillReturnError(errors.New("db error"))
+
+	if err := repo.UpsertPendingScan(context.Background(), "ver-1"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResetStaleScanningRecords
+// ---------------------------------------------------------------------------
+
 func TestResetStaleScanningRecords_Success(t *testing.T) {
 	repo, mock := newScanRepo(t)
 	mock.ExpectExec("UPDATE module_version_scans.*SET status = 'pending'").

--- a/backend/internal/jobs/module_scanner_job.go
+++ b/backend/internal/jobs/module_scanner_job.go
@@ -27,6 +27,8 @@ type ModuleScannerJob struct {
 	moduleRepo *repositories.ModuleRepository
 	storage    storage.Storage
 	stopChan   chan struct{}
+	mu         sync.Mutex
+	started    bool
 }
 
 // NewModuleScannerJob constructs a ModuleScannerJob.
@@ -49,7 +51,10 @@ func NewModuleScannerJob(
 func (j *ModuleScannerJob) Name() string { return "module-scanner" }
 
 // Start begins the scan polling loop.  It is a no-op when scanning is disabled
-// or the binary path is not configured.
+// or the binary path is not configured.  It is safe to call multiple times: if
+// a loop is already running the call returns immediately without starting a
+// second one.  This allows the setup wizard to call Start after enabling
+// scanning at runtime without requiring a server restart.
 func (j *ModuleScannerJob) Start(ctx context.Context) error {
 	if !j.cfg.Enabled {
 		slog.Info("module scanner: disabled (scanning.enabled=false)")
@@ -59,6 +64,15 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 		slog.Info("module scanner: disabled (scanning.binary_path not set)")
 		return nil
 	}
+
+	j.mu.Lock()
+	if j.started {
+		j.mu.Unlock()
+		slog.Info("module scanner: already running, ignoring duplicate Start call")
+		return nil
+	}
+	j.started = true
+	j.mu.Unlock()
 
 	s, err := scanner.New(j.cfg)
 	if err != nil {
@@ -112,6 +126,9 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 
 // Stop signals the job to exit gracefully.
 func (j *ModuleScannerJob) Stop() error {
+	j.mu.Lock()
+	j.started = false
+	j.mu.Unlock()
 	select {
 	case <-j.stopChan:
 		// already stopped

--- a/backend/internal/jobs/module_scanner_job_test.go
+++ b/backend/internal/jobs/module_scanner_job_test.go
@@ -88,3 +88,23 @@ func TestModuleScannerJob_Start_InaccessibleBinary(t *testing.T) {
 		t.Errorf("Start (inaccessible binary) error = %v", err)
 	}
 }
+
+func TestModuleScannerJob_Start_AlreadyRunning(t *testing.T) {
+	// Simulate a job that is already started; calling Start again must be a no-op.
+	job := newTestScannerJob(true, "/nonexistent/path/to/scanner")
+	job.started = true
+	if err := job.Start(context.Background()); err != nil {
+		t.Errorf("Start (already running) error = %v", err)
+	}
+}
+
+func TestModuleScannerJob_Stop_ResetsStarted(t *testing.T) {
+	job := newTestScannerJob(false, "")
+	job.started = true
+	if err := job.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if job.started {
+		t.Error("Stop() did not reset started flag")
+	}
+}


### PR DESCRIPTION
Closes #257

## Root cause

Security scanning configured via the setup wizard was silently broken in three ways, and a fourth bug prevented re-scanning any version that already had a scan record.

**Bug 1 — JSON tag mismatch (root cause)**
`config.ScanningConfig` only has `mapstructure:` tags. `json.Unmarshal` ignores them, so snake_case DB keys like `binary_path` never deserialised into `BinaryPath`. Every restart left `BinaryPath = ""`, the scanner condition `h.cfg.Scanning.BinaryPath != ""` was always false, and `CreatePendingScan` was never called. Confirmed by the backend logs: `POST /reanalyze` returns 200, subsequent `GET /scan` still 404.

**Bug 2 — Missing goroutine**
`moduleScannerJob.Start()` is a blocking ticker loop but was called without `go` at startup. Once the JSON bug is fixed, the server would hang on startup when scanning is loaded from DB.

**Bug 3 — Scanner job never restarted after setup wizard**
`Start()` was not safe to call more than once (no idempotency guard). After the setup wizard enables scanning at runtime, the scanner goroutine was never launched — pending records sat unprocessed until the next restart.

**Bug 4 — `ON CONFLICT DO NOTHING` permanently broke re-scan**
`CreatePendingScan` was idempotent in the wrong direction: once a version had any scan record the button did nothing. The new `UpsertPendingScan` resets `error`/`clean`/`findings` records back to `pending`; `pending`/`scanning` records are left alone.

## Changes

| File | Change |
|------|--------|
| `api/router.go` | Deserialise DB scanning config via anonymous struct with `json:` tags; wrap `Start()` in goroutine |
| `jobs/module_scanner_job.go` | Make `Start()` idempotent via `sync.Mutex` + `started bool`; reset on `Stop()` |
| `api/setup/handlers.go` | `WithScannerJob` option; call `job.Start()` after `SaveScanningConfig` |
| `db/repositories/module_scan_repository.go` | Add `UpsertPendingScan` (ON CONFLICT DO UPDATE, skips pending/scanning) |
| `api/admin/modules.go` | Use `UpsertPendingScan`; add `"scan":"not_configured"` to response |
| `db/repositories/module_scan_repository_test.go` | Tests for `UpsertPendingScan` |

## Does re-scanning work for modules uploaded before scanning existed?

Yes. Those versions have no scan record. `UpsertPendingScan` inserts a fresh `pending` record, and the now-correctly-started scanner job picks it up.

## Changelog
- fix: security scanning configured via setup wizard silently broken — JSON tag mismatch discarded binary path on restart, scanner goroutine never started, re-scan idempotency broken for existing records