### PR TITLE
fix(users): include memberships inline in list and search responses

### DIFF
--- a/backend/internal/api/admin/users.go
+++ b/backend/internal/api/admin/users.go
@@ -59,8 +59,8 @@ func (h *UserHandlers) ListUsersHandler() gin.HandlerFunc {
 
 		offset := (page - 1) * perPage
 
-		// Get users with role template information
-		users, total, err := h.userRepo.ListUsersWithRoles(c.Request.Context(), perPage, offset)
+		// Get users with memberships (2 queries total, not N+1)
+		users, total, err := h.userRepo.ListUsersWithMemberships(c.Request.Context(), perPage, offset)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to list users",
@@ -371,8 +371,8 @@ func (h *UserHandlers) SearchUsersHandler() gin.HandlerFunc {
 
 		offset := (page - 1) * perPage
 
-		// Search users
-		users, err := h.userRepo.Search(c.Request.Context(), query, perPage, offset)
+		// Search users with memberships
+		users, err := h.userRepo.SearchWithMemberships(c.Request.Context(), query, perPage, offset)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to search users",

--- a/backend/internal/api/admin/users_test.go
+++ b/backend/internal/api/admin/users_test.go
@@ -33,6 +33,16 @@ var membershipSQLCols = []string{
 	"role_template_name", "role_template_display_name", "role_template_scopes",
 }
 
+// bulkMembershipSQLCols are the columns returned by loadMembershipsForUsers (includes user_id).
+var bulkMembershipSQLCols = []string{
+	"user_id", "organization_id", "organization_name", "role_template_id", "created_at",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+func emptyBulkMembershipRows() *sqlmock.Rows {
+	return sqlmock.NewRows(bulkMembershipSQLCols)
+}
+
 func sampleUserRow() *sqlmock.Rows {
 	return sqlmock.NewRows(userSQLCols).
 		AddRow("user-1", "alice@example.com", "Alice", nil, time.Now(), time.Now())
@@ -96,6 +106,9 @@ func TestListUsersHandler_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery("SELECT").
 		WillReturnRows(sampleUserRow())
+	// loadMembershipsForUsers bulk query
+	mock.ExpectQuery("ANY").
+		WillReturnRows(emptyBulkMembershipRows())
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/users", nil))
@@ -109,6 +122,15 @@ func TestListUsersHandler_Success(t *testing.T) {
 	}
 	if resp["pagination"] == nil {
 		t.Error("response missing 'pagination' key")
+	}
+	// Verify memberships are embedded in the users array
+	users, ok := resp["users"].([]interface{})
+	if !ok || len(users) == 0 {
+		t.Fatal("expected at least one user in response")
+	}
+	userMap, _ := users[0].(map[string]interface{})
+	if _, hasMemberships := userMap["memberships"]; !hasMemberships {
+		t.Error("user response missing 'memberships' key")
 	}
 }
 
@@ -416,6 +438,9 @@ func TestSearchUsersHandler_Success(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").
 		WillReturnRows(sampleUserRow())
+	// loadMembershipsForUsers bulk query
+	mock.ExpectQuery("ANY").
+		WillReturnRows(emptyBulkMembershipRows())
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/users/search?q=alice", nil))
@@ -764,6 +789,9 @@ func TestSearchUsersHandler_PaginationDefaults(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").
 		WillReturnRows(sampleUserRow())
+	// loadMembershipsForUsers bulk query
+	mock.ExpectQuery("ANY").
+		WillReturnRows(emptyBulkMembershipRows())
 
 	// page < 1 and perPage > 100 → clamped to defaults
 	w := httptest.NewRecorder()

--- a/backend/internal/db/models/user.go
+++ b/backend/internal/db/models/user.go
@@ -17,7 +17,7 @@ type User struct {
 // UserWithOrgRoles represents a user with their per-organization role template information
 type UserWithOrgRoles struct {
 	User
-	Memberships []UserMembership // Per-organization role templates
+	Memberships []UserMembership `json:"memberships"` // Per-organization role templates
 }
 
 // GetAllowedScopes returns all unique scopes across all organization memberships

--- a/backend/internal/db/repositories/user_repository.go
+++ b/backend/internal/db/repositories/user_repository.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
@@ -422,6 +423,101 @@ func (r *UserRepository) GetUserWithOrgRoles(ctx context.Context, userID string)
 		User:        *user,
 		Memberships: memberships,
 	}, rows.Err()
+}
+
+// loadMembershipsForUsers bulk-fetches memberships for a slice of users in a single
+// database round trip, then attaches them to per-user UserWithOrgRoles structs.
+// The returned slice preserves the order of the input users slice.
+func (r *UserRepository) loadMembershipsForUsers(ctx context.Context, users []*models.User) ([]*models.UserWithOrgRoles, error) {
+	result := make([]*models.UserWithOrgRoles, len(users))
+	for i, u := range users {
+		result[i] = &models.UserWithOrgRoles{
+			User:        *u,
+			Memberships: []models.UserMembership{},
+		}
+	}
+
+	if len(users) == 0 {
+		return result, nil
+	}
+
+	userIDs := make([]string, len(users))
+	for i, u := range users {
+		userIDs[i] = u.ID
+	}
+
+	query := `
+		SELECT om.user_id, om.organization_id, COALESCE(o.name, '') as organization_name,
+		       om.role_template_id, om.created_at,
+		       rt.name as role_template_name, rt.display_name as role_template_display_name,
+		       COALESCE(rt.scopes, '[]'::jsonb) as role_template_scopes
+		FROM organization_members om
+		LEFT JOIN organizations o ON om.organization_id = o.id
+		LEFT JOIN role_templates rt ON om.role_template_id = rt.id
+		WHERE om.user_id = ANY($1)
+		ORDER BY om.user_id, om.created_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(userIDs))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Index result by user ID for O(1) lookup when attaching memberships
+	resultByUserID := make(map[string]*models.UserWithOrgRoles, len(result))
+	for _, uwor := range result {
+		resultByUserID[uwor.User.ID] = uwor
+	}
+
+	for rows.Next() {
+		var userID string
+		m := models.UserMembership{}
+		var scopesJSON []byte
+		err := rows.Scan(
+			&userID,
+			&m.OrganizationID,
+			&m.OrganizationName,
+			&m.RoleTemplateID,
+			&m.CreatedAt,
+			&m.RoleTemplateName,
+			&m.RoleTemplateDisplayName,
+			&scopesJSON,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(scopesJSON) > 0 {
+			if err := json.Unmarshal(scopesJSON, &m.RoleTemplateScopes); err != nil {
+				return nil, err
+			}
+		}
+		if uwor, ok := resultByUserID[userID]; ok {
+			uwor.Memberships = append(uwor.Memberships, m)
+		}
+	}
+
+	return result, rows.Err()
+}
+
+// ListUsersWithMemberships returns a paginated list of users with their organization
+// memberships fetched in a single additional query (2 queries total, not N+1).
+func (r *UserRepository) ListUsersWithMemberships(ctx context.Context, limit, offset int) ([]*models.UserWithOrgRoles, int, error) {
+	users, total, err := r.ListUsers(ctx, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	result, err := r.loadMembershipsForUsers(ctx, users)
+	return result, total, err
+}
+
+// SearchWithMemberships searches users and returns results with their organization memberships.
+func (r *UserRepository) SearchWithMemberships(ctx context.Context, query string, limit, offset int) ([]*models.UserWithOrgRoles, error) {
+	users, err := r.Search(ctx, query, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return r.loadMembershipsForUsers(ctx, users)
 }
 
 // ListUsersWithRoles is deprecated - use ListUsers instead

--- a/backend/internal/db/repositories/user_repository_test.go
+++ b/backend/internal/db/repositories/user_repository_test.go
@@ -703,3 +703,131 @@ func TestGetOrCreateUserFromOIDC_EmailMatch(t *testing.T) {
 		t.Fatal("expected user, got nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ListUsersWithMemberships / SearchWithMemberships (N+1 elimination)
+// ---------------------------------------------------------------------------
+
+// bulkMembershipCols matches the SELECT produced by loadMembershipsForUsers.
+var bulkMembershipCols = []string{
+	"user_id", "organization_id", "organization_name", "role_template_id", "created_at",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+func emptyBulkMembershipRowsRepo() *sqlmock.Rows {
+	return sqlmock.NewRows(bulkMembershipCols)
+}
+
+func TestListUsersWithMemberships_Success(t *testing.T) {
+	repo, mock := newUserRepo(t)
+
+	mock.ExpectQuery("SELECT COUNT.*FROM users").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT.*FROM users.*ORDER BY").
+		WillReturnRows(sampleUserRow())
+	// Bulk membership query for user-1
+	mock.ExpectQuery("ANY").
+		WillReturnRows(emptyBulkMembershipRowsRepo())
+
+	result, total, err := repo.ListUsersWithMemberships(context.Background(), 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("total = %d, want 1", total)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].User.ID != "user-1" {
+		t.Errorf("user ID = %q, want %q", result[0].User.ID, "user-1")
+	}
+	// Memberships should be an empty (non-nil) slice, not nil
+	if result[0].Memberships == nil {
+		t.Error("Memberships should be a non-nil empty slice when there are no memberships")
+	}
+}
+
+func TestListUsersWithMemberships_WithMembership(t *testing.T) {
+	repo, mock := newUserRepo(t)
+
+	mock.ExpectQuery("SELECT COUNT.*FROM users").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT.*FROM users.*ORDER BY").
+		WillReturnRows(sampleUserRow())
+
+	// Return one membership row for user-1
+	memberRows := sqlmock.NewRows(bulkMembershipCols).AddRow(
+		"user-1", "org-1", "Acme Corp", "rt-1", time.Now(),
+		"admin", "Administrator", []byte(`["admin","users:read"]`),
+	)
+	mock.ExpectQuery("ANY").WillReturnRows(memberRows)
+
+	result, _, err := repo.ListUsersWithMemberships(context.Background(), 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result[0].Memberships) != 1 {
+		t.Fatalf("memberships = %d, want 1", len(result[0].Memberships))
+	}
+	m := result[0].Memberships[0]
+	if m.OrganizationName != "Acme Corp" {
+		t.Errorf("org name = %q, want %q", m.OrganizationName, "Acme Corp")
+	}
+	if len(m.RoleTemplateScopes) != 2 {
+		t.Errorf("scopes len = %d, want 2", len(m.RoleTemplateScopes))
+	}
+}
+
+func TestListUsersWithMemberships_Empty(t *testing.T) {
+	repo, mock := newUserRepo(t)
+
+	mock.ExpectQuery("SELECT COUNT.*FROM users").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT.*FROM users.*ORDER BY").
+		WillReturnRows(emptyUserRow())
+	// No users → no bulk membership query should be issued
+
+	result, total, err := repo.ListUsersWithMemberships(context.Background(), 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 || len(result) != 0 {
+		t.Errorf("expected empty result, got total=%d len=%d", total, len(result))
+	}
+}
+
+func TestListUsersWithMemberships_MembershipDBError(t *testing.T) {
+	repo, mock := newUserRepo(t)
+
+	mock.ExpectQuery("SELECT COUNT.*FROM users").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery("SELECT.*FROM users.*ORDER BY").
+		WillReturnRows(sampleUserRow())
+	mock.ExpectQuery("ANY").WillReturnError(errDB)
+
+	_, _, err := repo.ListUsersWithMemberships(context.Background(), 20, 0)
+	if err == nil {
+		t.Error("expected error from membership query, got nil")
+	}
+}
+
+func TestSearchWithMemberships_Success(t *testing.T) {
+	repo, mock := newUserRepo(t)
+
+	mock.ExpectQuery("SELECT.*FROM users.*ILIKE").
+		WillReturnRows(sampleUserRow())
+	mock.ExpectQuery("ANY").
+		WillReturnRows(emptyBulkMembershipRowsRepo())
+
+	result, err := repo.SearchWithMemberships(context.Background(), "alice", 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+	if result[0].Memberships == nil {
+		t.Error("Memberships should be a non-nil empty slice")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes N+1 database/API query pattern on the Users admin page. The list and search endpoints now include each user's organisation memberships inline, eliminating the per-user `GET /api/v1/users/{id}/memberships` calls that previously caused 429 rate-limit errors and inconsistent org/role display.

## What changed

### `internal/db/repositories/user_repository.go`
- Added `loadMembershipsForUsers` (private): takes a `[]*models.User` slice and fetches all their memberships in one `WHERE user_id = ANY()` query using `pq.Array`.
- Added `ListUsersWithMemberships`: calls `ListUsers` then `loadMembershipsForUsers` (2 queries total).
- Added `SearchWithMemberships`: same pattern for search results.

### `internal/db/models/user.go`
- Added `json:"memberships"` tag to `UserWithOrgRoles.Memberships` so the field serialises as lowercase `memberships` in API responses.

### `internal/api/admin/users.go`
- `ListUsersHandler` now calls `ListUsersWithMemberships` instead of `ListUsersWithRoles`.
- `SearchUsersHandler` now calls `SearchWithMemberships` instead of `Search`.

### Tests
- Updated `TestListUsersHandler_Success`, `TestSearchUsersHandler_Success`, `TestSearchUsersHandler_PaginationDefaults` to expect the bulk membership query.
- Added `TestListUsersHandler_Success` assertion that the response includes a `memberships` key on each user.
- Added 5 repository tests covering success, with-membership data, empty result, DB-error, and search paths.

## How tested

- `go test ./internal/api/admin/ -run TestListUsersHandler|TestSearchUsersHandler` — all pass
- `go test ./internal/db/repositories/ -run TestListUsersWithMemberships|TestSearchWithMemberships` — all pass
- `go build ./internal/... ./cmd/...` — clean

## Related

Closes #324
Frontend fix: sethbacon/terraform-registry-frontend#259