### PR TITLE
fix: resolve publish-release collision with release-please GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,12 @@ jobs:
 
       - name: Create GitHub Release with all assets
         run: |
+          # release-please creates a GitHub Release (changelog, no assets) when
+          # the release PR is merged.  Immutable Releases prevents uploading to
+          # an existing release, so delete the empty one first (keep the tag).
+          gh release delete "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" -y --cleanup-tag=false 2>/dev/null || true
+
           gh release create "${GITHUB_REF_NAME}" \
             --repo "${GITHUB_REPOSITORY}" \
             --title "Release ${GITHUB_REF_NAME}" \


### PR DESCRIPTION
## Summary
- release-please creates a GitHub Release (changelog only, 0 assets) when the release PR is merged
- Our `publish-release` job then fails with `a release with the same tag name already exists` because Immutable Releases rejects duplicate releases
- Fix: delete the empty release-please release (preserving the tag) before recreating with all binary assets attached
- This was the cause of the v0.13.2 release failure

## Changelog
- ci: fix publish-release collision with release-please GitHub Release

## Checklist
- [x] `go fmt ./...` passes
- [x] `go vet ./...` passes
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge