### PR TITLE
fix: FuzzParseDelivery panics on nil BitbucketDCConnector receiver

### DIFF
--- a/backend/internal/scm/bitbucket/connector_fuzz_test.go
+++ b/backend/internal/scm/bitbucket/connector_fuzz_test.go
@@ -1,0 +1,38 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+var fuzzConnector = func() *BitbucketDCConnector {
+	c, _ := NewBitbucketDCConnector(&scm.ConnectorSettings{
+		InstanceBaseURL: "https://bitbucket.example.com",
+	})
+	return c
+}()
+
+// FuzzParseDelivery exercises the Bitbucket Data Center webhook payload parser
+// against arbitrary bytes. Must never panic.
+func FuzzParseDelivery(f *testing.F) {
+	f.Add(
+		[]byte(`{"changes":[{"ref":{"id":"refs/tags/v1.0.0","type":"TAG"},"toHash":"abc123"}],"repository":{"slug":"repo","links":{"clone":[{"href":"https://bitbucket.example.com/scm/proj/repo.git","name":"http"}],"self":[{"href":"https://bitbucket.example.com/projects/PROJ/repos/repo/browse"}]},"project":{"key":"PROJ"}}}`),
+		"repo:refs_changed",
+		"",
+		"sha256=abc",
+	)
+	f.Add([]byte(`{"changes":[]}`), "repo:refs_changed", "", "")
+	f.Add([]byte{}, "repo:refs_changed", "", "")
+	f.Add([]byte(`not json`), "repo:refs_changed", "tok", "sig")
+	f.Add([]byte(`null`), "repo:refs_changed", "", "")
+
+	f.Fuzz(func(t *testing.T, payload []byte, event string, token string, sig string) {
+		headers := map[string]string{
+			"X-Event-Key":       event,
+			"X-Hub-Signature":   sig,
+			"X-Atlassian-Token": token,
+		}
+		_, _ = fuzzConnector.ParseDelivery(payload, headers)
+	})
+}


### PR DESCRIPTION
`NewBitbucketDCConnector` requires a non-empty `InstanceBaseURL`. The fuzz test passed an empty `ConnectorSettings{}`, causing the constructor to return `nil, error`. The test discarded the error, leaving `fuzzConnector == nil`. On the first seed run, `ParseDelivery` called `convertWebhookRepo` which dereferenced `c.baseURL` and panicked.

Fix: supply `InstanceBaseURL: "https://bitbucket.example.com"` so the constructor succeeds. All five seed corpus entries now pass. The other SCM fuzz tests (GitHub, GitLab, Azure DevOps) already supplied required fields and were unaffected.

## Changelog
- fix: FuzzParseDelivery panics on nil BitbucketDCConnector receiver in seed corpus run