### PR TITLE
fix(ci): add --output-bundle for cosign v3 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
           done
           cp dist/checksums.txt release/
           cp dist/checksums.txt.sig release/
+          cp dist/checksums.txt.sig.bundle release/
           cp "dist/deployment-configs-${GITHUB_REF_NAME}.tar.gz" release/
           ls -la release/
 
@@ -229,7 +230,7 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [ goreleaser, docker ]
+    needs: [goreleaser, docker]
     permissions:
       contents: write
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,13 +46,13 @@ builds:
 
 archives:
   - id: terraform-registry-binaries
-    builds: [ terraform-registry ]
-    formats: [ binary ]
+    builds: [terraform-registry]
+    formats: [binary]
     name_template: "terraform-registry-{{ .Os }}-{{ .Arch }}"
 
   - id: registry-import-binaries
-    builds: [ registry-import ]
-    formats: [ binary ]
+    builds: [registry-import]
+    formats: [binary]
     name_template: "registry-import-{{ .Os }}-{{ .Arch }}"
 
 checksum:
@@ -77,6 +77,7 @@ signs:
       - sign-blob
       - --yes
       - --output-signature=${signature}
+      - --output-bundle=${signature}.bundle
       - ${artifact}
 
 docker_signs:


### PR DESCRIPTION
## Summary

- Adds `--output-bundle=${signature}.bundle` to the goreleaser cosign `sign-blob` args, required by cosign v3
- Stages the `.bundle` file as a release asset alongside the existing `.sig`

## Context

PR #408 bumped `sigstore/cosign-installer` from v3.8.2 → v4.1.2, which installs cosign **v3.0.6** (previously v2.4.3). Cosign v3 requires `--output-bundle` when signing blobs — without it the v1.2.5 release failed with:

```
create bundle file: open : no such file or directory
```

## Test plan

- [ ] Merge and delete the draft v1.2.5 release + tag
- [ ] Let release-please cut a new release PR
- [ ] Verify the Release workflow completes successfully with cosign signing