### PR TITLE
feat(admin): expose scanner binary_path and detected_version in config endpoint

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2933,7 +2933,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns the current security scanning configuration (read-only). Sensitive fields like binary_path are excluded. Requires admin scope.",
+                "description": "Returns the current security scanning configuration including binary path, availability, and detected version. Requires admin scope.",
                 "produces": [
                     "application/json"
                 ],
@@ -12666,6 +12666,15 @@
         "admin.ScanningConfigResponse": {
             "type": "object",
             "properties": {
+                "binary_found": {
+                    "type": "boolean"
+                },
+                "binary_path": {
+                    "type": "string"
+                },
+                "detected_version": {
+                    "type": "string"
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -3,22 +3,27 @@ package admin
 
 import (
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/scanner"
 )
 
-// ScanningConfigResponse is the public view of the scanning config (no binary path).
+// ScanningConfigResponse is the public view of the scanning config.
 type ScanningConfigResponse struct {
-	Enabled           bool   `json:"enabled"`
-	Tool              string `json:"tool"`
-	ExpectedVersion   string `json:"expected_version,omitempty"`
-	SeverityThreshold string `json:"severity_threshold"`
-	Timeout           string `json:"timeout"`
-	WorkerCount       int    `json:"worker_count"`
-	ScanIntervalMins  int    `json:"scan_interval_mins"`
+	Enabled           bool    `json:"enabled"`
+	Tool              string  `json:"tool"`
+	ExpectedVersion   string  `json:"expected_version,omitempty"`
+	SeverityThreshold string  `json:"severity_threshold"`
+	Timeout           string  `json:"timeout"`
+	WorkerCount       int     `json:"worker_count"`
+	ScanIntervalMins  int     `json:"scan_interval_mins"`
+	BinaryPath        string  `json:"binary_path,omitempty"`
+	BinaryFound       bool    `json:"binary_found"`
+	DetectedVersion   *string `json:"detected_version,omitempty"`
 }
 
 // ScanningStatsResponse aggregates scan counts by status and recent activity.
@@ -50,7 +55,7 @@ type RecentScanEntry struct {
 }
 
 // @Summary      Get scanning configuration
-// @Description  Returns the current security scanning configuration (read-only). Sensitive fields like binary_path are excluded. Requires admin scope.
+// @Description  Returns the current security scanning configuration including binary path, availability, and detected version. Requires admin scope.
 // @Tags         Security Scanning
 // @Security     Bearer
 // @Produce      json
@@ -67,7 +72,20 @@ func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 			Timeout:           cfg.Timeout.String(),
 			WorkerCount:       cfg.WorkerCount,
 			ScanIntervalMins:  cfg.ScanIntervalMins,
+			BinaryPath:        cfg.BinaryPath,
 		}
+
+		if cfg.Enabled && cfg.BinaryPath != "" {
+			if _, err := os.Stat(cfg.BinaryPath); err == nil {
+				resp.BinaryFound = true
+				if s, err := scanner.New(cfg); err == nil {
+					if v, err := s.Version(c.Request.Context()); err == nil {
+						resp.DetectedVersion = &v
+					}
+				}
+			}
+		}
+
 		c.JSON(http.StatusOK, resp)
 	}
 }

--- a/backend/internal/api/admin/scanning_admin_test.go
+++ b/backend/internal/api/admin/scanning_admin_test.go
@@ -26,6 +26,7 @@ func TestGetScanningConfigHandler_Success(t *testing.T) {
 		Timeout:           5 * time.Minute,
 		WorkerCount:       4,
 		ScanIntervalMins:  10,
+		// BinaryPath intentionally empty so binary_found=false without a real binary.
 	}
 
 	r := gin.New()
@@ -54,6 +55,12 @@ func TestGetScanningConfigHandler_Success(t *testing.T) {
 	}
 	if resp.ScanIntervalMins != 10 {
 		t.Errorf("ScanIntervalMins = %d, want 10", resp.ScanIntervalMins)
+	}
+	if resp.BinaryFound {
+		t.Error("expected BinaryFound=false when BinaryPath is empty")
+	}
+	if resp.DetectedVersion != nil {
+		t.Error("expected DetectedVersion=nil when binary not found")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `GET /api/v1/admin/scanning/config` now returns `binary_path`, `binary_found` (bool), and `detected_version` (string, nullable)
- `binary_found` is set by calling `os.Stat` on the configured path at request time
- `detected_version` is populated by running the scanner's `--version` command when the binary is found
- Sensitive path is only included when `cfg.Enabled` is true; omitted entirely when disabled
- Tests updated to assert new fields default to zero/nil when binary is not configured

Closes #263