### PR TITLE
fix(swagger): correct @Router annotations on 4 mis-documented routes

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5445,92 +5445,14 @@
                 }
             }
         },
-        "/api/v1/modules/search": {
-            "get": {
-                "description": "Search for modules by name, namespace, or provider system with pagination and sorting.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Modules"
-                ],
-                "summary": "Search modules",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Search query",
-                        "name": "q",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by namespace",
-                        "name": "namespace",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by target system",
-                        "name": "system",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort field: relevance, name, downloads, created, updated",
-                        "name": "sort",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort order: asc or desc (default desc)",
-                        "name": "order",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Maximum results to return (default 20, max 100)",
-                        "name": "limit",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Offset for pagination (default 0)",
-                        "name": "offset",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/modules.ModuleSearchResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid sort parameter",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/modules/{namespace}/{name}/{provider}/{version}": {
+        "/api/v1/modules": {
             "post": {
                 "security": [
                     {
                         "Bearer": []
                     }
                 ],
-                "description": "Uploads a new module version archive",
+                "description": "Uploads a new module version archive. Module identity (namespace, name, system, version) is supplied as multipart form fields, not path params. Requires modules:write scope.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -5632,52 +5554,76 @@
                 }
             }
         },
-        "/api/v1/modules/{namespace}/{name}/{provider}/{version}/download": {
+        "/api/v1/modules/search": {
             "get": {
-                "description": "Streams a module version archive file",
+                "description": "Search for modules by name, namespace, or provider system with pagination and sorting.",
                 "produces": [
-                    "application/zip"
+                    "application/json"
                 ],
                 "tags": [
                     "Modules"
                 ],
-                "summary": "Download module archive",
+                "summary": "Search modules",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Namespace",
+                        "description": "Search query",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by namespace",
                         "name": "namespace",
-                        "in": "path",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Module name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
+                        "description": "Filter by target system",
+                        "name": "system",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "path",
-                        "required": true
+                        "description": "Sort field: relevance, name, downloads, created, updated",
+                        "name": "sort",
+                        "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Version",
-                        "name": "version",
-                        "in": "path",
-                        "required": true
+                        "description": "Sort order: asc or desc (default desc)",
+                        "name": "order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum results to return (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset for pagination (default 0)",
+                        "name": "offset",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/modules.ModuleSearchResponse"
+                        }
                     },
-                    "404": {
-                        "description": "Not Found",
+                    "400": {
+                        "description": "Invalid sort parameter",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -6194,6 +6140,70 @@
                 }
             }
         },
+        "/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/docs": {
+            "get": {
+                "description": "Returns terraform-docs metadata (inputs, outputs, providers, requirements) extracted from the module archive at upload time.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Modules"
+                ],
+                "summary": "Get module documentation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target system (e.g. aws, azurerm)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module version",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/analyzer.ModuleDoc"
+                        }
+                    },
+                    "404": {
+                        "description": "Module, version, or docs not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/reanalyze": {
             "post": {
                 "security": [
@@ -6389,70 +6399,6 @@
                     },
                     "404": {
                         "description": "Module or version not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/modules/{namespace}/{name}/{system}/{version}/docs": {
-            "get": {
-                "description": "Returns terraform-docs metadata (inputs, outputs, providers, requirements) extracted from the module archive at upload time.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Modules"
-                ],
-                "summary": "Get module documentation",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Module namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Module name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Target system (e.g. aws, azurerm)",
-                        "name": "system",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Module version",
-                        "name": "version",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/analyzer.ModuleDoc"
-                        }
-                    },
-                    "404": {
-                        "description": "Module, version, or docs not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -7101,6 +7047,127 @@
                 }
             }
         },
+        "/api/v1/providers": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope.",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Providers"
+                ],
+                "summary": "Upload provider version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Provider namespace",
+                        "name": "namespace",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider type (e.g. aws, azurerm)",
+                        "name": "type",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Semantic version (e.g. 1.2.3)",
+                        "name": "version",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target OS (e.g. linux, darwin, windows)",
+                        "name": "os",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target architecture (e.g. amd64, arm64)",
+                        "name": "arch",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "JSON array of supported protocols (default [\\",
+                        "name": "protocols",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "ASCII-armored GPG public key for signing verification",
+                        "name": "gpg_public_key",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Provider description",
+                        "name": "description",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Source URL",
+                        "name": "source",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "file",
+                        "description": "Provider binary (.zip, max 500MB)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/providers/search": {
             "get": {
                 "description": "Search for providers by name or namespace with pagination and sorting.",
@@ -7650,127 +7717,6 @@
                     },
                     "502": {
                         "description": "Failed to fetch from upstream",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/providers/{namespace}/{type}/{version}/{os}/{arch}": {
-            "post": {
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "description": "Uploads a new provider version binary and associated files",
-                "consumes": [
-                    "multipart/form-data"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Providers"
-                ],
-                "summary": "Upload provider version",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Provider namespace",
-                        "name": "namespace",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Provider type (e.g. aws, azurerm)",
-                        "name": "type",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Semantic version (e.g. 1.2.3)",
-                        "name": "version",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Target OS (e.g. linux, darwin, windows)",
-                        "name": "os",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Target architecture (e.g. amd64, arm64)",
-                        "name": "arch",
-                        "in": "formData",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "JSON array of supported protocols (default [\\",
-                        "name": "protocols",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "ASCII-armored GPG public key for signing verification",
-                        "name": "gpg_public_key",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Provider description",
-                        "name": "description",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Source URL",
-                        "name": "source",
-                        "in": "formData"
-                    },
-                    {
-                        "type": "file",
-                        "description": "Provider binary (.zip, max 500MB)",
-                        "name": "file",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "409": {
-                        "description": "Conflict",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -11159,6 +11105,53 @@
                     },
                     "404": {
                         "description": "Provider or version not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/files/{filepath}": {
+            "get": {
+                "description": "Streams a stored archive file. Only registered when the local storage backend has ServeDirectly enabled. Path traversal sequences are rejected.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "Files"
+                ],
+                "summary": "Serve archive file from local storage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Storage-relative file path",
+                        "name": "filepath",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Invalid file path",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "File not found",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/modules/docs.go
+++ b/backend/internal/api/modules/docs.go
@@ -20,7 +20,7 @@ import (
 // @Success      200  {object}  analyzer.ModuleDoc
 // @Failure      404  {object}  map[string]interface{}  "Module, version, or docs not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
-// @Router       /api/v1/modules/{namespace}/{name}/{system}/{version}/docs [get]
+// @Router       /api/v1/modules/{namespace}/{name}/{system}/versions/{version}/docs [get]
 func GetModuleDocsHandler(db *sql.DB) gin.HandlerFunc {
 	moduleRepo := repositories.NewModuleRepository(db)
 	orgRepo := repositories.NewOrganizationRepository(db)

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -17,18 +17,17 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
-// ServeFileHandler serves a module archive file.
-// @Summary      Download module archive
-// @Description  Streams a module version archive file
-// @Tags         Modules
-// @Param        namespace  path  string  true  "Namespace"
-// @Param        name       path  string  true  "Module name"
-// @Param        provider   path  string  true  "Provider"
-// @Param        version    path  string  true  "Version"
-// @Produce      application/zip
+// ServeFileHandler serves a module or provider archive file directly from local storage.
+// @Summary      Serve archive file from local storage
+// @Description  Streams a stored archive file. Only registered when the local storage backend has ServeDirectly enabled. Path traversal sequences are rejected.
+// @Tags         Files
+// @Param        filepath   path  string  true  "Storage-relative file path"
+// @Produce      application/octet-stream
 // @Success      200
-// @Failure      404  {object}  map[string]interface{}
-// @Router       /api/v1/modules/{namespace}/{name}/{provider}/{version}/download [get]
+// @Failure      400  {object}  map[string]interface{}  "Invalid file path"
+// @Failure      404  {object}  map[string]interface{}  "File not found"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /v1/files/{filepath} [get]
 // ServeFileHandler handles direct file serving for local storage
 // Implements: GET /v1/files/*filepath
 // Only used when local storage has ServeDirectly: true

--- a/backend/internal/api/modules/upload.go
+++ b/backend/internal/api/modules/upload.go
@@ -21,7 +21,7 @@ import (
 )
 
 // @Summary      Upload module version
-// @Description  Uploads a new module version archive
+// @Description  Uploads a new module version archive. Module identity (namespace, name, system, version) is supplied as multipart form fields, not path params. Requires modules:write scope.
 // @Tags         Modules
 // @Security     Bearer
 // @Accept       multipart/form-data
@@ -39,7 +39,7 @@ import (
 // @Failure      409  {object}  map[string]interface{}
 // @Failure      422  {object}  map[string]interface{}  "Policy violation (block mode)"
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /api/v1/modules/{namespace}/{name}/{provider}/{version} [post]
+// @Router       /api/v1/modules [post]
 // UploadHandler handles module upload requests
 // Implements: POST /api/v1/modules
 // Accepts multipart form with: namespace, name, system, version, description (optional), file

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -26,7 +26,7 @@ const (
 )
 
 // @Summary      Upload provider version
-// @Description  Uploads a new provider version binary and associated files
+// @Description  Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope.
 // @Tags         Providers
 // @Security     Bearer
 // @Accept       multipart/form-data
@@ -46,7 +46,7 @@ const (
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      409  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /api/v1/providers/{namespace}/{type}/{version}/{os}/{arch} [post]
+// @Router       /api/v1/providers [post]
 // UploadHandler handles provider upload requests
 // Implements: POST /api/v1/providers
 // Accepts multipart form with: namespace, type, version, os, arch, protocols, gpg_public_key, file


### PR DESCRIPTION
Closes #343.

## Summary

Surfaced by the frontend's new contract-check job ([terraform-registry-frontend#273](https://github.com/sethbacon/terraform-registry-frontend/issues/273)). A router-vs-swagger audit found 4 `@Router` annotations whose declared paths did not match the routes actually registered in `router.go`. The frontend's contract check was working around them via 3 allowlist entries; one (the `/v1/files` annotation) was previously invisible because it pointed at a path that doesn't exist either.

## Changes

| File | Fix |
|---|---|
| `modules/upload.go` | `@Router` declared `/api/v1/modules/{namespace}/{name}/{provider}/{version}` but the route is registered at `/api/v1/modules` with all identity fields supplied as multipart form fields. |
| `providers/upload.go` | Same pattern. `@Router` claimed `/api/v1/providers/{namespace}/{type}/{version}/{os}/{arch}` for what is actually `/api/v1/providers`. |
| `modules/docs.go` | `@Router` declared `.../{system}/{version}/docs` but the route includes a `/versions/` segment: `.../{system}/versions/{version}/docs`. |
| `modules/serve.go` | `ServeFileHandler` is registered at `/v1/files/*filepath` but had a copy-pasted `@Router` pointing at the module download path. Corrected to `/v1/files/{filepath}` with `@Tags Files` and an accurate description. |

## Audit methodology

Parsed `router.go` to extract every `(method, path)` tuple across nested `gin.RouterGroup` chains (resolving `Group("...")` calls recursively), parsed every `@Router` annotation across `backend/internal/api`, computed the symmetric difference.

After these 4 fixes the only remaining drift is:

| Drift | Why |
|---|---|
| `/api/v1/dev/*` (4 routes) | DEV_MODE-only, intentionally undocumented in production swagger. Frontend allowlist will keep these as permanent entries. |
| `/api-docs/*`, `/swagger.json` | Swagger UI itself, not API surface. |
| `/v1/files/*filepath` registration | Internal file server. The fix in this PR makes the swagger entry match the registration's logical path even though gin's `*filepath` wildcard doesn't have a clean OpenAPI translation. |
| `GET /api/v1/admin/users/{id}/export`, `POST /api/v1/admin/users/{id}/erase` | Handlers exist with annotations but the routes are never registered. Filed separately as #347 — this is roadmap recovery (C3.4 GDPR tooling, marked ✅ but never finished), not documentation work. |

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./internal/api/modules/ ./internal/api/providers/ ./internal/api/admin/` all pass.
- [x] `swag init` regenerated `backend/docs/swagger.json`; verified all 4 routes appear at the corrected paths.
- [ ] CI green.

## Frontend follow-up

After this lands and v1.1.3 (or whatever the next release is) ships, the frontend can:

1. Bump `deployments/docker-compose.contract-check.yml` to the new backend tag.
2. Remove 3 entries from `frontend/scripts/contract-check.allowlist.json`:
   - `POST /api/v1/modules`
   - `POST /api/v1/providers`
   - `GET /api/v1/modules/{}/{}/{}/versions/{}/docs`

Allowlist will then be down to 7 entries (the 4 `/api/v1/dev/*` permanent ones + 3 still-open frontend bugs #276/#277).
