### PR TITLE
ci: update actions/github-script to Node.js 24 compatible SHA

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -78,7 +78,7 @@ jobs:
       issues: write
     steps:
       - name: Create issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const title = `Fuzz failure detected — ${new Date().toISOString().slice(0, 10)}`;


### PR DESCRIPTION
## Summary

- Updates `actions/github-script` from `60a0d83` (Node.js 20) to `f28e40c7` (v7, Node.js 24 compatible) in `fuzz.yml`
- Prevents CI breakage on 2026-06-02 when GitHub removes Node.js 20 runner support

Closes #268