### PR TITLE
chore: release v0.12.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,11 @@ deployments/ @sethbacon
 
 # Release configuration
 .goreleaser.yml @sethbacon
+
+# Architecture decision records and compliance docs require security-team review.
+# These documents define threat models, auth schemes, and control mappings — changes
+# must be reviewed by a security-aware owner before merging.
+docs/adr/ @sethbacon @security-team
+docs/compliance/ @sethbacon @security-team
+docs/threat-model.md @sethbacon @security-team
+SECURITY.md @sethbacon @security-team

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main, development]
+    branches: [ main, development ]
   workflow_dispatch: {}
   workflow_call: {} # allows release.yml to call this as a prerequisite
 
@@ -103,7 +103,8 @@ jobs:
         # require a live external dependency (DB, SCM, OIDC issuer, scanner,
         # upstream HTTP registry) to exercise and are covered by the
         # integration suite in cmd/api-test / docker-compose.test.yml.
-        run: go run ./scripts/coverfilter -in coverage.out -out coverage.filtered.out -root .
+        run: go run ./scripts/coverfilter -in coverage.out -out coverage.filtered.out
+          -root .
 
       - name: Check coverage threshold
         working-directory: backend
@@ -111,8 +112,7 @@ jobs:
         #   - Security & core business logic (auth, middleware, repositories): target 85-95%
         #   - APIs & handlers: target 75-85%
         #   - Utilities & helpers: target 70-80%
-        #   - Overall floor: 80% (Google "good for production" after honoring
-        #     coverage:skip markers for unit-untestable integration surface).
+        #   - Overall floor: 80% (target 85% by Phase 5 / H5.2 milestone)
         # The threshold below is the hard CI floor; the build fails if coverage drops below it.
         run: |
           THRESHOLD=80
@@ -147,7 +147,7 @@ jobs:
         run: |
           COVERAGE=$(go tool cover -func=coverage.filtered.out | grep "^total:" | awk '{print $3}' | tr -d '%')
           echo "percent=${COVERAGE}" >> $GITHUB_OUTPUT
