### PR TITLE
chore: bump frontend image tag to v0.12.3

### DIFF
--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -61,7 +61,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.12.2"
+    tag: "0.12.3"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -72,4 +72,4 @@ images:
     newTag: v0.12.0
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.12.2
+    newTag: v0.12.3

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -80,4 +80,4 @@ images:
     newTag: v0.12.0
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.12.2
+    newTag: v0.12.3


### PR DESCRIPTION
Bumps frontend image tag to `v0.12.3` across deployment configs following the frontend patch release.

**Files updated:**
- `deployments/helm/values.yaml` — `frontend.image.tag`
- `deployments/kubernetes/overlays/gke/kustomization.yaml` — `newTag`
- `deployments/kubernetes/overlays/eks/kustomization.yaml` — `newTag`

## Changelog
- chore: bump frontend image tag to v0.12.3