### PR TITLE
chore: bump image tags and align version with frontend

### DIFF
--- a/deployments/helm/values-aks.yaml
+++ b/deployments/helm/values-aks.yaml
@@ -24,7 +24,7 @@ backend:
     # Replace <ACR_NAME> with your ACR name (e.g. mycompanyacr → mycompanyacr.azurecr.io)
     repository: <ACR_NAME>.azurecr.io/terraform-registry-backend
     # Pin to a specific semver tag. Never use 'latest' in production.
-    tag: "v0.12.0"
+    tag: "v0.15.0"
     pullPolicy: IfNotPresent
   # Production resource sizing — adjust to match your workload
   replicaCount: 3
@@ -40,7 +40,7 @@ frontend:
   enabled: true
   image:
     repository: <ACR_NAME>.azurecr.io/terraform-registry-frontend
-    tag: "v0.12.0"
+    tag: "v0.15.1"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -23,7 +23,7 @@ backend:
   image:
     # Format: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    tag: "v0.12.0"
+    tag: "v0.15.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -52,7 +52,7 @@ frontend:
   enabled: true
   image:
     repository: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    tag: "v0.12.0"
+    tag: "v0.15.1"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -21,7 +21,7 @@ backend:
   image:
     # Format: <REGION>-docker.pkg.dev/<PROJECT_ID>/<REPO_NAME>/terraform-registry-backend
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    tag: "v0.12.0"
+    tag: "v0.15.0"
     pullPolicy: IfNotPresent
   replicaCount: 3
   resources:
@@ -50,7 +50,7 @@ frontend:
   enabled: true
   image:
     repository: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    tag: "v0.12.0"
+    tag: "v0.15.1"
     pullPolicy: IfNotPresent
   replicaCount: 2
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -61,7 +61,7 @@ frontend:
   replicaCount: 2
   image:
     repository: terraform-registry-frontend
-    tag: "0.12.0"
+    tag: "0.15.1"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deployments/kubernetes/overlays/eks/kustomization.yaml
+++ b/deployments/kubernetes/overlays/eks/kustomization.yaml
@@ -69,7 +69,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-backend
-    newTag: v0.12.0
+    newTag: v0.15.0
   - name: terraform-registry-frontend
     newName: <ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/terraform-registry-frontend
-    newTag: v0.12.0
+    newTag: v0.15.1

--- a/deployments/kubernetes/overlays/gke/kustomization.yaml
+++ b/deployments/kubernetes/overlays/gke/kustomization.yaml
@@ -77,7 +77,7 @@ patches:
 images:
   - name: terraform-registry-backend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-backend
-    newTag: v0.12.0
+    newTag: v0.15.0
   - name: terraform-registry-frontend
     newName: <REGION>-docker.pkg.dev/<PROJECT_ID>/<AR_REPO>/terraform-registry-frontend
-    newTag: v0.12.0
+    newTag: v0.15.1


### PR DESCRIPTION
## Summary

Two related bumps in one PR:

**Image tags** in `deployments/helm/values*.yaml` and the kustomize cloud overlays (eks, gke):
- Backend: \`v0.12.0\` → \`v0.15.0\` (this release)
- Frontend: \`v0.12.0\` → \`v0.15.1\` (released today, includes i18n public list pages and DeepL translation cleanup)

**Version alignment** — the commit body carries a \`Release-As: 0.15.0\` footer so release-please cuts a minor release rather than the patch (\`0.14.4\`) it would otherwise infer from a \`chore:\` commit. The intent is that backend \`X.Y.*\` and frontend \`X.Y.*\` track together as a compatibility pair, even though the individual change here is small.

This is a one-time alignment skip; future patches/features will follow normal semver.

## Files

- \`deployments/helm/values.yaml\` — frontend tag only (default chart)
- \`deployments/helm/values-aks.yaml\`, \`values-eks.yaml\`, \`values-gke.yaml\` — both tags
- \`deployments/kubernetes/overlays/eks/kustomization.yaml\`, \`gke/kustomization.yaml\` — both tags

## Test plan

- [x] No backend Go code changed; quality gate (go fmt / vet / tests / gosec) is n/a.
- [ ] CI \`Deployment Config Validation\` job validates helm + kustomize syntax.
- [ ] After merge, release-please opens a \`chore(main): release 0.15.0\` PR (not 0.14.4) thanks to the Release-As footer.