### PR TITLE
fix: use draft releases for Immutable Releases compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,14 +213,19 @@ jobs:
           echo "  --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-  # ── Create the GitHub Release atomically ─────────────────────────────────
-  # The repository enforces GitHub's Immutable Releases security feature: a
-  # release (including drafts) is frozen at creation time and cannot accept
-  # additional asset uploads later. We therefore wait until all artifacts
-  # (binaries, checksums, signatures, SBOMs, deployment configs) are available,
-  # then create the release once with everything attached.
-  # Build provenance is stored in the GitHub attestation API (not as a release
-  # asset) and can be verified with `gh attestation verify`.
+  # ── Publish the GitHub Release ────────────────────────────────────────────
+  # release-please creates a DRAFT GitHub Release (with changelog) when the
+  # release PR is merged (configured via "draft": true in
+  # .release-please-config.json).  Draft releases are not subject to the
+  # Immutable Releases restriction, so we can upload assets freely.  Once
+  # all assets are attached we publish the draft, which makes it immutable.
+  #
+  # If no draft release exists (e.g. manual workflow_dispatch), we create
+  # the release from scratch using `gh release create`, which internally
+  # uses a draft→upload→publish flow that is also Immutable-Releases-safe.
+  #
+  # Build provenance is stored in the GitHub attestation API (not as a
+  # release asset) and can be verified with `gh attestation verify`.
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
@@ -228,6 +233,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: CHANGELOG.md
+          sparse-checkout-cone-mode: false
+
       - name: Download release artifacts (binaries, checksums, sigs, deployment configs)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -237,29 +247,15 @@ jobs:
       - name: List release assets
         run: ls -la release/
 
-      - name: Upload assets and update GitHub Release
+      - name: Upload assets and publish GitHub Release
         run: |
-          # release-please creates a GitHub Release (with changelog) when the
-          # release PR is merged.  Immutable Releases prevents deleting or
-          # recreating that release, so upload assets to it and append notes.
-          gh release upload "${GITHUB_REF_NAME}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --clobber \
-            release/*
+          TAG="${GITHUB_REF_NAME}"
+          REPO="${GITHUB_REPOSITORY}"
 
