### PR TITLE
fix(api): terraform-mirror version deprecate/undeprecate endpoints

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4248,6 +4248,130 @@
                 }
             }
         },
+        "/api/v1/admin/terraform-mirrors/{id}/versions/{version}/deprecate": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires mirrors:manage scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Terraform Mirror"
+                ],
+                "summary": "Deprecate a mirrored Terraform version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Mirror config UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Terraform version (e.g. 1.7.0)",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires mirrors:manage scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Terraform Mirror"
+                ],
+                "summary": "Undeprecate a mirrored Terraform version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Mirror config UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Terraform version (e.g. 1.7.0)",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/terraform-mirrors/{id}/versions/{version}/platforms": {
             "get": {
                 "security": [

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -548,6 +548,86 @@ func (h *TerraformMirrorHandler) DeleteVersion(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Version deleted", "version": versionStr})
 }
 
+// ---- POST /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate --
+
+// @Summary      Deprecate a mirrored Terraform version
+// @Description  Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires mirrors:manage scope.
+// @Tags         Terraform Mirror
+// @Security     Bearer
+// @Produce      json
+// @Param        id       path  string  true  "Mirror config UUID"
+// @Param        version  path  string  true  "Terraform version (e.g. 1.7.0)"
+// @Success      200  {object}  map[string]interface{}
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/terraform-mirrors/{id}/versions/{version}/deprecate [post]
+func (h *TerraformMirrorHandler) DeprecateVersion(c *gin.Context) {
+	id, ok := parseMirrorID(c)
+	if !ok {
+		return
+	}
+
+	versionStr := c.Param("version")
+
+	v, err := h.repo.GetVersionByString(c.Request.Context(), id, versionStr)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to look up version: " + err.Error()})
+		return
+	}
+	if v == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	if updErr := h.repo.SetVersionDeprecated(c.Request.Context(), v.ID, true); updErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to deprecate version: " + updErr.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Version deprecated", "version": versionStr})
+}
+
+// ---- DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate
+
+// @Summary      Undeprecate a mirrored Terraform version
+// @Description  Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires mirrors:manage scope.
+// @Tags         Terraform Mirror
+// @Security     Bearer
+// @Produce      json
+// @Param        id       path  string  true  "Mirror config UUID"
+// @Param        version  path  string  true  "Terraform version (e.g. 1.7.0)"
+// @Success      200  {object}  map[string]interface{}
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/terraform-mirrors/{id}/versions/{version}/deprecate [delete]
+func (h *TerraformMirrorHandler) UndeprecateVersion(c *gin.Context) {
+	id, ok := parseMirrorID(c)
+	if !ok {
+		return
+	}
+
+	versionStr := c.Param("version")
+
+	v, err := h.repo.GetVersionByString(c.Request.Context(), id, versionStr)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to look up version: " + err.Error()})
+		return
+	}
+	if v == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
+		return
+	}
+
+	if updErr := h.repo.SetVersionDeprecated(c.Request.Context(), v.ID, false); updErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to undeprecate version: " + updErr.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Version deprecation cleared", "version": versionStr})
+}
+
 // ---- GET /api/v1/admin/terraform-mirrors/:id/history ----------------------
 
 // @Summary      Get Terraform mirror sync history

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -105,6 +105,8 @@ func newTerraformMirrorRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	r.GET("/terraform-mirrors/:id/versions", h.ListVersions)
 	r.GET("/terraform-mirrors/:id/versions/:version", h.GetVersion)
 	r.DELETE("/terraform-mirrors/:id/versions/:version", h.DeleteVersion)
+	r.POST("/terraform-mirrors/:id/versions/:version/deprecate", h.DeprecateVersion)
+	r.DELETE("/terraform-mirrors/:id/versions/:version/deprecate", h.UndeprecateVersion)
 	r.GET("/terraform-mirrors/:id/history", h.GetSyncHistory)
 	r.GET("/terraform-mirrors/:id/versions/:version/platforms", h.ListPlatforms)
 
