### PR TITLE
fix(webhooks): look up SCM link by id, not module_id

### DIFF
--- a/backend/internal/api/webhooks/scm_webhook.go
+++ b/backend/internal/api/webhooks/scm_webhook.go
@@ -73,8 +73,11 @@ func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
 		return
 	}
 
-	// Get the module source repository link
-	moduleSourceRepo, err := h.scmRepo.GetModuleSourceRepo(c.Request.Context(), repoID)
+	// Get the module source repository link.
+	// The URL path segment is the link's own id (module_scm_repos.id), not the
+	// module_id — so we must look up by id. Using GetModuleSourceRepo (which
+	// queries WHERE module_id = $1) would always return nil and produce 404.
+	moduleSourceRepo, err := h.scmRepo.GetModuleSourceRepoByID(c.Request.Context(), repoID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get repository link"})
 		return

--- a/backend/internal/api/webhooks/scm_webhook_test.go
+++ b/backend/internal/api/webhooks/scm_webhook_test.go
@@ -115,9 +115,33 @@ func TestWebhook_InvalidUUID(t *testing.T) {
 	}
 }
 
+// TestWebhook_LookupUsesLinkID is a regression test for the bug where the
+// inbound webhook handler looked up module_scm_repos by module_id instead of
+// by the link's own id. The webhook URL embeds the link id (module_scm_repos.id),
+// so any lookup keyed on module_id would always miss and return 404 in
+// production. Asserting WithArgs(linkID) pins that the handler queries with
+// the URL path UUID — not some other column.
+func TestWebhook_LookupUsesLinkID(t *testing.T) {
+	mock, r := newWebhookRouter(t)
+	linkID := uuid.MustParse(webhookTestUUID)
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
+		WithArgs(linkID).
+		WillReturnRows(sqlmock.NewRows(moduleSourceRepoCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (empty rows → link not found)", w.Code)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sql expectations not met (handler used the wrong column or argument): %v", err)
+	}
+}
+
 func TestWebhook_GetModuleSourceRepo_DBError(t *testing.T) {
 	mock, r := newWebhookRouter(t)
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnError(webhookErrDB)
 
 	w := httptest.NewRecorder()
@@ -130,7 +154,7 @@ func TestWebhook_GetModuleSourceRepo_DBError(t *testing.T) {
 
 func TestWebhook_GetModuleSourceRepo_NotFound(t *testing.T) {
 	mock, r := newWebhookRouter(t)
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sqlmock.NewRows(moduleSourceRepoCols))
 
 	w := httptest.NewRecorder()
@@ -144,7 +168,7 @@ func TestWebhook_GetModuleSourceRepo_NotFound(t *testing.T) {
 func TestWebhook_GetProvider_DBError(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRow(providerID))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
 		WillReturnError(webhookErrDB)
@@ -161,7 +185,7 @@ func TestWebhook_GetProvider_NotFound(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
 	// Use matching secret so the URL-secret check passes and we reach the provider lookup.
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -190,7 +214,7 @@ func TestWebhook_InvalidConnectorType(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRow(providerID))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
 		WillReturnRows(sampleProviderRow(providerID, "unknown_type"))
@@ -208,7 +232,7 @@ func TestWebhook_GetProviderDBError(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -227,7 +251,7 @@ func TestWebhook_InvalidConnectorTypeMismatch(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -247,7 +271,7 @@ func TestWebhook_InvalidHMACSignature(t *testing.T) {
 	mock, r := newWebhookRouter(t)
 	providerID := uuid.New()
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -268,7 +292,7 @@ func TestWebhook_InvalidSignature(t *testing.T) {
 	providerID := uuid.New()
 
 	// Use a webhook URL whose embedded secret does NOT match "secret123" → 401.
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/different-secret"))
 
@@ -418,7 +442,7 @@ func TestWebhook_ParseDeliveryError(t *testing.T) {
 	payload := []byte("this is not json")
 	sig := bbHMAC(payload, testWebhookSecret)
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -442,7 +466,7 @@ func TestWebhook_CreateWebhookLogError(t *testing.T) {
 	payload := []byte(`{}`)
 	sig := bbHMAC(payload, testWebhookSecret)
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
@@ -468,7 +492,7 @@ func TestWebhook_Success(t *testing.T) {
 	payload := []byte(`{}`)
 	sig := bbHMAC(payload, testWebhookSecret)
 
-	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE module_id").
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").


### PR DESCRIPTION
## Summary

- Inbound SCM webhook deliveries always returned HTTP 404 because the handler resolved the link by `module_id` while the URL embeds the link's own `id`. As a result, no tag push ever auto-published a module version.
- Switch `HandleWebhook` to `GetModuleSourceRepoByID` (the same lookup the retry job already uses correctly) so the link is found and `ProcessTagPush` runs.
- Update existing sqlmock expectations from `WHERE module_id` to `WHERE id`, and add `TestWebhook_LookupUsesLinkID` that pins `WithArgs(linkID)` so the column / argument can't silently drift back.

Closes #409

## Test plan

- [x] `go fmt ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/api/webhooks/...` — passes including new regression test
- [x] Full suite: `go test ./internal/... ./pkg/... -coverprofile=coverage.out -covermode=atomic` — all packages pass
- [x] Coverage filter: `total: 80.0%` (at threshold)
- [x] `gosec` baseline compare: **New: 0** (21 active vs. 24 baseline; 3 resolved unrelated to this change)
- [ ] Manual: push a tag to a linked repo and confirm a new module version is auto-published (covered by deploying this build)