### PR TITLE
fix(scanner): use writable cache dir for trivy on read-only filesystems

### DIFF
--- a/backend/internal/scanner/trivy.go
+++ b/backend/internal/scanner/trivy.go
@@ -2,7 +2,7 @@
 // Trivy is the default tool choice; it supports filesystem scanning for vulnerabilities,
 // secrets, and IaC misconfigurations in a single invocation.
 //
-// Invocation: trivy fs --format json --scanners vuln,secret,misconfig --exit-code 0 --quiet <dir>
+// Invocation: trivy fs --format json --scanners vuln,secret,misconfig --exit-code 0 --cache-dir <dir> --quiet <dir>
 // Output schema: {"Results": [{"Vulnerabilities": [{"Severity": "HIGH"}], "Misconfigurations": [...]}]}
 package scanner
 
@@ -11,10 +11,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
+
+// trivyCacheDir returns a writable directory for trivy's vulnerability DB
+// and other cached data. This avoids failures on read-only root filesystems
+// (e.g. Kubernetes pods with readOnlyRootFilesystem: true) where the default
+// ~/.cache path is not writable. The TRIVY_CACHE_DIR env var takes precedence.
+func trivyCacheDir() string {
+	if d := os.Getenv("TRIVY_CACHE_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join(os.TempDir(), "trivy-cache")
+}
 
 type trivyScanner struct {
 	binaryPath string
@@ -55,6 +68,7 @@ func (s *trivyScanner) ScanDirectory(ctx context.Context, dir string) (*ScanResu
 		"fs", "--format", "json",
 		"--scanners", "vuln,secret,misconfig",
 		"--exit-code", "0",
+		"--cache-dir", trivyCacheDir(),
 		"--quiet",
 		dir,
 	)


### PR DESCRIPTION
## Summary

- Passes `--cache-dir /tmp/trivy-cache` to trivy so it writes its vulnerability DB to a writable location
- Fixes `trivy: exit status 1` caused by `mkdir /home/registry/.cache: read-only file system` on Kubernetes pods with `readOnlyRootFilesystem: true`
- Respects `TRIVY_CACHE_DIR` env var if set (operator override)

**Root cause:** All deployment configs (Helm, Kustomize) set `readOnlyRootFilesystem: true`. Trivy's default cache at `~/.cache/trivy/` is on the read-only root. `/tmp` is already a writable emptyDir mount.

Closes #287

## Test plan

- [ ] Scanner tests pass (`go test ./internal/scanner/`)
- [ ] Deploy to AKS UAT, trigger a scan, verify trivy completes successfully