@@ -691,6 +693,106 @@ func TestTMMirrorDeleteVersion_Success(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeprecateVersion / UndeprecateVersion (mirror handler) tests
+// ---------------------------------------------------------------------------
+
+func TestTMMirrorDeprecateVersion_InvalidID(t *testing.T) {
+	_, r := newTerraformMirrorRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors/not-a-uuid/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorDeprecateVersion_LookupDBError(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorDeprecateVersion_NotFound(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(tfvCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorDeprecateVersion_UpdateDBError(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sampleTFVRow())
+	mock.ExpectExec("UPDATE terraform_versions SET is_deprecated").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorDeprecateVersion_Success(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sampleTFVRow())
+	mock.ExpectExec("UPDATE terraform_versions SET is_deprecated").
+		WithArgs(true, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorUndeprecateVersion_NotFound(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(tfvCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMMirrorUndeprecateVersion_Success(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sampleTFVRow())
+	mock.ExpectExec("UPDATE terraform_versions SET is_deprecated").
+		WithArgs(false, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0/deprecate", nil))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -986,6 +986,8 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 				tfMirrorGroup.GET("/:id/versions", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListVersions)
 				tfMirrorGroup.GET("/:id/versions/:version", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetVersion)
 				tfMirrorGroup.DELETE("/:id/versions/:version", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.DeleteVersion)
+				tfMirrorGroup.POST("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.DeprecateVersion)
+				tfMirrorGroup.DELETE("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.UndeprecateVersion)
 				tfMirrorGroup.GET("/:id/versions/:version/platforms", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListPlatforms)
 				// Sync history
 				tfMirrorGroup.GET("/:id/history", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetSyncHistory)

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -471,6 +471,21 @@ func (r *TerraformMirrorRepository) DeleteVersion(ctx context.Context, versionID
 	return nil
 }
 
+// SetVersionDeprecated flips the is_deprecated flag on a version row.
+// When deprecated, the sync job will skip re-downloading the version's binaries;
+// the version row and any already-downloaded artifacts remain in place so
+// existing pulls still resolve.
+func (r *TerraformMirrorRepository) SetVersionDeprecated(ctx context.Context, versionID uuid.UUID, deprecated bool) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE terraform_versions SET is_deprecated = $1, updated_at = NOW() WHERE id = $2`,
+		deprecated, versionID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update terraform version deprecation: %w", err)
+	}
+	return nil
+}
+
 // ---- Platforms -------------------------------------------------------------
 
 // UpsertPlatform inserts or updates a platform row.
@@ -579,6 +594,7 @@ func (r *TerraformMirrorRepository) ListPendingPlatforms(ctx context.Context, co
 		FROM terraform_version_platforms p
 		JOIN terraform_versions v ON v.id = p.version_id
 		WHERE v.config_id = $1
+		  AND v.is_deprecated = false
 		  AND p.sync_status IN ('pending', 'failed')
 		ORDER BY p.created_at
 	`

--- a/backend/internal/db/repositories/terraform_mirror_repository_test.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository_test.go
@@ -672,6 +672,47 @@ func TestTerraformMirrorDeleteVersion_DBError(t *testing.T) {
 	}
 }
 
+// --- SetVersionDeprecated ---
+
+func TestSetVersionDeprecated_True(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE terraform_versions SET is_deprecated`).
+		WithArgs(true, id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repo.SetVersionDeprecated(context.Background(), id, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetVersionDeprecated_False(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE terraform_versions SET is_deprecated`).
+		WithArgs(false, id).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repo.SetVersionDeprecated(context.Background(), id, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetVersionDeprecated_DBError(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE terraform_versions SET is_deprecated`).
+		WithArgs(true, id).
+		WillReturnError(fmt.Errorf("db error"))
+
+	if err := repo.SetVersionDeprecated(context.Background(), id, true); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 // --- SetLatestVersion ---
 
 func TestSetLatestVersion_Success(t *testing.T) {


### PR DESCRIPTION
Closes #344.

## Summary

Adds the missing write side for terraform-mirror version deprecation. The schema (`terraform_versions.is_deprecated`) and read path have existed since migration #4 and the frontend already renders the flag (chip + dimmed row); only the handlers, routes, and sync-job awareness were missing. Frontend calls were silently 404'ing — frontend issue [terraform-registry-frontend#275](https://github.com/sethbacon/terraform-registry-frontend/issues/275) tracked the resulting bug.

Classified as `fix:` because it completes a half-shipped feature whose schema, model, read path, and UI were already in place; the missing handlers were a regression in the original implementation, not new functionality.

## Endpoints

| Route | Method | Scope |
|---|---|---|
| `/api/v1/admin/terraform-mirrors/{id}/versions/{version}/deprecate` | `POST` | `mirrors:manage` |
| `/api/v1/admin/terraform-mirrors/{id}/versions/{version}/deprecate` | `DELETE` | `mirrors:manage` |

Returns 200 on success, 404 when config or version not found, 401 when scope missing. Empty request body — flag-only, no message column. We can add a deprecation message later if a use case appears (the frontend's UI is dialog-only with no message field today).

## Sync-job behavior

`ListPendingPlatforms` now `JOIN`s `terraform_versions` and filters out platforms whose version has `is_deprecated = true`. `UpsertVersion`'s `ON CONFLICT` clause already preserves `is_deprecated` across upserts (only `release_date` and `updated_at` are touched), so a deprecated version that re-appears in the upstream index does not get its flag cleared.

The frontend tooltip says "prevents re-sync" and the success message says "It will not be re-synced" — that's the contract this implements. Already-downloaded artifacts remain available so existing pulls keep working.

## Tests

- Repository: `SetVersionDeprecated` true / false / DB error.
- Handler: invalid UUID, lookup DB error, not-found, update DB error, deprecate success, undeprecate not-found, undeprecate success.

## Swagger

`swag init` regenerated. Both routes appear in `backend/docs/swagger.json` with full `@Router` / `@Summary` / `@Tags` annotations.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo test suite passes locally)
- [ ] CI green.
- [ ] After release, frontend follow-up to remove the corresponding entries from `frontend/scripts/contract-check.allowlist.json`.

## Release

Patch release (`v1.1.1`) via release-please.
