### PR TITLE
fix(auth): add session_expires_at to GET /api/v1/auth/me response

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -15819,6 +15819,9 @@
                         }
                     },
                     "role_template": {},
+                    "session_expires_at": {
+                        "type": "string"
+                    },
                     "user": {
                         "$ref": "#/components/schemas/User"
                     }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12834,6 +12834,9 @@
                     }
                 },
                 "role_template": {},
+                "session_expires_at": {
+                    "type": "string"
+                },
                 "user": {
                     "$ref": "#/definitions/User"
                 }

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -755,7 +755,7 @@ func (h *AuthHandlers) MeHandler() gin.HandlerFunc {
 		// Include session expiry from JWT claims so the frontend can schedule the
 		// pre-expiry warning dialog for cookie-based sessions. Absent for API-key auth.
 		if claimsVal, ok := c.Get("jwt_claims"); ok {
-			if claims, ok := claimsVal.(*auth.Claims); ok {
+			if claims, ok := claimsVal.(*auth.Claims); ok && claims.ExpiresAt != nil {
 				t := claims.ExpiresAt.Time
 				response["session_expires_at"] = t
 			}

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -752,6 +752,15 @@ func (h *AuthHandlers) MeHandler() gin.HandlerFunc {
 		// and provide a "primary" role template (highest privilege) for backward compatibility
 		response["allowed_scopes"] = userWithRoles.GetAllowedScopes()
 
+		// Include session expiry from JWT claims so the frontend can schedule the
+		// pre-expiry warning dialog for cookie-based sessions. Absent for API-key auth.
+		if claimsVal, ok := c.Get("jwt_claims"); ok {
+			if claims, ok := claimsVal.(*auth.Claims); ok {
+				t := claims.ExpiresAt.Time
+				response["session_expires_at"] = t
+			}
+		}
+
 		// For backward compatibility, provide the first membership's role template as primary
 		// In a multi-org setup, the frontend should use per-org memberships
 		if len(userWithRoles.Memberships) > 0 && userWithRoles.Memberships[0].RoleTemplateID != nil {

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -36,10 +36,11 @@ type MeMembershipEntry struct {
 
 // MeResponse is returned by GET /api/v1/auth/me.
 type MeResponse struct {
-	User          MeUserInfo          `json:"user"`
-	Memberships   []MeMembershipEntry `json:"memberships"`
-	AllowedScopes []string            `json:"allowed_scopes"`
-	RoleTemplate  interface{}         `json:"role_template"`
+	User             MeUserInfo          `json:"user"`
+	Memberships      []MeMembershipEntry `json:"memberships"`
+	AllowedScopes    []string            `json:"allowed_scopes"`
+	RoleTemplate     interface{}         `json:"role_template"`
+	SessionExpiresAt *time.Time          `json:"session_expires_at,omitempty"`
 }
 
 // APIKeyItem represents a single API key in list/get responses.


### PR DESCRIPTION
## Summary

- `GET /api/v1/auth/me` now returns `session_expires_at` (RFC 3339) populated from JWT claims already in the gin context
- Field is omitted for API-key authenticated requests (no JWT session)
- `MeResponse` Swagger struct updated to document the new field

## Problem (see #393)

The frontend's session-expiry warning dialog was never shown for cookie-based OIDC sessions because the HttpOnly cookie expiry is inaccessible to JavaScript. The frontend needs the expiry timestamp from the server to schedule the pre-expiry warning and silent-refresh attempt.

## Fix

The auth middleware already validates the JWT and stores the parsed claims as `"jwt_claims"` in the gin context. `MeHandler` retrieves these claims and includes `ExpiresAt` in the response:

```go
if claimsVal, ok := c.Get("jwt_claims"); ok {
    if claims, ok := claimsVal.(*auth.Claims); ok {
        response["session_expires_at"] = claims.ExpiresAt.Time
    }
}
```

No new DB queries — the expiry comes from the already-validated in-memory claims.

## Test plan

- [ ] `curl -b <cookie> /api/v1/auth/me` — confirm `session_expires_at` present and ~24h in the future
- [ ] `curl -H "Authorization: ApiKey <key>" /api/v1/auth/me` — confirm `session_expires_at` absent
- [ ] Existing auth handler tests pass

Closes #393