### PR TITLE
feat(api): add GET /api/v1/modules/{namespace}/{name}/{system}/{version}

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6189,6 +6189,70 @@
                 }
             }
         },
+        "/api/v1/modules/{namespace}/{name}/{system}/{version}": {
+            "get": {
+                "description": "Retrieve a single module version's metadata, including deprecation fields. No authentication required; authentication is optional and provides user context.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Get module version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target system (e.g. aws, azurerm)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Semantic version (e.g. 1.2.3)",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ModuleVersion"
+                        }
+                    },
+                    "404": {
+                        "description": "Module or version not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/modules/{namespace}/{name}/{system}/{version}/docs": {
             "get": {
                 "description": "Returns terraform-docs metadata (inputs, outputs, providers, requirements) extracted from the module archive at upload time.",
@@ -14009,6 +14073,80 @@
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.ModuleVersion": {
+            "type": "object",
+            "properties": {
+                "checksum": {
+                    "type": "string"
+                },
+                "commit_sha": {
+                    "description": "SCM source tracking fields (populated for webhook/sync-published versions)",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "deprecated": {
+                    "description": "Whether this version is deprecated",
+                    "type": "boolean"
+                },
+                "deprecated_at": {
+                    "description": "When the version was deprecated",
+                    "type": "string"
+                },
+                "deprecation_message": {
+                    "description": "Optional message explaining deprecation",
+                    "type": "string"
+                },
+                "download_count": {
+                    "type": "integer"
+                },
+                "has_docs": {
+                    "description": "Whether terraform-docs metadata exists (joined from module_version_docs)",
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "module_id": {
+                    "type": "string"
+                },
+                "published_by": {
+                    "type": "string"
+                },
+                "published_by_name": {
+                    "description": "Joined fields (not stored in module_versions table)",
+                    "type": "string"
+                },
+                "readme": {
+                    "type": "string"
+                },
+                "replacement_source": {
+                    "description": "Replacement module source address (Terraform CLI \u003e=1.10 protocol)",
+                    "type": "string"
+                },
+                "scm_repo_id": {
+                    "description": "FK to module_scm_repos.id",
+                    "type": "string"
+                },
+                "size_bytes": {
+                    "type": "integer"
+                },
+                "storage_backend": {
+                    "type": "string"
+                },
+                "storage_path": {
+                    "type": "string"
+                },
+                "tag_name": {
+                    "description": "Git tag name that triggered publish",
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -210,6 +210,66 @@ func (h *ModuleAdminHandlers) GetModule(c *gin.Context) {
 	})
 }
 
+// @Summary      Get module version
+// @Description  Retrieve a single module version's metadata, including deprecation fields. No authentication required; authentication is optional and provides user context.
+// @Tags         Modules
+// @Produce      json
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Target system (e.g. aws, azurerm)"
+// @Param        version    path  string  true  "Semantic version (e.g. 1.2.3)"
+// @Success      200  {object}  models.ModuleVersion
+// @Failure      404  {object}  map[string]interface{}  "Module or version not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/modules/{namespace}/{name}/{system}/{version} [get]
+// GetModuleVersion retrieves a single module version's metadata.
+//
+// This endpoint is the Read counterpart for the registry_module_version_deprecation
+// Terraform resource and any other consumer that needs to fetch a specific version
+// (with deprecation fields) without pulling the entire version list.
+// GET /api/v1/modules/:namespace/:name/:system/:version
+func (h *ModuleAdminHandlers) GetModuleVersion(c *gin.Context) {
+	namespace := c.Param("namespace")
+	name := c.Param("name")
+	system := c.Param("system")
+	version := c.Param("version")
+
+	// Get organization context (default org for single-tenant mode). Mirrors GetModule
+	// so that callers without an authenticated org still resolve to the default tenant.
+	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get organization context"})
+		return
+	}
+
+	var orgID string
+	if org != nil {
+		orgID = org.ID
+	}
+
+	module, err := h.moduleRepo.GetModule(c.Request.Context(), orgID, namespace, name, system)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get module"})
+		return
+	}
+	if module == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Module not found"})
+		return
+	}
+
+	mv, err := h.moduleRepo.GetVersion(c.Request.Context(), module.ID, version)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get module version"})
+		return
+	}
+	if mv == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, mv)
+}
+
 // @Summary      Delete module
 // @Description  Delete a module and all its versions, including files in storage. Requires modules:delete scope.
 // @Tags         Modules

