### PR TITLE
fix: bump Go to 1.26.2 and fix OSV scanner args

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -28,7 +28,8 @@ jobs:
         continue-on-error: true
         with:
           scan-args: |-
-            --lockfile=backend/go.sum
+            --recursive
+            ./backend
             --format=table
 
       - name: Create issue on new vulnerabilities
@@ -104,7 +105,7 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
-    needs: [ci, osv-scan, codeql, stale-dependabot]
+    needs: [ ci, osv-scan, codeql, stale-dependabot ]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-registry/terraform-registry
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/storage v1.59.2


### PR DESCRIPTION
## Summary

- Bumps \`go\` directive in \`backend/go.mod\` from 1.26.1 → 1.26.2, resolving stdlib vulnerabilities GO-2026-4865 through GO-2026-4947
- Fixes \`weekly-security.yml\` OSV scan args: replaces \`--lockfile=backend/go.sum\` with \`--recursive ./backend\`, which is the correct invocation for OSV-Scanner v2.3.5. The old args caused exit code 127 ("no suitable extractor"), which the workflow treated as a vulnerability finding — generating a false-positive issue on every weekly run.

Closes #290