-          if awk "BEGIN {exit !(${COVERAGE} >= 80)}"; then
+          if awk "BEGIN {exit !(${COVERAGE} >= 85)}"; then
             echo "color=brightgreen" >> $GITHUB_OUTPUT
           elif awk "BEGIN {exit !(${COVERAGE} >= 70)}"; then
             echo "color=green" >> $GITHUB_OUTPUT

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,101 @@
+name: Fuzz Tests
+
+on:
+  schedule:
+    # Run every night at 02:17 UTC. Off-peak time; avoids :00/:30 pile-up.
+    - cron: "17 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fuzz:
+    name: Fuzz — ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: FuzzAnalyzeArchive
+            package: ./internal/analyzer/...
+          - target: FuzzParseDelivery-github
+            package: ./internal/scm/github/...
+            fuzz_name: FuzzParseDelivery
+          - target: FuzzParseDelivery-gitlab
+            package: ./internal/scm/gitlab/...
+            fuzz_name: FuzzParseDelivery
+          - target: FuzzParseDelivery-bitbucket
+            package: ./internal/scm/bitbucket/...
+            fuzz_name: FuzzParseDelivery
+          - target: FuzzParseDelivery-azuredevops
+            package: ./internal/scm/azuredevops/...
+            fuzz_name: FuzzParseDelivery
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@d60b41a563a30bd3e08e3a7ba8b3df35d568bc3a # v5
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+
+      - name: Determine fuzz target name
+        id: target
+        run: |
+          if [ -n "${{ matrix.fuzz_name }}" ]; then
+            echo "name=${{ matrix.fuzz_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "name=${{ matrix.target }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run fuzz target for 10 minutes
+        working-directory: backend
+        run: |
+          go test ${{ matrix.package }} \
+            -run='^$' \
+            -fuzz=${{ steps.target.outputs.name }} \
+            -fuzztime=10m \
+            -v
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: |
+            backend/**/testdata/fuzz/**
+          retention-days: 30
+
+  fuzz-failure-issue:
+    name: Open issue on fuzz failure
+    runs-on: ubuntu-latest
+    needs: fuzz
+    if: failure() && github.event_name == 'schedule'
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const title = `Fuzz failure detected — ${new Date().toISOString().slice(0, 10)}`;
+            const body = [
+              '## Fuzz test failure',
+              '',
+              `A nightly fuzz run failed. See the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for crash artifacts.`,
+              '',
+              '**Action required:** download the crash artifact, reproduce with `go test -run=FuzzXxx/testdata/fuzz/FuzzXxx/<filename>`, and fix the underlying bug.',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'fuzz'],
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-24
+
+### Changed
+
+- chore: add fuzz testing workflow and fuzz tests for analyzer and SCM connectors
+- chore: extend CODEOWNERS with security-team review for security docs
+- chore: update ROADMAP with Phase 4 completion status
+- chore: bump deployment configs for v0.11.1 backend + v0.12.0 frontend
+
+## [0.11.1] - 2026-04-24
+
+### Fixed
+
+- fix: security scanning broken when configured via setup wizard
+- fix: FuzzParseDelivery panics on nil BitbucketDCConnector receiver
+
+### Changed
+
+- ci: add private-repository: true to SLSA binary provenance
+
 ## [0.11.0] - 2026-04-24
 
 ## [0.10.5] - 2026-04-23

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -369,7 +369,7 @@ The following items require coordinated work with `terraform-registry-frontend`:
 - **AC:** `terraform init` prints deprecation notice; API conformance test.
 - **↔ Frontend E4.1:** Deprecation banner on module detail page; admin toggle.
 
-#### E4.2 · OCI distribution endpoint for modules · [P1/L]
+#### E4.2 · OCI distribution endpoint for modules · [P1/L] ✅
 
 - Add `backend/internal/api/oci/` implementing OCI distribution spec v1.1.
 - Modules mirror-pushable/pullable as OCI artifacts (media type `application/vnd.opentofu.modulepkg`).
@@ -377,7 +377,7 @@ The following items require coordinated work with `terraform-registry-frontend`:
 - **AC:** `oras push` + `oras pull` round-trip succeeds; Harbor federation tested.
 - **↔ Frontend E4.5:** OCI pull snippet on module detail.
 
-#### E4.3 · Policy engine integration (OPA/Rego + Conftest) · [P1/L]
+#### E4.3 · Policy engine integration (OPA/Rego + Conftest) · [P1/L] ✅
 
 - New `backend/internal/policy/` evaluates Rego bundles on module publish + on consumer metadata endpoint.
 - Admin-configurable bundle sources (OCI, HTTP, S3).
@@ -386,7 +386,7 @@ The following items require coordinated work with `terraform-registry-frontend`:
 - **AC:** Example "no public S3 buckets" policy blocks non-compliant upload.
 - **↔ Frontend E4.2:** Policy results in upload flow.
 
-#### E4.4 · Module test orchestration on publish · [P1/L]
+#### E4.4 · Module test orchestration on publish · [P1/L] ⏳ _Deferred to post-phase 5_
 
 - Trigger ephemeral `terraform init && terraform validate && terraform test` sandbox against declared examples on upload.
 - Store results alongside version metadata.
@@ -395,20 +395,20 @@ The following items require coordinated work with `terraform-registry-frontend`:
 - **AC:** Malformed example blocks publish with clear error.
 - **↔ Frontend E4.3:** Test results UI.
 
-#### E4.5 · Inbound webhook / run-task approval surface · [P2/M]
+#### E4.5 · Inbound webhook / run-task approval surface · [P2/M] ✅
 
 - Add `/webhooks/approvals/:token` endpoint for external CI systems to approve pending publishes.
 - Signed tokens, single-use.
 - **Files:** `backend/internal/api/webhook_routes.go`, `backend/internal/services/approval_service.go`
 - **AC:** Jenkins/GitHub Actions approval round-trip tested.
 
-#### E4.6 · Optional mTLS / IP allowlist on binary mirror · [P2/M]
+#### E4.6 · Optional mTLS / IP allowlist on binary mirror · [P2/M] ✅
 
 - `config.yaml`: `binary_mirror.auth: none|allowlist|mtls`.
 - **Files:** `backend/internal/config/config.go`, `backend/internal/middleware/binary_mirror_auth.go`
 - **AC:** Locked-down mode rejects anonymous; open mode preserves protocol compliance.
 
-#### E4.7 · Bulk namespace import tooling · [P2/M]
+#### E4.7 · Bulk namespace import tooling · [P2/M] ✅
 
 - New `cmd/registry-import/` CLI: given a public namespace, mirror all modules/versions into the registry.
 - Respects pull-through cache.
@@ -417,14 +417,14 @@ The following items require coordinated work with `terraform-registry-frontend`:
 
 ### Track F — Observability extensions
 
-#### F4.1 · Trace-based SLO dashboards · [P1/M]
+#### F4.1 · Trace-based SLO dashboards · [P1/M] ✅
 
 - Exemplar wiring between metrics and OTel traces.
 - Publish Grafana dashboard + Prometheus recording rules.
 - **Files:** `deployments/observability/grafana-dashboard.json`, `deployments/observability/recording-rules.yml`
 - **AC:** Dashboards render; p95 latency alert rule firing tested.
 
-#### F4.2 · Structured audit log export (OCSF) · [P2/M]
+#### F4.2 · Structured audit log export (OCSF) · [P2/M] ✅
 
 - Convert audit events to OCSF JSON on export endpoint.
 - **Files:** `backend/internal/audit/ocsf_exporter.go`, `backend/internal/api/audit_routes.go`

--- a/backend/internal/analyzer/analyzer_fuzz_test.go
+++ b/backend/internal/analyzer/analyzer_fuzz_test.go
@@ -1,0 +1,73 @@
+package analyzer
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+// FuzzAnalyzeArchive ensures the archive parser does not panic or leak memory
+// when fed arbitrary bytes. The function must handle any input gracefully
+// (return an error, not panic).
+func FuzzAnalyzeArchive(f *testing.F) {
+	// Seed with a minimal valid tar.gz archive containing a single .tf file.
+	f.Add(minimalTarGz())
+
+	// Seed with an empty input.
+	f.Add([]byte{})
+
+	// Seed with random-looking garbage.
+	f.Add([]byte("\x1f\x8b\x08\x00garbage"))
+
+	// Seed with a valid gzip header but invalid tar content.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, _ = gz.Write([]byte("not a tar archive"))
+	_ = gz.Close()
+	f.Add(buf.Bytes())
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// AnalyzeArchive must never panic — only return (nil, err) or (*ModuleDoc, nil).
+		r := bytes.NewReader(data)
+		doc, err := AnalyzeArchive(r)
+		if err != nil {
+			// Errors are expected for malformed input; that is fine.
+			return
+		}
+		if doc == nil {
+			return
+		}
+		// If a doc was returned, it must be marshallable without panicking.
+		if doc.Inputs != nil {
+			_, _ = MarshalInputs(doc.Inputs)
+		}
+		if doc.Outputs != nil {
+			_, _ = MarshalOutputs(doc.Outputs)
+		}
+		if doc.Providers != nil {
+			_, _ = MarshalProviders(doc.Providers)
+		}
+	})
+}
+
+// minimalTarGz builds a minimal tar.gz archive containing a trivial main.tf.
+// It is used as a seed so the fuzzer starts from a plausible input.
+func minimalTarGz() []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	content := []byte(`variable "region" { default = "us-east-1" }`)
+	hdr := &tar.Header{
+		Name: "main.tf",
+		Mode: 0600,
+		Size: int64(len(content)),
+	}
+	_ = tw.WriteHeader(hdr)
+	_, _ = tw.Write(content)
+	_ = tw.Close()
+	_ = gz.Close()
+
+	return buf.Bytes()
+}

--- a/backend/internal/scm/azuredevops/connector_fuzz_test.go
+++ b/backend/internal/scm/azuredevops/connector_fuzz_test.go
@@ -1,0 +1,36 @@
+package azuredevops
+
+import (
+	"testing"
+)
+
+var fuzzConnector = &AzureDevOpsConnector{
+	clientID:     "fuzz-client",
+	clientSecret: "fuzz-secret",
+	callbackURL:  "http://localhost/callback",
+	baseURL:      "https://dev.azure.com",
+	tenantID:     "fuzz-tenant",
+	organization: "fuzzorg",
+}
+
+// FuzzParseDelivery exercises the Azure DevOps webhook payload parser against
+// arbitrary bytes. Must never panic.
+func FuzzParseDelivery(f *testing.F) {
+	f.Add(
+		[]byte(`{"eventType":"git.push","resource":{"refUpdates":[{"name":"refs/tags/v1.0.0","newObjectId":"abc123","oldObjectId":"0000000000000000000000000000000000000000"}],"repository":{"remoteUrl":"https://dev.azure.com/fuzzorg/proj/_git/repo","webUrl":"https://dev.azure.com/fuzzorg/proj/_git/repo"}}}`),
+		"",
+		"",
+	)
+	f.Add([]byte(`{"eventType":"git.push","resource":{}}`), "", "")
+	f.Add([]byte{}, "", "")
+	f.Add([]byte(`not json`), "tok", "sig")
+	f.Add([]byte(`{"eventType":null}`), "", "")
+
+	f.Fuzz(func(t *testing.T, payload []byte, token string, sig string) {
+		headers := map[string]string{
+			"Authorization":       token,
+			"X-Hub-Signature-256": sig,
+		}
+		_, _ = fuzzConnector.ParseDelivery(payload, headers)
+	})
+}

--- a/backend/internal/scm/github/connector_fuzz_test.go
+++ b/backend/internal/scm/github/connector_fuzz_test.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// connector used for all fuzz targets in this package.
+var fuzzConnector = func() *GitHubConnector {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{
+		ClientID:     "fuzz-client",
+		ClientSecret: "fuzz-secret",
+		CallbackURL:  "http://localhost/callback",
+	})
+	return c
+}()
+
+// FuzzParseDelivery exercises the GitHub webhook payload parser against arbitrary
+// bytes. The parser processes untrusted network input, making it a high-priority
+// fuzz target. It must never panic regardless of input.
+func FuzzParseDelivery(f *testing.F) {
+	// Seed with a minimal push-event payload.
+	f.Add(
+		[]byte(`{"ref":"refs/tags/v1.0.0","repository":{"full_name":"org/repo","clone_url":"https://github.com/org/repo.git","html_url":"https://github.com/org/repo"}}`),
+		"push",
+		"sha256=abc123",
+	)
+	// Seed with a ping event.
+	f.Add([]byte(`{"zen":"Keep it logically awesome","hook_id":1}`), "ping", "")
+	// Seed with empty payload.
+	f.Add([]byte{}, "push", "")
+	// Seed with garbage.
+	f.Add([]byte(`not json`), "push", "sha256=deadbeef")
+	// Seed with deeply nested JSON (should not stack-overflow).
+	f.Add([]byte(`{"a":{"b":{"c":{"d":{"e":{}}}}}}`), "push", "")
+
+	f.Fuzz(func(t *testing.T, payload []byte, event string, sig string) {
+		headers := map[string]string{
+			"X-GitHub-Event":      event,
+			"X-Hub-Signature-256": sig,
+		}
+		// Must not panic; errors are acceptable.
+		_, _ = fuzzConnector.ParseDelivery(payload, headers)
+	})
+}

--- a/backend/internal/scm/gitlab/connector_fuzz_test.go
+++ b/backend/internal/scm/gitlab/connector_fuzz_test.go
@@ -1,0 +1,38 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+var fuzzConnector = func() *GitLabConnector {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{
+		ClientID:     "fuzz-client",
+		ClientSecret: "fuzz-secret",
+		CallbackURL:  "http://localhost/callback",
+	})
+	return c
+}()
+
+// FuzzParseDelivery exercises the GitLab webhook payload parser against arbitrary
+// bytes. Must never panic.
+func FuzzParseDelivery(f *testing.F) {
+	f.Add(
+		[]byte(`{"object_kind":"tag_push","ref":"refs/tags/v1.0.0","project":{"path_with_namespace":"org/repo","http_url":"https://gitlab.com/org/repo.git","web_url":"https://gitlab.com/org/repo"}}`),
+		"Tag Push Hook",
+		"fuzz-secret",
+	)
+	f.Add([]byte(`{"object_kind":"push"}`), "Push Hook", "")
+	f.Add([]byte{}, "Push Hook", "")
+	f.Add([]byte(`not json`), "Tag Push Hook", "sig")
+	f.Add([]byte(`{"object_kind":null}`), "Tag Push Hook", "")
+
+	f.Fuzz(func(t *testing.T, payload []byte, event string, token string) {
+		headers := map[string]string{
+			"X-Gitlab-Event": event,
+			"X-Gitlab-Token": token,
+		}
+		_, _ = fuzzConnector.ParseDelivery(payload, headers)
+	})
+}

--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: terraform-registry
 description: A Helm chart for deploying the Enterprise Terraform Registry
 type: application
 version: 0.2.0
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 keywords:
   - terraform
   - registry

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.11.1"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3

--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.11.0"
+    tag: "v0.11.1"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.10.3"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.11.0"
+    tag: "v0.11.1"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.10.3"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.11.1"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.11.0"
+    tag: "v0.11.1"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.10.3"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.11.1"
+    tag: "v0.12.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -61,7 +61,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.10.3"
+    tag: "0.12.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.11.1
+    newTag: v0.12.0
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
     newTag: v0.12.0

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.10.3
+    newTag: v0.12.0

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.11.1
+    newTag: v0.12.0
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
     newTag: v0.12.0

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.10.3
+    newTag: v0.12.0


### PR DESCRIPTION
## Release v0.12.0

### Changes since v0.11.1

- chore: add fuzz testing workflow and fuzz tests for analyzer and SCM connectors
- chore: extend CODEOWNERS with security-team review for security docs
- chore: update ROADMAP with Phase 4 completion status
- chore: bump deployment configs to v0.12.0 backend + v0.12.0 frontend
- chore: backfill CHANGELOG for v0.11.1

### Deployment config updates

- Helm Chart appVersion: 0.12.0
- All cloud-specific values files: backend v0.12.0, frontend v0.12.0
- Kustomize overlays: backend v0.12.0, frontend v0.12.0