### PR TITLE
fix(jobs): handle uuid.Parse error in mirror_sync; fix N+1 ListVersions query

### DIFF
--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -470,7 +470,10 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 		localProvider = existingProvider
 
 		// Get existing mirrored provider record
-		providerUUID, _ := uuid.Parse(localProvider.ID)
+		providerUUID, err := uuid.Parse(localProvider.ID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid provider ID %q in database: %w", localProvider.ID, err)
+		}
 		mirroredProvider, err = j.mirrorRepo.GetMirroredProviderByProviderID(ctx, providerUUID)
 
 		// If the provider exists but isn't tracked as mirrored yet, create the tracking record
@@ -480,7 +483,7 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 			mirroredProvider = &models.MirroredProvider{
 				ID:                uuid.New(),
 				MirrorConfigID:    config.ID,
-				ProviderID:        uuid.MustParse(localProvider.ID),
+				ProviderID:        providerUUID,
 				UpstreamNamespace: namespace,
 				UpstreamType:      providerName,
 				LastSyncedAt:      time.Now(),

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -372,12 +372,12 @@ func (j *TerraformMirrorSyncJob) performSync(
 		versionID uuid.UUID
 		platforms []models.TerraformVersionPlatform
 	}
-	allVersionsList, versionsErr := j.repo.ListVersions(ctx, cfg.ID, false)
+	dbVersions, versionsErr := j.repo.ListVersions(ctx, cfg.ID, false)
 	if versionsErr != nil {
 		return 0, 0, 0, details, fmt.Errorf("failed to list versions for grouping: %w", versionsErr)
 	}
-	versionByID := make(map[uuid.UUID]models.TerraformVersion, len(allVersionsList))
-	for _, vv := range allVersionsList {
+	versionByID := make(map[uuid.UUID]models.TerraformVersion, len(dbVersions))
+	for _, vv := range dbVersions {
 		versionByID[vv.ID] = vv
 	}
 

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -777,11 +777,6 @@ func gpgKeyForTool(tool string) string {
 	case "terraform":
 		return mirror.HashiCorpReleasesGPGKey
 	case "opentofu":
-		// OpenTofu key requires a non-placeholder value to be embedded.
-		// Until the real key is embedded, return "" to skip verification.
-		if strings.Contains(mirror.OpenTofuReleasesGPGKey, "<INSERT_OPENTOFU_GPG_KEY_HERE>") {
-			return ""
-		}
 		return mirror.OpenTofuReleasesGPGKey
 	default:
 		return ""

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -372,17 +372,22 @@ func (j *TerraformMirrorSyncJob) performSync(
 		versionID uuid.UUID
 		platforms []models.TerraformVersionPlatform
 	}
+	allVersionsList, versionsErr := j.repo.ListVersions(ctx, cfg.ID, false)
+	if versionsErr != nil {
+		return 0, 0, 0, details, fmt.Errorf("failed to list versions for grouping: %w", versionsErr)
+	}
+	versionByID := make(map[uuid.UUID]models.TerraformVersion, len(allVersionsList))
+	for _, vv := range allVersionsList {
+		versionByID[vv.ID] = vv
+	}
+
 	groups := make(map[uuid.UUID]*platformGroup)
 	for _, p := range pendingPlatforms {
 		if _, ok := groups[p.VersionID]; !ok {
-			versions, _ := j.repo.ListVersions(ctx, cfg.ID, false)
-			for _, vv := range versions {
-				if vv.ID == p.VersionID {
-					groups[p.VersionID] = &platformGroup{
-						version:   vv.Version,
-						versionID: vv.ID,
-					}
-					break
+			if vv, found := versionByID[p.VersionID]; found {
+				groups[p.VersionID] = &platformGroup{
+					version:   vv.Version,
+					versionID: vv.ID,
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- **#384** (`mirror_sync.go`): `uuid.Parse` error was silently discarded (`_, _`). On a malformed ID, `GetMirroredProviderByProviderID` would receive the zero UUID and potentially return `nil`, after which `uuid.MustParse` would **panic** and crash the sync goroutine. Now returns a wrapped error; the parsed UUID is reused in the `MirroredProvider` struct, removing the duplicate `MustParse` call.

- **#381** (`terraform_mirror_sync.go`): The platform-grouping loop called `j.repo.ListVersions` once per unique `VersionID` in `pendingPlatforms` — O(N) queries each returning all versions for the config. Hoisted the call before the loop, built a `dbVersions` lookup map (O(1) access per entry), and surfaced the error instead of discarding it. Renamed `allVersionsList` → `dbVersions` to avoid confusion with the upstream `allVersions` variable in the same function.

- **Dead code removal** (`terraform_mirror_sync.go`, `gpgKeyForTool`): removed the `strings.Contains(..., "<INSERT_OPENTOFU_GPG_KEY_HERE>")` guard. The real OpenTofu PGP key is already embedded in `mirror/terraform_releases.go` (verified: key block starts `mQINBGVUyIwBEAD...`); the placeholder string is not present so the guard was always a no-op. Removing it keeps the switch consistent with the `terraform` case. Closed #387 as not-a-bug.

## Test plan

- [ ] Mirror sync completes normally with valid provider IDs
- [ ] Mirror sync with a large number of pending platforms issues exactly one `ListVersions` query (check query logs / metrics)
- [ ] DB corruption simulation: malformed provider ID returns a clean error, not a panic
- [ ] OpenTofu mirror sync with `gpg_verify: true` verifies binaries correctly (key is present and returned by `gpgKeyForTool`)