### PR TITLE
feat(scanner): capture scanner stderr as execution_log

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13630,6 +13630,9 @@
                 "error_message": {
                     "type": "string"
                 },
+                "execution_log": {
+                    "type": "string"
+                },
                 "expected_version": {
                     "type": "string"
                 },

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -15,7 +15,7 @@ import (
 var scanAdminCols = []string{
 	"id", "module_version_id", "scanner", "scanner_version", "expected_version",
 	"status", "scanned_at", "critical_count", "high_count", "medium_count", "low_count",
-	"raw_results", "error_message", "created_at", "updated_at",
+	"raw_results", "error_message", "execution_log", "created_at", "updated_at",
 }
 
 var orgColsScan = []string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}
@@ -73,7 +73,7 @@ func sampleScanResultRow() *sqlmock.Rows {
 	return sqlmock.NewRows(scanAdminCols).AddRow(
 		"scan-1", "ver-1", "trivy", "0.50.0", nil,
 		"clean", time.Now(), 0, 0, 0, 0,
-		`{}`, nil, time.Now(), time.Now(),
+		`{}`, nil, nil, time.Now(), time.Now(),
 	)
 }
 

--- a/backend/internal/db/migrations/000030_scan_execution_log.down.sql
+++ b/backend/internal/db/migrations/000030_scan_execution_log.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE module_version_scans
+    DROP COLUMN IF EXISTS execution_log;

--- a/backend/internal/db/migrations/000030_scan_execution_log.up.sql
+++ b/backend/internal/db/migrations/000030_scan_execution_log.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE module_version_scans
+    ADD COLUMN IF NOT EXISTS execution_log TEXT;

--- a/backend/internal/db/models/module_scan.go
+++ b/backend/internal/db/models/module_scan.go
@@ -24,6 +24,7 @@ type ModuleScan struct {
 	LowCount        int             `db:"low_count"         json:"low_count"`
 	RawResults      json.RawMessage `db:"raw_results"       json:"raw_results,omitempty" swaggertype:"object"` //nolint:tagliatelle
 	ErrorMessage    *string         `db:"error_message"     json:"error_message,omitempty"`
+	ExecutionLog    *string         `db:"execution_log"     json:"execution_log,omitempty"`
 	CreatedAt       time.Time       `db:"created_at"        json:"created_at"`
 	UpdatedAt       time.Time       `db:"updated_at"        json:"updated_at"`
 }

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -69,7 +69,7 @@ func (r *ModuleScanRepository) ListPendingScans(ctx context.Context, limit int) 
 	const q = `
 		SELECT id, module_version_id, scanner, scanner_version, expected_version,
 		       status, scanned_at, critical_count, high_count, medium_count, low_count,
-		       raw_results, error_message, created_at, updated_at
+		       raw_results, error_message, execution_log, created_at, updated_at
 		FROM module_version_scans
 		WHERE status = 'pending'
 		ORDER BY created_at
@@ -88,7 +88,7 @@ func (r *ModuleScanRepository) ListPendingScans(ctx context.Context, limit int) 
 		if err := rows.Scan(
 			&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
 			&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
-			&rawResults, &s.ErrorMessage, &s.CreatedAt, &s.UpdatedAt,
+			&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
@@ -143,18 +143,22 @@ func (r *ModuleScanRepository) MarkComplete(
 		expVer = &expectedVersion
 	}
 	actualVer := &result.ScannerVersion
+	var execLog *string
+	if result.ExecutionLog != "" {
+		execLog = &result.ExecutionLog
+	}
 
 	const q = `
 		UPDATE module_version_scans
 		SET status = $2, scanned_at = $3, scanner_version = $4, expected_version = $5,
 		    critical_count = $6, high_count = $7, medium_count = $8, low_count = $9,
-		    raw_results = $10, updated_at = NOW()
+		    raw_results = $10, execution_log = $11, updated_at = NOW()
 		WHERE id = $1
 	`
 	_, err := r.db.ExecContext(ctx, q,
 		scanID, status, now, actualVer, expVer,
 		result.CriticalCount, result.HighCount, result.MediumCount, result.LowCount,
-		rawJSON,
+		rawJSON, execLog,
 	)
 	if err != nil {
 		return fmt.Errorf("mark complete: %w", err)
@@ -181,7 +185,7 @@ func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionI
 	const q = `
 		SELECT id, module_version_id, scanner, scanner_version, expected_version,
 		       status, scanned_at, critical_count, high_count, medium_count, low_count,
