### PR TITLE
fix(scanner): pass --cache-dir to trivy version probe

### DIFF
--- a/backend/internal/scanner/trivy.go
+++ b/backend/internal/scanner/trivy.go
@@ -41,10 +41,16 @@ func newTrivyScanner(binaryPath string, timeout time.Duration) Scanner {
 func (s *trivyScanner) Name() string { return "trivy" }
 
 func (s *trivyScanner) Version(ctx context.Context) (string, error) {
-	out, err := exec.CommandContext(ctx, s.binaryPath, "version", "--format", "json").Output() // #nosec G204 -- binaryPath is operator-configured, not user input
+	// Pass --cache-dir so `trivy version` does not attempt to write to
+	// ~/.cache on read-only root filesystems (e.g. Kubernetes pods with
+	// readOnlyRootFilesystem: true). Without this, the version probe
+	// fails and the admin UI shows "Not reported by backend" even
+	// though scans themselves succeed. See #288 / #287.
+	cacheDir := trivyCacheDir()
+	out, err := exec.CommandContext(ctx, s.binaryPath, "--cache-dir", cacheDir, "version", "--format", "json").Output() // #nosec G204 -- binaryPath is operator-configured, not user input
 	if err != nil {
 		// Fall back to plain version output
-		out, err = exec.CommandContext(ctx, s.binaryPath, "--version").Output() // #nosec G204 -- binaryPath is operator-configured, not user input
+		out, err = exec.CommandContext(ctx, s.binaryPath, "--cache-dir", cacheDir, "--version").Output() // #nosec G204 -- binaryPath is operator-configured, not user input
 		if err != nil {
 			return "", fmt.Errorf("trivy version: %w", err)
 		}


### PR DESCRIPTION
## Summary

The admin Security Scanning page shows `Detected Version: Not reported by backend` even though per-scan records correctly show e.g. `trivy 0.70.0`.

## Root cause

`GetScanningConfigHandler` calls `scanner.Version()` live to populate `detected_version` in the config response. On read-only root filesystems (Kubernetes pods with `readOnlyRootFilesystem: true`), `trivy version --format json` still attempts to write to `~/.cache` and fails. The fallback `trivy --version` does the same. Both error → `DetectedVersion` stays `nil` → JSON omits the field → frontend renders 'Not reported by backend'.

The findings modal is unaffected because that data comes from persisted scan records produced by `ScanDirectory`, which already received the `--cache-dir` fix in #288.

## Fix

Pass `--cache-dir` to both the JSON and fallback `--version` invocations in `trivyScanner.Version`, mirroring the #288 fix.

## Closes

Follow-up to #288 / #287.