### PR TITLE
fix: startup_failure in release.yml and weekly-security.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch: {}
-  workflow_call:
-    inputs:
-      run-security-deep:
-        description: Run OSV-Scanner and CodeQL (used by weekly-security.yml)
-        type: boolean
-        default: false
+  workflow_call: {} # allows release.yml and weekly-security.yml to call this
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.head_ref || github.ref }}
@@ -350,73 +345,3 @@ jobs:
       - name: Terraform validate (GCP)
         working-directory: deployments/terraform/gcp
         run: terraform init -backend=false && terraform validate
-
-  osv-scan:
-    name: OSV Vulnerability Scan
-    runs-on: ubuntu-latest
-    if: inputs.run-security-deep
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Run OSV-Scanner
-        id: osv
-        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
-        continue-on-error: true
-        with:
-          scan-args: |-
-            --lockfile=backend/go.sum
-            --format=table
-
-      - name: Create issue on new vulnerabilities
-        if: steps.osv.outcome == 'failure'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
-        with:
-          script: |
-            const title = `OSV-Scanner: vulnerabilities found — ${new Date().toISOString().slice(0,10)}`;
-            const body = [
-              '## OSV-Scanner Vulnerability Report',
-              '',
-              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              '',
-              'OSV-Scanner found known vulnerabilities in `go.sum`. Please review the workflow logs and update affected dependencies.',
-            ].join('\n');
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ['security', 'dependencies'],
-            });
-
-  codeql:
-    name: CodeQL Analysis (Go)
-    runs-on: ubuntu-latest
-    if: inputs.run-security-deep
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Go toolchain
-        uses: ./.github/actions/setup-backend
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3 # TODO: pin to SHA — see repo security policy
-        with:
-          languages: go
-
-      - name: Build for CodeQL
-        working-directory: backend
-        run: go build ./...
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3 # TODO: pin to SHA — see repo security policy
-        with:
-          category: /language:go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,6 @@ jobs:
   ci:
     name: CI
     needs: guard
-    # issues:write is required by the gosec job inside ci.yml to open GitHub
-    # issues when new findings are detected.  Reusable workflows can only
-    # receive permissions that the caller explicitly grants.
-    # contents:write is required by the swagger auto-commit step in ci.yml.
-    permissions:
-      contents: write
-      issues: write
     secrets: inherit # passes GIST_TOKEN (coverage badge) and other secrets to the reusable workflow
     uses: ./.github/workflows/ci.yml
 

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -7,15 +7,79 @@ on:
 
 jobs:
   ci:
-    name: CI (with deep security)
-    permissions:
-      contents: write
-      issues: write
-      security-events: write
+    name: CI
     secrets: inherit
     uses: ./.github/workflows/ci.yml
-    with:
-      run-security-deep: true
+
+  # ── OSV Vulnerability Scan ────────────────────────────
+  osv-scan:
+    name: OSV Vulnerability Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run OSV-Scanner
+        id: osv
+        uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
+        continue-on-error: true
+        with:
+          scan-args: |-
+            --lockfile=backend/go.sum
+            --format=table
+
+      - name: Create issue on new vulnerabilities
+        if: steps.osv.outcome == 'failure'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const title = `OSV-Scanner: vulnerabilities found — ${new Date().toISOString().slice(0,10)}`;
+            const body = [
+              '## OSV-Scanner Vulnerability Report',
+              '',
+              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'OSV-Scanner found known vulnerabilities in `go.sum`. Please review the workflow logs and update affected dependencies.',
+            ].join('\n');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['security', 'dependencies'],
+            });
+
+  # ── CodeQL Analysis ───────────────────────────────────
+  codeql:
+    name: CodeQL Analysis (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-backend
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3 # TODO: pin to SHA — see repo security policy
+        with:
+          languages: go
+
+      - name: Build for CodeQL
+        working-directory: backend
+        run: go build ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3 # TODO: pin to SHA — see repo security policy
+        with:
+          category: /language:go
 
   stale-dependabot:
     name: Flag stale Dependabot PRs
@@ -40,7 +104,7 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ci, osv-scan, codeql, stale-dependabot]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- `permissions:` on a job that calls a reusable workflow (`uses:`) is invalid in GitHub Actions and causes `startup_failure` before any jobs start — removed from the `ci` job in both `release.yml` and `weekly-security.yml`
- `workflow_call` with a `type: boolean` input causes type validation errors when callers pass string values; reverted `ci.yml` to `workflow_call: {}` (no inputs)
- `osv-scan` and `codeql` jobs moved directly into `weekly-security.yml` where they belong

## Test plan

- [ ] Merge this PR → CI passes on main
- [ ] Dispatch `release.yml` manually to verify no `startup_failure`
- [ ] Dispatch `weekly-security.yml` manually to verify OSV and CodeQL run correctly

Closes #272