### PR TITLE
feat(config): add system-wide default language setting

### DIFF
--- a/backend/cmd/registry-import/main.go
+++ b/backend/cmd/registry-import/main.go
@@ -423,7 +423,7 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 			return nil, err
 		}
 		if !info.IsDir() {
-			const maxEntryBytes = 500 * 1024 * 1024 // 500 MB per-entry limit — prevents decompression bombs
+			const maxEntryBytes = 500 * 1024 * 1024                                   // 500 MB per-entry limit — prevents decompression bombs
 			if _, err := io.Copy(tw, io.LimitReader(rc, maxEntryBytes)); err != nil { // #nosec G110
 				_ = rc.Close() // explicitly discard — already returning the io.Copy error
 				return nil, err

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -9,6 +9,10 @@ server:
   # public_url: https://registry.example.com
   read_timeout: 30s
   write_timeout: 30s
+  # default_language sets the system-wide default UI language for the frontend.
+  # Users can override this in their browser. Supported: en, es, fr, de, ja, pt, nl, nb, zh, it
+  # Environment variable: TFR_SERVER_DEFAULT_LANGUAGE
+  # default_language: en
 
 # OpenAPI / Swagger spec metadata — customisable at deploy time without recompiling.
 # These values override the defaults baked into the binary when non-empty.

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13077,6 +13077,9 @@
                 "build_date": {
                     "type": "string"
                 },
+                "default_language": {
+                    "type": "string"
+                },
                 "protocols": {
                     "$ref": "#/definitions/api.ProtocolVersions"
                 },

--- a/backend/internal/api/responses.go
+++ b/backend/internal/api/responses.go
@@ -38,8 +38,9 @@ type ProtocolVersions struct {
 
 // VersionResponse is returned by GET /version.
 type VersionResponse struct {
-	Version    string           `json:"version"`
-	BuildDate  string           `json:"build_date"`
-	APIVersion string           `json:"api_version"`
-	Protocols  ProtocolVersions `json:"protocols"`
+	Version         string           `json:"version"`
+	BuildDate       string           `json:"build_date"`
+	APIVersion      string           `json:"api_version"`
+	DefaultLanguage string           `json:"default_language"`
+	Protocols       ProtocolVersions `json:"protocols"`
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -292,7 +292,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	}
 
 	// API version
-	router.GET("/version", versionHandler())
+	router.GET("/version", versionHandler(cfg))
 
 	// Swagger UI - served from embedded static assets (air-gap safe)
 	swaggerUIFS, _ := fs.Sub(docs.SwaggerUIAssets, "swagger-ui")
@@ -1224,13 +1224,14 @@ func serviceDiscoveryHandler(cfg *config.Config) gin.HandlerFunc {
 // @Success      200  {object}  api.VersionResponse
 // @Router       /version [get]
 // versionHandler returns the API version
-func versionHandler() gin.HandlerFunc {
+func versionHandler(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"version":     AppVersion,
-			"build_date":  AppBuildDate,
-			"api_version": "v1",
-			"crypto_mode": AppCryptoMode,
+			"version":          AppVersion,
+			"build_date":       AppBuildDate,
+			"api_version":      "v1",
+			"crypto_mode":      AppCryptoMode,
+			"default_language": cfg.Server.DefaultLanguage,
 			"protocols": gin.H{
 				"modules":   "v1",
 				"providers": "v1",

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -213,8 +213,10 @@ func TestServiceDiscoveryHandler(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestVersionHandler(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.DefaultLanguage = "en"
 	r := gin.New()
-	r.GET("/version", versionHandler())
+	r.GET("/version", versionHandler(cfg))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/version", nil))
@@ -234,6 +236,9 @@ func TestVersionHandler(t *testing.T) {
 	}
 	if body["api_version"] == nil {
 		t.Error("response missing 'api_version'")
+	}
+	if body["default_language"] != "en" {
+		t.Errorf("default_language = %v, want \"en\"", body["default_language"])
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -143,12 +143,13 @@ type ScanningConfig struct {
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
-	Host         string        `mapstructure:"host"`
-	Port         int           `mapstructure:"port"`
-	BaseURL      string        `mapstructure:"base_url"`
-	PublicURL    string        `mapstructure:"public_url"`
-	ReadTimeout  time.Duration `mapstructure:"read_timeout"`
-	WriteTimeout time.Duration `mapstructure:"write_timeout"`
+	Host            string        `mapstructure:"host"`
+	Port            int           `mapstructure:"port"`
+	BaseURL         string        `mapstructure:"base_url"`
+	PublicURL       string        `mapstructure:"public_url"`
+	ReadTimeout     time.Duration `mapstructure:"read_timeout"`
+	WriteTimeout    time.Duration `mapstructure:"write_timeout"`
+	DefaultLanguage string        `mapstructure:"default_language"`
 }
 
 // GetPublicURL returns the public-facing URL used for OAuth callbacks and external redirects.
@@ -589,6 +590,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"server.public_url",
 		"server.read_timeout",
 		"server.write_timeout",
+		"server.default_language",
 
 		// Storage
 		"storage.default_backend",
@@ -780,6 +782,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.public_url", "")
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "30s")
+	v.SetDefault("server.default_language", "en")
 
 	// Redis defaults (empty host = disabled, in-memory fallback used)
 	v.SetDefault("redis.host", "")
@@ -884,6 +887,10 @@ func (c *Config) Validate() error {
 	}
 	if c.Server.BaseURL == "" {
 		return fmt.Errorf("server.base_url is required")
+	}
+	validLangs := map[string]bool{"en": true, "es": true, "fr": true, "de": true, "ja": true, "pt": true, "nl": true, "nb": true, "zh": true, "it": true}
+	if !validLangs[c.Server.DefaultLanguage] {
+		return fmt.Errorf("invalid server.default_language: %q (must be one of en, es, fr, de, ja, pt, nl, nb, zh, it)", c.Server.DefaultLanguage)
 	}
 
 	// Validate database

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -97,8 +97,9 @@ func TestGetAddress(t *testing.T) {
 func minimalValidConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Port:    8080,
-			BaseURL: "http://localhost:8080",
+			Port:            8080,
+			BaseURL:         "http://localhost:8080",
+			DefaultLanguage: "en",
 		},
 		Database: DatabaseConfig{
 			Host: "localhost",
@@ -334,6 +335,24 @@ func TestValidate(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("invalid default_language", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Server.DefaultLanguage = "xx"
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for invalid default_language, got nil")
+		}
+	})
+
+	t.Run("all supported languages pass", func(t *testing.T) {
+		for _, lang := range []string{"en", "es", "fr", "de", "ja", "pt", "nl", "nb", "zh", "it"} {
+			cfg := minimalValidConfig()
+			cfg.Server.DefaultLanguage = lang
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("Validate() unexpected error for default_language %q: %v", lang, err)
+			}
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -503,6 +522,9 @@ logging:
 	}
 	if !cfg.Auth.APIKeys.Enabled {
 		t.Error("default Auth.APIKeys.Enabled = false, want true")
+	}
+	if cfg.Server.DefaultLanguage != "en" {
+		t.Errorf("default Server.DefaultLanguage = %q, want \"en\"", cfg.Server.DefaultLanguage)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `server.default_language` config option (env: `TFR_SERVER_DEFAULT_LANGUAGE`, default: `"en"`)
- Expose in `GET /version` response so the frontend can read it on init
- Validate against 10 supported locales: en, es, fr, de, ja, pt, nl, nb, zh, it
- Update config example, Swagger docs, and tests

## Frontend cross-reference

sethbacon/terraform-registry-frontend#200

## Test plan

- [x] `go fmt ./...` and `go vet ./...` clean
- [x] All existing tests pass
- [x] New validation tests: invalid language rejected, all 10 supported codes accepted
- [x] `TestVersionHandler` asserts `default_language` in response
- [x] `TestLoad_DefaultsApplied` asserts default is `"en"`
- [x] Coverage at 80.0% (meets threshold)
- [x] Swagger regenerated

Closes #265