### PR TITLE
fix(api): add status filter and pagination to scanning stats endpoint

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3191,7 +3191,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns aggregate scan counts by status and a list of recent scans. Requires admin scope.",
+                "description": "Returns aggregate scan counts by status and a list of recent scans. Supports optional status filter and pagination via query parameters. Requires admin scope.",
                 "produces": [
                     "application/json"
                 ],
@@ -3199,6 +3199,26 @@
                     "Security Scanning"
                 ],
                 "summary": "Get scanning statistics",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Filter recent scans by status (pending, scanning, clean, findings, error)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of recent scans to return (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset for pagination (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -12990,6 +13010,9 @@
                     "type": "integer"
                 },
                 "total": {
+                    "type": "integer"
+                },
+                "total_filtered": {
                     "type": "integer"
                 }
             }

--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -2,7 +2,9 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -27,13 +29,14 @@ type ScanningConfigResponse struct {
 
 // ScanningStatsResponse aggregates scan counts by status and recent activity.
 type ScanningStatsResponse struct {
-	Total       int64             `json:"total"`
-	Pending     int64             `json:"pending"`
-	Scanning    int64             `json:"scanning"`
-	Clean       int64             `json:"clean"`
-	Findings    int64             `json:"findings"`
-	Error       int64             `json:"error"`
-	RecentScans []RecentScanEntry `json:"recent_scans"`
+	Total         int64             `json:"total"`
+	Pending       int64             `json:"pending"`
+	Scanning      int64             `json:"scanning"`
+	Clean         int64             `json:"clean"`
+	Findings      int64             `json:"findings"`
+	Error         int64             `json:"error"`
+	RecentScans   []RecentScanEntry `json:"recent_scans"`
+	TotalFiltered int64             `json:"total_filtered"`
 }
 
 // RecentScanEntry summarises a single recent scan for the admin UI.
@@ -91,21 +94,53 @@ func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 }
 
 // @Summary      Get scanning statistics
-// @Description  Returns aggregate scan counts by status and a list of recent scans. Requires admin scope.
+// @Description  Returns aggregate scan counts by status and a list of recent scans. Supports optional status filter and pagination via query parameters. Requires admin scope.
 // @Tags         Security Scanning
 // @Security     Bearer
 // @Produce      json
+// @Param        status  query  string  false  "Filter recent scans by status (pending, scanning, clean, findings, error)"
+// @Param        limit   query  int     false  "Maximum number of recent scans to return (default 20, max 100)"
+// @Param        offset  query  int     false  "Offset for pagination (default 0)"
 // @Success      200  {object}  ScanningStatsResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/scanning/stats [get]
 func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
+	validStatuses := map[string]bool{
+		"pending":  true,
+		"scanning": true,
+		"clean":    true,
+		"findings": true,
+		"error":    true,
+	}
+
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
+		// Parse query parameters.
+		statusFilter := c.Query("status")
+		if statusFilter != "" && !validStatuses[statusFilter] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status filter; must be one of: pending, scanning, clean, findings, error"})
+			return
+		}
+
+		limit := 20
+		if l := c.Query("limit"); l != "" {
+			if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
+				limit = parsed
+			}
+		}
+
+		offset := 0
+		if o := c.Query("offset"); o != "" {
+			if parsed, err := strconv.Atoi(o); err == nil && parsed >= 0 {
+				offset = parsed
+			}
+		}
+
 		var stats ScanningStatsResponse
 