-		       raw_results, error_message, created_at, updated_at
+		       raw_results, error_message, execution_log, created_at, updated_at
 		FROM module_version_scans
 		WHERE module_version_id = $1
 		ORDER BY created_at DESC
@@ -192,7 +196,7 @@ func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionI
 	err := r.db.QueryRowContext(ctx, q, moduleVersionID).Scan(
 		&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
 		&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
-		&rawResults, &s.ErrorMessage, &s.CreatedAt, &s.UpdatedAt,
+		&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -14,7 +14,7 @@ import (
 var scanCols = []string{
 	"id", "module_version_id", "scanner", "scanner_version", "expected_version",
 	"status", "scanned_at", "critical_count", "high_count", "medium_count", "low_count",
-	"raw_results", "error_message", "created_at", "updated_at",
+	"raw_results", "error_message", "execution_log", "created_at", "updated_at",
 }
 
 func newScanRepo(t *testing.T) (*ModuleScanRepository, sqlmock.Sqlmock) {
@@ -31,7 +31,7 @@ func sampleScanRow() *sqlmock.Rows {
 	return sqlmock.NewRows(scanCols).AddRow(
 		"scan-1", "ver-1", "trivy", "0.50.0", nil,
 		"clean", time.Now(), 0, 0, 0, 0,
-		json.RawMessage(`{}`), nil, time.Now(), time.Now(),
+		json.RawMessage(`{}`), nil, nil, time.Now(), time.Now(),
 	)
 }
 

--- a/backend/internal/scanner/checkov.go
+++ b/backend/internal/scanner/checkov.go
@@ -10,6 +10,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -43,16 +44,21 @@ func (s *checkovScanner) ScanDirectory(ctx context.Context, dir string) (*ScanRe
 
 	// checkov exits 1 on findings; capture output regardless.
 	// #nosec G204
-	out, _ := exec.CommandContext(ctx, s.binaryPath,
-		"-d", dir, "-o", "json", "--quiet",
-	).Output()
+	cmd := exec.CommandContext(ctx, s.binaryPath, "-d", dir, "-o", "json", "--quiet")
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	out, _ := cmd.Output()
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("checkov timed out after %s", s.timeout)
 	}
 	if len(out) == 0 {
 		return &ScanResult{}, nil
 	}
-	return parseCheckovJSON(s.Name(), out)
+	result, err := parseCheckovJSON(s.Name(), out)
+	if err == nil {
+		result.ExecutionLog = truncateExecutionLog(stderrBuf.String())
+	}
+	return result, err
 }
 
 type checkovOutput struct {

--- a/backend/internal/scanner/custom.go
+++ b/backend/internal/scanner/custom.go
@@ -4,6 +4,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -51,7 +52,10 @@ func (s *customScanner) ScanDirectory(ctx context.Context, dir string) (*ScanRes
 
 	args := append(s.scanArgs, dir)
 	// #nosec G204
-	out, _ := exec.CommandContext(ctx, s.binaryPath, args...).Output()
+	cmd := exec.CommandContext(ctx, s.binaryPath, args...)
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	out, _ := cmd.Output()
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("custom scanner timed out after %s", s.timeout)
 	}
@@ -59,12 +63,17 @@ func (s *customScanner) ScanDirectory(ctx context.Context, dir string) (*ScanRes
 		return &ScanResult{}, nil
 	}
 
+	var result *ScanResult
+	var parseErr error
 	switch strings.ToLower(s.outputFormat) {
 	case "sarif":
-		return parseSARIF(s.Name(), out)
+		result, parseErr = parseSARIF(s.Name(), out)
 	default:
 		// Generic JSON: store raw, no severity parsing
-		result := &ScanResult{RawJSON: json.RawMessage(out)}
-		return result, nil
+		result = &ScanResult{RawJSON: json.RawMessage(out)}
 	}
+	if parseErr == nil && result != nil {
+		result.ExecutionLog = truncateExecutionLog(stderrBuf.String())
+	}
+	return result, parseErr
 }

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -38,6 +38,16 @@ type ScanResult struct {
 	LowCount       int
 	HasFindings    bool
 	RawJSON        json.RawMessage // raw output from the tool stored as-is
+	ExecutionLog   string          // stderr captured during execution (truncated to 10 KiB)
+}
+
+// truncateExecutionLog caps the log at 10 KiB to prevent unbounded DB growth.
+func truncateExecutionLog(s string) string {
+	const maxBytes = 10 * 1024
+	if len(s) <= maxBytes {
+		return s
+	}
+	return s[:maxBytes] + "\n... (truncated)"
 }
 
 // New constructs the appropriate Scanner implementation based on the operator config.

--- a/backend/internal/scanner/snyk.go
+++ b/backend/internal/scanner/snyk.go
@@ -7,6 +7,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -40,16 +41,21 @@ func (s *snykScanner) ScanDirectory(ctx context.Context, dir string) (*ScanResul
 
 	// snyk exits 1 when issues found; we capture output regardless.
 	// #nosec G204
-	out, _ := exec.CommandContext(ctx, s.binaryPath,
-		"iac", "test", dir, "--json",
-	).Output()
+	cmd := exec.CommandContext(ctx, s.binaryPath, "iac", "test", dir, "--json")
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	out, _ := cmd.Output()
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("snyk timed out after %s", s.timeout)
 	}
 	if len(out) == 0 {
 		return &ScanResult{}, nil
 	}
-	return parseSnykJSON(s.Name(), out)
+	result, err := parseSnykJSON(s.Name(), out)
+	if err == nil {
+		result.ExecutionLog = truncateExecutionLog(stderrBuf.String())
+	}
+	return result, err
 }
 
 // snyk output may be a single object or an array when scanning multiple files

--- a/backend/internal/scanner/terrascan.go
+++ b/backend/internal/scanner/terrascan.go
@@ -7,6 +7,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -45,16 +46,21 @@ func (s *terrascanScanner) ScanDirectory(ctx context.Context, dir string) (*Scan
 
 	// terrascan exits 3 when violations are found; that is expected, not an error.
 	// #nosec G204
-	out, _ := exec.CommandContext(ctx, s.binaryPath,
-		"scan", "-t", "terraform", "-d", dir, "-o", "json",
-	).Output()
+	cmd := exec.CommandContext(ctx, s.binaryPath, "scan", "-t", "terraform", "-d", dir, "-o", "json")
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	out, _ := cmd.Output()
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("terrascan timed out after %s", s.timeout)
 	}
 	if len(out) == 0 {
 		return &ScanResult{}, nil
 	}
-	return parseTerrascanJSON(s.Name(), out)
+	result, err := parseTerrascanJSON(s.Name(), out)
+	if err == nil {
+		result.ExecutionLog = truncateExecutionLog(stderrBuf.String())
+	}
+	return result, err
 }
 
 type terrascanOutput struct {

--- a/backend/internal/scanner/trivy.go
+++ b/backend/internal/scanner/trivy.go
@@ -7,6 +7,7 @@
 package scanner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -50,13 +51,16 @@ func (s *trivyScanner) ScanDirectory(ctx context.Context, dir string) (*ScanResu
 	defer cancel()
 
 	// #nosec G204 -- binaryPath is set from operator config, not user input
-	out, err := exec.CommandContext(ctx, s.binaryPath,
+	cmd := exec.CommandContext(ctx, s.binaryPath,
 		"fs", "--format", "json",
 		"--scanners", "vuln,secret,misconfig",
 		"--exit-code", "0",
 		"--quiet",
 		dir,
-	).Output()
+	)
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	out, err := cmd.Output()
 	if err != nil && ctx.Err() != nil {
 		return nil, fmt.Errorf("trivy timed out after %s", s.timeout)
 	}
@@ -65,7 +69,11 @@ func (s *trivyScanner) ScanDirectory(ctx context.Context, dir string) (*ScanResu
 	if err != nil && len(out) == 0 {
 		return nil, fmt.Errorf("trivy: %w", err)
 	}
-	return parseTrivyJSON(s.Name(), out)
+	result, err := parseTrivyJSON(s.Name(), out)
+	if err == nil {
+		result.ExecutionLog = truncateExecutionLog(stderrBuf.String())
+	}
+	return result, err
 }
 
 // trivyResult mirrors the relevant portions of Trivy's JSON output schema.


### PR DESCRIPTION
## Summary

- All five scanner implementations (trivy, snyk, checkov, terrascan, custom) now capture stderr via `cmd.Stderr` and store in `ScanResult.ExecutionLog` (truncated to 10 KiB)
- New DB migration `000030_scan_execution_log` adds nullable `execution_log TEXT` column to `module_version_scans`
- `ModuleScan` model gains `ExecutionLog *string` field exposed as `execution_log` in JSON
- `MarkComplete` persists the log; `GetLatestScan` and `ListPendingScans` select and scan it

Closes #264