### PR TITLE
fix: support org rename with cascade to modules and providers

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -8329,7 +8329,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing organization's display name and optional IdP binding (idp_type + idp_name). Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
+                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
                 "tags": [
                     "Organizations"
                 ],
@@ -8368,7 +8368,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid request body",
+                        "description": "Invalid request body or name format",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -8391,6 +8391,17 @@
                     },
                     "404": {
                         "description": "Organization not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Organization name already taken",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -16147,6 +16158,7 @@
                 "type": "object",
                 "properties": {
                     "display_name": {
+                        "description": "Human-readable display name",
                         "type": "string"
                     },
                     "idp_name": {
@@ -16155,6 +16167,10 @@
                     },
                     "idp_type": {
                         "description": "\"oidc\", \"saml\", \"ldap\", or null to clear",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Optional rename; must satisfy registry naming rules",
                         "type": "string"
                     }
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6659,7 +6659,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing organization's display name and optional IdP binding (idp_type + idp_name). Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
+                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6696,7 +6696,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid request body",
+                        "description": "Invalid request body or name format",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -6711,6 +6711,13 @@
                     },
                     "404": {
                         "description": "Organization not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Organization name already taken",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -13205,6 +13212,7 @@
             "type": "object",
             "properties": {
                 "display_name": {
+                    "description": "Human-readable display name",
                     "type": "string"
                 },
                 "idp_name": {
@@ -13213,6 +13221,10 @@
                 },
                 "idp_type": {
                     "description": "\"oidc\", \"saml\", \"ldap\", or null to clear",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Optional rename; must satisfy registry naming rules",
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
 // OrganizationHandlers handles organization management endpoints
@@ -257,13 +258,14 @@ func (h *OrganizationHandlers) CreateOrganizationHandler() gin.HandlerFunc {
 
 // UpdateOrganizationRequest represents the request to update an organization
 type UpdateOrganizationRequest struct {
-	DisplayName *string `json:"display_name"`
-	IdpType     *string `json:"idp_type"` // "oidc", "saml", "ldap", or null to clear
-	IdpName     *string `json:"idp_name"` // IdP name within type, or null to clear
+	Name        *string `json:"name"`         // Optional rename; must satisfy registry naming rules
+	DisplayName *string `json:"display_name"` // Human-readable display name
+	IdpType     *string `json:"idp_type"`     // "oidc", "saml", "ldap", or null to clear
+	IdpName     *string `json:"idp_name"`     // IdP name within type, or null to clear
 }
 
 // @Summary      Update organization
-// @Description  Update an existing organization's display name and optional IdP binding (idp_type + idp_name). Set idp_type to "oidc", "saml", or "ldap" to restrict login; set to empty string to clear.
+// @Description  Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to "oidc", "saml", or "ldap" to restrict login; set to empty string to clear.
 // @Tags         Organizations
 // @Security     Bearer
 // @Accept       json
@@ -271,9 +273,10 @@ type UpdateOrganizationRequest struct {
 // @Param        id    path  string                    true  "Organization ID"
 // @Param        body  body  UpdateOrganizationRequest  true  "Fields to update"
 // @Success      200  {object}  admin.OrganizationResponse
-// @Failure      400  {object}  map[string]interface{}  "Invalid request body"
+// @Failure      400  {object}  map[string]interface{}  "Invalid request body or name format"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Organization not found"
+// @Failure      409  {object}  map[string]interface{}  "Organization name already taken"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/organizations/{id} [put]
 // UpdateOrganizationHandler updates an organization
@@ -306,7 +309,38 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Update fields
+		// Handle rename — validate format, check uniqueness, then cascade.
+		if req.Name != nil && *req.Name != org.Name {
+			newName := *req.Name
+			if err := validation.ValidateRegistrySegment(newName); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "invalid organization name: " + err.Error(),
+				})
+				return
+			}
+			existing, err := h.orgRepo.GetByName(c.Request.Context(), newName)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to check name availability",
+				})
+				return
+			}
+			if existing != nil {
+				c.JSON(http.StatusConflict, gin.H{
+					"error": "Organization name already taken",
+				})
+				return
+			}
+			if err := h.orgRepo.RenameWithCascade(c.Request.Context(), orgID, org.Name, newName); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to rename organization",
+				})
+				return
+			}
+			org.Name = newName
+		}
+
+		// Update remaining fields
 		if req.DisplayName != nil {
 			org.DisplayName = *req.DisplayName
 		}

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -254,6 +254,98 @@ func TestUpdateOrganization_Success(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Rename tests
+// ---------------------------------------------------------------------------
+
+func TestUpdateOrganization_RenameSuccess(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	// 1. GetByID — return current org (name = "default")
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	// 2. GetByName uniqueness check — new name is available
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+		WillReturnRows(emptyOrgRow())
+	// 3. RenameWithCascade transaction
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE organizations SET name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE modules SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE providers SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	// 4. Regular Update for remaining fields (display_name / idp_type)
+	mock.ExpectExec("UPDATE organizations SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	newName := "new-org-name"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1",
+		jsonBody(map[string]interface{}{"name": &newName})))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateOrganization_RenameConflict(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	// GetByName — name already taken
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+		WillReturnRows(sampleOrgRow())
+
+	taken := "already-taken"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1",
+		jsonBody(map[string]interface{}{"name": &taken})))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateOrganization_RenameInvalidFormat(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+
+	// Name with spaces and uppercase — fails ValidateRegistrySegment before any DB call
+	badName := "My Bad Name!"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1",
+		jsonBody(map[string]interface{}{"name": &badName})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateOrganization_RenameSameName(t *testing.T) {
+	// Sending the same name as current should be a no-op (no cascade, no conflict check)
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	// No rename branch runs; only the regular Update executes
+	mock.ExpectExec("UPDATE organizations SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	sameName := "default" // matches sampleOrgRow name
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1",
+		jsonBody(map[string]interface{}{"name": &sameName})))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
 // DeleteOrganizationHandler tests
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/db/repositories/organization_repository.go
+++ b/backend/internal/db/repositories/organization_repository.go
@@ -398,6 +398,56 @@ func (r *OrganizationRepository) Update(ctx context.Context, org *models.Organiz
 	return nil
 }
 
+// RenameWithCascade atomically renames an organization and propagates the new name
+// to all module and provider namespace columns that currently carry oldName for this
+// organization. User membership links are stored by organization UUID and are therefore
+// unaffected by a rename.
+//
+// The three UPDATE statements run inside a single database transaction. If any step
+// fails the transaction is rolled back and the error is returned.
+func (r *OrganizationRepository) RenameWithCascade(ctx context.Context, orgID, oldName, newName string) (retErr error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin rename transaction: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// 1. Rename the organization itself.
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE organizations SET name = $1, updated_at = NOW() WHERE id = $2`,
+		newName, orgID,
+	); err != nil {
+		return fmt.Errorf("rename organization: %w", err)
+	}
+
+	// 2. Cascade to module namespaces.
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE modules SET namespace = $1, updated_at = NOW() WHERE organization_id = $2 AND namespace = $3`,
+		newName, orgID, oldName,
+	); err != nil {
+		return fmt.Errorf("cascade rename to modules: %w", err)
+	}
+
+	// 3. Cascade to provider namespaces.
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE providers SET namespace = $1, updated_at = NOW() WHERE organization_id = $2 AND namespace = $3`,
+		newName, orgID, oldName,
+	); err != nil {
+		return fmt.Errorf("cascade rename to providers: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit rename transaction: %w", err)
+	}
+
+	r.InvalidateDefaultOrgCache()
+	return nil
+}
+
 // Delete deletes an organization
 func (r *OrganizationRepository) Delete(ctx context.Context, orgID string) error {
 	query := `DELETE FROM organizations WHERE id = $1`

--- a/backend/internal/validation/segment.go
+++ b/backend/internal/validation/segment.go
@@ -1,0 +1,31 @@
+// segment.go validates registry identifier segments (namespace, module name, provider type)
+// against the naming rules required by the Terraform registry protocol. Each segment is used
+// as a URL path component in source addresses of the form
+// <hostname>/<namespace>/<name>/<provider>, so only URL-safe, lowercase characters are allowed.
+package validation
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// reRegistrySegment matches valid Terraform registry identifier segments:
+//   - lowercase alphanumeric, hyphens, and underscores only
+//   - must start with a lowercase alphanumeric character
+//   - length: 1–64 characters
+var reRegistrySegment = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,63}$`)
+
+// ValidateRegistrySegment returns an error if s is not a valid Terraform registry
+// identifier segment. The same rule applies to namespace, module name, and provider
+// type fields wherever they appear in the API.
+func ValidateRegistrySegment(s string) error {
+	if !reRegistrySegment.MatchString(s) {
+		return fmt.Errorf(
+			"%q is not a valid registry identifier: must be 1–64 characters, "+
+				"start with a lowercase letter or digit, and contain only "+
+				"lowercase letters, digits, hyphens, or underscores",
+			s,
+		)
+	}
+	return nil
+}