-		// Aggregate counts by status.
+		// Aggregate counts by status (always unfiltered).
 		err := db.QueryRowContext(ctx, `
 			SELECT
 				COUNT(*) AS total,
@@ -128,8 +163,26 @@ func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
 			return
 		}
 
-		// Recent scans — last 10, with module info joined.
-		rows, err := db.QueryContext(ctx, `
+		// Build filtered recent scans query.
+		var whereClause string
+		var args []interface{}
+		argIdx := 1
+
+		if statusFilter != "" {
+			whereClause = fmt.Sprintf(" WHERE s.status = $%d", argIdx)
+			args = append(args, statusFilter)
+			argIdx++
+		}
+
+		// Get total count for filtered results.
+		countQuery := `SELECT COUNT(*) FROM module_version_scans s` + whereClause
+		if err := db.QueryRowContext(ctx, countQuery, args...).Scan(&stats.TotalFiltered); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query filtered count"})
+			return
+		}
+
+		// Recent scans with optional status filter and pagination.
+		query := fmt.Sprintf(`
 			SELECT
 				s.id, mv.version, m.name, m.namespace, m.system,
 				s.scanner, s.status,
@@ -138,9 +191,13 @@ func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
 			FROM module_version_scans s
 			JOIN module_versions mv ON mv.id = s.module_version_id
 			JOIN modules m ON m.id = mv.module_id
+			%s
 			ORDER BY s.updated_at DESC
-			LIMIT 10
-		`)
+			LIMIT $%d OFFSET $%d
+		`, whereClause, argIdx, argIdx+1)
+		args = append(args, limit, offset)
+
+		rows, err := db.QueryContext(ctx, query, args...)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query recent scans"})
 			return

--- a/backend/internal/api/admin/scanning_admin_test.go
+++ b/backend/internal/api/admin/scanning_admin_test.go
@@ -154,6 +154,10 @@ func TestGetScanningStatsHandler_Success(t *testing.T) {
 			"total", "pending", "scanning", "clean", "findings", "error_count",
 		}).AddRow(100, 5, 2, 80, 10, 3))
 
+	// Mock total_filtered count query
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(100))
+
 	// Mock recent scans
 	now := time.Now()
 	mock.ExpectQuery("module_version_scans s").
@@ -187,12 +191,96 @@ func TestGetScanningStatsHandler_Success(t *testing.T) {
 	if resp.Clean != 80 {
 		t.Errorf("Clean = %d, want 80", resp.Clean)
 	}
+	if resp.TotalFiltered != 100 {
+		t.Errorf("TotalFiltered = %d, want 100", resp.TotalFiltered)
+	}
 	if len(resp.RecentScans) != 1 {
 		t.Errorf("len(RecentScans) = %d, want 1", len(resp.RecentScans))
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestGetScanningStatsHandler_WithStatusFilter(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	r := gin.New()
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+
+	// Mock aggregate counts
+	mock.ExpectQuery("module_version_scans").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"total", "pending", "scanning", "clean", "findings", "error_count",
+		}).AddRow(100, 5, 2, 80, 10, 3))
+
+	// Mock filtered count
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs("findings").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(10))
+
+	// Mock filtered recent scans
+	now := time.Now()
+	mock.ExpectQuery("module_version_scans s").
+		WithArgs("findings", 20, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "version", "name", "namespace", "system",
+			"scanner", "status",
+			"critical_count", "high_count", "medium_count", "low_count",
+			"scanned_at", "created_at",
+		}).AddRow(
+			"scan-1", "1.0.0", "vpc", "hashicorp", "aws",
+			"trivy", "findings",
+			1, 2, 3, 0,
+			now, now,
+		))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/scanning/stats?status=findings", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp ScanningStatsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.TotalFiltered != 10 {
+		t.Errorf("TotalFiltered = %d, want 10", resp.TotalFiltered)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestGetScanningStatsHandler_InvalidStatusFilter(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	r := gin.New()
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/scanning/stats?status=invalid", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }
 
@@ -237,6 +325,10 @@ func TestGetScanningStatsHandler_RecentQueryError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"total", "pending", "scanning", "clean", "findings", "error_count",
 		}).AddRow(10, 0, 0, 10, 0, 0))
+
+	// Filtered count succeeds
+	mock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(10))
 
 	// Recent scans query fails
 	mock.ExpectQuery("module_version_scans s").


### PR DESCRIPTION
## Summary

Adds optional query parameters to GET /api/v1/admin/scanning/stats:
- status — filter recent scans by status (pending, scanning, clean, indings, rror)
- limit — pagination limit (1-100, default 20)
- offset — pagination offset (default 0)

Also adds 	otal_filtered to the response for pagination UI support.

## Problem

The endpoint previously returned a hardcoded last 10 scans with no filtering capability. The frontend security scanning page could not surface all modules with findings (e.g., 8 findings exist but only 1 was visible in the table).

## Changes

- ackend/internal/api/admin/scanning_admin.go — Added query param parsing, input validation, parameterized SQL with optional WHERE clause
- ackend/internal/api/admin/scanning_admin_test.go — Updated existing tests, added tests for status filter and invalid status validation

## Testing

- All existing tests pass
- New tests cover: status filtering, invalid status rejection, pagination params

Fixes #338