### PR TITLE
fix(jobs): reset started flag and reinitialize stopChan on scanner lifecycle

### DIFF
--- a/backend/internal/jobs/module_scanner_job.go
+++ b/backend/internal/jobs/module_scanner_job.go
@@ -72,6 +72,7 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 		return nil
 	}
 	j.started = true
+	stopChan := j.stopChan // capture under mutex; Stop() may replace the field concurrently
 	j.mu.Unlock()
 
 	s, err := scanner.New(j.cfg)
@@ -125,9 +126,12 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 		select {
 		case <-ticker.C:
 			j.runScanCycle(ctx, s, actualVersion)
-		case <-j.stopChan:
+		case <-stopChan:
 			return nil
 		case <-ctx.Done():
+			j.mu.Lock()
+			j.started = false
+			j.mu.Unlock()
 			return nil
 		}
 	}

--- a/backend/internal/jobs/module_scanner_job.go
+++ b/backend/internal/jobs/module_scanner_job.go
@@ -76,6 +76,9 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 
 	s, err := scanner.New(j.cfg)
 	if err != nil {
+		j.mu.Lock()
+		j.started = false
+		j.mu.Unlock()
 		slog.Error("module scanner: failed to construct scanner", "error", err)
 		return nil // non-fatal — do not crash the server
 	}
@@ -83,11 +86,17 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 	// Supply-chain version pinning check.
 	actualVersion, err := s.Version(ctx)
 	if err != nil {
+		j.mu.Lock()
+		j.started = false
+		j.mu.Unlock()
 		slog.Error("module scanner: cannot get binary version",
 			"tool", j.cfg.Tool, "binary", j.cfg.BinaryPath, "error", err)
 		return nil
 	}
 	if j.cfg.ExpectedVersion != "" && actualVersion != j.cfg.ExpectedVersion {
+		j.mu.Lock()
+		j.started = false
+		j.mu.Unlock()
 		slog.Error("module scanner: binary version mismatch — refusing to run",
 			"tool", j.cfg.Tool,
 			"expected", j.cfg.ExpectedVersion,
@@ -127,13 +136,11 @@ func (j *ModuleScannerJob) Start(ctx context.Context) error {
 // Stop signals the job to exit gracefully.
 func (j *ModuleScannerJob) Stop() error {
 	j.mu.Lock()
-	j.started = false
-	j.mu.Unlock()
-	select {
-	case <-j.stopChan:
-		// already stopped
-	default:
+	defer j.mu.Unlock()
+	if j.started {
 		close(j.stopChan)
+		j.stopChan = make(chan struct{}) // fresh channel so Start() can be called again
+		j.started = false
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- On init failure (`scanner.New`, `s.Version`, version-pin mismatch), `Start()` now resets `j.started = false` before returning, so the setup wizard can retry without a server restart. Fixes #382.
- `Stop()` now closes and **replaces** `j.stopChan` under the mutex; a subsequent `Start()` gets a fresh channel instead of immediately exiting its select loop. Fixes #383.

## Test plan

- [ ] Start scanner with a bad binary path → confirm `Start()` returns early, `started` is false, calling `Start()` again with a correct path succeeds
- [ ] Call `Start()`, then `Stop()`, then `Start()` again → confirm the scan loop resumes (not immediately exits)
- [ ] Duplicate `Start()` while running → confirm "already running" log and no second goroutine