### PR TITLE
fix(db): quote `references` reserved keyword in migration 032 and repository SQL

### DIFF
--- a/backend/internal/db/migrations/000032_cve_advisories.up.sql
+++ b/backend/internal/db/migrations/000032_cve_advisories.up.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS cve_advisories (
     severity      TEXT NOT NULL DEFAULT 'unknown', -- critical|high|medium|low|unknown
     summary       TEXT NOT NULL DEFAULT '',
     details       TEXT NOT NULL DEFAULT '',
-    references    JSONB NOT NULL DEFAULT '[]',   -- array of URL strings
+    "references"  JSONB NOT NULL DEFAULT '[]',   -- array of URL strings
     published_at  TIMESTAMPTZ,
     modified_at   TIMESTAMPTZ,
     fetched_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/backend/internal/db/repositories/cve_repository.go
+++ b/backend/internal/db/repositories/cve_repository.go
@@ -35,14 +35,14 @@ func (r *CVERepository) UpsertAdvisory(ctx context.Context, a *models.CVEAdvisor
 
 	row := r.db.QueryRowContext(ctx, `
 		INSERT INTO cve_advisories
-			(source, source_id, severity, summary, details, references,
+			(source, source_id, severity, summary, details, "references",
 			 published_at, modified_at, fetched_at, withdrawn_at)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,NOW(),$9)
 		ON CONFLICT (source, source_id) DO UPDATE
 			SET severity     = EXCLUDED.severity,
 			    summary      = EXCLUDED.summary,
 			    details      = EXCLUDED.details,
-			    references   = EXCLUDED.references,
+			    "references" = EXCLUDED."references",
 			    modified_at  = EXCLUDED.modified_at,
 			    fetched_at   = NOW(),
 			    withdrawn_at = EXCLUDED.withdrawn_at,
@@ -115,7 +115,7 @@ func (r *CVERepository) ReplaceAffectedTargets(ctx context.Context, advisoryID u
 func (r *CVERepository) ListActive(ctx context.Context) ([]models.CVEAdvisory, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT DISTINCT a.id, a.source, a.source_id, a.severity, a.summary, a.details,
-		       a.references, a.published_at, a.modified_at, a.fetched_at,
+		       a."references", a.published_at, a.modified_at, a.fetched_at,
 		       a.withdrawn_at, a.created_at, a.updated_at
 		FROM cve_advisories a
 		WHERE a.withdrawn_at IS NULL
@@ -181,7 +181,7 @@ func (r *CVERepository) ListActive(ctx context.Context) ([]models.CVEAdvisory, e
 func (r *CVERepository) ListAll(ctx context.Context, kindFilter string) ([]models.CVEAdvisory, error) {
 	query := `
 		SELECT a.id, a.source, a.source_id, a.severity, a.summary, a.details,
-		       a.references, a.published_at, a.modified_at, a.fetched_at,
+		       a."references", a.published_at, a.modified_at, a.fetched_at,
 		       a.withdrawn_at, a.created_at, a.updated_at
 		FROM cve_advisories a
 	`


### PR DESCRIPTION
Closes #310

## Summary

`references` is a reserved keyword in PostgreSQL and cannot appear as an unquoted column identifier. Migration `000032_cve_advisories.up.sql` used it bare in the `CREATE TABLE cve_advisories` definition, causing PostgreSQL to return a syntax error. This left `schema_migrations` in a dirty state (`version=32, dirty=true`) on every v0.18.0 deployment, putting the backend pod into `CrashLoopBackOff`.

The same unquoted column name appeared in four SQL statements in `cve_repository.go` (INSERT, ON CONFLICT SET, and two SELECTs), which would have caused runtime errors on any CVE query once the tables existed.

## Changes

- `backend/internal/db/migrations/000032_cve_advisories.up.sql` — quote column as `"references"` in `CREATE TABLE cve_advisories`
- `backend/internal/db/repositories/cve_repository.go` — quote column as `"references"` in `UpsertAdvisory` INSERT + ON CONFLICT SET, `ListActive` SELECT, and `ListAll` SELECT

## Testing

- `go fmt ./...` — clean
- `go vet ./...` — clean  
- `go test ./internal/... ./pkg/...` — all pass, coverage 80.2%
- `gosec` — 0 new findings vs baseline