### PR TITLE
fix(scanner): fall back to {install_dir}/{tool} when binary_path is missing

### DIFF
--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -3,7 +3,6 @@ package admin
 
 import (
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -75,9 +74,10 @@ func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 			BinaryPath:        cfg.BinaryPath,
 		}
 
-		if cfg.Enabled && cfg.BinaryPath != "" {
-			if _, err := os.Stat(cfg.BinaryPath); err == nil {
+		if cfg.Enabled {
+			if resolved, ok := scanner.ResolveBinaryPath(cfg); ok {
 				resp.BinaryFound = true
+				resp.BinaryPath = resolved
 				if s, err := scanner.New(cfg); err == nil {
 					if v, err := s.Version(c.Request.Context()); err == nil {
 						resp.DetectedVersion = &v

--- a/backend/internal/api/admin/scanning_admin_test.go
+++ b/backend/internal/api/admin/scanning_admin_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -61,6 +63,46 @@ func TestGetScanningConfigHandler_Success(t *testing.T) {
 	}
 	if resp.DetectedVersion != nil {
 		t.Error("expected DetectedVersion=nil when binary not found")
+	}
+}
+
+func TestGetScanningConfigHandler_FallsBackToInstallDir(t *testing.T) {
+	// When BinaryPath points nowhere but the auto-installer has placed a
+	// binary at {InstallDir}/{Tool}, the response should advertise that path
+	// as the active binary so the admin UI shows the truth.
+	installDir := t.TempDir()
+	fallbackBinary := filepath.Join(installDir, "trivy")
+	if err := os.WriteFile(fallbackBinary, []byte("fake"), 0o755); err != nil {
+		t.Fatalf("stage fallback binary: %v", err)
+	}
+
+	cfg := &config.ScanningConfig{
+		Enabled:    true,
+		Tool:       "trivy",
+		BinaryPath: "/nonexistent/path/to/trivy",
+		InstallDir: installDir,
+		Timeout:    time.Second,
+	}
+
+	r := gin.New()
+	r.GET("/scanning/config", GetScanningConfigHandler(cfg))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/scanning/config", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp ScanningConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.BinaryFound {
+		t.Error("expected BinaryFound=true when fallback binary exists")
+	}
+	if resp.BinaryPath != fallbackBinary {
+		t.Errorf("BinaryPath = %q, want %q (the resolved fallback)", resp.BinaryPath, fallbackBinary)
 	}
 }
 

--- a/backend/internal/scanner/scanner.go
+++ b/backend/internal/scanner/scanner.go
@@ -11,7 +11,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -50,11 +52,50 @@ func truncateExecutionLog(s string) string {
 	return s[:maxBytes] + "\n... (truncated)"
 }
 
+// ResolveBinaryPath returns the path to the scanner binary that should actually
+// be invoked. It prefers the operator-configured cfg.BinaryPath when that file
+// exists, and falls back to the auto-installer's symlink at
+// {InstallDir}/{Tool} when BinaryPath is missing.  This lets installations that
+// rely on the in-app auto-installer keep working even if BinaryPath in the chart
+// values still points at the legacy /usr/local/bin/<tool> default.
+//
+// The second return value is the path that was actually checked successfully,
+// which may differ from cfg.BinaryPath when the fallback was used.  An empty
+// string means no usable binary was found.
+func ResolveBinaryPath(cfg *config.ScanningConfig) (string, bool) {
+	if cfg.BinaryPath != "" {
+		if _, err := os.Stat(cfg.BinaryPath); err == nil {
+			return cfg.BinaryPath, true
+		}
+	}
+	if cfg.InstallDir != "" && cfg.Tool != "" {
+		fallback := filepath.Join(cfg.InstallDir, cfg.Tool)
+		if _, err := os.Stat(fallback); err == nil {
+			return fallback, true
+		}
+	}
+	return "", false
+}
+
 // New constructs the appropriate Scanner implementation based on the operator config.
-// Returns an error if the tool is unknown or the binary is not accessible.
+// Returns an error if the tool is unknown or no usable binary can be located.
+//
+// When cfg.BinaryPath does not exist but {InstallDir}/{Tool} does, the latter is
+// used and a warning is logged.  This handles the common case where the chart
+// default BinaryPath (e.g. /usr/local/bin/trivy) is wrong for installations that
+// rely on the in-app auto-installer.
 func New(cfg *config.ScanningConfig) (Scanner, error) {
-	if _, err := os.Stat(cfg.BinaryPath); err != nil {
-		return nil, fmt.Errorf("scanner binary not accessible at %q: %w", cfg.BinaryPath, err)
+	resolved, ok := ResolveBinaryPath(cfg)
+	if !ok {
+		return nil, fmt.Errorf("scanner binary not accessible at %q (also checked %s): no usable binary found",
+			cfg.BinaryPath, filepath.Join(cfg.InstallDir, cfg.Tool))
+	}
+	if resolved != cfg.BinaryPath {
+		slog.Warn("scanner: configured binary_path missing, using auto-installed binary",
+			"tool", cfg.Tool,
+			"configured_path", cfg.BinaryPath,
+			"resolved_path", resolved,
+			"hint", "update scanning.binary_path in your config to "+resolved)
 	}
 	timeout := cfg.Timeout
 	if timeout == 0 {
@@ -62,15 +103,15 @@ func New(cfg *config.ScanningConfig) (Scanner, error) {
 	}
 	switch cfg.Tool {
 	case "trivy":
-		return newTrivyScanner(cfg.BinaryPath, timeout), nil
+		return newTrivyScanner(resolved, timeout), nil
 	case "terrascan":
-		return newTerrascanScanner(cfg.BinaryPath, timeout), nil
+		return newTerrascanScanner(resolved, timeout), nil
 	case "snyk":
-		return newSnykScanner(cfg.BinaryPath, timeout), nil
+		return newSnykScanner(resolved, timeout), nil
 	case "checkov":
-		return newCheckovScanner(cfg.BinaryPath, timeout), nil
+		return newCheckovScanner(resolved, timeout), nil
 	case "custom":
-		return newCustomScanner(cfg.BinaryPath, cfg.VersionArgs, cfg.ScanArgs, cfg.OutputFormat, timeout), nil
+		return newCustomScanner(resolved, cfg.VersionArgs, cfg.ScanArgs, cfg.OutputFormat, timeout), nil
 	default:
 		return nil, fmt.Errorf("unknown scanner tool %q (supported: trivy, terrascan, snyk, checkov, custom)", cfg.Tool)
 	}

--- a/backend/internal/scanner/scanner_test.go
+++ b/backend/internal/scanner/scanner_test.go
@@ -7,6 +7,8 @@ package scanner
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -231,6 +233,120 @@ func TestNew_InaccessibleBinary(t *testing.T) {
 	_, err := New(cfg)
 	if err == nil {
 		t.Error("expected error for inaccessible binary, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveBinaryPath / New() fallback to InstallDir
+// ---------------------------------------------------------------------------
+
+// stageInstalledBinary copies the test binary to {installDir}/{tool} so that
+// ResolveBinaryPath can find it as the auto-installer fallback would.
+func stageInstalledBinary(t *testing.T, tool string) (installDir, binaryAtInstallDir string) {
+	t.Helper()
+	installDir = t.TempDir()
+	binaryAtInstallDir = filepath.Join(installDir, tool)
+	src, err := os.ReadFile(selfPath(t))
+	if err != nil {
+		t.Fatalf("read self: %v", err)
+	}
+	if err := os.WriteFile(binaryAtInstallDir, src, 0o755); err != nil {
+		t.Fatalf("write fake installed binary: %v", err)
+	}
+	return installDir, binaryAtInstallDir
+}
+
+func TestResolveBinaryPath_PrefersConfiguredPath(t *testing.T) {
+	bin := selfPath(t)
+	installDir, _ := stageInstalledBinary(t, "trivy")
+	cfg := &config.ScanningConfig{
+		BinaryPath: bin,
+		Tool:       "trivy",
+		InstallDir: installDir,
+	}
+	resolved, ok := ResolveBinaryPath(cfg)
+	if !ok {
+		t.Fatal("expected resolution to succeed")
+	}
+	if resolved != bin {
+		t.Errorf("resolved = %q, want configured path %q", resolved, bin)
+	}
+}
+
+func TestResolveBinaryPath_FallsBackToInstallDir(t *testing.T) {
+	installDir, fallback := stageInstalledBinary(t, "trivy")
+	cfg := &config.ScanningConfig{
+		BinaryPath: "/nonexistent/path/to/trivy",
+		Tool:       "trivy",
+		InstallDir: installDir,
+	}
+	resolved, ok := ResolveBinaryPath(cfg)
+	if !ok {
+		t.Fatal("expected fallback resolution to succeed")
+	}
+	if resolved != fallback {
+		t.Errorf("resolved = %q, want fallback %q", resolved, fallback)
+	}
+}
+
+func TestResolveBinaryPath_NoUsableBinary(t *testing.T) {
+	cfg := &config.ScanningConfig{
+		BinaryPath: "/nonexistent/binary",
+		Tool:       "trivy",
+		InstallDir: "/nonexistent/installdir",
+	}
+	if _, ok := ResolveBinaryPath(cfg); ok {
+		t.Error("expected resolution to fail when neither path exists")
+	}
+}
+
+func TestResolveBinaryPath_EmptyBinaryPathStillFallsBack(t *testing.T) {
+	// Operators may leave BinaryPath blank and rely entirely on the auto-installer.
+	installDir, fallback := stageInstalledBinary(t, "trivy")
+	cfg := &config.ScanningConfig{
+		BinaryPath: "",
+		Tool:       "trivy",
+		InstallDir: installDir,
+	}
+	resolved, ok := ResolveBinaryPath(cfg)
+	if !ok {
+		t.Fatal("expected fallback to succeed with empty BinaryPath")
+	}
+	if resolved != fallback {
+		t.Errorf("resolved = %q, want %q", resolved, fallback)
+	}
+}
+
+func TestNew_FallsBackToInstallDir(t *testing.T) {
+	installDir, _ := stageInstalledBinary(t, "trivy")
+	cfg := &config.ScanningConfig{
+		BinaryPath: "/nonexistent/path/to/trivy",
+		Tool:       "trivy",
+		InstallDir: installDir,
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: unexpected error: %v", err)
+	}
+	if s.Name() != "trivy" {
+		t.Errorf("Name = %q, want trivy", s.Name())
+	}
+
+	// Exercising Version() against the staged binary requires it to be
+	// launchable via os/exec.  Windows refuses to exec a file without .exe,
+	// and the production auto-installer is Linux/macOS-only (catalog.go has
+	// no Windows entries), so skip the exec-side check on Windows — the
+	// construction-side assertions above are sufficient.
+	if runtime.GOOS == "windows" {
+		return
+	}
+	t.Setenv("FAKE_SCANNER_MODE", "trivy-version")
+	ver, err := s.Version(t.Context())
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if ver != "0.45.0" {
+		t.Errorf("Version = %q, want 0.45.0", ver)
 	}
 }
 

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -295,8 +295,11 @@ scanning:
   enabled: false
   # -- Scanner tool: trivy, terrascan, snyk, checkov, custom
   tool: "trivy"
-  # -- Absolute path to scanner binary inside the container
-  binaryPath: "/usr/local/bin/trivy"
+  # -- Absolute path to scanner binary inside the container.
+  #    Default matches the symlink the in-app auto-installer creates at
+  #    {installDir}/{tool}.  Override only if you bake the scanner into
+  #    your image at a different path.
+  binaryPath: "/app/scanners/trivy"
   # -- Pin expected binary version
   # (supply-chain protection; leave empty to skip check)
   expectedVersion: ""


### PR DESCRIPTION
## Summary

- Closes #313.
- `scanner.New` now uses a new `ResolveBinaryPath` helper: it prefers `cfg.BinaryPath` when that file exists, and falls back to `{InstallDir}/{Tool}` when it doesn't. If neither is found, it errors with both candidate paths in the message.
- Chart default `scanning.binaryPath` updated from `/usr/local/bin/trivy` to `/app/scanners/trivy` so the default lines up with `installDir` (which is what the in-app auto-installer writes to).
- Admin `/scanning/config` response now returns the resolved path (the one actually being used), so the UI shows reality instead of an unused configured path.

## Why

Pods running 0.18.x with the chart default `binaryPath: /usr/local/bin/trivy` and an auto-installed trivy at `/app/scanners/trivy` would fail at startup:

```
ERROR module scanner: failed to construct scanner
  error="scanner binary not accessible at \"/usr/local/bin/trivy\":
  stat /usr/local/bin/trivy: no such file or directory"
```

The worker exited, all scans stayed pending, and the admin UI silently showed "Not reported by backend" for Detected Version. The fallback turns the misconfiguration into a logged warning instead of a hard failure, so deployments self-heal as long as the auto-installer succeeded.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] New unit tests cover: configured path preferred when present, fallback to `{InstallDir}/{Tool}`, no-binary error path, empty `BinaryPath` falls back, `New()` end-to-end fallback (including a `Version()` exec check on non-Windows), and admin handler returning the resolved fallback path.
- [ ] Post-merge: verify on a UAT pod that admin `/scanning/config` returns the auto-installed path and Detected Version is populated.