### PR TITLE
fix(security): resolve CodeQL path-injection and SSRF findings

### DIFF
--- a/backend/internal/scanner/installer/installer.go
+++ b/backend/internal/scanner/installer/installer.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	goversion "github.com/hashicorp/go-version"
 )
 
 // Size caps to prevent zip-bomb / decompression-bomb DoS.
@@ -219,6 +221,12 @@ func resolveRelease(ctx context.Context, client *http.Client, spec AssetSpec, pi
 		url = spec.LatestReleaseAPI
 	} else {
 		v := strings.TrimPrefix(pinnedVersion, "v")
+		// Validate pinnedVersion is a recognisable semver before interpolating it into
+		// the GitHub API URL.  An attacker-controlled value could otherwise redirect
+		// the request to an unexpected path (CWE-918 / CodeQL go/path-injection).
+		if _, err := goversion.NewSemver(v); err != nil {
+			return nil, fmt.Errorf("invalid pinned version %q: must be a valid semantic version", pinnedVersion)
+		}
 		url = fmt.Sprintf(spec.VersionedAPI, v)
 	}
 

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -66,8 +66,10 @@ func (s *LocalStorage) safeJoin(path string) (string, error) {
 
 // Upload stores a file in the local filesystem
 func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
-	// Create full path
-	fullPath := filepath.Join(s.basePath, filepath.FromSlash(path))
+	fullPath, err := s.safeJoin(path)
+	if err != nil {
+		return nil, err
+	}
 
 	// Ensure directory exists
 	dir := filepath.Dir(fullPath)
@@ -76,7 +78,7 @@ func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader
 	}
 
 	// Create file
-	file, err := os.Create(fullPath) // #nosec G304 -- path is constructed from validated namespace/name/version components; path traversal is prevented at the API and archive-extraction layers
+	file, err := os.Create(fullPath) // #nosec G304 -- fullPath has been validated by safeJoin to remain within basePath
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes the two genuine CodeQL findings identified during triage. All other 22 alerts are dismissed in this PR as false positives (see dismissal notes in each alert).

### `installer.go` — SSRF / go/request-forgery (alert #4)

`resolveRelease()` interpolated the caller-supplied `pinnedVersion` directly into a GitHub API URL via `fmt.Sprintf`. An operator could set `scanning.expected_version` to a crafted value and redirect the HTTP request to an unexpected endpoint (CWE-918).

Fix: validate `pinnedVersion` is a recognised semantic version using `hashicorp/go-version` before constructing the URL. Invalid values are rejected with a clear error.

### `local.go` — path-injection in `Upload()` (alerts #21–24)

`Upload()` used a bare `filepath.Join` to build the destination path, unlike every other method in the file which routes through `safeJoin()`. `safeJoin()` verifies the resolved path remains within `basePath`, providing defence-in-depth against path traversal.

Fix: use `safeJoin()` in `Upload()` — consistent with `Download`, `GetURL`, `Exists`, and `GetMetadata`.