--- a/backend/internal/api/admin/modules_test.go
+++ b/backend/internal/api/admin/modules_test.go
@@ -90,6 +90,7 @@ func newModuleRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	r := gin.New()
 	r.POST("/modules/create", h.CreateModuleRecord)
 	r.GET("/modules/:namespace/:name/:system", h.GetModule)
+	r.GET("/modules/:namespace/:name/:system/:version", h.GetModuleVersion)
 	r.DELETE("/modules/:namespace/:name/:system", h.DeleteModule)
 	r.DELETE("/modules/:namespace/:name/:system/versions/:version", h.DeleteVersion)
 	r.POST("/modules/:namespace/:name/:system/versions/:version/deprecate", h.DeprecateVersion)
@@ -284,6 +285,115 @@ func TestGetModule_Success_WithVersions(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetModuleVersion tests
+// ---------------------------------------------------------------------------
+
+func TestGetModuleVersion_OrgDBError(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").
+		WithArgs("default").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/1.0.0", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestGetModuleVersion_ModuleNotFound(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	expectNoDefaultOrg(mock)
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(emptyModuleRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/1.0.0", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestGetModuleVersion_ModuleDBError(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	expectNoDefaultOrg(mock)
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/1.0.0", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestGetModuleVersion_VersionNotFound(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	expectNoDefaultOrg(mock)
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sampleModuleRow())
+	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
+		WillReturnRows(emptyModVersionGetRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/9.9.9", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestGetModuleVersion_VersionDBError(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	expectNoDefaultOrg(mock)
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sampleModuleRow())
+	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/1.0.0", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestGetModuleVersion_Success(t *testing.T) {
+	mock, r := newModuleRouter(t)
+
+	expectNoDefaultOrg(mock)
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sampleModuleRow())
+	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
+		WillReturnRows(sampleModVersionGetRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/modules/hashicorp/vpc/aws/1.0.0", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	resp := getJSON(w)
+	if resp["version"] != "1.0.0" {
+		t.Errorf("response version = %v, want 1.0.0", resp["version"])
+	}
+	// Deprecation fields must be present in the JSON shape so the provider Read
+	// implementation can reconcile state (even when null/false on a non-deprecated version).
+	if _, ok := resp["deprecated"]; !ok {
+		t.Error("response missing 'deprecated' key")
 	}
 }
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -745,6 +745,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 		publicDetailGroup.Use(middleware.RateLimitMiddleware(generalRateLimiter))
 		{
 			publicDetailGroup.GET("/modules/:namespace/:name/:system", moduleAdminHandlers.GetModule)
+			publicDetailGroup.GET("/modules/:namespace/:name/:system/:version", moduleAdminHandlers.GetModuleVersion)
 			publicDetailGroup.GET("/modules/:namespace/:name/:system/versions/:version/docs", modules.GetModuleDocsHandler(db))
 			publicDetailGroup.GET("/providers/:namespace/:type", providerAdminHandlers.GetProvider)
 			publicDetailGroup.GET("/providers/:namespace/:type/versions/:version/docs", providers.ListProviderDocsHandler(db))


### PR DESCRIPTION
Closes #332

## Summary

Adds a public read endpoint that returns a single module version's metadata
(including deprecation fields). This is the Read counterpart used by the
terraform-provider-registry's `client.GetModuleVersion` call, which backs the
`registry_module_version_deprecation` resource Read. Previously every refresh
of that resource silently 404'd because no such route was registered.

The handler:

- Resolves the module by `namespace/name/system` in the default org context
  (mirroring the existing public `GetModule` route).
- Looks up the version by version string via the existing `GetVersion`
  repository method.
- Returns 404 if either the module or the version is missing.
- Returns the `models.ModuleVersion` shape on success so deprecation fields
  can be reconciled by Terraform state.

The route is registered in `publicDetailGroup` alongside the existing public
`GET /modules/:namespace/:name/:system` route.

## Changelog

- feat(api): add GET /api/v1/modules/{namespace}/{name}/{system}/{version} for fetching a single module version with deprecation fields

## Checklist

- [x] Swagger annotation block added (will be auto-regenerated and committed by CI)
- [x] Unit tests cover happy path, module-not-found, version-not-found, plus DB error branches
- [x] No new gosec findings expected (handler mirrors existing GetModule pattern)
- [x] PR targets `main`