### PR TITLE
fix(terraform-binaries): persist and serve SHA256SUMS + GPG signature

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -18018,6 +18018,12 @@
                     "sha256": {
                         "type": "string"
                     },
+                    "shasums_signature_url": {
+                        "type": "string"
+                    },
+                    "shasums_url": {
+                        "type": "string"
+                    },
                     "version": {
                         "type": "string"
                     }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -15033,6 +15033,12 @@
                 "sha256": {
                     "type": "string"
                 },
+                "shasums_signature_url": {
+                    "type": "string"
+                },
+                "shasums_url": {
+                    "type": "string"
+                },
                 "version": {
                     "type": "string"
                 }

--- a/backend/internal/api/terraform_binaries/binaries.go
+++ b/backend/internal/api/terraform_binaries/binaries.go
@@ -291,6 +291,27 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 		return
 	}
 
+	// Generate pre-signed URLs for the per-version SHA256SUMS and its detached
+	// GPG signature when the sync job has uploaded them. Both are optional —
+	// older versions synced before signature persistence was introduced will
+	// not have storage keys and the corresponding URLs will be empty strings.
+	shasumsURL := ""
+	if version.SumsStorageKey != nil && *version.SumsStorageKey != "" {
+		if url, sumsErr := h.storageBackend.GetURL(c.Request.Context(), *version.SumsStorageKey, 15*time.Minute); sumsErr == nil {
+			shasumsURL = url
+		} else {
+			slog.Warn("failed to generate SHA256SUMS URL", "version", version.Version, "error", sumsErr)
+		}
+	}
+	shasumsSignatureURL := ""
+	if version.SigStorageKey != nil && *version.SigStorageKey != "" {
+		if url, sigErr := h.storageBackend.GetURL(c.Request.Context(), *version.SigStorageKey, 15*time.Minute); sigErr == nil {
+			shasumsSignatureURL = url
+		} else {
+			slog.Warn("failed to generate SHA256SUMS signature URL", "version", version.Version, "error", sigErr)
+		}
+	}
+
 	// Increment Prometheus download counter and persist to DB (non-blocking).
 	telemetry.TerraformBinaryDownloadsTotal.WithLabelValues(versionStr, osStr, archStr).Inc()
 	go func() {
@@ -334,11 +355,13 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, models.TerraformBinaryDownloadResponse{
-		OS:          platform.OS,
-		Arch:        platform.Arch,
-		Version:     version.Version,
-		Filename:    platform.Filename,
-		SHA256:      platform.SHA256,
-		DownloadURL: downloadURL,
+		OS:                  platform.OS,
+		Arch:                platform.Arch,
+		Version:             version.Version,
+		Filename:            platform.Filename,
+		SHA256:              platform.SHA256,
+		DownloadURL:         downloadURL,
+		ShasumsURL:          shasumsURL,
+		ShasumsSignatureURL: shasumsSignatureURL,
 	})
 }

