### PR TITLE
fix(scanning): store actual scanner tool name on scan completion

### DIFF
--- a/backend/internal/db/migrations/000031_backfill_scanner_name.down.sql
+++ b/backend/internal/db/migrations/000031_backfill_scanner_name.down.sql
@@ -1,0 +1,1 @@
+-- no-op: reverting scanner names is not meaningful

--- a/backend/internal/db/migrations/000031_backfill_scanner_name.up.sql
+++ b/backend/internal/db/migrations/000031_backfill_scanner_name.up.sql
@@ -1,0 +1,1 @@
+UPDATE module_version_scans SET scanner = 'trivy' WHERE scanner = 'pending';

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -124,6 +124,7 @@ func (r *ModuleScanRepository) MarkScanning(ctx context.Context, scanID string) 
 func (r *ModuleScanRepository) MarkComplete(
 	ctx context.Context,
 	scanID string,
+	scannerName string,
 	result *scanner.ScanResult,
 	expectedVersion string,
 ) error {
@@ -150,13 +151,13 @@ func (r *ModuleScanRepository) MarkComplete(
 
 	const q = `
 		UPDATE module_version_scans
-		SET status = $2, scanned_at = $3, scanner_version = $4, expected_version = $5,
-		    critical_count = $6, high_count = $7, medium_count = $8, low_count = $9,
-		    raw_results = $10, execution_log = $11, updated_at = NOW()
+		SET scanner = $2, status = $3, scanned_at = $4, scanner_version = $5, expected_version = $6,
+		    critical_count = $7, high_count = $8, medium_count = $9, low_count = $10,
+		    raw_results = $11, execution_log = $12, updated_at = NOW()
 		WHERE id = $1
 	`
 	_, err := r.db.ExecContext(ctx, q,
-		scanID, status, now, actualVer, expVer,
+		scanID, scannerName, status, now, actualVer, expVer,
 		result.CriticalCount, result.HighCount, result.MediumCount, result.LowCount,
 		rawJSON, execLog,
 	)

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -163,10 +163,10 @@ func TestMarkComplete_Clean(t *testing.T) {
 		RawJSON:        json.RawMessage(`{"results": []}`),
 	}
 
-	mock.ExpectExec("UPDATE module_version_scans.*SET status").
+	mock.ExpectExec("UPDATE module_version_scans.*SET scanner").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := repo.MarkComplete(context.Background(), "scan-1", result, ""); err != nil {
+	if err := repo.MarkComplete(context.Background(), "scan-1", "trivy", result, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -181,10 +181,10 @@ func TestMarkComplete_WithFindings(t *testing.T) {
 		RawJSON:        json.RawMessage(`{"results": [{"severity": "CRITICAL"}]}`),
 	}
 
-	mock.ExpectExec("UPDATE module_version_scans.*SET status").
+	mock.ExpectExec("UPDATE module_version_scans.*SET scanner").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	if err := repo.MarkComplete(context.Background(), "scan-1", result, "0.50.0"); err != nil {
+	if err := repo.MarkComplete(context.Background(), "scan-1", "trivy", result, "0.50.0"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -192,10 +192,10 @@ func TestMarkComplete_WithFindings(t *testing.T) {
 func TestMarkComplete_DBError(t *testing.T) {
 	repo, mock := newScanRepo(t)
 	result := &scanner.ScanResult{ScannerVersion: "0.50.0"}
-	mock.ExpectExec("UPDATE module_version_scans.*SET status").
+	mock.ExpectExec("UPDATE module_version_scans.*SET scanner").
 		WillReturnError(errors.New("db error"))
 
-	if err := repo.MarkComplete(context.Background(), "scan-1", result, ""); err == nil {
+	if err := repo.MarkComplete(context.Background(), "scan-1", "trivy", result, ""); err == nil {
 		t.Error("expected error, got nil")
 	}
 }

--- a/backend/internal/jobs/module_scanner_job.go
+++ b/backend/internal/jobs/module_scanner_job.go
@@ -210,7 +210,7 @@ func (j *ModuleScannerJob) scanOne(ctx context.Context, s scanner.Scanner, scanI
 	}
 	result.ScannerVersion = actualVersion
 
-	if err := j.scanRepo.MarkComplete(ctx, scanID, result, j.cfg.ExpectedVersion); err != nil {
+	if err := j.scanRepo.MarkComplete(ctx, scanID, s.Name(), result, j.cfg.ExpectedVersion); err != nil {
 		slog.Error("module scanner: failed to store result", "scan_id", scanID, "error", err)
 		return
 	}


### PR DESCRIPTION
## Summary

- Add `scannerName` parameter to `MarkComplete` and include `scanner` in the UPDATE SQL
- Pass `s.Name()` from the scanning job so the actual tool name is persisted
- Migration 000031 backfills existing records: `UPDATE module_version_scans SET scanner = 'trivy' WHERE scanner = 'pending'`

Closes #298