### PR TITLE
fix(api): allow namespace update in PUT /api/v1/admin/modules/{id}

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1395,7 +1395,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update a module record's description or source URL. Requires modules:write scope.",
+                "description": "Update a module record's namespace, description, or source URL. Requires modules:write scope.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1447,6 +1447,13 @@
                     },
                     "404": {
                         "description": "Module not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict - namespace/name/system already exists",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -589,7 +589,7 @@ func (h *ModuleAdminHandlers) UndeprecateVersion(c *gin.Context) {
 
 // UpdateModuleRecord handler
 // @Summary      Update module record
-// @Description  Update a module record's description or source URL. Requires modules:write scope.
+// @Description  Update a module record's namespace, description, or source URL. Requires modules:write scope.
 // @Tags         Modules
 // @Security     Bearer
 // @Accept       json
@@ -600,6 +600,7 @@ func (h *ModuleAdminHandlers) UndeprecateVersion(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}  "Invalid request"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Module not found"
+// @Failure      409  {object}  map[string]interface{}  "Conflict - namespace/name/system already exists"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/modules/{id} [put]
 // UpdateModuleRecord updates a module record
@@ -610,6 +611,7 @@ func (h *ModuleAdminHandlers) UpdateModuleRecord(c *gin.Context) {
 	var req struct {
 		Description *string `json:"description"`
 		Source      *string `json:"source"`
+		Namespace   *string `json:"namespace"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -626,6 +628,26 @@ func (h *ModuleAdminHandlers) UpdateModuleRecord(c *gin.Context) {
 		return
 	}
 
+	if req.Namespace != nil {
+		ns := *req.Namespace
+		if ns == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "namespace must not be empty"})
+			return
+		}
+		if ns != module.Namespace {
+			// Check for conflict with existing module at the new namespace.
+			existing, err := h.moduleRepo.GetModule(c.Request.Context(), module.OrganizationID, ns, module.Name, module.System)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check namespace availability"})
+				return
+			}
+			if existing != nil {
+				c.JSON(http.StatusConflict, gin.H{"error": "a module with the same name and system already exists in the target namespace"})
+				return
+			}
+			module.Namespace = ns
+		}
+	}
 	if req.Description != nil {
 		module.Description = req.Description
 	}

--- a/backend/internal/api/admin/modules_test.go
+++ b/backend/internal/api/admin/modules_test.go
@@ -1004,6 +1004,44 @@ func TestUpdateModuleRecord_Success(t *testing.T) {
 	}
 }
 
+func TestUpdateModuleRecord_NamespaceChange_Success(t *testing.T) {
+	mock, r := newModuleRouter(t)
+	mock.ExpectQuery("SELECT.*FROM modules").WithArgs("mod-1").WillReturnRows(sampleModuleRow())
+	// Conflict check — no existing module at new namespace
+	mock.ExpectQuery("SELECT.*FROM modules").WillReturnRows(emptyModuleRow())
+	mock.ExpectQuery("UPDATE modules").WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/modules/id/mod-1",
+		jsonBody(map[string]string{"namespace": "new-namespace"})))
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateModuleRecord_NamespaceChange_Conflict(t *testing.T) {
+	mock, r := newModuleRouter(t)
+	mock.ExpectQuery("SELECT.*FROM modules").WithArgs("mod-1").WillReturnRows(sampleModuleRow())
+	// Conflict check — module already exists at target namespace
+	mock.ExpectQuery("SELECT.*FROM modules").WillReturnRows(sampleModuleRow())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/modules/id/mod-1",
+		jsonBody(map[string]string{"namespace": "other-namespace"})))
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateModuleRecord_NamespaceEmpty(t *testing.T) {
+	mock, r := newModuleRouter(t)
+	mock.ExpectQuery("SELECT.*FROM modules").WithArgs("mod-1").WillReturnRows(sampleModuleRow())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/modules/id/mod-1",
+		jsonBody(map[string]string{"namespace": ""})))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DeprecateModule tests
 // ---------------------------------------------------------------------------

--- a/backend/internal/db/repositories/module_repository.go
+++ b/backend/internal/db/repositories/module_repository.go
@@ -162,12 +162,13 @@ func (r *ModuleRepository) GetModuleByID(ctx context.Context, id string) (*model
 func (r *ModuleRepository) UpdateModule(ctx context.Context, module *models.Module) error {
 	query := `
 		UPDATE modules
-		SET description = $1, source = $2, updated_at = NOW()
-		WHERE id = $3
+		SET namespace = $1, description = $2, source = $3, updated_at = NOW()
+		WHERE id = $4
 		RETURNING updated_at
 	`
 
 	err := r.db.QueryRowContext(ctx, query,
+		module.Namespace,
 		module.Description,
 		module.Source,
 		module.ID,

--- a/backend/internal/db/repositories/module_repository_test.go
+++ b/backend/internal/db/repositories/module_repository_test.go
@@ -330,7 +330,7 @@ func TestIncrementDownloadCount_Success(t *testing.T) {
 
 func TestUpdateModule_Success(t *testing.T) {
 	repo, mock := newModuleRepo(t)
-	mock.ExpectQuery("UPDATE modules.*SET description").
+	mock.ExpectQuery("UPDATE modules.*SET namespace").
 		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
 
 	m := &models.Module{ID: "mod-1", Namespace: "hashicorp", Name: "vpc", System: "aws"}
@@ -816,7 +816,7 @@ func TestSearchModulesWithStats_ScanError(t *testing.T) {
 
 func TestUpdateModule_DBError(t *testing.T) {
 	repo, mock := newModuleRepo(t)
-	mock.ExpectQuery("UPDATE modules.*SET description").
+	mock.ExpectQuery("UPDATE modules.*SET namespace").
 		WillReturnError(errDB)
 
 	m := &models.Module{ID: "mod-1"}


### PR DESCRIPTION
## Summary

The module update endpoint (PUT /api/v1/admin/modules/{id}) now accepts an optional \
amespace\ field in the request body.

## Changes

- **backend/internal/api/admin/modules.go** — Added \Namespace\ to the update request struct with validation (non-empty, conflict check against existing modules)
- **backend/internal/db/repositories/module_repository.go** — Added \
amespace\ to the UPDATE SQL query
- **backend/internal/api/admin/modules_test.go** — Added tests for namespace change success, conflict (409), and empty namespace (400)
- **backend/internal/db/repositories/module_repository_test.go** — Updated mock expectations

## Behavior

- If \
amespace\ is omitted or matches the current value, no change occurs (backward-compatible)
- If \
amespace\ is empty string, returns 400
- If a module with the same name+system already exists in the target namespace, returns 409 Conflict
- Otherwise, updates the namespace and returns the updated module

Fixes #339