### PR TITLE
fix: use gh release upload for Immutable Releases compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,18 +237,26 @@ jobs:
       - name: List release assets
         run: ls -la release/
 
-      - name: Create GitHub Release with all assets
+      - name: Upload assets and update GitHub Release
         run: |
-          # release-please creates a GitHub Release (changelog, no assets) when
-          # the release PR is merged.  Immutable Releases prevents uploading to
-          # an existing release, so delete the empty one first (keep the tag).
-          gh release delete "${GITHUB_REF_NAME}" \
-            --repo "${GITHUB_REPOSITORY}" -y --cleanup-tag=false 2>/dev/null || true
-
-          gh release create "${GITHUB_REF_NAME}" \
+          # release-please creates a GitHub Release (with changelog) when the
+          # release PR is merged.  Immutable Releases prevents deleting or
+          # recreating that release, so upload assets to it and append notes.
+          gh release upload "${GITHUB_REF_NAME}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --title "Release ${GITHUB_REF_NAME}" \
-            --notes "## Docker Image
+            --clobber \
+            release/*
+
+          # Append Docker pull and verification instructions to the existing
+          # release-please changelog body.
+          EXISTING_BODY="$(gh release view "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" --json body -q .body)"
+
+          gh release edit "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --notes "${EXISTING_BODY}
+
+          ## Docker Image
 
           \`\`\`
           docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}
@@ -270,8 +278,7 @@ jobs:
             --certificate-identity-regexp 'https://github\\.com/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend/' \\\\
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\
             ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}
-          \`\`\`" \
-            release/*
+          \`\`\`"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Replace `gh release delete` + `gh release create` with `gh release upload --clobber` + `gh release edit`
- release-please creates a GitHub Release with the changelog when the release PR merges
- Immutable Releases prevents both deleting that release and creating a new one with the same tag (HTTP 422)
- The new approach uploads binary assets to the existing release and appends Docker/verification notes to the changelog

This fixes the v0.13.2 and v0.14.0 release failures.

## Test plan

- [ ] Merge this PR, then re-run the v0.14.0 release workflow manually (or trigger a new release)
- [ ] Verify the GitHub Release has both the changelog from release-please AND the Docker/verification notes
- [ ] Verify all binary assets are attached