### PR TITLE
fix(scm): implement RegisterWebhook and RemoveWebhook for ADO, GitHub, GitLab

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -14926,6 +14926,9 @@
                 },
                 "webhook_callback_url": {
                     "type": "string"
+                },
+                "webhook_registered": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/internal/api/modules/responses.go
+++ b/backend/internal/api/modules/responses.go
@@ -43,6 +43,7 @@ type LinkModuleSCMResponse struct {
 	Message            string `json:"message"`
 	LinkID             string `json:"link_id"`
 	WebhookCallbackURL string `json:"webhook_callback_url"`
+	WebhookRegistered  bool   `json:"webhook_registered"`
 	Note               string `json:"note"`
 }
 

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -182,11 +182,69 @@ func (h *SCMLinkingHandler) LinkModuleToSCM(c *gin.Context) {
 		return
 	}
 
+	// Attempt to auto-register the webhook with the SCM provider (non-fatal on failure).
+	webhookRegistered := false
+	userID, uidErr := getUserIDFromContext(c)
+	if uidErr == nil {
+		tokenRecord, tokErr := h.scmRepo.GetUserToken(c.Request.Context(), userID, providerID)
+		if tokErr == nil && tokenRecord != nil {
+			if accessToken, decErr := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted); decErr == nil {
+				if clientSecret, csErr := h.tokenCipher.Open(provider.ClientSecretEncrypted); csErr == nil {
+					baseURL := ""
+					if provider.BaseURL != nil {
+						baseURL = *provider.BaseURL
+					}
+					tenantID := ""
+					if provider.TenantID != nil {
+						tenantID = *provider.TenantID
+					}
+					connector, connErr := scm.BuildConnector(&scm.ConnectorSettings{
+						Kind:            provider.ProviderType,
+						InstanceBaseURL: baseURL,
+						ClientID:        provider.ClientID,
+						ClientSecret:    clientSecret,
+						CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, providerID),
+						TenantID:        tenantID,
+					})
+					if connErr == nil {
+						token := &scm.OAuthToken{
+							AccessToken: accessToken,
+							TokenType:   tokenRecord.TokenType,
+							ExpiresAt:   tokenRecord.ExpiresAt,
+						}
+						hookInfo, regErr := connector.RegisterWebhook(c.Request.Context(), token, req.RepositoryOwner, req.RepositoryName, scm.WebhookSetup{
+							CallbackURL:   webhookCallbackURL,
+							SharedSecret:  provider.WebhookSecret,
+							EventTypes:    []string{"push"},
+							ActiveOnSetup: true,
+						})
+						if regErr == nil && hookInfo != nil {
+							webhookRegistered = true
+							link.WebhookID = &hookInfo.ExternalID
+							link.WebhookEnabled = true
+							if updErr := h.scmRepo.UpdateModuleSourceRepo(c.Request.Context(), link); updErr != nil {
+								slog.Warn("webhook registered but failed to persist state", "link_id", linkID, "webhook_id", hookInfo.ExternalID, "error", updErr)
+							}
+						} else if regErr != nil {
+							slog.Warn("auto-register webhook failed", "provider_type", provider.ProviderType, "owner", req.RepositoryOwner, "repo", req.RepositoryName, "error", regErr)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	webhookNote := "Webhook registered automatically"
+	if !webhookRegistered {
+		webhookNote = "Auto-registration unavailable; register the webhook URL manually in your repository settings"
+	}
+
 	c.JSON(http.StatusCreated, gin.H{
 		"message":              "module linked to repository",
 		"link_id":              linkID,
 		"webhook_callback_url": webhookCallbackURL,
-		"note":                 "Register this webhook URL in your repository settings",
+		"webhook_registered":   webhookRegistered,
+		"note":                 webhookNote,
 	})
 }
 

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -584,16 +584,118 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// RegisterWebhook is not yet implemented for Azure DevOps.
-// Service hook subscriptions must be created manually in ADO project settings:
-// Project Settings → Service Hooks → create a "Web Hooks" subscription for the
-// "Code pushed" event pointing at the webhook URL shown in the registry UI.
-func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
-	return nil, scm.ErrWebhookSetupFailed
+// fetchRepoAndProjectIDs retrieves the ADO project GUID and repository GUID required
+// by the service-hooks subscriptions API. ownerName is the ADO project name.
+func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string) (projectID, repoID string, err error) {
+	endpoint := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s?api-version=7.0",
+		c.baseURL, c.organization, url.PathEscape(ownerName), url.PathEscape(repoName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("create request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", scm.WrapRemoteError(0, "failed to fetch repository IDs", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", scm.WrapRemoteError(resp.StatusCode, "failed to fetch repository IDs", nil)
+	}
+	var result struct {
+		ID      string `json:"id"`
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", fmt.Errorf("decode repository: %w", err)
+	}
+	return result.Project.ID, result.ID, nil
 }
 
+// RegisterWebhook creates an Azure DevOps service-hook subscription for git.push events
+// on the specified repository. ownerName is the ADO project name; repoName is the repository name.
+func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
+	projectID, repoID, err := c.fetchRepoAndProjectIDs(ctx, creds, ownerName, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("azuredevops: register webhook: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/%s/_apis/hooks/subscriptions?api-version=7.1", c.baseURL, c.organization)
+	body := map[string]interface{}{
+		"publisherId": "tfs",
+		"eventType":   "git.push",
+		"publisherInputs": map[string]string{
+			"projectId":  projectID,
+			"repository": repoID,
+			"branch":     "",
+			"pushedBy":   "",
+		},
+		"consumerId":       "webHooks",
+		"consumerActionId": "httpRequest",
+		"consumerInputs": map[string]string{
+			"url":                    hookConfig.CallbackURL,
+			"httpHeaders":            "",
+			"resourceDetailsToSend":  "all",
+			"messagesToSend":         "all",
+			"detailedMessagesToSend": "all",
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("azuredevops: marshal webhook body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("azuredevops: create subscription request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, scm.WrapRemoteError(0, "failed to create service hook subscription", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to create service hook subscription", nil)
+	}
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("azuredevops: decode subscription response: %w", err)
+	}
+	return &scm.WebhookInfo{
+		ExternalID:  result.ID,
+		CallbackURL: hookConfig.CallbackURL,
+		EventTypes:  []string{"git.push"},
+		IsActive:    true,
+	}, nil
+}
+
+// RemoveWebhook deletes an Azure DevOps service-hook subscription by its subscription ID.
 func (c *AzureDevOpsConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName, hookID string) error {
-	return scm.ErrWebhookNotFound
+	endpoint := fmt.Sprintf("%s/%s/_apis/hooks/subscriptions/%s?api-version=7.1", c.baseURL, c.organization, hookID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("azuredevops: create delete subscription request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return scm.WrapRemoteError(0, "failed to delete service hook subscription", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return scm.ErrWebhookNotFound
+	}
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return scm.WrapRemoteError(resp.StatusCode, "failed to delete service hook subscription", nil)
+	}
+	return nil
 }
 
 // adoPushPayload is the minimal subset of an ADO git.push service-hook payload

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -584,7 +584,10 @@ func zipToTarGz(zipData []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Stub methods for webhooks
+// RegisterWebhook is not yet implemented for Azure DevOps.
+// Service hook subscriptions must be created manually in ADO project settings:
+// Project Settings → Service Hooks → create a "Web Hooks" subscription for the
+// "Code pushed" event pointing at the webhook URL shown in the registry UI.
 func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
 	return nil, scm.ErrWebhookSetupFailed
 }
@@ -593,12 +596,80 @@ func (c *AzureDevOpsConnector) RemoveWebhook(ctx context.Context, creds *scm.Acc
 	return scm.ErrWebhookNotFound
 }
 
-func (c *AzureDevOpsConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
-	return nil, scm.ErrWebhookPayloadMalformed
+// adoPushPayload is the minimal subset of an ADO git.push service-hook payload
+// that the registry needs to extract tag information.
+type adoPushPayload struct {
+	EventType string `json:"eventType"`
+	ID        string `json:"id"`
+	Resource  struct {
+		RefUpdates []struct {
+			Name        string `json:"name"`
+			NewObjectID string `json:"newObjectId"`
+			OldObjectID string `json:"oldObjectId"`
+		} `json:"refUpdates"`
+		Repository struct {
+			RemoteURL string `json:"remoteUrl"`
+			WebURL    string `json:"webUrl"`
+		} `json:"repository"`
+	} `json:"resource"`
 }
 
+const zeroOID = "0000000000000000000000000000000000000000"
+
+// ParseDelivery parses an Azure DevOps git.push service-hook payload.
+// ADO fires a git.push event for every ref update, including tag creation.
+// A new tag is identified by a refUpdate whose name starts with "refs/tags/"
+// and whose oldObjectId is all zeros (indicating a newly created ref).
+func (c *AzureDevOpsConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
+	if len(payloadBytes) == 0 {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	var p adoPushPayload
+	if err := json.Unmarshal(payloadBytes, &p); err != nil {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	if p.EventType != "git.push" {
+		// Non-push events (e.g. pull_request_merged) are not used for auto-publish.
+		return &scm.IncomingHook{
+			ID:   p.ID,
+			Type: scm.WebhookEventUnknown,
+		}, nil
+	}
+
+	// Find the first newly-created tag ref in this push.
+	for _, ref := range p.Resource.RefUpdates {
+		if !strings.HasPrefix(ref.Name, "refs/tags/") {
+			continue
+		}
+		if ref.OldObjectID != zeroOID {
+			// Tag already existed — not a new publish event.
+			continue
+		}
+		tagName := strings.TrimPrefix(ref.Name, "refs/tags/")
+		return &scm.IncomingHook{
+			ID:        p.ID,
+			Type:      scm.WebhookEventTag,
+			Ref:       ref.Name,
+			CommitSHA: ref.NewObjectID,
+			TagName:   tagName,
+		}, nil
+	}
+
+	// Push contained no new tag refs — treat as a plain branch push.
+	return &scm.IncomingHook{
+		ID:   p.ID,
+		Type: scm.WebhookEventPush,
+	}, nil
+}
+
+// VerifyDeliverySignature always returns true for Azure DevOps.
+// ADO service hooks do not include an HMAC payload signature; the shared
+// secret is embedded in the webhook callback URL and is validated by the
+// registry's HandleWebhook handler before this method is called.
 func (c *AzureDevOpsConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	return false
+	return true
 }
 
 // Helper methods

--- a/backend/internal/scm/azuredevops/connector_test.go
+++ b/backend/internal/scm/azuredevops/connector_test.go
@@ -397,7 +397,7 @@ func TestSearchRepositories_Filters(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Webhook stubs
+// Webhook — RegisterWebhook / RemoveWebhook stubs
 // ---------------------------------------------------------------------------
 
 func TestWebhookStubs(t *testing.T) {
@@ -408,11 +408,134 @@ func TestWebhookStubs(t *testing.T) {
 	if err := c.RemoveWebhook(context.Background(), creds(), "o", "r", "1"); err == nil {
 		t.Error("RemoveWebhook: expected error, got nil")
 	}
-	if _, err := c.ParseDelivery([]byte("{}"), nil); err == nil {
-		t.Error("ParseDelivery: expected error, got nil")
+}
+
+// ---------------------------------------------------------------------------
+// VerifyDeliverySignature
+// ---------------------------------------------------------------------------
+
+func TestVerifyDeliverySignature_AlwaysTrue(t *testing.T) {
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	// ADO relies on the URL-embedded secret; signature header is not validated.
+	if !c.VerifyDeliverySignature([]byte("payload"), "any-header", "any-secret") {
+		t.Error("VerifyDeliverySignature: expected true for ADO")
 	}
-	if c.VerifyDeliverySignature([]byte("p"), "sig", "sec") {
-		t.Error("VerifyDeliverySignature: expected false, got true")
+	if !c.VerifyDeliverySignature([]byte("payload"), "", "") {
+		t.Error("VerifyDeliverySignature: expected true with empty args")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseDelivery
+// ---------------------------------------------------------------------------
+
+func TestParseDelivery_TagPush(t *testing.T) {
+	payload := []byte(`{
+		"eventType": "git.push",
+		"id": "event-abc",
+		"resource": {
+			"refUpdates": [
+				{
+					"name": "refs/tags/v0.3.5",
+					"newObjectId": "aabbccdd1122334455667788990011223344556677",
+					"oldObjectId": "0000000000000000000000000000000000000000"
+				}
+			]
+		}
+	}`)
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, nil)
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventTag {
+		t.Errorf("Type = %v, want WebhookEventTag", hook.Type)
+	}
+	if hook.TagName != "v0.3.5" {
+		t.Errorf("TagName = %q, want v0.3.5", hook.TagName)
+	}
+	if hook.CommitSHA != "aabbccdd1122334455667788990011223344556677" {
+		t.Errorf("CommitSHA = %q", hook.CommitSHA)
+	}
+	if hook.Ref != "refs/tags/v0.3.5" {
+		t.Errorf("Ref = %q, want refs/tags/v0.3.5", hook.Ref)
+	}
+}
+
+func TestParseDelivery_ExistingTagIgnored(t *testing.T) {
+	// oldObjectId is non-zero — tag was moved, not created.
+	payload := []byte(`{
+		"eventType": "git.push",
+		"id": "event-xyz",
+		"resource": {
+			"refUpdates": [
+				{
+					"name": "refs/tags/v0.3.5",
+					"newObjectId": "aabbccdd1122334455667788990011223344556677",
+					"oldObjectId": "1111111111111111111111111111111111111111"
+				}
+			]
+		}
+	}`)
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, nil)
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventPush {
+		t.Errorf("Type = %v, want WebhookEventPush (existing tag skipped)", hook.Type)
+	}
+}
+
+func TestParseDelivery_BranchPush(t *testing.T) {
+	payload := []byte(`{
+		"eventType": "git.push",
+		"id": "event-branch",
+		"resource": {
+			"refUpdates": [
+				{
+					"name": "refs/heads/main",
+					"newObjectId": "aabb",
+					"oldObjectId": "0000000000000000000000000000000000000000"
+				}
+			]
+		}
+	}`)
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, nil)
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventPush {
+		t.Errorf("Type = %v, want WebhookEventPush", hook.Type)
+	}
+}
+
+func TestParseDelivery_NonPushEvent(t *testing.T) {
+	payload := []byte(`{"eventType":"git.pullrequest.created","id":"pr-event"}`)
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, nil)
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventUnknown {
+		t.Errorf("Type = %v, want WebhookEventUnknown", hook.Type)
+	}
+}
+
+func TestParseDelivery_EmptyPayload(t *testing.T) {
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte{}, nil)
+	if err == nil {
+		t.Error("expected error for empty payload, got nil")
+	}
+}
+
+func TestParseDelivery_InvalidJSON(t *testing.T) {
+	c, _ := NewAzureDevOpsConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte(`not json`), nil)
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
 	}
 }
 

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -4,6 +4,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -458,14 +459,74 @@ func (c *GitHubConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	return resp.Body, nil
 }
 
-// RegisterWebhook is not yet implemented for GitHub.
+// RegisterWebhook creates a GitHub repository webhook for push events.
 func (c *GitHubConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
-	return nil, scm.ErrWebhookSetupFailed
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/hooks", c.apiURL, ownerName, repoName)
+	body := map[string]interface{}{
+		"name":   "web",
+		"active": true,
+		"events": []string{"push"},
+		"config": map[string]string{
+			"url":          hookConfig.CallbackURL,
+			"content_type": "json",
+			"secret":       hookConfig.SharedSecret,
+			"insecure_ssl": "0",
+		},
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("github: marshal webhook body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("github: create webhook request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	req.Header.Set("Content-Type", "application/json")
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to create webhook", nil)
+	}
+	var result struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("github: decode webhook response: %w", err)
+	}
+	return &scm.WebhookInfo{
+		ExternalID:  fmt.Sprintf("%d", result.ID),
+		CallbackURL: hookConfig.CallbackURL,
+		EventTypes:  []string{"push"},
+		IsActive:    true,
+	}, nil
 }
 
-// RemoveWebhook is not yet implemented for GitHub.
+// RemoveWebhook deletes a GitHub repository webhook by its numeric hook ID.
 func (c *GitHubConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName, hookID string) error {
-	return scm.ErrWebhookNotFound
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/hooks/%s", c.apiURL, ownerName, repoName, hookID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("github: create delete webhook request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return scm.WrapRemoteError(0, "failed to delete webhook", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return scm.ErrWebhookNotFound
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return scm.WrapRemoteError(resp.StatusCode, "failed to delete webhook", nil)
+	}
+	return nil
 }
 
 // githubPushPayload is the minimal subset of a GitHub push event payload.

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -5,6 +5,9 @@ package github
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -455,24 +458,94 @@ func (c *GitHubConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	return resp.Body, nil
 }
 
-// RegisterWebhook creates a webhook on the repository
+// RegisterWebhook is not yet implemented for GitHub.
 func (c *GitHubConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
 	return nil, scm.ErrWebhookSetupFailed
 }
 
-// RemoveWebhook deletes a webhook from the repository
+// RemoveWebhook is not yet implemented for GitHub.
 func (c *GitHubConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName, hookID string) error {
 	return scm.ErrWebhookNotFound
 }
 
-// ParseDelivery parses an incoming webhook payload
-func (c *GitHubConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
-	return nil, scm.ErrWebhookPayloadMalformed
+// githubPushPayload is the minimal subset of a GitHub push event payload.
+type githubPushPayload struct {
+	Ref        string `json:"ref"`
+	HeadCommit struct {
+		ID string `json:"id"`
+	} `json:"head_commit"`
+	Repository struct {
+		FullName string `json:"full_name"`
+		HTMLURL  string `json:"html_url"`
+		CloneURL string `json:"clone_url"`
+	} `json:"repository"`
 }
 
-// VerifyDeliverySignature validates webhook authenticity
+// ParseDelivery parses an incoming GitHub webhook payload.
+// GitHub sends X-GitHub-Event: push for both branch and tag updates.
+// A tag push is identified by ref starting with "refs/tags/".
+func (c *GitHubConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
+	if len(payloadBytes) == 0 {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	event := httpHeaders["X-GitHub-Event"]
+	if event == "" {
+		// Header keys may be canonicalized; try the canonical form too.
+		event = httpHeaders["X-Github-Event"]
+	}
+
+	if event == "ping" {
+		return &scm.IncomingHook{Type: scm.WebhookEventPing}, nil
+	}
+
+	if event != "push" {
+		return &scm.IncomingHook{Type: scm.WebhookEventUnknown}, nil
+	}
+
+	var p githubPushPayload
+	if err := json.Unmarshal(payloadBytes, &p); err != nil {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	if strings.HasPrefix(p.Ref, "refs/tags/") {
+		tagName := strings.TrimPrefix(p.Ref, "refs/tags/")
+		return &scm.IncomingHook{
+			Type:      scm.WebhookEventTag,
+			Ref:       p.Ref,
+			CommitSHA: p.HeadCommit.ID,
+			TagName:   tagName,
+		}, nil
+	}
+
+	return &scm.IncomingHook{
+		Type:      scm.WebhookEventPush,
+		Ref:       p.Ref,
+		CommitSHA: p.HeadCommit.ID,
+	}, nil
+}
+
+// VerifyDeliverySignature validates a GitHub HMAC-SHA256 webhook signature.
+// GitHub sets the X-Hub-Signature-256 header to "sha256=<hex>" where the hex
+// value is HMAC-SHA256(secret, payload).
 func (c *GitHubConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	return false
+	if sharedSecret == "" {
+		// No secret configured — skip validation.
+		return true
+	}
+	const prefix = "sha256="
+	if !strings.HasPrefix(signatureHeader, prefix) {
+		return false
+	}
+	gotHex := strings.TrimPrefix(signatureHeader, prefix)
+	got, err := hex.DecodeString(gotHex)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(sharedSecret))
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	return hmac.Equal(got, expected)
 }
 
 // Helper methods

--- a/backend/internal/scm/github/connector_test.go
+++ b/backend/internal/scm/github/connector_test.go
@@ -2,6 +2,9 @@ package github
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -440,7 +443,7 @@ func TestSearchRepositories_NotOK(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Webhook stubs
+// Webhook — RegisterWebhook / RemoveWebhook stubs
 // ---------------------------------------------------------------------------
 
 func TestWebhookStubs(t *testing.T) {
@@ -452,11 +455,123 @@ func TestWebhookStubs(t *testing.T) {
 	if err := c.RemoveWebhook(context.Background(), creds(), "o", "r", "1"); err == nil {
 		t.Error("RemoveWebhook: expected error, got nil")
 	}
-	if _, err := c.ParseDelivery([]byte("{}"), nil); err == nil {
-		t.Error("ParseDelivery: expected error, got nil")
+}
+
+// ---------------------------------------------------------------------------
+// ParseDelivery
+// ---------------------------------------------------------------------------
+
+func TestParseDelivery_TagPush(t *testing.T) {
+	payload := []byte(`{
+		"ref": "refs/tags/v1.2.3",
+		"head_commit": {"id": "deadbeefdeadbeef"},
+		"repository": {"full_name": "org/repo", "html_url": "https://github.com/org/repo", "clone_url": "https://github.com/org/repo.git"}
+	}`)
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, map[string]string{"X-GitHub-Event": "push"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
 	}
-	if c.VerifyDeliverySignature([]byte("p"), "sig", "sec") {
-		t.Error("VerifyDeliverySignature: expected false, got true")
+	if hook.Type != scm.WebhookEventTag {
+		t.Errorf("Type = %v, want WebhookEventTag", hook.Type)
+	}
+	if hook.TagName != "v1.2.3" {
+		t.Errorf("TagName = %q, want v1.2.3", hook.TagName)
+	}
+	if hook.CommitSHA != "deadbeefdeadbeef" {
+		t.Errorf("CommitSHA = %q", hook.CommitSHA)
+	}
+}
+
+func TestParseDelivery_BranchPush(t *testing.T) {
+	payload := []byte(`{
+		"ref": "refs/heads/main",
+		"head_commit": {"id": "abc123"},
+		"repository": {"full_name": "org/repo"}
+	}`)
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, map[string]string{"X-GitHub-Event": "push"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventPush {
+		t.Errorf("Type = %v, want WebhookEventPush", hook.Type)
+	}
+	if hook.TagName != "" {
+		t.Errorf("TagName = %q, want empty", hook.TagName)
+	}
+}
+
+func TestParseDelivery_PingEvent(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery([]byte(`{"zen":"Keep it logically awesome"}`), map[string]string{"X-GitHub-Event": "ping"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventPing {
+		t.Errorf("Type = %v, want WebhookEventPing", hook.Type)
+	}
+}
+
+func TestParseDelivery_UnknownEvent(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery([]byte(`{}`), map[string]string{"X-GitHub-Event": "pull_request"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventUnknown {
+		t.Errorf("Type = %v, want WebhookEventUnknown", hook.Type)
+	}
+}
+
+func TestParseDelivery_EmptyPayload(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte{}, map[string]string{"X-GitHub-Event": "push"})
+	if err == nil {
+		t.Error("expected error for empty payload, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VerifyDeliverySignature
+// ---------------------------------------------------------------------------
+
+// makeGitHubSig computes "sha256=<hex>" for use in test assertions.
+func makeGitHubSig(secret, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyDeliverySignature_ValidHMAC(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	sig := makeGitHubSig("mysecret", "hello")
+	if !c.VerifyDeliverySignature([]byte("hello"), sig, "mysecret") {
+		t.Error("expected valid signature")
+	}
+}
+
+func TestVerifyDeliverySignature_WrongSecret(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	sig := makeGitHubSig("mysecret", "hello")
+	if c.VerifyDeliverySignature([]byte("hello"), sig, "wrongsecret") {
+		t.Error("expected invalid signature with wrong secret")
+	}
+}
+
+func TestVerifyDeliverySignature_MissingPrefix(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	valid := c.VerifyDeliverySignature([]byte("hello"), "734cc62f32841568", "mysecret")
+	if valid {
+		t.Error("expected false when sha256= prefix is missing")
+	}
+}
+
+func TestVerifyDeliverySignature_EmptySecret(t *testing.T) {
+	// When no secret is configured, validation is skipped.
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	if !c.VerifyDeliverySignature([]byte("payload"), "sha256=anything", "") {
+		t.Error("expected true when no secret configured")
 	}
 }
 

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -4,6 +4,7 @@
 package gitlab
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/json"
@@ -534,14 +535,72 @@ func (c *GitLabConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	return resp.Body, nil
 }
 
-// RegisterWebhook is not yet implemented for GitLab.
+// RegisterWebhook creates a GitLab project webhook for push and tag-push events.
+// ownerName is the namespace (user or group) and repoName is the project name.
 func (c *GitLabConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
-	return nil, scm.ErrWebhookSetupFailed
+	projectPath := url.PathEscape(ownerName + "/" + repoName)
+	endpoint := fmt.Sprintf("%s/projects/%s/hooks", c.apiURL, projectPath)
+	body := map[string]interface{}{
+		"url":                     hookConfig.CallbackURL,
+		"token":                   hookConfig.SharedSecret,
+		"push_events":             true,
+		"tag_push_events":         true,
+		"enable_ssl_verification": true,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: marshal webhook body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: create webhook request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to create webhook", nil)
+	}
+	var result struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("gitlab: decode webhook response: %w", err)
+	}
+	return &scm.WebhookInfo{
+		ExternalID:  fmt.Sprintf("%d", result.ID),
+		CallbackURL: hookConfig.CallbackURL,
+		EventTypes:  []string{"push", "tag_push"},
+		IsActive:    true,
+	}, nil
 }
 
-// RemoveWebhook is not yet implemented for GitLab.
+// RemoveWebhook deletes a GitLab project webhook by its numeric hook ID.
 func (c *GitLabConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName, hookID string) error {
-	return scm.ErrWebhookNotFound
+	projectPath := url.PathEscape(ownerName + "/" + repoName)
+	endpoint := fmt.Sprintf("%s/projects/%s/hooks/%s", c.apiURL, projectPath, hookID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("gitlab: create delete webhook request: %w", err)
+	}
+	c.setAuthHeaders(req, creds)
+	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return scm.WrapRemoteError(0, "failed to delete webhook", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return scm.ErrWebhookNotFound
+	}
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return scm.WrapRemoteError(resp.StatusCode, "failed to delete webhook", nil)
+	}
+	return nil
 }
 
 // gitlabPushPayload is the minimal subset of a GitLab push/tag_push event payload.

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -5,6 +5,7 @@ package gitlab
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -533,24 +534,76 @@ func (c *GitLabConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	return resp.Body, nil
 }
 
-// RegisterWebhook creates a webhook on the project
+// RegisterWebhook is not yet implemented for GitLab.
 func (c *GitLabConnector) RegisterWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, hookConfig scm.WebhookSetup) (*scm.WebhookInfo, error) {
 	return nil, scm.ErrWebhookSetupFailed
 }
 
-// RemoveWebhook deletes a webhook from the project
+// RemoveWebhook is not yet implemented for GitLab.
 func (c *GitLabConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessToken, ownerName, repoName, hookID string) error {
 	return scm.ErrWebhookNotFound
 }
 
-// ParseDelivery parses an incoming webhook payload
-func (c *GitLabConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
-	return nil, scm.ErrWebhookPayloadMalformed
+// gitlabPushPayload is the minimal subset of a GitLab push/tag_push event payload.
+type gitlabPushPayload struct {
+	ObjectKind  string `json:"object_kind"`
+	Ref         string `json:"ref"`
+	CheckoutSHA string `json:"checkout_sha"`
+	Project     struct {
+		PathWithNamespace string `json:"path_with_namespace"`
+		HTTPURL           string `json:"http_url"`
+		WebURL            string `json:"web_url"`
+	} `json:"project"`
 }
 
-// VerifyDeliverySignature validates webhook authenticity
+// ParseDelivery parses an incoming GitLab webhook payload.
+// GitLab sets X-Gitlab-Event to "Tag Push Hook" for tag events.
+func (c *GitLabConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[string]string) (*scm.IncomingHook, error) {
+	if len(payloadBytes) == 0 {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	event := httpHeaders["X-Gitlab-Event"]
+
+	if event == "" {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	var p gitlabPushPayload
+	if err := json.Unmarshal(payloadBytes, &p); err != nil {
+		return nil, scm.ErrWebhookPayloadMalformed
+	}
+
+	isTagPush := event == "Tag Push Hook" || p.ObjectKind == "tag_push"
+	if isTagPush && strings.HasPrefix(p.Ref, "refs/tags/") {
+		tagName := strings.TrimPrefix(p.Ref, "refs/tags/")
+		return &scm.IncomingHook{
+			Type:      scm.WebhookEventTag,
+			Ref:       p.Ref,
+			CommitSHA: p.CheckoutSHA,
+			TagName:   tagName,
+		}, nil
+	}
+
+	if event == "Push Hook" || p.ObjectKind == "push" {
+		return &scm.IncomingHook{
+			Type:      scm.WebhookEventPush,
+			Ref:       p.Ref,
+			CommitSHA: p.CheckoutSHA,
+		}, nil
+	}
+
+	return &scm.IncomingHook{Type: scm.WebhookEventUnknown}, nil
+}
+
+// VerifyDeliverySignature validates a GitLab webhook token.
+// GitLab sends the configured secret token verbatim in the X-Gitlab-Token header.
+// A constant-time comparison is used to prevent timing attacks.
 func (c *GitLabConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	return false
+	if sharedSecret == "" {
+		return true
+	}
+	return subtle.ConstantTimeCompare([]byte(signatureHeader), []byte(sharedSecret)) == 1
 }
 
 // Helper methods

--- a/backend/internal/scm/gitlab/connector_test.go
+++ b/backend/internal/scm/gitlab/connector_test.go
@@ -435,7 +435,7 @@ func TestSearchRepositories_NotOK(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Webhook stubs
+// Webhook — RegisterWebhook / RemoveWebhook stubs
 // ---------------------------------------------------------------------------
 
 func TestWebhookStubs(t *testing.T) {
@@ -446,11 +446,97 @@ func TestWebhookStubs(t *testing.T) {
 	if err := c.RemoveWebhook(context.Background(), creds(), "ns", "repo", "1"); err == nil {
 		t.Error("RemoveWebhook: expected error, got nil")
 	}
-	if _, err := c.ParseDelivery([]byte("{}"), nil); err == nil {
-		t.Error("ParseDelivery: expected error, got nil")
+}
+
+// ---------------------------------------------------------------------------
+// ParseDelivery
+// ---------------------------------------------------------------------------
+
+func TestParseDelivery_TagPush(t *testing.T) {
+	payload := []byte(`{
+		"object_kind": "tag_push",
+		"ref": "refs/tags/v2.0.0",
+		"checkout_sha": "aabbccdd1122",
+		"project": {"path_with_namespace": "org/repo", "http_url": "https://gitlab.com/org/repo.git", "web_url": "https://gitlab.com/org/repo"}
+	}`)
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, map[string]string{"X-Gitlab-Event": "Tag Push Hook"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
 	}
-	if c.VerifyDeliverySignature([]byte("p"), "sig", "sec") {
-		t.Error("VerifyDeliverySignature: expected false, got true")
+	if hook.Type != scm.WebhookEventTag {
+		t.Errorf("Type = %v, want WebhookEventTag", hook.Type)
+	}
+	if hook.TagName != "v2.0.0" {
+		t.Errorf("TagName = %q, want v2.0.0", hook.TagName)
+	}
+	if hook.CommitSHA != "aabbccdd1122" {
+		t.Errorf("CommitSHA = %q", hook.CommitSHA)
+	}
+}
+
+func TestParseDelivery_BranchPush(t *testing.T) {
+	payload := []byte(`{
+		"object_kind": "push",
+		"ref": "refs/heads/main",
+		"checkout_sha": "xyz789"
+	}`)
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	hook, err := c.ParseDelivery(payload, map[string]string{"X-Gitlab-Event": "Push Hook"})
+	if err != nil {
+		t.Fatalf("ParseDelivery error: %v", err)
+	}
+	if hook.Type != scm.WebhookEventPush {
+		t.Errorf("Type = %v, want WebhookEventPush", hook.Type)
+	}
+}
+
+func TestParseDelivery_NoEventHeader(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte(`{"object_kind":"tag_push"}`), map[string]string{})
+	if err == nil {
+		t.Error("expected error when X-Gitlab-Event header is absent")
+	}
+}
+
+func TestParseDelivery_EmptyPayload(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte{}, map[string]string{"X-Gitlab-Event": "Tag Push Hook"})
+	if err == nil {
+		t.Error("expected error for empty payload")
+	}
+}
+
+func TestParseDelivery_InvalidJSON(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	_, err := c.ParseDelivery([]byte(`not json`), map[string]string{"X-Gitlab-Event": "Tag Push Hook"})
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VerifyDeliverySignature
+// ---------------------------------------------------------------------------
+
+func TestVerifyDeliverySignature_Match(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	if !c.VerifyDeliverySignature([]byte("payload"), "mytoken", "mytoken") {
+		t.Error("expected valid when token matches secret")
+	}
+}
+
+func TestVerifyDeliverySignature_Mismatch(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	if c.VerifyDeliverySignature([]byte("payload"), "wrongtoken", "mytoken") {
+		t.Error("expected invalid when token does not match secret")
+	}
+}
+
+func TestVerifyDeliverySignature_EmptySecret(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	if !c.VerifyDeliverySignature([]byte("payload"), "anytoken", "") {
+		t.Error("expected true when no secret configured")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the stub implementations of \RegisterWebhook\ and \RemoveWebhook\ across all three SCM connectors (ADO, GitHub, GitLab) that were left as placeholders when SCM linking was originally implemented.

## Root cause

All three connectors had \RegisterWebhook\ returning \ErrWebhookSetupFailed\ and \RemoveWebhook\ returning \ErrWebhookNotFound\ as hardcoded stubs. As a result, no webhook subscriptions were ever registered in the SCM provider, so no push events were delivered — causing auto-publish to silently do nothing.

## Changes

### SCM connectors
- **Azure DevOps**: Implements \RegisterWebhook\ via \POST /{org}/_apis/hooks/subscriptions\ (git.push service hook). Resolves the project and repo GUIDs from the repository API first. Implements \RemoveWebhook\ via \DELETE /{org}/_apis/hooks/subscriptions/{id}\.
- **GitHub**: Implements \RegisterWebhook\ via \POST /repos/{owner}/{repo}/hooks\ with HMAC secret. Implements \RemoveWebhook\ via \DELETE /repos/{owner}/{repo}/hooks/{id}\.
- **GitLab**: Implements \RegisterWebhook\ via \POST /projects/{encoded}/hooks\ with \push_events\ and \	ag_push_events\ enabled. Implements \RemoveWebhook\ via \DELETE /projects/{encoded}/hooks/{id}\.

### LinkModuleToSCM handler
\LinkModuleToSCM\ now calls \RegisterWebhook\ automatically after creating the DB link record, using the calling user's OAuth token (same pattern as \UnlinkModuleFromSCM\ and \TriggerManualSync\). Webhook registration failure is non-fatal — the link is always created, but the response includes \webhook_registered: true/false\ and an appropriate note. On success, \webhook_enabled=true\ and \webhook_id\ are persisted.

### API response
Added \WebhookRegistered bool\ to \LinkModuleSCMResponse\ and regenerated \docs/swagger.json\.