### PR TITLE
fix(security): enforce scanner Tool allowlist on save and startup-reload paths

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -211,20 +211,28 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 				InstallDir        string `json:"install_dir"`
 			}
 			if err := json.Unmarshal(scanConfigJSON, &dbInput); err == nil && dbInput.Enabled {
-				cfg.Scanning.Enabled = dbInput.Enabled
-				cfg.Scanning.Tool = dbInput.Tool
-				cfg.Scanning.BinaryPath = dbInput.BinaryPath
-				cfg.Scanning.ExpectedVersion = dbInput.ExpectedVersion
-				cfg.Scanning.SeverityThreshold = dbInput.SeverityThreshold
-				cfg.Scanning.WorkerCount = dbInput.WorkerCount
-				if dbInput.TimeoutSecs > 0 {
-					cfg.Scanning.Timeout = time.Duration(dbInput.TimeoutSecs) * time.Second
-				}
-				if dbInput.ScanIntervalMins > 0 {
-					cfg.Scanning.ScanIntervalMins = dbInput.ScanIntervalMins
-				}
-				if dbInput.InstallDir != "" {
-					cfg.Scanning.InstallDir = dbInput.InstallDir
+				// Re-validate the persisted tool name. SaveScanningConfig now
+				// guards this at write time, but DB rows written by older
+				// versions could still carry a non-allowlisted value that
+				// would flow into filepath.Join(InstallDir, Tool) below.
+				if !setup.IsValidScanningTool(dbInput.Tool) {
+					log.Printf("scanner startup: refusing to apply DB config with unsupported tool %q; scanning will remain disabled until reconfigured", dbInput.Tool)
+				} else {
+					cfg.Scanning.Enabled = dbInput.Enabled
+					cfg.Scanning.Tool = dbInput.Tool
+					cfg.Scanning.BinaryPath = dbInput.BinaryPath
+					cfg.Scanning.ExpectedVersion = dbInput.ExpectedVersion
+					cfg.Scanning.SeverityThreshold = dbInput.SeverityThreshold
+					cfg.Scanning.WorkerCount = dbInput.WorkerCount
+					if dbInput.TimeoutSecs > 0 {
+						cfg.Scanning.Timeout = time.Duration(dbInput.TimeoutSecs) * time.Second
+					}
+					if dbInput.ScanIntervalMins > 0 {
+						cfg.Scanning.ScanIntervalMins = dbInput.ScanIntervalMins
+					}
+					if dbInput.InstallDir != "" {
+						cfg.Scanning.InstallDir = dbInput.InstallDir
+					}
 				}
 			}
 		}

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -575,6 +575,28 @@ func (h *Handlers) CompleteSetup(c *gin.Context) {
 
 // === Scanning Configuration ===
 
+// validScanningTools is the allowlist of supported scanner backends. Any code
+// path that accepts a Tool value from outside the binary (HTTP body, DB row)
+// MUST validate against this set before the value flows into filesystem or
+// process-invocation paths — see internal/scanner.ResolveBinaryPath, which
+// joins InstallDir + Tool when falling back from a missing BinaryPath.
+var validScanningTools = map[string]bool{
+	"trivy":     true,
+	"terrascan": true,
+	"snyk":      true,
+	"checkov":   true,
+	"custom":    true,
+}
+
+// IsValidScanningTool reports whether tool is in the supported-scanners allowlist.
+// Exported so the router's startup-reload path can re-validate persisted DB values
+// before they are written into the live config.
+func IsValidScanningTool(tool string) bool {
+	return validScanningTools[tool]
+}
+
+const supportedScanningToolsList = "trivy, terrascan, snyk, checkov, custom"
+
 // TestScanningConfigInput is the request body for testing a scanning configuration.
 type TestScanningConfigInput struct {
 	Tool            string `json:"tool" binding:"required"`
@@ -601,14 +623,11 @@ func (h *Handlers) TestScanningConfig(c *gin.Context) {
 		return
 	}
 
-	// Validate tool is one of the supported scanners
-	validTools := map[string]bool{
-		"trivy": true, "terrascan": true, "snyk": true, "checkov": true, "custom": true,
-	}
-	if !validTools[input.Tool] {
+	// Validate tool is one of the supported scanners.
+	if !IsValidScanningTool(input.Tool) {
 		c.JSON(http.StatusOK, TestScanningConfigResponse{
 			Success: false,
-			Error:   fmt.Sprintf("unsupported tool %q; must be one of: trivy, terrascan, snyk, checkov, custom", input.Tool),
+			Error:   fmt.Sprintf("unsupported tool %q; must be one of: %s", input.Tool, supportedScanningToolsList),
 		})
 		return
 	}
@@ -705,6 +724,16 @@ func (h *Handlers) SaveScanningConfig(c *gin.Context) {
 	var input SaveScanningConfigInput
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Validate tool is one of the supported scanners. Without this, an arbitrary
+	// Tool value would be persisted and later flow into filepath.Join(InstallDir,
+	// Tool) at scanner startup (see internal/scanner.ResolveBinaryPath).
+	if !IsValidScanningTool(input.Tool) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("unsupported tool %q; must be one of: %s", input.Tool, supportedScanningToolsList),
+		})
 		return
 	}
 

--- a/backend/internal/api/setup/scanning_test.go
+++ b/backend/internal/api/setup/scanning_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,6 +156,54 @@ func TestSaveScanningConfig_MissingToolField(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400 for missing tool", w.Code)
+	}
+}
+
+func TestIsValidScanningTool(t *testing.T) {
+	cases := []struct {
+		tool string
+		want bool
+	}{
+		{"trivy", true},
+		{"terrascan", true},
+		{"snyk", true},
+		{"checkov", true},
+		{"custom", true},
+		{"", false},
+		{"TRIVY", false},
+		{"../etc/passwd", false},
+		{"trivy ", false},
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.tool, func(t *testing.T) {
+			if got := IsValidScanningTool(tc.tool); got != tc.want {
+				t.Errorf("IsValidScanningTool(%q) = %v, want %v", tc.tool, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSaveScanningConfig_UnsupportedTool(t *testing.T) {
+	env := newTestEnv(t)
+
+	r := gin.New()
+	r.POST("/scanning", env.h.SaveScanningConfig)
+
+	// Non-allowlisted Tool value — must be rejected before any DB/filesystem call.
+	body := jsonBody(map[string]string{
+		"tool":        "../etc/passwd",
+		"binary_path": "/app/scanners/trivy",
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scanning", body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for unsupported tool", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "unsupported tool") {
+		t.Errorf("response body missing 'unsupported tool': %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
`SaveScanningConfig` accepted any string for `tool` and persisted it verbatim. On startup, `router.go` reads the DB row back and feeds it into `filepath.Join(InstallDir, Tool)` via `ResolveBinaryPath` — an `os.Stat` against an attacker-chosen path inside or above the scanner install directory. The `TestScanningConfig` endpoint already had the allowlist; this closes the TOCTOU gap.

- Hoist the supported-scanners map to package scope as `validScanningTools`.
- Export `IsValidScanningTool` so the router'\''s startup-reload path can re-use it.
- Reject non-allowlisted `Tool` values in `SaveScanningConfig` with HTTP 400 before any filesystem or DB call.
- Re-validate the persisted `Tool` on startup; if a DB row from an older version carries a non-allowlisted value, log and leave scanning disabled rather than apply it.

## CodeQL impact
Closes the genuine portion of `go/path-injection` alerts #33 and #34 on `scanner.go:67` and `:73`. The remaining alerts on those lines and on `handlers.go:629` are CodeQL-untraceable sanitization (InstallDir prefix check, semver validation upstream of URL interpolation) and will be **dismissed as `won''t fix`** with references back to this PR after merge.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/api/... -count=1` — all green
- [x] New tests: `TestIsValidScanningTool` table-driven (incl. `../etc/passwd`, uppercase, trailing space, unknown); `TestSaveScanningConfig_UnsupportedTool` confirms HTTP 400 before any filesystem call.