-          # Append Docker pull and verification instructions to the existing
-          # release-please changelog body.
-          EXISTING_BODY="$(gh release view "${GITHUB_REF_NAME}" \
-            --repo "${GITHUB_REPOSITORY}" --json body -q .body)"
-
-          gh release edit "${GITHUB_REF_NAME}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --notes "${EXISTING_BODY}
-
-          ## Docker Image
+          DOCKER_NOTES="## Docker Image
 
           \`\`\`
-          docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}
+          docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${TAG}
           \`\`\`
 
           ## Supply-chain verification
@@ -268,17 +264,50 @@ jobs:
 
           \`\`\`bash
           # Verify binary provenance
-          gh attestation verify <binary-file> --repo ${GITHUB_REPOSITORY}
+          gh attestation verify <binary-file> --repo ${REPO}
 
           # Verify container provenance
-          gh attestation verify oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME} --repo ${GITHUB_REPOSITORY}
+          gh attestation verify oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${TAG} --repo ${REPO}
 
           # Verify cosign signature
           cosign verify \\\\
             --certificate-identity-regexp 'https://github\\.com/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend/' \\\\
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\
-            ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${GITHUB_REF_NAME}
+            ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${TAG}
           \`\`\`"
+
+          # Check whether release-please already created a draft release for
+          # this tag.  If so, upload assets to the draft, append notes, and
+          # publish.  Otherwise create the release from scratch.
+          if gh release view "${TAG}" --repo "${REPO}" > /dev/null 2>&1; then
+            echo "Draft release found — uploading assets and publishing."
+            gh release upload "${TAG}" \
+              --repo "${REPO}" \
+              --clobber \
+              release/*
+
+            EXISTING_BODY="$(gh release view "${TAG}" \
+              --repo "${REPO}" --json body -q .body)"
+
+            gh release edit "${TAG}" \
+              --repo "${REPO}" \
+              --draft=false \
+              --notes "${EXISTING_BODY}
+
+          ${DOCKER_NOTES}"
+          else
+            echo "No existing release — creating release with assets."
+            # Extract changelog section for this version from CHANGELOG.md
+            CHANGELOG_BODY="$(sed -n "/^## \\[${TAG#v}\\]/,/^## \\[/{ /^## \\[${TAG#v}\\]/d; /^## \\[/d; p; }" CHANGELOG.md)"
+
+            gh release create "${TAG}" \
+              --repo "${REPO}" \
+              --title "${TAG}" \
+              --notes "${CHANGELOG_BODY}
+
+          ${DOCKER_NOTES}" \
+              release/*
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,10 +59,10 @@ checksum:
   name_template: checksums.txt
   algorithm: sha256
 
-# Release creation is disabled here because the repository has GitHub's
-# Immutable Releases feature enabled, which freezes a release (including
-# drafts) at the moment of creation. The publish-release job in release.yml
-# creates the release atomically with all binary assets attached.
+# Release creation is disabled here because release-please creates a draft
+# GitHub Release (with changelog) when the release PR is merged.  The
+# publish-release job in release.yml uploads binary assets to the draft and
+# then publishes it, which is compatible with Immutable Releases.
 release:
   disable: true
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "go",
@@ -17,14 +19,38 @@
         }
       ],
       "changelog-sections": [
-        {"type": "feat", "section": "Features"},
-        {"type": "fix", "section": "Bug Fixes"},
-        {"type": "perf", "section": "Performance"},
-        {"type": "deps", "section": "Dependencies"},
-        {"type": "docs", "section": "Documentation"},
-        {"type": "refactor", "section": "Refactor"},
-        {"type": "revert", "section": "Reverts"},
-        {"type": "security", "section": "Security"}
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "deps",
+          "section": "Dependencies"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactor"
+        },
+        {
+          "type": "revert",
+          "section": "Reverts"
+        },
+        {
+          "type": "security",
+          "section": "Security"
+        }
       ]
     }
   }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ Releases are fully automated via `release-please.yml` and `release.yml`.
    - Pushes Docker image to `ghcr.io` (tagged with version + latest).
    - Attests build provenance via GitHub Artifact Attestations (binaries + container).
    - Signs the container image with cosign (keyless, Sigstore).
-   - Creates the GitHub Release with all assets attached atomically.
+   - Uploads assets to the draft GitHub Release and publishes it.
    - Updates the wiki Home page version badge.
 
 ## Verifying supply-chain attestations


### PR DESCRIPTION
## Summary

- Configures release-please to create **draft** GitHub Releases (`"draft": true`, `"force-tag-creation": true` in `.release-please-config.json`)
- Updates `publish-release` job to upload assets to the draft, append Docker/verification notes, then publish (`--draft=false`)
- Adds fallback for `workflow_dispatch`: creates the release from scratch using `gh release create` (which internally uses draft→upload→publish)
- Fixes incorrect goreleaser comment claiming drafts are also frozen (they are not per GitHub docs)

**Root cause of v0.13.2/v0.14.0/v0.14.1 release failures:** release-please created a published release, and Immutable Releases blocked all subsequent asset uploads.

**Evidence that draft releases work:**
- [GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository): "create releases as drafts first, attach all assets, and then publish"
- [`gh` CLI PR #11945](https://github.com/cli/cli/pull/11945): "`gh release create` internally creates as draft, uploads assets, then publishes"
- [`gh` CLI issue #11589](https://github.com/cli/cli/issues/11589): API response shows `"immutable": false` for draft releases

Closes #284

## Test plan

- [ ] Merge this PR → release-please opens a v0.14.2 release PR
- [ ] Merge the release PR → verify release-please creates a **draft** release + pushes tag
- [ ] Verify release workflow uploads assets to the draft and publishes it
- [ ] Confirm the published release has all binary assets attached