--- a/backend/internal/api/terraform_binaries/binaries_test.go
+++ b/backend/internal/api/terraform_binaries/binaries_test.go
@@ -39,6 +39,7 @@ var configCols = []string{
 var versionCols = []string{
 	"id", "config_id", "version", "is_latest", "is_deprecated", "release_date",
 	"sync_status", "sync_error", "synced_at", "created_at", "updated_at",
+	"sums_storage_key", "sig_storage_key",
 }
 
 var platformCols = []string{
@@ -61,6 +62,18 @@ func sampleVersionRow(version string, isLatest bool) *sqlmock.Rows {
 	return sqlmock.NewRows(versionCols).AddRow(
 		sampleVersionID, sampleConfigID, version, isLatest, false, nil,
 		"synced", nil, time.Now(), time.Now(), time.Now(),
+		nil, nil,
+	)
+}
+
+// sampleVersionRowWithSignature is like sampleVersionRow but with populated
+// sums_storage_key and sig_storage_key columns — used to exercise the GPG
+// signature URL path on the download response.
+func sampleVersionRowWithSignature(version string, isLatest bool, sumsKey, sigKey string) *sqlmock.Rows {
+	return sqlmock.NewRows(versionCols).AddRow(
+		sampleVersionID, sampleConfigID, version, isLatest, false, nil,
+		"synced", nil, time.Now(), time.Now(), time.Now(),
+		sumsKey, sigKey,
 	)
 }
 
@@ -309,6 +322,7 @@ func TestGetVersion_PendingVersion(t *testing.T) {
 	pendingRow := sqlmock.NewRows(versionCols).AddRow(
 		sampleVersionID, sampleConfigID, "1.9.0", false, false, nil,
 		"pending", nil, nil, time.Now(), time.Now(),
+		nil, nil,
 	)
 
 	mock.ExpectQuery(`SELECT.*FROM terraform_mirror_configs.*WHERE name`).
@@ -355,6 +369,50 @@ func TestDownloadBinary_Success(t *testing.T) {
 	assert.Equal(t, "https://example.com/signed-download-url", resp["download_url"])
 	assert.Equal(t, "linux", resp["os"])
 	assert.Equal(t, "amd64", resp["arch"])
+	// Versions synced before signature persistence have no storage keys —
+	// the URLs must still be present in the response (empty strings) so
+	// clients can rely on the field being there.
+	assert.Equal(t, "", resp["shasums_url"])
+	assert.Equal(t, "", resp["shasums_signature_url"])
+}
+
+func TestDownloadBinary_ReturnsSignatureURLsWhenStored(t *testing.T) {
+	// Verifies the fix for #402: when the sync job has stored both the
+	// SHA256SUMS file and its detached GPG signature for a version, the
+	// public download endpoint returns signed URLs for both alongside
+	// the binary's download URL.
+	store := &mockStorage{url: "https://example.com/signed-download-url"}
+	mock, r := newRouter(t, store)
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_mirror_configs.*WHERE name`).
+		WithArgs(sampleConfigName).
+		WillReturnRows(sampleConfigRow())
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_versions.*WHERE config_id.*version`).
+		WithArgs(sampleConfigID, "1.9.0").
+		WillReturnRows(sampleVersionRowWithSignature(
+			"1.9.0", true,
+			"terraform-binaries/1.9.0/SHA256SUMS",
+			"terraform-binaries/1.9.0/SHA256SUMS.terraform.sig",
+		))
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms.*WHERE version_id.*os.*arch`).
+		WithArgs(sampleVersionID, "linux", "amd64").
+		WillReturnRows(samplePlatformRow("tf/1.9.0/linux_amd64.zip"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+sampleConfigName+"/versions/1.9.0/linux/amd64", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	// All three URLs come from the same mock storage so they share a value;
+	// what we care about is that both signature fields are NON-EMPTY when
+	// keys exist in the DB.
+	assert.NotEmpty(t, resp["shasums_url"], "shasums_url must be returned when sums_storage_key is set")
+	assert.NotEmpty(t, resp["shasums_signature_url"], "shasums_signature_url must be returned when sig_storage_key is set")
 }
 
 func TestDownloadBinary_InvalidVersion(t *testing.T) {

--- a/backend/internal/db/migrations/000034_terraform_version_signature_storage.down.sql
+++ b/backend/internal/db/migrations/000034_terraform_version_signature_storage.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE terraform_versions
+    DROP COLUMN IF EXISTS sums_storage_key,
+    DROP COLUMN IF EXISTS sig_storage_key;

--- a/backend/internal/db/migrations/000034_terraform_version_signature_storage.up.sql
+++ b/backend/internal/db/migrations/000034_terraform_version_signature_storage.up.sql
@@ -1,0 +1,13 @@
+-- Persist the GPG signature and SHA256SUMS files alongside the binaries so
+-- the public download endpoint can hand them back to clients for offline
+-- verification. Prior to this migration the sync job fetched both files
+-- only to verify GPG and then discarded them, leaving no way to serve a
+-- .sig file at download time.
+ALTER TABLE terraform_versions
+    ADD COLUMN IF NOT EXISTS sums_storage_key TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS sig_storage_key  TEXT DEFAULT NULL;
+
+COMMENT ON COLUMN terraform_versions.sums_storage_key IS
+    'Storage backend key for the GPG-verified SHA256SUMS file. NULL until sync has stored it.';
+COMMENT ON COLUMN terraform_versions.sig_storage_key IS
+    'Storage backend key for the GPG signature (.sig) of SHA256SUMS. NULL until sync has stored it.';

--- a/backend/internal/db/models/terraform_mirror.go
+++ b/backend/internal/db/models/terraform_mirror.go
@@ -49,6 +49,13 @@ type TerraformVersion struct {
 	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
 
+	// Storage keys for the per-version GPG-verified SHA256SUMS file and its
+	// detached signature. NULL until the sync job has uploaded them. Used by
+	// the public download endpoint to hand clients both files for offline
+	// signature verification.
+	SumsStorageKey *string `json:"-" db:"sums_storage_key"`
+	SigStorageKey  *string `json:"-" db:"sig_storage_key"`
+
 	// Populated by joins — not stored in columns
 	Platforms []TerraformVersionPlatform `json:"platforms,omitempty" db:"-"`
 }
@@ -147,11 +154,16 @@ type TerraformSyncHistoryListResponse struct {
 }
 
 // TerraformBinaryDownloadResponse is returned by the public download endpoint.
+// ShasumsURL and ShasumsSignatureURL are populated when the sync job has stored
+// the GPG-verified SHA256SUMS and its detached .sig file for this version; they
+// are empty strings when no signature/sums file is available yet.
 type TerraformBinaryDownloadResponse struct {
-	OS          string `json:"os"`
-	Arch        string `json:"arch"`
-	Version     string `json:"version"`
-	Filename    string `json:"filename"`
-	SHA256      string `json:"sha256"`
-	DownloadURL string `json:"download_url"`
+	OS                  string `json:"os"`
+	Arch                string `json:"arch"`
+	Version             string `json:"version"`
+	Filename            string `json:"filename"`
+	SHA256              string `json:"sha256"`
+	DownloadURL         string `json:"download_url"`
+	ShasumsURL          string `json:"shasums_url"`
+	ShasumsSignatureURL string `json:"shasums_signature_url"`
 }

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -280,7 +280,8 @@ func (r *TerraformMirrorRepository) UpsertVersion(ctx context.Context, v *models
 		SET release_date  = COALESCE(EXCLUDED.release_date, terraform_versions.release_date),
 		    updated_at    = EXCLUDED.updated_at
 		RETURNING id, config_id, version, is_latest, is_deprecated, release_date,
-		          sync_status, sync_error, synced_at, created_at, updated_at
+		          sync_status, sync_error, synced_at, created_at, updated_at,
+		          sums_storage_key, sig_storage_key
 	`
 
 	return r.db.QueryRowContext(ctx, query,
@@ -305,6 +306,8 @@ func (r *TerraformMirrorRepository) UpsertVersion(ctx context.Context, v *models
 		&v.SyncedAt,
 		&v.CreatedAt,
 		&v.UpdatedAt,
+		&v.SumsStorageKey,
+		&v.SigStorageKey,
 	)
 }
 
@@ -312,7 +315,8 @@ func (r *TerraformMirrorRepository) UpsertVersion(ctx context.Context, v *models
 func (r *TerraformMirrorRepository) GetVersionByString(ctx context.Context, configID uuid.UUID, version string) (*models.TerraformVersion, error) {
 	query := `
 		SELECT id, config_id, version, is_latest, is_deprecated, release_date,
-		       sync_status, sync_error, synced_at, created_at, updated_at
+		       sync_status, sync_error, synced_at, created_at, updated_at,
+		       sums_storage_key, sig_storage_key
 		FROM terraform_versions
 		WHERE config_id = $1 AND version = $2
 	`
@@ -333,7 +337,8 @@ func (r *TerraformMirrorRepository) GetVersionByString(ctx context.Context, conf
 func (r *TerraformMirrorRepository) GetLatestVersion(ctx context.Context, configID uuid.UUID) (*models.TerraformVersion, error) {
 	query := `
 		SELECT id, config_id, version, is_latest, is_deprecated, release_date,
-		       sync_status, sync_error, synced_at, created_at, updated_at
+		       sync_status, sync_error, synced_at, created_at, updated_at,
+		       sums_storage_key, sig_storage_key
 		FROM terraform_versions
 		WHERE config_id = $1 AND is_latest = true
 		LIMIT 1
@@ -356,7 +361,8 @@ func (r *TerraformMirrorRepository) GetLatestVersion(ctx context.Context, config
 func (r *TerraformMirrorRepository) ListVersions(ctx context.Context, configID uuid.UUID, syncedOnly bool) ([]models.TerraformVersion, error) {
 	query := `
 		SELECT id, config_id, version, is_latest, is_deprecated, release_date,
-		       sync_status, sync_error, synced_at, created_at, updated_at
+		       sync_status, sync_error, synced_at, created_at, updated_at,
+		       sums_storage_key, sig_storage_key
 		FROM terraform_versions
 		WHERE config_id = $1
 	`
@@ -390,7 +396,8 @@ func (r *TerraformMirrorRepository) ListVersionsPaginated(ctx context.Context, c
 
 	query := `
 		SELECT id, config_id, version, is_latest, is_deprecated, release_date,
-		       sync_status, sync_error, synced_at, created_at, updated_at
+		       sync_status, sync_error, synced_at, created_at, updated_at,
+		       sums_storage_key, sig_storage_key
 		FROM terraform_versions
 		WHERE config_id = $1
 	`
@@ -409,6 +416,24 @@ func (r *TerraformMirrorRepository) ListVersionsPaginated(ctx context.Context, c
 	}
 
 	return versions, total, nil
+}
+
+// UpdateVersionSignatureStorage persists the storage keys for the per-version
+// SHA256SUMS file and its detached GPG signature. Both keys may be set
+// independently — a nil value leaves the existing column unchanged.
+func (r *TerraformMirrorRepository) UpdateVersionSignatureStorage(ctx context.Context, id uuid.UUID, sumsKey, sigKey *string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE terraform_versions
+		    SET sums_storage_key = COALESCE($2, sums_storage_key),
+		        sig_storage_key  = COALESCE($3, sig_storage_key),
+		        updated_at       = NOW()
+		  WHERE id = $1`,
+		id, sumsKey, sigKey,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update terraform version signature storage: %w", err)
+	}
+	return nil
 }
 
 // UpdateVersionSyncStatus updates the sync_status, sync_error, and synced_at for a version.

--- a/backend/internal/db/repositories/terraform_mirror_repository_test.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository_test.go
@@ -498,12 +498,14 @@ func TestTerraformMirrorUpdateSyncStatus_DBError(t *testing.T) {
 var tfVersionCols = []string{
 	"id", "config_id", "version", "is_latest", "is_deprecated", "release_date",
 	"sync_status", "sync_error", "synced_at", "created_at", "updated_at",
+	"sums_storage_key", "sig_storage_key",
 }
 
 func newTFVersionRow(mock sqlmock.Sqlmock, v *models.TerraformVersion) *sqlmock.Rows {
 	return mock.NewRows(tfVersionCols).AddRow(
 		v.ID, v.ConfigID, v.Version, v.IsLatest, v.IsDeprecated, v.ReleaseDate,
 		v.SyncStatus, v.SyncError, v.SyncedAt, v.CreatedAt, v.UpdatedAt,
+		v.SumsStorageKey, v.SigStorageKey,
 	)
 }
 

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -420,6 +420,14 @@ func (j *TerraformMirrorSyncJob) performSync(
 		log.Printf("[terraform-mirror] SHA256 back-fill error for %s: %v", cfg.Name, backfillErr)
 	}
 
+	// 6c. Signature back-fill: upload SHA256SUMS and its detached GPG signature
+	// for any already-synced version whose storage keys are still NULL. This
+	// covers versions synced before signature persistence was introduced; the
+	// public download endpoint will now return populated URLs for them.
+	if backfillErr := j.backfillSignatureStorage(ctx, client, cfg, allVersions); backfillErr != nil {
+		log.Printf("[terraform-mirror] signature back-fill error for %s: %v", cfg.Name, backfillErr)
+	}
+
 	// 7. Mark the highest fully-synced stable version as is_latest.
 	if setLatestErr := j.updateLatestVersion(ctx, cfg.ID); setLatestErr != nil {
 		log.Printf("[terraform-mirror] failed to update latest version for %s: %v", cfg.Name, setLatestErr)
@@ -790,6 +798,71 @@ func (j *TerraformMirrorSyncJob) backfillGPGVerification(
 		if updErr := j.repo.UpdateGPGVerifiedForVersion(ctx, sv.ID, true); updErr != nil {
 			log.Printf("[terraform-mirror] backfill: failed to update gpg_verified for %s: %v", sv.Version, updErr)
 		}
+	}
+
+	return nil
+}
+
+// backfillSignatureStorage uploads the per-version SHA256SUMS file and (when
+// GPG verification succeeds) its detached signature for any already-synced
+// version whose sums_storage_key or sig_storage_key column is still NULL.
+// This covers versions synced before signature persistence was introduced.
+// Binaries are never re-downloaded — only the small SUMS + signature files.
+// coverage:skip:integration-only — fetches SUMS/sig files over HTTP and writes to storage + DB; covered by integration tests.
+func (j *TerraformMirrorSyncJob) backfillSignatureStorage(
+	ctx context.Context,
+	client terraformReleasesClient,
+	cfg *models.TerraformMirrorConfig,
+	filteredVersions []mirror.TerraformVersionInfo,
+) error {
+	// Limit work to versions the operator has actually opted into via the
+	// platform/version/stable filters.
+	wantedVersions := make(map[string]bool, len(filteredVersions))
+	for _, vi := range filteredVersions {
+		wantedVersions[vi.Version] = true
+	}
+
+	syncedVersions, err := j.repo.ListVersions(ctx, cfg.ID, true /* syncedOnly */)
+	if err != nil {
+		return fmt.Errorf("failed to list synced versions: %w", err)
+	}
+
+	gpgKey := gpgKeyForConfig(cfg)
+
+	for _, sv := range syncedVersions {
+		if !wantedVersions[sv.Version] {
+			continue
+		}
+		// Skip versions that already have at least the SUMS stored. A sig may
+		// still be missing if GPG was disabled the first time around, but we
+		// re-attempt that on every sync to pick up a newly-configured key.
+		sumsAlreadyStored := sv.SumsStorageKey != nil && *sv.SumsStorageKey != ""
+		sigAlreadyStored := sv.SigStorageKey != nil && *sv.SigStorageKey != ""
+		if sumsAlreadyStored && (sigAlreadyStored || !cfg.GPGVerify || gpgKey == "") {
+			continue
+		}
+
+		_, sumsRaw, sumsErr := client.FetchSHASums(ctx, sv.Version)
+		if sumsErr != nil {
+			log.Printf("[terraform-mirror] sig backfill: failed to fetch SHA256SUMS for %s: %v", sv.Version, sumsErr)
+			continue
+		}
+
+		var verifiedSigBytes []byte
+		if cfg.GPGVerify && gpgKey != "" {
+			sigBytes, sigErr := client.FetchSHASumsSignature(ctx, sv.Version)
+			if sigErr != nil {
+				log.Printf("[terraform-mirror] sig backfill: failed to fetch GPG sig for %s: %v", sv.Version, sigErr)
+			} else if verifyErr := validation.VerifySignature(gpgKey, sumsRaw, sigBytes); verifyErr != nil {
+				log.Printf("[terraform-mirror] sig backfill: GPG verification FAILED for %s: %v", sv.Version, verifyErr)
+			} else {
+				verifiedSigBytes = sigBytes
+			}
+		}
+
+		// Reuse the same upload helper used during the normal sync path so
+		// storage path conventions and DB updates stay consistent.
+		j.storeVersionVerificationFiles(ctx, cfg, sv.Version, sv.ID, sumsRaw, verifiedSigBytes)
 	}
 
 	return nil

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -12,6 +12,7 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -446,8 +447,10 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 		sums = nil
 	}
 
-	// GPG-verify the SUMS file if enabled.
+	// GPG-verify the SUMS file if enabled. Capture sigBytes so we can persist
+	// it alongside the SUMS file for the public download endpoint to serve.
 	sumsGPGVerified := false
+	var verifiedSigBytes []byte
 	if cfg.GPGVerify && sumsRaw != nil {
 		gpgKey := gpgKeyForConfig(cfg)
 		if gpgKey != "" {
@@ -460,6 +463,7 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 						version, cfg.Name, verifyErr)
 				} else {
 					sumsGPGVerified = true
+					verifiedSigBytes = sigBytes
 					log.Printf("[terraform-mirror] GPG verification OK for %s SHA256SUMS (%s)", version, cfg.Name)
 				}
 			}
@@ -467,6 +471,11 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 			log.Printf("[terraform-mirror] GPG verify enabled but no key for tool %q — skipping GPG check", cfg.Tool)
 		}
 	}
+
+	// Persist SHA256SUMS (always, if we fetched it) and the GPG signature
+	// (only when GPG verification succeeded). These are served by the public
+	// download endpoint so clients can verify integrity offline.
+	j.storeVersionVerificationFiles(ctx, cfg, version, versionID, sumsRaw, verifiedSigBytes)
 
 	// If GPG verification succeeded, back-fill the flag on any already-synced
 	// platforms for this version (they were skipped by ListPendingPlatforms but
@@ -502,6 +511,61 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 
 	platformsSynced = platformOK
 	return versionsSynced, platformsSynced, versionsFailed
+}
+
+// storeVersionVerificationFiles persists the per-version SHA256SUMS file and
+// (when GPG verification succeeded) its detached signature to the storage
+// backend, then records the storage keys on terraform_versions so the public
+// download endpoint can return URLs for them.
+//
+// Behaviour:
+//   - sumsRaw is uploaded whenever non-nil; the file is small (~few KB) and
+//     useful to clients even without GPG.
+//   - sigBytes is uploaded only when non-nil, which the caller arranges only
+//     after VerifySignature has returned nil — never store an unverified sig.
+//   - Storage or DB failures are logged but do not fail the sync run; the
+//     binaries are still usable, just without offline GPG verification.
+//
+// coverage:skip:integration-only — performs storage uploads and DB writes; covered by integration tests.
+func (j *TerraformMirrorSyncJob) storeVersionVerificationFiles(
+	ctx context.Context,
+	cfg *models.TerraformMirrorConfig,
+	version string,
+	versionID uuid.UUID,
+	sumsRaw []byte,
+	sigBytes []byte,
+) {
+	if len(sumsRaw) == 0 && len(sigBytes) == 0 {
+		return
+	}
+
+	var sumsKey, sigKey *string
+
+	if len(sumsRaw) > 0 {
+		path := fmt.Sprintf("terraform-binaries/%s/SHA256SUMS", version)
+		if _, err := j.storageBackend.Upload(ctx, path, bytes.NewReader(sumsRaw), int64(len(sumsRaw))); err != nil {
+			log.Printf("[terraform-mirror] failed to upload SHA256SUMS for %s@%s: %v", version, cfg.Name, err)
+		} else {
+			sumsKey = &path
+		}
+	}
+
+	if len(sigBytes) > 0 {
+		path := fmt.Sprintf("terraform-binaries/%s/SHA256SUMS.%s.sig", version, cfg.Tool)
+		if _, err := j.storageBackend.Upload(ctx, path, bytes.NewReader(sigBytes), int64(len(sigBytes))); err != nil {
+			log.Printf("[terraform-mirror] failed to upload SHA256SUMS sig for %s@%s: %v", version, cfg.Name, err)
+		} else {
+			sigKey = &path
+		}
+	}
+
+	if sumsKey == nil && sigKey == nil {
+		return
+	}
+
+	if err := j.repo.UpdateVersionSignatureStorage(ctx, versionID, sumsKey, sigKey); err != nil {
+		log.Printf("[terraform-mirror] failed to persist signature storage keys for %s@%s: %v", version, cfg.Name, err)
+	}
 }
 
 // syncOnePlatform downloads a single binary and stores it.


### PR DESCRIPTION
## Summary

Fixes #402.

The terraform binary mirror previously fetched `SHA256SUMS` and its detached GPG signature only to verify integrity during sync, then discarded both. The public download endpoint therefore had no way to hand clients a `.sig` file for offline verification. This PR persists both files to the storage backend during sync and returns pre-signed URLs for them on the download response.

## Changes

**Schema** — migration `000034_terraform_version_signature_storage` adds two nullable columns to `terraform_versions`:
- `sums_storage_key` — storage key for the GPG-verified SHA256SUMS file
- `sig_storage_key` — storage key for the detached `.sig` file

**Sync job** — after successful GPG verification, uploads SHA256SUMS to `terraform-binaries/{version}/SHA256SUMS` and the verified signature to `terraform-binaries/{version}/SHA256SUMS.{tool}.sig`. The signature is uploaded **only** when verification succeeded — never store an unverified sig. The SUMS file is uploaded whenever fetched; it is useful to clients even when GPG is disabled.

**Repository** — `TerraformVersion` gains `SumsStorageKey`/`SigStorageKey` fields; new `UpdateVersionSignatureStorage` method writes them; all SELECT queries return the new columns; `UpsertVersion` RETURNING clause includes them.

**Download handler** — `TerraformBinaryDownloadResponse` gains `shasums_url` and `shasums_signature_url`. Both are 15-minute pre-signed URLs generated from the stored keys, or empty strings when no keys are available (e.g. versions synced before this change).

**Tests** —
- Existing fixtures updated for the new columns.
- `TestDownloadBinary_Success` now asserts the empty-default behavior.
- New `TestDownloadBinary_ReturnsSignatureURLsWhenStored` covers the populated path end-to-end.

## Backwards compatibility

- Clients ignoring unknown fields are unaffected.
- Versions synced **before** this migration will have `NULL` storage keys → response returns empty strings → frontend renders no link. Re-syncing a version (manual trigger or next scheduled run) populates the keys.

## Frontend changes required

The CI swagger job will auto-commit regenerated `docs/swagger.json` and `docs/openapi3.json` on merge. The frontend type pipeline will then pick up the two new fields automatically. UI work:
- Render two new conditional download links (`shasums_url`, `shasums_signature_url`) on the binary detail page — mirroring the existing provider download page treatment.
- Optional: surface a "How to verify" snippet with `gpg --verify` / `sha256sum -c` commands.

## Out of scope (filed as follow-up)

The symmetric gap on **provider uploads** — `providers/upload.go` hard-codes `ShasumURL` and `ShasumSignatureURL` to empty strings; the upload form does not accept these files. A follow-up issue will track adding multipart fields for them.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/... ./pkg/...` — all packages pass
- [x] CI green on this PR
- [ ] Migration applies cleanly against a real postgres
- [ ] After merge, swagger regen lands automatically; frontend typegen picks up new fields
- [ ] After a manual mirror sync on a deployed instance, download response includes non-empty signature URLs