--- a/backend/internal/validation/segment_test.go
+++ b/backend/internal/validation/segment_test.go
@@ -1,0 +1,41 @@
+package validation
+
+import "testing"
+
+func TestValidateRegistrySegment(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid
+		{"simple lowercase", "myorg", false},
+		{"with hyphen", "my-org", false},
+		{"with underscore", "my_org", false},
+		{"starts with digit", "1org", false},
+		{"single char", "a", false},
+		{"64 chars", "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01", false},
+		{"mixed valid", "terraform-aws-123", false},
+		{"leading digit", "1-myorg", false},
+
+		// Invalid
+		{"empty string", "", true},
+		{"starts with hyphen", "-myorg", true},
+		{"starts with underscore", "_myorg", true},
+		{"contains space", "my org", true},
+		{"contains uppercase", "MyOrg", true},
+		{"contains dot", "my.org", true},
+		{"contains slash", "my/org", true},
+		{"65 chars", "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012", true},
+		{"contains @", "my@org", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRegistrySegment(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRegistrySegment(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements full organization rename support with atomic cascade to all module and provider namespace columns.

## Changes

### `internal/validation/segment.go` (new)
Adds `ValidateRegistrySegment(s string) error` — enforces Terraform registry naming rules:
- Lowercase alphanumeric, hyphens, and underscores only
- Must start with a lowercase letter or digit
- Length 1–64 characters
- Regex: `^[a-z0-9][a-z0-9_-]{0,63}$`

### `internal/db/repositories/organization_repository.go`
Adds `RenameWithCascade(ctx, orgID, oldName, newName string) error` which runs three UPDATE statements in a single transaction:
1. `UPDATE organizations SET name = $newName WHERE id = $orgID`
2. `UPDATE modules SET namespace = $newName WHERE organization_id = $orgID AND namespace = $oldName`
3. `UPDATE providers SET namespace = $newName WHERE organization_id = $orgID AND namespace = $oldName`

User memberships (`organization_members`) store the organization by UUID and are not affected; `OrganizationName` is resolved dynamically via JOIN at query time.

### `internal/api/admin/organizations.go`
- Adds `Name *string` field to `UpdateOrganizationRequest`
- Handler validates the new name with `ValidateRegistrySegment` (returns 400 on failure)
- Checks uniqueness via `GetByName` (returns 409 on conflict)
- Calls `RenameWithCascade` before the regular display-name/IDP update
- Updated Swagger annotations to document the new field and 409 response

## Testing

Added 4 regression tests:
- `TestUpdateOrganization_RenameSuccess` — rename cascades through begin/exec/exec/exec/commit
- `TestUpdateOrganization_RenameConflict` — returns 409 when new name is taken
- `TestUpdateOrganization_RenameInvalidFormat` — returns 400 for names with spaces/uppercase
- `TestUpdateOrganization_RenameSameName` — no-op when name matches current (skips cascade)

Closes #364
