### PR TITLE
feat(scanning): add GET scan-by-ID endpoint

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3018,6 +3018,68 @@
                 }
             }
         },
+        "/api/v1/admin/scanning/scans/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns a security scan record by its unique ID, including severity counts and raw output. Requires scanning:read scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Security Scanning"
+                ],
+                "summary": "Get scan result by ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Scan ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ModuleScan"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid scan ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Scan not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/scanning/stats": {
             "get": {
                 "security": [

--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -67,6 +68,42 @@ func GetModuleScanHandler(db *sql.DB) gin.HandlerFunc {
 		}
 		if scan == nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "no scan found for this module version"})
+			return
+		}
+
+		c.JSON(http.StatusOK, scan)
+	}
+}
+
+// @Summary      Get scan result by ID
+// @Description  Returns a security scan record by its unique ID, including severity counts and raw output. Requires scanning:read scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Produce      json
+// @Param        id  path  string  true  "Scan ID (UUID)"
+// @Success      200  {object}  models.ModuleScan
+// @Failure      400  {object}  map[string]interface{}  "Invalid scan ID"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Scan not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/scanning/scans/{id} [get]
+func GetScanByIDHandler(db *sql.DB) gin.HandlerFunc {
+	scanRepo := repositories.NewModuleScanRepository(db)
+
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := uuid.Parse(id); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scan ID"})
+			return
+		}
+
+		scan, err := scanRepo.GetScanByID(c.Request.Context(), id)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query scan result"})
+			return
+		}
+		if scan == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
 			return
 		}
 

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -201,3 +201,64 @@ func TestGetModuleScan_ScanNotFound(t *testing.T) {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GetScanByIDHandler tests
+// ---------------------------------------------------------------------------
+
+func newScanByIDRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	r := gin.New()
+	r.GET("/admin/scanning/scans/:id", GetScanByIDHandler(db))
+	return mock, r
+}
+
+func TestGetScanByID_Success(t *testing.T) {
+	mock, r := newScanByIDRouter(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
+		WillReturnRows(sampleScanResultRow())
+
+	w := doScanGET(r, "/admin/scanning/scans/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetScanByID_InvalidUUID(t *testing.T) {
+	_, r := newScanByIDRouter(t)
+
+	w := doScanGET(r, "/admin/scanning/scans/not-a-uuid")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetScanByID_NotFound(t *testing.T) {
+	mock, r := newScanByIDRouter(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
+		WillReturnRows(sqlmock.NewRows(scanAdminCols))
+
+	w := doScanGET(r, "/admin/scanning/scans/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetScanByID_DBError(t *testing.T) {
+	mock, r := newScanByIDRouter(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
+		WillReturnError(errors.New("db error"))
+
+	w := doScanGET(r, "/admin/scanning/scans/a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -832,6 +832,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			authenticatedGroup.GET("/admin/scanning/stats",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScanningStatsHandler(sqlxDB))
+			authenticatedGroup.GET("/admin/scanning/scans/:id",
+				middleware.RequireScope(auth.ScopeScanningRead),
+				admin.GetScanByIDHandler(db))
 			authenticatedGroup.POST("/admin/scanning/install",
 				middleware.RequireScope(auth.ScopeAdmin),
 				admin.InstallScannerHandler(&cfg.Scanning, nil))

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -210,6 +210,34 @@ func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionI
 	return s, nil
 }
 
+// GetScanByID returns a single scan record by its primary key, or nil if not found.
+func (r *ModuleScanRepository) GetScanByID(ctx context.Context, scanID string) (*models.ModuleScan, error) {
+	const q = `
+		SELECT id, module_version_id, scanner, scanner_version, expected_version,
+		       status, scanned_at, critical_count, high_count, medium_count, low_count,
+		       raw_results, error_message, execution_log, created_at, updated_at
+		FROM module_version_scans
+		WHERE id = $1
+	`
+	s := &models.ModuleScan{}
+	var rawResults []byte
+	err := r.db.QueryRowContext(ctx, q, scanID).Scan(
+		&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
+		&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
+		&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get scan by id: %w", err)
+	}
+	if len(rawResults) > 0 {
+		s.RawResults = json.RawMessage(rawResults)
+	}
+	return s, nil
+}
+
 // ResetStaleScanningRecords resets records stuck in 'scanning' for longer than olderThan.
 // This recovers from worker crashes.
 func (r *ModuleScanRepository) ResetStaleScanningRecords(ctx context.Context, olderThan time.Duration) error {

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -226,6 +226,55 @@ func TestMarkError_DBError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// GetScanByID
+// ---------------------------------------------------------------------------
+
+func TestGetScanByID_Found(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("scan-1").
+		WillReturnRows(sampleScanRow())
+
+	scan, err := repo.GetScanByID(context.Background(), "scan-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scan == nil {
+		t.Fatal("expected non-nil scan")
+	}
+	if scan.ID != "scan-1" {
+		t.Errorf("ID = %q, want scan-1", scan.ID)
+	}
+}
+
+func TestGetScanByID_NotFound(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("scan-99").
+		WillReturnRows(sqlmock.NewRows(scanCols))
+
+	scan, err := repo.GetScanByID(context.Background(), "scan-99")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scan != nil {
+		t.Errorf("expected nil scan, got %+v", scan)
+	}
+}
+
+func TestGetScanByID_DBError(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+		WithArgs("scan-1").
+		WillReturnError(errors.New("db error"))
+
+	_, err := repo.GetScanByID(context.Background(), "scan-1")
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // GetLatestScan
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/admin/scanning/scans/:id` endpoint that returns a full `ModuleScan` record by scan ID
- Requires `scanning:read` scope (same as existing scan endpoints)
- Validates UUID format, returns 400/404/500 as appropriate
- Enables the frontend scan findings modal to fetch scan details directly without reconstructing the module version path

## Test plan

- [x] Repository unit tests: found, not-found, DB error
- [x] Handler unit tests: success, invalid UUID, not-found, DB error
- [x] `go fmt`, `go vet` pass
- [x] Swagger annotations regenerated

Closes #294