### PR TITLE
fix: persist SHA256 from SUMS file to terraform_version_platforms (#368)

### DIFF
--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -647,6 +647,47 @@ func (r *TerraformMirrorRepository) UpdatePlatformSyncStatus(
 	return nil
 }
 
+// UpdatePlatformSHA256 writes the hex SHA256 of a platform's zip to its row.
+// Called once the upstream SHA256SUMS hash for the platform's filename is known
+// (either after fresh download/verify or during back-fill from the SUMS file).
+func (r *TerraformMirrorRepository) UpdatePlatformSHA256(ctx context.Context, id uuid.UUID, sha256Hex string) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE terraform_version_platforms
+		SET sha256 = $2, updated_at = NOW()
+		WHERE id = $1
+	`, id, sha256Hex)
+	if err != nil {
+		return fmt.Errorf("failed to update sha256 for platform %s: %w", id, err)
+	}
+	return nil
+}
+
+// BackfillPlatformSHA256 populates sha256 from the supplied SUMS map for any
+// synced platform of the given version whose sha256 column is still empty.
+// No binaries are re-downloaded. sums maps filename -> hex SHA256.
+func (r *TerraformMirrorRepository) BackfillPlatformSHA256(ctx context.Context, versionID uuid.UUID, sums map[string]string) error {
+	if len(sums) == 0 {
+		return nil
+	}
+	platforms, err := r.ListPlatformsForVersion(ctx, versionID)
+	if err != nil {
+		return err
+	}
+	for _, p := range platforms {
+		if p.SHA256 != "" || p.SyncStatus != "synced" {
+			continue
+		}
+		hash, ok := sums[p.Filename]
+		if !ok || hash == "" {
+			continue
+		}
+		if updErr := r.UpdatePlatformSHA256(ctx, p.ID, hash); updErr != nil {
+			return updErr
+		}
+	}
+	return nil
+}
+
 // UpdateGPGVerifiedForVersion sets gpg_verified on all synced platforms for a version.
 // Used to back-fill the flag when a sync run successfully verifies the GPG signature
 // but the platforms were already stored in a previous run.

--- a/backend/internal/db/repositories/terraform_mirror_repository_test.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository_test.go
@@ -1115,6 +1115,98 @@ func TestTerraformMirrorUpdateGPGVerifiedForVersion_DBError(t *testing.T) {
 	}
 }
 
+// --- UpdatePlatformSHA256 ---
+
+func TestTerraformMirrorUpdatePlatformSHA256_Success(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE terraform_version_platforms\s+SET sha256`).
+		WithArgs(id, "deadbeef").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.UpdatePlatformSHA256(context.Background(), id, "deadbeef"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTerraformMirrorUpdatePlatformSHA256_DBError(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE terraform_version_platforms\s+SET sha256`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	if err := repo.UpdatePlatformSHA256(context.Background(), id, "abc"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// --- BackfillPlatformSHA256 ---
+
+func TestTerraformMirrorBackfillPlatformSHA256_NoSums(t *testing.T) {
+	repo, _ := newTerraformMirrorRepo(t)
+	if err := repo.BackfillPlatformSHA256(context.Background(), uuid.New(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTerraformMirrorBackfillPlatformSHA256_UpdatesEmptyHashes(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	versionID := uuid.New()
+
+	// Three platforms: one needs backfill, one already has sha256, one not synced.
+	pNeed := testTFPlatform(versionID)
+	pNeed.SHA256 = ""
+	pNeed.SyncStatus = "synced"
+
+	pHas := testTFPlatform(versionID)
+	pHas.SHA256 = "alreadyset"
+	pHas.SyncStatus = "synced"
+	pHas.Filename = "terraform_1.9.0_darwin_amd64.zip"
+	pHas.OS = "darwin"
+
+	pPending := testTFPlatform(versionID)
+	pPending.SHA256 = ""
+	pPending.SyncStatus = "pending"
+	pPending.Filename = "terraform_1.9.0_windows_amd64.zip"
+	pPending.OS = "windows"
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
+		WithArgs(versionID).
+		WillReturnRows(newTFPlatformRow(mock, pNeed).
+			AddRow(pHas.ID, pHas.VersionID, pHas.OS, pHas.Arch, pHas.UpstreamURL, pHas.Filename, pHas.SHA256,
+				pHas.StorageKey, pHas.StorageBackend, pHas.SHA256Verified, pHas.GPGVerified,
+				pHas.SyncStatus, pHas.SyncError, pHas.SyncedAt, pHas.DownloadCount, pHas.CreatedAt, pHas.UpdatedAt).
+			AddRow(pPending.ID, pPending.VersionID, pPending.OS, pPending.Arch, pPending.UpstreamURL, pPending.Filename, pPending.SHA256,
+				pPending.StorageKey, pPending.StorageBackend, pPending.SHA256Verified, pPending.GPGVerified,
+				pPending.SyncStatus, pPending.SyncError, pPending.SyncedAt, pPending.DownloadCount, pPending.CreatedAt, pPending.UpdatedAt))
+
+	mock.ExpectExec(`UPDATE terraform_version_platforms\s+SET sha256`).
+		WithArgs(pNeed.ID, "linuxhash").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	sums := map[string]string{
+		pNeed.Filename:    "linuxhash",
+		pHas.Filename:     "darwinhash",
+		pPending.Filename: "windowshash",
+	}
+	if err := repo.BackfillPlatformSHA256(context.Background(), versionID, sums); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTerraformMirrorBackfillPlatformSHA256_ListError(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	versionID := uuid.New()
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	if err := repo.BackfillPlatformSHA256(context.Background(), versionID, map[string]string{"x": "y"}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 // --- CountVersionStats ---
 
 func TestTerraformMirrorCountVersionStats_Success(t *testing.T) {

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -407,6 +407,13 @@ func (j *TerraformMirrorSyncJob) performSync(
 		}
 	}
 
+	// 6b. SHA256 back-fill: for already-synced platforms with sha256='', fetch the
+	// upstream SHA256SUMS text (~5KB) and write the per-filename hashes into the
+	// sha256 column. No binaries are re-downloaded.
+	if backfillErr := j.backfillSHA256(ctx, client, cfg, allVersions); backfillErr != nil {
+		log.Printf("[terraform-mirror] SHA256 back-fill error for %s: %v", cfg.Name, backfillErr)
+	}
+
 	// 7. Mark the highest fully-synced stable version as is_latest.
 	if setLatestErr := j.updateLatestVersion(ctx, cfg.ID); setLatestErr != nil {
 		log.Printf("[terraform-mirror] failed to update latest version for %s: %v", cfg.Name, setLatestErr)
@@ -558,6 +565,12 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 		}
 	}
 
+	if sha256Verified {
+		if shaErr := j.repo.UpdatePlatformSHA256(ctx, p.ID, strings.ToLower(actualSHA256)); shaErr != nil {
+			log.Printf("[terraform-mirror] failed to persist sha256 for %s %s/%s: %v", version, p.OS, p.Arch, shaErr)
+		}
+	}
+
 	if _, seekErr := tmpFile.Seek(0, io.SeekStart); seekErr != nil {
 		errStr := fmt.Sprintf("failed to seek temp file: %v", seekErr)
 		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, sha256Verified, sumsGPGVerified, &errStr)
@@ -577,6 +590,66 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 	_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", &storagePath, &backendName, sha256Verified, sumsGPGVerified, nil)
 	log.Printf("[terraform-mirror] stored %s %s/%s -> %s", version, p.OS, p.Arch, storagePath)
 	return true
+}
+
+// backfillSHA256 populates the sha256 column for already-synced platforms whose
+// hash was not persisted during their original sync run. It fetches the
+// lightweight upstream SHA256SUMS text for each filtered version (~5KB each)
+// and writes per-filename hashes — no binary downloads.
+// coverage:skip:integration-only — fetches SUMS files over HTTP and writes to the database; covered by integration tests.
+func (j *TerraformMirrorSyncJob) backfillSHA256(
+	ctx context.Context,
+	client terraformReleasesClient,
+	cfg *models.TerraformMirrorConfig,
+	filteredVersions []mirror.TerraformVersionInfo,
+) error {
+	wantedVersions := make(map[string]bool, len(filteredVersions))
+	for _, vi := range filteredVersions {
+		wantedVersions[vi.Version] = true
+	}
+
+	syncedVersions, err := j.repo.ListVersions(ctx, cfg.ID, true /* syncedOnly */)
+	if err != nil {
+		return fmt.Errorf("failed to list synced versions: %w", err)
+	}
+
+	for _, sv := range syncedVersions {
+		if !wantedVersions[sv.Version] {
+			continue
+		}
+
+		platforms, plErr := j.repo.ListPlatformsForVersion(ctx, sv.ID)
+		if plErr != nil {
+			log.Printf("[terraform-mirror] sha256 backfill: failed to list platforms for %s: %v", sv.Version, plErr)
+			continue
+		}
+		needsBackfill := false
+		for _, p := range platforms {
+			if p.SyncStatus == "synced" && p.SHA256 == "" {
+				needsBackfill = true
+				break
+			}
+		}
+		if !needsBackfill {
+			continue
+		}
+
+		sums, _, sumsErr := client.FetchSHASums(ctx, sv.Version)
+		if sumsErr != nil {
+			log.Printf("[terraform-mirror] sha256 backfill: failed to fetch SUMS for %s: %v", sv.Version, sumsErr)
+			continue
+		}
+		if len(sums) == 0 {
+			continue
+		}
+		if bfErr := j.repo.BackfillPlatformSHA256(ctx, sv.ID, sums); bfErr != nil {
+			log.Printf("[terraform-mirror] sha256 backfill: DB update failed for %s: %v", sv.Version, bfErr)
+			continue
+		}
+		log.Printf("[terraform-mirror] sha256 backfill: populated hashes for version %s", sv.Version)
+	}
+
+	return nil
 }
 
 // backfillGPGVerification re-verifies the SHA256SUMS GPG signature for any synced


### PR DESCRIPTION
Closes #368

## Summary
- Persist the verified hex SHA256 on each platform row during sync so the per-platform download endpoint returns a non-empty `sha256` field.
- Add a backfill pass to `performSync` that populates the column for already-synced rows by re-fetching only the upstream `SHA256SUMS` text (~5KB per version) — no binaries are re-downloaded.
- Add `UpdatePlatformSHA256` and `BackfillPlatformSHA256` repo helpers, with unit tests.

## Why
API consumers (e.g. the `PipelineTerraformInstaller` ADO task) need the hash to verify the downloaded zip locally instead of trusting the pre-signed URL implicitly.

## Backfill
Once deployed, hitting `POST /terraform/binaries/:name/sync` (or the next scheduled tick) will populate all historical `sha256 = ""` rows. The pass is a no-op after rows are populated.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/db/repositories ./internal/jobs -count=1` — passes; repositories at 88.5%
- [ ] After deploy: trigger manual sync on an existing mirror config, confirm `terraform_version_platforms.sha256` is populated and `GET /terraform/binaries/:name/versions/:v/:os/:arch` returns a non-empty `sha256` field.