### PR TITLE
feat(mirror): auto-refresh release signing keys with pre-expiry warning

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -69,15 +69,16 @@ import (
 // be stopped during graceful shutdown. The caller (cmd/server) is responsible for
 // calling Shutdown() when the process receives a termination signal.
 type BackgroundServices struct {
-	mirrorSyncJob      *jobs.MirrorSyncJob
-	tfMirrorSyncJob    *jobs.TerraformMirrorSyncJob
-	expiryNotifier     *jobs.APIKeyExpiryNotifier
-	moduleScannerJob   *jobs.ModuleScannerJob
-	auditCleanupJob    *jobs.AuditCleanupJob
-	webhookRetryJob    *jobs.WebhookRetryJob
-	cvePollJob         *jobs.CVEPollJob
-	rateLimiters       []middleware.RateLimiterBackend
-	principalOverrides *middleware.PrincipalOverrideLimiters
+	mirrorSyncJob         *jobs.MirrorSyncJob
+	tfMirrorSyncJob       *jobs.TerraformMirrorSyncJob
+	expiryNotifier        *jobs.APIKeyExpiryNotifier
+	moduleScannerJob      *jobs.ModuleScannerJob
+	auditCleanupJob       *jobs.AuditCleanupJob
+	webhookRetryJob       *jobs.WebhookRetryJob
+	cvePollJob            *jobs.CVEPollJob
+	releasesKeyRefreshJob *jobs.ReleasesKeyRefreshJob
+	rateLimiters          []middleware.RateLimiterBackend
+	principalOverrides    *middleware.PrincipalOverrideLimiters
 }
 
 // Shutdown stops all background goroutines. It should be called after the HTTP
@@ -102,6 +103,9 @@ func (bg *BackgroundServices) Shutdown() {
 	}
 	if bg.webhookRetryJob != nil {
 		bg.webhookRetryJob.Stop()
+	}
+	if bg.releasesKeyRefreshJob != nil {
+		bg.releasesKeyRefreshJob.Stop()
 	}
 	if bg.cvePollJob != nil {
 		bg.cvePollJob.Stop()
@@ -180,6 +184,24 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	tfMirrorSyncJob := jobs.NewTerraformMirrorSyncJob(tfMirrorRepo, storageBackend, cfg.Storage.DefaultBackend)
 	tfMirrorSyncJob.Start(context.Background(), 10)
 	log.Println("Terraform binary mirror sync job started (checking every 10 minutes)")
+
+	// Initialize and start the upstream release-signing GPG key refresh job.
+	// On success it installs itself as the in-process resolver consulted by
+	// terraform mirror sync, so the next sync tick after a successful refresh
+	// uses the cached upstream key instead of the embedded snapshot.
+	releasesKeyRepo := repositories.NewReleasesGPGKeyRepository(sqlxDB)
+	releasesKeyRefreshJob, releasesKeyJobErr := jobs.NewReleasesKeyRefreshJob(&cfg.ReleasesGPGKeys, releasesKeyRepo, nil)
+	if releasesKeyJobErr != nil {
+		// The only way construction fails is a parse error on the embedded
+		// OpenTofu snapshot — fatal because the fingerprint pin can't be
+		// derived. Log and continue without auto-refresh; the embedded
+		// fallback still works.
+		log.Printf("Releases key refresh job: construction failed: %v (auto-refresh disabled)", releasesKeyJobErr)
+	} else {
+		jobs.SetReleasesKeyResolver(releasesKeyRefreshJob)
+		go releasesKeyRefreshJob.Start(context.Background())
+		log.Println("Releases key refresh job started")
+	}
 
 	// Public handler is created here (before route registration)
 	tfBinariesHandler := terraform_binaries.NewHandler(tfMirrorRepo, storageBackend, auditRepo)
@@ -1200,15 +1222,16 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	router.POST("/webhooks/approvals/:token", approvalWebhookHandler.RedeemApprovalToken)
 
 	bg := &BackgroundServices{
-		mirrorSyncJob:      mirrorSyncJob,
-		tfMirrorSyncJob:    tfMirrorSyncJob,
-		expiryNotifier:     expiryNotifier,
-		moduleScannerJob:   moduleScannerJob,
-		auditCleanupJob:    auditCleanupJob,
-		webhookRetryJob:    webhookRetryJob,
-		cvePollJob:         cvePollJob,
-		rateLimiters:       collectRateLimiterBackends(authRateLimiter, generalRateLimiter, uploadRateLimiter, orgRateLimiter),
-		principalOverrides: principalOverrides,
+		mirrorSyncJob:         mirrorSyncJob,
+		tfMirrorSyncJob:       tfMirrorSyncJob,
+		expiryNotifier:        expiryNotifier,
+		moduleScannerJob:      moduleScannerJob,
+		auditCleanupJob:       auditCleanupJob,
+		webhookRetryJob:       webhookRetryJob,
+		cvePollJob:            cvePollJob,
+		releasesKeyRefreshJob: releasesKeyRefreshJob,
+		rateLimiters:          collectRateLimiterBackends(authRateLimiter, generalRateLimiter, uploadRateLimiter, orgRateLimiter),
+		principalOverrides:    principalOverrides,
 	}
 
 	return router, bg

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -28,19 +28,20 @@ type Config struct {
 	Storage  StorageConfig  `mapstructure:"storage"`
 	Auth     AuthConfig     `mapstructure:"auth"`
 	// ApiDocs holds OpenAPI/Swagger metadata that can be overridden at deploy-time
-	ApiDocs        ApiDocsConfig        `mapstructure:"api_docs"`
-	MultiTenancy   MultiTenancyConfig   `mapstructure:"multi_tenancy"`
-	Security       SecurityConfig       `mapstructure:"security"`
-	Logging        LoggingConfig        `mapstructure:"logging"`
-	Telemetry      TelemetryConfig      `mapstructure:"telemetry"`
-	Audit          AuditConfig          `mapstructure:"audit"`
-	Notifications  NotificationsConfig  `mapstructure:"notifications"`
-	Scanning       ScanningConfig       `mapstructure:"scanning"`
-	AuditRetention AuditRetentionConfig `mapstructure:"audit_retention"`
-	Webhooks       WebhooksConfig       `mapstructure:"webhooks"`
-	BinaryMirror   BinaryMirrorConfig   `mapstructure:"binary_mirror"`
-	Policy         PolicyConfig         `mapstructure:"policy"`
-	CVE            CVEConfig            `mapstructure:"cve"`
+	ApiDocs         ApiDocsConfig         `mapstructure:"api_docs"`
+	MultiTenancy    MultiTenancyConfig    `mapstructure:"multi_tenancy"`
+	Security        SecurityConfig        `mapstructure:"security"`
+	Logging         LoggingConfig         `mapstructure:"logging"`
+	Telemetry       TelemetryConfig       `mapstructure:"telemetry"`
+	Audit           AuditConfig           `mapstructure:"audit"`
+	Notifications   NotificationsConfig   `mapstructure:"notifications"`
+	Scanning        ScanningConfig        `mapstructure:"scanning"`
+	AuditRetention  AuditRetentionConfig  `mapstructure:"audit_retention"`
+	Webhooks        WebhooksConfig        `mapstructure:"webhooks"`
+	BinaryMirror    BinaryMirrorConfig    `mapstructure:"binary_mirror"`
+	Policy          PolicyConfig          `mapstructure:"policy"`
+	CVE             CVEConfig             `mapstructure:"cve"`
+	ReleasesGPGKeys ReleasesGPGKeysConfig `mapstructure:"releases_gpg_keys"`
 }
 
 // AuditRetentionConfig controls the background audit log cleanup job.
@@ -55,6 +56,36 @@ type AuditRetentionConfig struct {
 type WebhooksConfig struct {
 	MaxRetries        int `mapstructure:"max_retries"`
 	RetryIntervalMins int `mapstructure:"retry_interval_mins"`
+}
+
+// ReleasesGPGKeysConfig controls the background job that refreshes upstream
+// release-signing GPG keys (Terraform / OpenTofu) from each tool's
+// .well-known/pgp-key.txt endpoint. When Enabled is false the cache is never
+// written and mirror sync falls back to the embedded snapshots in
+// internal/mirror — recommended for air-gapped deployments.
+//
+// New keys are accepted only if the parsed primary-key fingerprint matches a
+// hardcoded allow-list in internal/jobs; a compromised TLS path can therefore
+// never substitute a different key. Rotating to a new fingerprint requires a
+// reviewed code change to update the allow-list.
+type ReleasesGPGKeysConfig struct {
+	// Enabled gates the background refresh job. Default true.
+	Enabled bool `mapstructure:"enabled"`
+	// RefreshIntervalHours is how often (in hours) the job re-fetches each
+	// upstream key. Default 24.
+	RefreshIntervalHours int `mapstructure:"refresh_interval_hours"`
+	// ExpiryWarningDays is the warning threshold: when the effective key
+	// (cache or embedded fallback) is within this many days of its earliest
+	// signing-key expiry, the job logs a high-visibility warning and the
+	// terraform_registry_releases_key_expires_seconds gauge falls below the
+	// equivalent threshold. Default 60.
+	ExpiryWarningDays int `mapstructure:"expiry_warning_days"`
+	// HashiCorpURL overrides the upstream URL for the HashiCorp Terraform
+	// release-signing key. Default https://www.hashicorp.com/.well-known/pgp-key.txt.
+	HashiCorpURL string `mapstructure:"hashicorp_url"`
+	// OpenTofuURL overrides the upstream URL for the OpenTofu release-signing
+	// key. Default https://opentofu.org/.well-known/pgp-key.txt.
+	OpenTofuURL string `mapstructure:"opentofu_url"`
 }
 
 // BinaryMirrorConfig controls access control for the /terraform/binaries endpoint group.
@@ -903,6 +934,14 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("cve.poll_binaries", true)
 	v.SetDefault("cve.poll_providers", true)
 	v.SetDefault("cve.poll_scanner", true)
+
+	// Releases-key auto-refresh defaults. Enabled by default because the
+	// embedded snapshot is the failure mode this feature exists to prevent.
+	v.SetDefault("releases_gpg_keys.enabled", true)
+	v.SetDefault("releases_gpg_keys.refresh_interval_hours", 24)
+	v.SetDefault("releases_gpg_keys.expiry_warning_days", 60)
+	v.SetDefault("releases_gpg_keys.hashicorp_url", "https://www.hashicorp.com/.well-known/pgp-key.txt")
+	v.SetDefault("releases_gpg_keys.opentofu_url", "https://opentofu.org/.well-known/pgp-key.txt")
 }
 
 // expandEnv expands environment variables in the format ${VAR_NAME}

--- a/backend/internal/db/migrations/000036_releases_gpg_keys.down.sql
+++ b/backend/internal/db/migrations/000036_releases_gpg_keys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS releases_gpg_keys;

--- a/backend/internal/db/migrations/000036_releases_gpg_keys.up.sql
+++ b/backend/internal/db/migrations/000036_releases_gpg_keys.up.sql
@@ -1,0 +1,14 @@
+-- Cache of release-signing GPG keys auto-refreshed from each tool's
+-- .well-known/pgp-key.txt. Mirror sync prefers the cached row over the
+-- embedded snapshot. Refresh is fingerprint-pinned in code; a row with an
+-- unexpected primary_fpr can never be inserted by the job, so this table is
+-- safe to consult without additional in-DB validation.
+
+CREATE TABLE releases_gpg_keys (
+    tool           TEXT PRIMARY KEY,
+    armored_key    TEXT NOT NULL,
+    primary_fpr    TEXT NOT NULL,
+    key_expires_at TIMESTAMP WITH TIME ZONE,
+    source_url     TEXT NOT NULL,
+    fetched_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);

--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -33,6 +33,7 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000024 | `module_deprecation`                   | ✅ Yes         | Drops deprecation columns; existing deprecation data lost |
 | 000025 | `org_idp_binding`                      | ✅ Yes         | Drops IdP binding columns; IdP associations lost          |
 | 000026 | `org_quotas`                           | ✅ Yes         | Drops quota tables; quota config and usage data lost      |
+| 000036 | `releases_gpg_keys`                    | ✅ Yes         | Drops the cached upstream-key table; cache is rebuilt on next refresh tick |
 
 ## How to Run Migrations
 

--- a/backend/internal/db/models/releases_gpg_key.go
+++ b/backend/internal/db/models/releases_gpg_key.go
@@ -1,0 +1,20 @@
+// Package models - releases_gpg_key.go defines the cached upstream release-signing
+// GPG key model populated by the ReleasesKeyRefreshJob from each tool's
+// .well-known/pgp-key.txt endpoint.
+package models
+
+import "time"
+
+// ReleasesGPGKey is a cached ASCII-armored release-signing key for a single
+// tool ("terraform" | "opentofu"). PrimaryFingerprint is the hex-encoded,
+// uppercase 40-character SHA-1 fingerprint of the OpenPGP primary key; the
+// refresh job pins this against a hardcoded allow-list before writing so a
+// compromised TLS path cannot substitute a different key.
+type ReleasesGPGKey struct {
+	Tool               string     `db:"tool"`
+	ArmoredKey         string     `db:"armored_key"`
+	PrimaryFingerprint string     `db:"primary_fpr"`
+	KeyExpiresAt       *time.Time `db:"key_expires_at"`
+	SourceURL          string     `db:"source_url"`
+	FetchedAt          time.Time  `db:"fetched_at"`
+}

--- a/backend/internal/db/repositories/releases_gpg_key_repository.go
+++ b/backend/internal/db/repositories/releases_gpg_key_repository.go
@@ -1,0 +1,65 @@
+// releases_gpg_key_repository.go is the persistence layer for the cached
+// release-signing GPG keys table populated by the ReleasesKeyRefreshJob.
+// Get returns nil/nil when no row has been cached yet so callers can fall
+// back to the embedded snapshot without conflating "no cache" with errors.
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// ReleasesGPGKeyRepository handles reads and upserts against releases_gpg_keys.
+type ReleasesGPGKeyRepository struct {
+	db *sqlx.DB
+}
+
+// NewReleasesGPGKeyRepository constructs a ReleasesGPGKeyRepository.
+func NewReleasesGPGKeyRepository(db *sqlx.DB) *ReleasesGPGKeyRepository {
+	return &ReleasesGPGKeyRepository{db: db}
+}
+
+// Get returns the cached key for the given tool, or nil if none has been
+// written yet.
+func (r *ReleasesGPGKeyRepository) Get(ctx context.Context, tool string) (*models.ReleasesGPGKey, error) {
+	var row models.ReleasesGPGKey
+	query := `
+		SELECT tool, armored_key, primary_fpr, key_expires_at, source_url, fetched_at
+		FROM releases_gpg_keys
+		WHERE tool = $1
+	`
+	err := r.db.GetContext(ctx, &row, query, tool)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+// Upsert writes the cached key for a tool, replacing any existing row.
+// The caller is responsible for fingerprint validation — this layer trusts
+// its input. fetched_at is always set to NOW() server-side.
+func (r *ReleasesGPGKeyRepository) Upsert(ctx context.Context, in *models.ReleasesGPGKey) error {
+	query := `
+		INSERT INTO releases_gpg_keys (
+			tool, armored_key, primary_fpr, key_expires_at, source_url, fetched_at
+		) VALUES (
+			$1, $2, $3, $4, $5, NOW()
+		)
+		ON CONFLICT (tool) DO UPDATE SET
+			armored_key    = EXCLUDED.armored_key,
+			primary_fpr    = EXCLUDED.primary_fpr,
+			key_expires_at = EXCLUDED.key_expires_at,
+			source_url     = EXCLUDED.source_url,
+			fetched_at     = NOW()
+	`
+	_, err := r.db.ExecContext(ctx, query,
+		in.Tool, in.ArmoredKey, in.PrimaryFingerprint, in.KeyExpiresAt, in.SourceURL,
+	)
+	return err
+}

--- a/backend/internal/db/repositories/releases_gpg_key_repository_test.go
+++ b/backend/internal/db/repositories/releases_gpg_key_repository_test.go
@@ -1,0 +1,110 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+func newReleasesGPGRepo(t *testing.T) (*ReleasesGPGKeyRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewReleasesGPGKeyRepository(sqlx.NewDb(db, "postgres")), mock
+}
+
+var releasesGPGCols = []string{
+	"tool", "armored_key", "primary_fpr", "key_expires_at", "source_url", "fetched_at",
+}
+
+func TestReleasesGPGRepo_Get_NoRow(t *testing.T) {
+	repo, mock := newReleasesGPGRepo(t)
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("terraform").
+		WillReturnRows(sqlmock.NewRows(releasesGPGCols))
+
+	got, err := repo.Get(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil row, got %+v", got)
+	}
+}
+
+func TestReleasesGPGRepo_Get_Found(t *testing.T) {
+	repo, mock := newReleasesGPGRepo(t)
+	expiry := time.Now().Add(365 * 24 * time.Hour)
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("terraform").
+		WillReturnRows(sqlmock.NewRows(releasesGPGCols).
+			AddRow("terraform", "ARMORED", "C874011F0AB405110D02105534365D9472D7468F", expiry, "https://example.com/key.txt", time.Now()))
+
+	got, err := repo.Get(context.Background(), "terraform")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Tool != "terraform" || got.PrimaryFingerprint != "C874011F0AB405110D02105534365D9472D7468F" {
+		t.Fatalf("unexpected row: %+v", got)
+	}
+	if got.KeyExpiresAt == nil {
+		t.Fatal("expected KeyExpiresAt to be populated")
+	}
+}
+
+func TestReleasesGPGRepo_Get_DBError(t *testing.T) {
+	repo, mock := newReleasesGPGRepo(t)
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("terraform").
+		WillReturnError(fmt.Errorf("db error"))
+
+	if _, err := repo.Get(context.Background(), "terraform"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestReleasesGPGRepo_Upsert_Success(t *testing.T) {
+	repo, mock := newReleasesGPGRepo(t)
+	expiry := time.Now().Add(365 * 24 * time.Hour)
+	mock.ExpectExec(`INSERT INTO releases_gpg_keys`).
+		WithArgs("terraform", "ARMORED", "C874011F0AB405110D02105534365D9472D7468F", expiry, "https://example.com/key.txt").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.Upsert(context.Background(), &models.ReleasesGPGKey{
+		Tool:               "terraform",
+		ArmoredKey:         "ARMORED",
+		PrimaryFingerprint: "C874011F0AB405110D02105534365D9472D7468F",
+		KeyExpiresAt:       &expiry,
+		SourceURL:          "https://example.com/key.txt",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestReleasesGPGRepo_Upsert_DBError(t *testing.T) {
+	repo, mock := newReleasesGPGRepo(t)
+	mock.ExpectExec(`INSERT INTO releases_gpg_keys`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	err := repo.Upsert(context.Background(), &models.ReleasesGPGKey{
+		Tool:               "terraform",
+		ArmoredKey:         "ARMORED",
+		PrimaryFingerprint: "FPR",
+		SourceURL:          "https://example.com/key.txt",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/backend/internal/jobs/releases_key_refresh_job.go
+++ b/backend/internal/jobs/releases_key_refresh_job.go
@@ -1,0 +1,370 @@
+// releases_key_refresh_job.go implements the background job that re-fetches
+// each tool's release-signing GPG key from its .well-known/pgp-key.txt
+// endpoint, with strict primary-fingerprint pinning, and caches the result so
+// the terraform mirror sync can prefer it over the embedded snapshot.
+//
+// The job also doubles as the in-process resolver consulted by gpgKeyForTool:
+// when terraform mirror sync asks for a tool's key, the job hands back the
+// cached row if available, "" otherwise. The caller then falls back to the
+// embedded constant. This avoids a second round trip to the DB on every
+// mirror tick.
+//
+// Expiry warnings: on every cycle, the effective key (cache ∪ embedded) is
+// parsed and its earliest signing-key expiry is exported as a gauge labeled
+// by source. If that expiry falls within ExpiryWarningDays the job also logs
+// a high-visibility warn so it shows up in deployment logs without scraping
+// Prometheus.
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
+)
+
+// allowedReleasesKeyFingerprints pins the primary-key fingerprint we trust per
+// tool. Rotating to a different fingerprint is a deliberate, reviewed change —
+// the refresh job will refuse anything else and keep the existing cache or
+// fall back to the embedded snapshot.
+var allowedReleasesKeyFingerprints = map[string]string{
+	"terraform": "C874011F0AB405110D02105534365D9472D7468F", // HashiCorp Security
+	"opentofu":  "",                                         // populated from the embedded snapshot at job construction
+}
+
+// ReleasesKeyRefreshJob implements ReleasesKeyResolver and runs the periodic
+// upstream-key refresh. Construct via NewReleasesKeyRefreshJob and Start the
+// returned value in a goroutine.
+type ReleasesKeyRefreshJob struct {
+	cfg        *config.ReleasesGPGKeysConfig
+	repo       *repositories.ReleasesGPGKeyRepository
+	httpClient *http.Client
+
+	// tools is the iteration order — keep deterministic for predictable logs
+	// and tests.
+	tools []toolEndpoint
+
+	// cache holds the in-process resolver state. The job updates it after a
+	// successful upsert; SetReleasesKeyResolver(job) installs the lookup hook
+	// in package jobs so terraform mirror sync sees the refreshed key.
+	cacheMu sync.RWMutex
+	cache   map[string]string // tool -> armored key
+
+	stopChan chan struct{}
+}
+
+type toolEndpoint struct {
+	tool        string
+	url         string
+	fingerprint string
+}
+
+// NewReleasesKeyRefreshJob constructs the refresh job. The embedded OpenTofu
+// key is parsed eagerly so the OpenTofu fingerprint pin matches whatever is
+// shipped — that avoids hardcoding a second fingerprint that must be kept in
+// sync with the snapshot. A parse failure here is fatal because the job has
+// nothing safe to do without a pin.
+func NewReleasesKeyRefreshJob(cfg *config.ReleasesGPGKeysConfig, repo *repositories.ReleasesGPGKeyRepository, httpClient *http.Client) (*ReleasesKeyRefreshJob, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	// Derive the OpenTofu fingerprint from the embedded snapshot so a future
+	// snapshot refresh automatically updates the pin without a second edit.
+	opentofuInfo, err := mirror.ParseReleasesKey(mirror.OpenTofuReleasesGPGKey)
+	if err != nil {
+		return nil, fmt.Errorf("releases key refresh: parse embedded OpenTofu key: %w", err)
+	}
+
+	pins := make(map[string]string, len(allowedReleasesKeyFingerprints))
+	for k, v := range allowedReleasesKeyFingerprints {
+		pins[k] = v
+	}
+	pins["opentofu"] = opentofuInfo.PrimaryFingerprint
+
+	tools := []toolEndpoint{
+		{tool: "terraform", url: cfg.HashiCorpURL, fingerprint: pins["terraform"]},
+		{tool: "opentofu", url: cfg.OpenTofuURL, fingerprint: pins["opentofu"]},
+	}
+
+	return &ReleasesKeyRefreshJob{
+		cfg:        cfg,
+		repo:       repo,
+		httpClient: httpClient,
+		tools:      tools,
+		cache:      make(map[string]string, len(tools)),
+		stopChan:   make(chan struct{}),
+	}, nil
+}
+
+// ResolveReleasesKey implements the ReleasesKeyResolver interface consumed by
+// terraform mirror sync. Returns "" when no cached key is available so the
+// caller can fall back to the embedded snapshot.
+func (j *ReleasesKeyRefreshJob) ResolveReleasesKey(tool string) string {
+	if j == nil {
+		return ""
+	}
+	j.cacheMu.RLock()
+	defer j.cacheMu.RUnlock()
+	return j.cache[strings.ToLower(tool)]
+}
+
+// Start runs an initial refresh cycle, primes the in-process cache from any
+// previously persisted rows, then loops on a ticker. It is a no-op when
+// cfg.Enabled is false.
+func (j *ReleasesKeyRefreshJob) Start(ctx context.Context) {
+	if !j.cfg.Enabled {
+		slog.Info("releases key refresh job: disabled (releases_gpg_keys.enabled=false)")
+		return
+	}
+
+	interval := time.Duration(j.cfg.RefreshIntervalHours) * time.Hour
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+
+	slog.Info("releases key refresh job: started",
+		"interval", interval,
+		"expiry_warning_days", j.cfg.ExpiryWarningDays,
+	)
+
+	// Prime in-memory cache from persisted rows so a restart immediately
+	// honors the last fetched keys even if the upstream is briefly
+	// unreachable on this cycle.
+	j.primeCacheFromDB(ctx)
+
+	// Run once immediately so the first sync after startup sees fresh keys
+	// (or at least the most recent attempt's outcome reflected in metrics).
+	j.runCycle(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			j.runCycle(ctx)
+		case <-j.stopChan:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop signals the job to exit gracefully.
+func (j *ReleasesKeyRefreshJob) Stop() {
+	if j == nil {
+		return
+	}
+	select {
+	case <-j.stopChan:
+		// already stopped
+	default:
+		close(j.stopChan)
+	}
+}
+
+// primeCacheFromDB loads any persisted rows into the in-process cache so the
+// resolver returns fresh keys immediately on startup, even before the first
+// refresh cycle completes.
+func (j *ReleasesKeyRefreshJob) primeCacheFromDB(ctx context.Context) {
+	for _, t := range j.tools {
+		row, err := j.repo.Get(ctx, t.tool)
+		if err != nil {
+			slog.Warn("releases key refresh: prime cache: db read failed",
+				"tool", t.tool, "error", err)
+			continue
+		}
+		if row == nil {
+			continue
+		}
+		// Defense in depth: the row should already match the pin (we wrote
+		// it ourselves) but a manual DB edit could break that. Verify and
+		// drop on mismatch so the resolver never hands a wrong-key string
+		// to the mirror sync.
+		if !strings.EqualFold(row.PrimaryFingerprint, t.fingerprint) {
+			slog.Error("releases key refresh: prime cache: fingerprint mismatch on persisted row; ignoring",
+				"tool", t.tool,
+				"got", row.PrimaryFingerprint,
+				"want", t.fingerprint,
+			)
+			continue
+		}
+		j.cacheMu.Lock()
+		j.cache[t.tool] = row.ArmoredKey
+		j.cacheMu.Unlock()
+		slog.Info("releases key refresh: primed cache from db",
+			"tool", t.tool, "fingerprint", row.PrimaryFingerprint, "fetched_at", row.FetchedAt)
+	}
+}
+
+// runCycle attempts to refresh each tool's key and then runs the expiry
+// warning pass on the resulting effective state.
+func (j *ReleasesKeyRefreshJob) runCycle(ctx context.Context) {
+	for _, t := range j.tools {
+		j.refreshOne(ctx, t)
+	}
+	j.exportExpiryGauges()
+}
+
+// refreshOne fetches a single tool's key and persists it on success. Every
+// outcome bumps the per-tool counter so failure modes are visible in
+// Prometheus regardless of whether they hit the log.
+func (j *ReleasesKeyRefreshJob) refreshOne(ctx context.Context, t toolEndpoint) {
+	armored, info, err := mirror.FetchReleasesKey(ctx, j.httpClient, t.url, t.fingerprint)
+	if err != nil {
+		switch {
+		case errors.Is(err, mirror.ErrFingerprintMismatch):
+			// This is the high-severity case: someone tried to serve us a
+			// different key. Log loud, count it, keep cache untouched.
+			gotFpr := ""
+			if info != nil {
+				gotFpr = info.PrimaryFingerprint
+			}
+			slog.Error("releases key refresh: FINGERPRINT MISMATCH — refusing to cache",
+				"tool", t.tool,
+				"url", t.url,
+				"got", gotFpr,
+				"want", t.fingerprint,
+			)
+			telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "fingerprint_mismatch").Inc()
+		case errors.Is(err, mirror.ErrNoUsableSigningKey),
+			errors.Is(err, mirror.ErrEmptyKeyring),
+			strings.Contains(err.Error(), "parse armored"):
+			slog.Warn("releases key refresh: parse failed",
+				"tool", t.tool, "url", t.url, "error", err)
+			telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "parse_failed").Inc()
+		default:
+			slog.Warn("releases key refresh: fetch failed",
+				"tool", t.tool, "url", t.url, "error", err)
+			telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "fetch_failed").Inc()
+		}
+		return
+	}
+
+	// Optimization: skip the DB write when the armored bytes haven't changed
+	// since last cycle. Reduces noise in the audit log without hiding the
+	// fact that we did make the upstream request (the success counter is
+	// distinct from skipped_unchanged so dashboards can show both).
+	j.cacheMu.RLock()
+	prev, hadPrev := j.cache[t.tool]
+	j.cacheMu.RUnlock()
+	if hadPrev && prev == armored {
+		telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "skipped_unchanged").Inc()
+		return
+	}
+
+	row := &models.ReleasesGPGKey{
+		Tool:               t.tool,
+		ArmoredKey:         armored,
+		PrimaryFingerprint: info.PrimaryFingerprint,
+		SourceURL:          t.url,
+	}
+	if !info.LatestSigningExpiry.IsZero() {
+		expiry := info.LatestSigningExpiry
+		row.KeyExpiresAt = &expiry
+	}
+	if err := j.repo.Upsert(ctx, row); err != nil {
+		slog.Warn("releases key refresh: db upsert failed",
+			"tool", t.tool, "error", err)
+		telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "db_failed").Inc()
+		return
+	}
+
+	j.cacheMu.Lock()
+	j.cache[t.tool] = armored
+	j.cacheMu.Unlock()
+
+	telemetry.ReleasesKeyRefreshTotal.WithLabelValues(t.tool, "success").Inc()
+	slog.Info("releases key refresh: cached upstream key",
+		"tool", t.tool, "fingerprint", info.PrimaryFingerprint,
+		"expires_at", info.LatestSigningExpiry.Format(time.RFC3339),
+	)
+}
+
+// exportExpiryGauges computes seconds-until-expiry for the cache (if present)
+// and the embedded snapshot, sets the gauges, and logs a warn if either
+// effective source is within ExpiryWarningDays of expiring.
+//
+// We export both sources so dashboards show the gap between cache freshness
+// and embedded staleness, and so the alert still fires if the cache is
+// somehow gone but the embedded snapshot is also near-expiry.
+func (j *ReleasesKeyRefreshJob) exportExpiryGauges() {
+	warnThreshold := time.Duration(j.cfg.ExpiryWarningDays) * 24 * time.Hour
+	if warnThreshold <= 0 {
+		warnThreshold = 60 * 24 * time.Hour
+	}
+	now := time.Now()
+
+	for _, t := range j.tools {
+		// Cache source: only if present.
+		j.cacheMu.RLock()
+		cached, hasCached := j.cache[t.tool]
+		j.cacheMu.RUnlock()
+		if hasCached {
+			j.exportOne(t.tool, "cache", cached, now, warnThreshold)
+		}
+		// Embedded source: always present (compiled in).
+		j.exportOne(t.tool, "embedded", embeddedKeyForTool(t.tool), now, warnThreshold)
+	}
+}
+
+func (j *ReleasesKeyRefreshJob) exportOne(tool, source, armored string, now time.Time, warnThreshold time.Duration) {
+	if armored == "" {
+		return
+	}
+	info, err := mirror.ParseReleasesKey(armored)
+	if err != nil {
+		slog.Warn("releases key refresh: expiry export: parse failed",
+			"tool", tool, "source", source, "error", err)
+		return
+	}
+	if info.LatestSigningExpiry.IsZero() {
+		// Key has no expiry — set gauge to 0 to surface "unknown / unset".
+		telemetry.ReleasesKeyExpiresSeconds.WithLabelValues(tool, source).Set(0)
+		return
+	}
+	remaining := info.LatestSigningExpiry.Sub(now)
+	telemetry.ReleasesKeyExpiresSeconds.WithLabelValues(tool, source).Set(remaining.Seconds())
+
+	if remaining < warnThreshold {
+		level := slog.LevelWarn
+		if remaining < 0 {
+			level = slog.LevelError
+		}
+		slog.Log(context.Background(), level,
+			"releases key refresh: key approaching expiry",
+			"tool", tool,
+			"source", source,
+			"expires_at", info.LatestSigningExpiry.Format(time.RFC3339),
+			"days_remaining", int(remaining.Hours()/24),
+			"fingerprint", info.PrimaryFingerprint,
+		)
+	}
+}
+
+// embeddedKeyForTool returns the compiled-in snapshot for a tool. Kept here
+// (rather than reaching into terraform_mirror_sync.go) so the refresh job
+// stays a single file and tests can drop it in without dragging the full
+// terraform_mirror_sync test surface.
+func embeddedKeyForTool(tool string) string {
+	switch strings.ToLower(tool) {
+	case "terraform":
+		return mirror.HashiCorpReleasesGPGKey
+	case "opentofu":
+		return mirror.OpenTofuReleasesGPGKey
+	default:
+		return ""
+	}
+}

--- a/backend/internal/jobs/releases_key_refresh_job_test.go
+++ b/backend/internal/jobs/releases_key_refresh_job_test.go
@@ -1,0 +1,279 @@
+package jobs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+)
+
+// helper: build a fully wired ReleasesKeyRefreshJob over a sqlmock + a stub
+// HTTP server serving the given body for HashiCorp's URL. OpenTofu URL is
+// pointed at an immediately-closed listener so the second tool always fails
+// without contaminating the HashiCorp telemetry counter we're asserting on.
+func newJobWithStubs(t *testing.T, hashicorpBody string) (*ReleasesKeyRefreshJob, sqlmock.Sqlmock, *httptest.Server) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewReleasesGPGKeyRepository(sqlx.NewDb(db, "postgres"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(hashicorpBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := &config.ReleasesGPGKeysConfig{
+		Enabled:              true,
+		RefreshIntervalHours: 1,
+		ExpiryWarningDays:    60,
+		HashiCorpURL:         srv.URL,
+		OpenTofuURL:          "http://127.0.0.1:0", // immediate connection refused
+	}
+	job, err := NewReleasesKeyRefreshJob(cfg, repo, srv.Client())
+	if err != nil {
+		t.Fatalf("NewReleasesKeyRefreshJob: %v", err)
+	}
+	return job, mock, srv
+}
+
+func TestReleasesKeyRefreshJob_Disabled_IsNoOp(t *testing.T) {
+	job, _, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+	job.cfg.Enabled = false
+
+	// Start should return immediately. Run on goroutine + short ctx to be sure.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		job.Start(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return when disabled")
+	}
+}
+
+func TestReleasesKeyRefreshJob_RefreshOne_Success(t *testing.T) {
+	job, mock, srv := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	mock.ExpectExec(`INSERT INTO releases_gpg_keys`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	job.refreshOne(context.Background(), toolEndpoint{
+		tool:        "terraform",
+		url:         srv.URL,
+		fingerprint: "C874011F0AB405110D02105534365D9472D7468F",
+	})
+
+	// Cache must be populated so the resolver hand-off works.
+	if got := job.ResolveReleasesKey("terraform"); got == "" {
+		t.Fatal("expected resolver to return the cached key after success")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestReleasesKeyRefreshJob_RefreshOne_FingerprintMismatch_LeavesCacheUntouched(t *testing.T) {
+	job, _, srv := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	// Pin a wrong-but-valid-shape fingerprint. No Upsert expectation —
+	// sqlmock will fail if the job tries to write.
+	job.refreshOne(context.Background(), toolEndpoint{
+		tool:        "terraform",
+		url:         srv.URL,
+		fingerprint: "0000000000000000000000000000000000000000",
+	})
+
+	if got := job.ResolveReleasesKey("terraform"); got != "" {
+		t.Fatal("expected cache to remain empty on fingerprint mismatch")
+	}
+}
+
+func TestReleasesKeyRefreshJob_RefreshOne_FetchFailure_LeavesCacheUntouched(t *testing.T) {
+	job, _, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	// Hit an immediately-closed listener so the HTTP fetch errors.
+	job.refreshOne(context.Background(), toolEndpoint{
+		tool:        "terraform",
+		url:         "http://127.0.0.1:0",
+		fingerprint: "C874011F0AB405110D02105534365D9472D7468F",
+	})
+
+	if got := job.ResolveReleasesKey("terraform"); got != "" {
+		t.Fatal("expected cache to remain empty on fetch failure")
+	}
+}
+
+func TestReleasesKeyRefreshJob_RefreshOne_SkipsUnchanged(t *testing.T) {
+	job, mock, srv := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	// First call inserts.
+	mock.ExpectExec(`INSERT INTO releases_gpg_keys`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	job.refreshOne(context.Background(), toolEndpoint{
+		tool:        "terraform",
+		url:         srv.URL,
+		fingerprint: "C874011F0AB405110D02105534365D9472D7468F",
+	})
+
+	// Second call with identical body — no second INSERT expected. If the
+	// job tries to write, sqlmock will fail when ExpectationsWereMet runs.
+	job.refreshOne(context.Background(), toolEndpoint{
+		tool:        "terraform",
+		url:         srv.URL,
+		fingerprint: "C874011F0AB405110D02105534365D9472D7468F",
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestReleasesKeyRefreshJob_PrimeCache_LoadsPersistedRow(t *testing.T) {
+	job, mock, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	expiry := time.Now().Add(365 * 24 * time.Hour)
+	cols := []string{"tool", "armored_key", "primary_fpr", "key_expires_at", "source_url", "fetched_at"}
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("terraform").
+		WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			"terraform",
+			mirror.HashiCorpReleasesGPGKey,
+			"C874011F0AB405110D02105534365D9472D7468F",
+			expiry, "https://example.com", time.Now(),
+		))
+	// OpenTofu row: not found — returns empty rowset so Get returns nil/nil.
+	otCols := cols
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("opentofu").
+		WillReturnRows(sqlmock.NewRows(otCols))
+
+	job.primeCacheFromDB(context.Background())
+
+	if got := job.ResolveReleasesKey("terraform"); got == "" {
+		t.Error("expected resolver to return terraform key after prime")
+	}
+	if got := job.ResolveReleasesKey("opentofu"); got != "" {
+		t.Error("expected resolver to return empty for opentofu (no row)")
+	}
+}
+
+func TestReleasesKeyRefreshJob_PrimeCache_RejectsFingerprintDriftOnDB(t *testing.T) {
+	job, mock, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	// Manually-edited DB row with the wrong fingerprint. The job must
+	// refuse to load it so a hostile DB write can't poison the resolver.
+	cols := []string{"tool", "armored_key", "primary_fpr", "key_expires_at", "source_url", "fetched_at"}
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("terraform").
+		WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			"terraform",
+			"ARMORED-MAYBE-HOSTILE",
+			"0000000000000000000000000000000000000000",
+			nil, "https://example.com", time.Now(),
+		))
+	mock.ExpectQuery(`SELECT.*FROM releases_gpg_keys WHERE tool`).
+		WithArgs("opentofu").
+		WillReturnRows(sqlmock.NewRows(cols))
+
+	job.primeCacheFromDB(context.Background())
+
+	if got := job.ResolveReleasesKey("terraform"); got != "" {
+		t.Error("expected resolver to ignore drift-fingerprint row")
+	}
+}
+
+func TestReleasesKeyRefreshJob_ExportExpiryGauges_DoesNotPanic(t *testing.T) {
+	job, _, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+	// Even with no cache entries, the embedded snapshots must export
+	// without panic so dashboards stay populated before the first fetch.
+	job.exportExpiryGauges()
+}
+
+func TestReleasesKeyRefreshJob_ResolveReleasesKey_NilSafe(t *testing.T) {
+	var job *ReleasesKeyRefreshJob
+	if got := job.ResolveReleasesKey("terraform"); got != "" {
+		t.Errorf("nil receiver should return empty, got %q", got)
+	}
+}
+
+func TestReleasesKeyRefreshJob_Stop_NilSafe(t *testing.T) {
+	var job *ReleasesKeyRefreshJob
+	// Should not panic.
+	job.Stop()
+}
+
+func TestReleasesKeyRefreshJob_Stop_Idempotent(t *testing.T) {
+	job, _, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+	job.Stop()
+	job.Stop() // second call must not panic on closed channel
+}
+
+// TestReleasesKeyRefreshJob_RunCycle drives the top-level cycle once. With
+// the HashiCorp stub serving a valid key it must persist that tool's row,
+// then with OpenTofu pointed at a dead listener the cycle must complete
+// without surfacing the failure (per-tool failures are counted but the
+// cycle keeps going).
+func TestReleasesKeyRefreshJob_RunCycle(t *testing.T) {
+	job, mock, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+
+	mock.ExpectExec(`INSERT INTO releases_gpg_keys`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	job.runCycle(context.Background())
+
+	// HashiCorp must be cached; OpenTofu must remain absent (its fetch hit a
+	// dead listener) — both outcomes prove the cycle iterated through both
+	// tools without aborting early.
+	if got := job.ResolveReleasesKey("terraform"); got == "" {
+		t.Error("expected terraform key to be cached after runCycle")
+	}
+	if got := job.ResolveReleasesKey("opentofu"); got != "" {
+		t.Error("expected opentofu cache to remain empty after fetch failure")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestReleasesKeyRefreshJob_ExportOne_KeyWithoutExpiry exercises the
+// "expiry == zero" branch of exportOne. A key with no LatestSigningExpiry
+// must still set the gauge (to 0) and not log a warning.
+func TestReleasesKeyRefreshJob_ExportOne_KeyWithoutExpiry(t *testing.T) {
+	job, _, _ := newJobWithStubs(t, mirror.HashiCorpReleasesGPGKey)
+	// Empty armored string → ParseReleasesKey errors; exportOne logs and
+	// returns. Exercises the parse-failure branch without panicking.
+	job.exportOne("terraform", "cache", "not a key", time.Now(), 60*24*time.Hour)
+	// Then the empty-armored fast path.
+	job.exportOne("terraform", "cache", "", time.Now(), 60*24*time.Hour)
+}
+
+// TestEmbeddedKeyForTool covers the helper directly so its switch arms are
+// all exercised.
+func TestEmbeddedKeyForTool(t *testing.T) {
+	if embeddedKeyForTool("terraform") == "" {
+		t.Error("terraform: expected embedded key, got empty")
+	}
+	if embeddedKeyForTool("Terraform") == "" {
+		t.Error("Terraform (mixed case): expected embedded key, got empty")
+	}
+	if embeddedKeyForTool("opentofu") == "" {
+		t.Error("opentofu: expected embedded key, got empty")
+	}
+	if embeddedKeyForTool("does-not-exist") != "" {
+		t.Error("unknown tool: expected empty, got non-empty")
+	}
+}

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -907,9 +907,37 @@ func productNameForTool(tool string) string {
 	}
 }
 
+// ReleasesKeyResolver returns the ASCII-armored release-signing key for the
+// given tool, preferring a fresh upstream snapshot over the embedded fallback.
+// Implementations must return "" only when no key (cached or embedded) is
+// available so callers can correctly choose to skip GPG verification.
+type ReleasesKeyResolver interface {
+	ResolveReleasesKey(tool string) string
+}
+
+// releasesKeyResolver is the package-level hook used by gpgKeyForTool. It is
+// nil by default — gpgKeyForTool then returns the embedded snapshot directly,
+// preserving the original behavior for tests and for deployments that have not
+// wired in the auto-refresh job. main.go calls SetReleasesKeyResolver during
+// startup to install the cache-aware resolver.
+var releasesKeyResolver ReleasesKeyResolver
+
+// SetReleasesKeyResolver installs a resolver consulted by gpgKeyForTool before
+// it falls back to the embedded constants. Passing nil clears the hook.
+func SetReleasesKeyResolver(r ReleasesKeyResolver) {
+	releasesKeyResolver = r
+}
+
 // gpgKeyForTool returns the PGP public key block for the given tool.
 // Returns "" if no key is configured (caller should skip GPG verification).
+// When a resolver is installed via SetReleasesKeyResolver it is consulted
+// first; the embedded snapshot is used only when the resolver returns "".
 func gpgKeyForTool(tool string) string {
+	if releasesKeyResolver != nil {
+		if k := releasesKeyResolver.ResolveReleasesKey(tool); k != "" {
+			return k
+		}
+	}
 	switch strings.ToLower(tool) {
 	case "terraform":
 		return mirror.HashiCorpReleasesGPGKey

--- a/backend/internal/jobs/terraform_mirror_sync_helpers_test.go
+++ b/backend/internal/jobs/terraform_mirror_sync_helpers_test.go
@@ -78,6 +78,47 @@ func TestGPGKeyForTool_Unknown(t *testing.T) {
 	}
 }
 
+// stubResolver is a test-only ReleasesKeyResolver that returns a fixed value
+// for one tool and "" for everything else.
+type stubResolver struct {
+	tool string
+	key  string
+}
+
+func (s *stubResolver) ResolveReleasesKey(tool string) string {
+	if tool == s.tool {
+		return s.key
+	}
+	return ""
+}
+
+func TestGPGKeyForTool_ResolverOverridesEmbedded(t *testing.T) {
+	SetReleasesKeyResolver(&stubResolver{tool: "terraform", key: "REFRESHED-KEY"})
+	t.Cleanup(func() { SetReleasesKeyResolver(nil) })
+
+	if got := gpgKeyForTool("terraform"); got != "REFRESHED-KEY" {
+		t.Errorf("expected resolver key, got %q", got)
+	}
+}
+
+func TestGPGKeyForTool_ResolverEmptyFallsBackToEmbedded(t *testing.T) {
+	// Resolver returns "" (cache miss). Embedded snapshot must be served.
+	SetReleasesKeyResolver(&stubResolver{tool: "nothing-matches", key: "irrelevant"})
+	t.Cleanup(func() { SetReleasesKeyResolver(nil) })
+
+	if got := gpgKeyForTool("terraform"); got == "" || got == "REFRESHED-KEY" {
+		t.Errorf("expected embedded HashiCorp key fallback, got %q", got)
+	}
+}
+
+func TestGPGKeyForTool_NilResolverUsesEmbedded(t *testing.T) {
+	// Explicit nil — exercise the default no-resolver path.
+	SetReleasesKeyResolver(nil)
+	if got := gpgKeyForTool("terraform"); got == "" {
+		t.Error("expected embedded HashiCorp key, got empty")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // hasPreReleaseSuffix
 // ---------------------------------------------------------------------------

--- a/backend/internal/mirror/key_fetcher.go
+++ b/backend/internal/mirror/key_fetcher.go
@@ -1,0 +1,212 @@
+// key_fetcher.go fetches and parses ASCII-armored release-signing GPG keys
+// from each tool's .well-known/pgp-key.txt endpoint, with strict primary-key
+// fingerprint pinning so a compromised TLS path can never substitute a
+// different key.
+//
+// The same parsing helper is reused by both the live fetcher and the
+// embedded-snapshot inspector so the expiry math stays consistent.
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+)
+
+// Fingerprint hex length in characters (20 bytes -> 40 hex chars).
+const fingerprintHexLen = 40
+
+// maxKeyBodyBytes caps the response body to a generous size so a hostile
+// server can't exhaust memory. Real release keys are <10 KB; 1 MB is plenty.
+const maxKeyBodyBytes = 1 << 20
+
+// Common errors returned by the fetcher / parser. Callers identify these by
+// errors.Is rather than string matching so telemetry labels stay stable.
+var (
+	// ErrFingerprintMismatch is returned when the parsed primary key
+	// fingerprint does not match the caller-supplied pin. The cached key is
+	// kept; the operator must investigate before allow-listing a new key.
+	ErrFingerprintMismatch = errors.New("releases key: primary fingerprint mismatch")
+
+	// ErrNoUsableSigningKey is returned when the parsed entity has no
+	// non-expired signing-capable key (primary or subkey). A key with this
+	// shape will produce "openpgp: key expired" at verification time.
+	ErrNoUsableSigningKey = errors.New("releases key: no unexpired signing-capable key")
+
+	// ErrEmptyKeyring is returned when the armored input parses but contains
+	// no entities at all.
+	ErrEmptyKeyring = errors.New("releases key: empty keyring")
+)
+
+// ReleasesKeyInfo summarizes the trust-relevant facts about an armored key.
+// LatestSigningExpiry is the latest expiry across all signing-capable subkeys
+// (and the primary if it has the sign flag), or zero if no expiry is set on
+// any signing key.
+type ReleasesKeyInfo struct {
+	PrimaryFingerprint  string
+	LatestSigningExpiry time.Time
+	HasUsableSigningKey bool
+}
+
+// ParseReleasesKey parses an ASCII-armored OpenPGP key block and reports the
+// primary fingerprint plus signing-key expiry information. It does not
+// network — the live fetcher delegates here after retrieving the body.
+func ParseReleasesKey(armored string) (*ReleasesKeyInfo, error) {
+	ring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(armored))
+	if err != nil {
+		return nil, fmt.Errorf("releases key: parse armored: %w", err)
+	}
+	if len(ring) == 0 {
+		return nil, ErrEmptyKeyring
+	}
+	entity := ring[0]
+	if entity.PrimaryKey == nil {
+		return nil, errors.New("releases key: entity has no primary key")
+	}
+
+	fpr := strings.ToUpper(fmt.Sprintf("%X", entity.PrimaryKey.Fingerprint))
+
+	now := time.Now()
+	var latest time.Time
+	hasUsable := false
+
+	// Walk all subkeys looking for signing-capable, non-expired ones.
+	for _, sub := range entity.Subkeys {
+		if sub.Sig == nil || !sub.Sig.FlagsValid || !sub.Sig.FlagSign {
+			continue
+		}
+		expiry, hasExpiry := subkeyExpiry(sub)
+		if hasExpiry {
+			if expiry.After(latest) {
+				latest = expiry
+			}
+			if expiry.Before(now) {
+				continue
+			}
+		}
+		hasUsable = true
+	}
+
+	// Primary key can sign directly only if its self-sig has the sign flag.
+	if !hasUsable {
+		ident := primaryIdentity(entity)
+		if ident != nil && ident.SelfSignature != nil && ident.SelfSignature.FlagsValid && ident.SelfSignature.FlagSign {
+			expiry, hasExpiry := primaryExpiry(entity, ident)
+			if hasExpiry {
+				if expiry.After(latest) {
+					latest = expiry
+				}
+				if !expiry.Before(now) {
+					hasUsable = true
+				}
+			} else {
+				hasUsable = true
+			}
+		}
+	}
+
+	if !hasUsable {
+		return &ReleasesKeyInfo{
+			PrimaryFingerprint:  fpr,
+			LatestSigningExpiry: latest,
+		}, ErrNoUsableSigningKey
+	}
+
+	return &ReleasesKeyInfo{
+		PrimaryFingerprint:  fpr,
+		LatestSigningExpiry: latest,
+		HasUsableSigningKey: true,
+	}, nil
+}
+
+// FetchReleasesKey downloads an ASCII-armored key from url, parses it,
+// and rejects it if the primary fingerprint does not match
+// allowedFingerprint. allowedFingerprint must be the 40-character uppercase
+// hex form (the format returned by ParseReleasesKey).
+//
+// On success it returns the raw armored body so callers can persist it
+// verbatim — preserving HashiCorp's own armor formatting matters for
+// auditability.
+func FetchReleasesKey(ctx context.Context, httpClient *http.Client, url string, allowedFingerprint string) (string, *ReleasesKeyInfo, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	if !isAllowedFingerprintShape(allowedFingerprint) {
+		return "", nil, fmt.Errorf("releases key: allowed fingerprint must be %d hex chars, got %q", fingerprintHexLen, allowedFingerprint)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("releases key: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/pgp-keys, text/plain")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("releases key: fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", nil, fmt.Errorf("releases key: fetch %s: status %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxKeyBodyBytes))
+	if err != nil {
+		return "", nil, fmt.Errorf("releases key: read body: %w", err)
+	}
+	armored := strings.TrimSpace(string(body))
+
+	info, err := ParseReleasesKey(armored)
+	if err != nil {
+		// ErrNoUsableSigningKey still returns info so the caller can log
+		// the parsed fingerprint and expiry for diagnosis.
+		return "", info, err
+	}
+
+	if !strings.EqualFold(info.PrimaryFingerprint, allowedFingerprint) {
+		return "", info, fmt.Errorf("%w: got %s, want %s", ErrFingerprintMismatch, info.PrimaryFingerprint, allowedFingerprint)
+	}
+
+	return armored, info, nil
+}
+
+func isAllowedFingerprintShape(fpr string) bool {
+	if len(fpr) != fingerprintHexLen {
+		return false
+	}
+	for _, c := range fpr {
+		isHex := (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')
+		if !isHex {
+			return false
+		}
+	}
+	return true
+}
+
+func primaryIdentity(e *openpgp.Entity) *openpgp.Identity {
+	for _, id := range e.Identities {
+		return id
+	}
+	return nil
+}
+
+func primaryExpiry(e *openpgp.Entity, ident *openpgp.Identity) (time.Time, bool) {
+	if ident == nil || ident.SelfSignature == nil || ident.SelfSignature.KeyLifetimeSecs == nil {
+		return time.Time{}, false
+	}
+	return e.PrimaryKey.CreationTime.Add(time.Duration(*ident.SelfSignature.KeyLifetimeSecs) * time.Second), true
+}
+
+func subkeyExpiry(sub openpgp.Subkey) (time.Time, bool) {
+	if sub.Sig == nil || sub.Sig.KeyLifetimeSecs == nil {
+		return time.Time{}, false
+	}
+	return sub.PublicKey.CreationTime.Add(time.Duration(*sub.Sig.KeyLifetimeSecs) * time.Second), true
+}

--- a/backend/internal/mirror/key_fetcher_test.go
+++ b/backend/internal/mirror/key_fetcher_test.go
@@ -1,0 +1,140 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// HashiCorp's release primary fingerprint — used as the pin in production.
+// Repeated here as a literal so a future test author can copy this pattern.
+const testHashiCorpFingerprint = "C874011F0AB405110D02105534365D9472D7468F"
+
+func TestParseReleasesKey_EmbeddedSnapshotsRoundTrip(t *testing.T) {
+	info, err := ParseReleasesKey(HashiCorpReleasesGPGKey)
+	if err != nil {
+		t.Fatalf("ParseReleasesKey: %v", err)
+	}
+	if info.PrimaryFingerprint != testHashiCorpFingerprint {
+		t.Errorf("PrimaryFingerprint = %q, want %q", info.PrimaryFingerprint, testHashiCorpFingerprint)
+	}
+	if !info.HasUsableSigningKey {
+		t.Error("HasUsableSigningKey = false, want true for embedded HashiCorp key")
+	}
+}
+
+func TestParseReleasesKey_Garbage(t *testing.T) {
+	if _, err := ParseReleasesKey("not a key block at all"); err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestParseReleasesKey_EmptyArmor(t *testing.T) {
+	// Valid armor frame, but empty payload — ReadArmoredKeyRing returns an error.
+	const empty = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+-----END PGP PUBLIC KEY BLOCK-----`
+	if _, err := ParseReleasesKey(empty); err == nil {
+		t.Fatal("expected parse error for empty armor, got nil")
+	}
+}
+
+func TestFetchReleasesKey_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(HashiCorpReleasesGPGKey))
+	}))
+	t.Cleanup(srv.Close)
+
+	armored, info, err := FetchReleasesKey(context.Background(), srv.Client(), srv.URL, testHashiCorpFingerprint)
+	if err != nil {
+		t.Fatalf("FetchReleasesKey: %v", err)
+	}
+	if info.PrimaryFingerprint != testHashiCorpFingerprint {
+		t.Errorf("PrimaryFingerprint = %q, want %q", info.PrimaryFingerprint, testHashiCorpFingerprint)
+	}
+	if armored == "" {
+		t.Error("armored body is empty")
+	}
+}
+
+func TestFetchReleasesKey_FingerprintMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(HashiCorpReleasesGPGKey))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Wrong fingerprint (all zeros, valid shape) — must be rejected.
+	const wrong = "0000000000000000000000000000000000000000"
+	_, _, err := FetchReleasesKey(context.Background(), srv.Client(), srv.URL, wrong)
+	if !errors.Is(err, ErrFingerprintMismatch) {
+		t.Fatalf("err = %v, want ErrFingerprintMismatch", err)
+	}
+}
+
+func TestFetchReleasesKey_FingerprintCaseInsensitive(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(HashiCorpReleasesGPGKey))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Allow-listed fingerprints are commonly copy-pasted in lowercase; the
+	// pin check must succeed regardless of case.
+	lower := "c874011f0ab405110d02105534365d9472d7468f"
+	if _, _, err := FetchReleasesKey(context.Background(), srv.Client(), srv.URL, lower); err != nil {
+		t.Fatalf("expected case-insensitive match to succeed, got %v", err)
+	}
+}
+
+func TestFetchReleasesKey_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := FetchReleasesKey(context.Background(), srv.Client(), srv.URL, testHashiCorpFingerprint)
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+}
+
+func TestFetchReleasesKey_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("this is not a pgp key block"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := FetchReleasesKey(context.Background(), srv.Client(), srv.URL, testHashiCorpFingerprint)
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestFetchReleasesKey_BadFingerprintShape(t *testing.T) {
+	// "too short" is not a 40-char hex string — the fetcher must reject the
+	// pin without making any HTTP call.
+	_, _, err := FetchReleasesKey(context.Background(), nil, "http://example.invalid", "TOO-SHORT")
+	if err == nil {
+		t.Fatal("expected validation error for bad fingerprint shape, got nil")
+	}
+}
+
+func TestIsAllowedFingerprintShape(t *testing.T) {
+	tests := []struct {
+		fpr string
+		ok  bool
+	}{
+		{"C874011F0AB405110D02105534365D9472D7468F", true},
+		{"c874011f0ab405110d02105534365d9472d7468f", true},   // lower
+		{"C874011F0AB405110D02105534365D9472D7468", false},   // 39 chars
+		{"C874011F0AB405110D02105534365D9472D7468FX", false}, // 41
+		{"G874011F0AB405110D02105534365D9472D7468F", false},  // non-hex
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := isAllowedFingerprintShape(tc.fpr); got != tc.ok {
+			t.Errorf("isAllowedFingerprintShape(%q) = %v, want %v", tc.fpr, got, tc.ok)
+		}
+	}
+}

--- a/backend/internal/mirror/terraform_releases_test.go
+++ b/backend/internal/mirror/terraform_releases_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 // ---------------------------------------------------------------------------
@@ -489,6 +487,8 @@ func TestValidateBinarySHA256_Mismatch(t *testing.T) {
 // "openpgp: key expired" and every mirror-sync GPG verification fails — the
 // admin UI then shows the GPG column as failed for every synced version. We
 // caught that the hard way (issue #415); this test fails fast in CI instead.
+//
+// It also doubles as a smoke test for ParseReleasesKey on real-world inputs.
 func TestEmbeddedReleasesGPGKeys_NotExpired(t *testing.T) {
 	cases := []struct {
 		name string
@@ -500,82 +500,19 @@ func TestEmbeddedReleasesGPGKeys_NotExpired(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(tc.key))
+			info, err := ParseReleasesKey(tc.key)
 			if err != nil {
-				t.Fatalf("failed to parse embedded %s key: %v", tc.name, err)
+				t.Fatalf("%s: ParseReleasesKey: %v — refresh from https://www.hashicorp.com/.well-known/pgp-key.txt (HashiCorp) or https://opentofu.org/.well-known/pgp-key.txt (OpenTofu)",
+					tc.name, err)
 			}
-			if len(ring) == 0 {
-				t.Fatalf("embedded %s key parsed to empty keyring", tc.name)
+			if !info.HasUsableSigningKey {
+				t.Errorf("%s: no unexpired signing-capable key on primary %s — refresh the embedded snapshot",
+					tc.name, info.PrimaryFingerprint)
 			}
-			now := time.Now()
-			for _, entity := range ring {
-				ident := primaryIdentity(entity)
-				if ident == nil || ident.SelfSignature == nil {
-					t.Errorf("%s: no primary self-signature on entity %X", tc.name, entity.PrimaryKey.Fingerprint)
-					continue
-				}
-				if ident.SelfSignature.KeyLifetimeSecs != nil {
-					expiry := entity.PrimaryKey.CreationTime.Add(
-						time.Duration(*ident.SelfSignature.KeyLifetimeSecs) * time.Second,
-					)
-					if !now.Before(expiry) {
-						t.Errorf("%s primary key %X expired at %s — refresh from https://www.hashicorp.com/.well-known/pgp-key.txt (HashiCorp) or https://opentofu.org/.well-known/pgp-key.txt (OpenTofu)",
-							tc.name, entity.PrimaryKey.Fingerprint, expiry.Format(time.RFC3339))
-					}
-				}
-				// At least one signing subkey must be unexpired so SHA256SUMS
-				// signatures can verify. HashiCorp's primary [SC] key can sign
-				// directly, but in practice they sign with a dedicated [S] subkey;
-				// fail the test if none of the available signing keys are usable
-				// today.
-				if !hasUsableSigningKey(entity, now) {
-					t.Errorf("%s: no unexpired signing-capable key (primary or subkey) — refresh the embedded snapshot",
-						tc.name)
-				}
+			if !info.LatestSigningExpiry.IsZero() && info.LatestSigningExpiry.Before(time.Now()) {
+				t.Errorf("%s: latest signing-key expiry %s is in the past — refresh the embedded snapshot",
+					tc.name, info.LatestSigningExpiry.Format(time.RFC3339))
 			}
 		})
 	}
-}
-
-// primaryIdentity returns the entity's primary identity, or nil if none.
-func primaryIdentity(e *openpgp.Entity) *openpgp.Identity {
-	for _, id := range e.Identities {
-		return id
-	}
-	return nil
-}
-
-// hasUsableSigningKey returns true if the entity's primary key or any of its
-// subkeys is signing-capable and not expired at the given instant.
-func hasUsableSigningKey(e *openpgp.Entity, now time.Time) bool {
-	// Primary key with SC capability.
-	if e.PrimaryKey != nil && e.PrivateKey == nil {
-		ident := primaryIdentity(e)
-		if ident != nil && ident.SelfSignature != nil && ident.SelfSignature.FlagsValid && ident.SelfSignature.FlagSign {
-			if !primaryExpired(e, ident, now) {
-				return true
-			}
-		}
-	}
-	for _, sub := range e.Subkeys {
-		if sub.Sig == nil || !sub.Sig.FlagsValid || !sub.Sig.FlagSign {
-			continue
-		}
-		if sub.Sig.KeyLifetimeSecs != nil {
-			expiry := sub.PublicKey.CreationTime.Add(time.Duration(*sub.Sig.KeyLifetimeSecs) * time.Second)
-			if !now.Before(expiry) {
-				continue
-			}
-		}
-		return true
-	}
-	return false
-}
-
-func primaryExpired(e *openpgp.Entity, ident *openpgp.Identity, now time.Time) bool {
-	if ident.SelfSignature.KeyLifetimeSecs == nil {
-		return false
-	}
-	expiry := e.PrimaryKey.CreationTime.Add(time.Duration(*ident.SelfSignature.KeyLifetimeSecs) * time.Second)
-	return !now.Before(expiry)
 }

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -345,3 +345,37 @@ func StartDBStatsCollector(db *sql.DB) {
 		}
 	}()
 }
+
+// ReleasesKeyRefreshTotal counts attempts by the releases-key refresh job with
+// labels {tool, outcome}. Possible outcome values: "success",
+// "fingerprint_mismatch", "fetch_failed", "parse_failed", "db_failed",
+// "skipped_unchanged".
+//
+// Example PromQL:
+//   - Fingerprint mismatches in the last hour (a critical alert):
+//     increase(terraform_registry_releases_key_refresh_total{outcome="fingerprint_mismatch"}[1h])
+//   - Refresh failure rate by tool:
+//     sum by (tool) (rate(terraform_registry_releases_key_refresh_total{outcome!~"success|skipped_unchanged"}[1h]))
+var ReleasesKeyRefreshTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "terraform_registry_releases_key_refresh_total",
+		Help: "Total release-signing GPG key refresh attempts by tool and outcome.",
+	},
+	[]string{"tool", "outcome"},
+)
+
+// ReleasesKeyExpiresSeconds is a GaugeVec reporting seconds until the earliest
+// signing-key expiry for each {tool, source} pair. source is "cache" or
+// "embedded". 0 means no expiry is set on the key (rare; usually means the
+// gauge has not been populated yet).
+//
+// Example PromQL:
+//   - Alert when any source is within 30 days of expiry:
+//     min by (tool) (terraform_registry_releases_key_expires_seconds) < 86400 * 30
+var ReleasesKeyExpiresSeconds = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "terraform_registry_releases_key_expires_seconds",
+		Help: "Seconds until the earliest signing-key expiry, by tool and source (cache|embedded).",
+	},
+	[]string{"tool", "source"},
+)

--- a/backend/internal/telemetry/metrics_test.go
+++ b/backend/internal/telemetry/metrics_test.go
@@ -30,6 +30,8 @@ func TestMetricRegistration(t *testing.T) {
 		{"AuditLogsCleanedTotal", AuditLogsCleanedTotal},
 		{"WebhookRetriesTotal", WebhookRetriesTotal},
 		{"DBOpenConnections", DBOpenConnections},
+		{"ReleasesKeyRefreshTotal", ReleasesKeyRefreshTotal},
+		{"ReleasesKeyExpiresSeconds", ReleasesKeyExpiresSeconds},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -83,6 +85,16 @@ func TestModuleScanDurationLabels(t *testing.T) {
 
 func TestWebhookRetriesTotalLabels(t *testing.T) {
 	WebhookRetriesTotal.WithLabelValues("success").Inc()
+}
+
+func TestReleasesKeyRefreshTotalLabels(t *testing.T) {
+	ReleasesKeyRefreshTotal.WithLabelValues("terraform", "success").Inc()
+	ReleasesKeyRefreshTotal.WithLabelValues("opentofu", "fingerprint_mismatch").Inc()
+}
+
+func TestReleasesKeyExpiresSecondsLabels(t *testing.T) {
+	ReleasesKeyExpiresSeconds.WithLabelValues("terraform", "cache").Set(86400 * 365)
+	ReleasesKeyExpiresSeconds.WithLabelValues("opentofu", "embedded").Set(86400 * 90)
 }
 
 func TestStartDBStatsCollector(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -609,6 +609,58 @@ counter with an `outcome` label (`success`, `failure`, `exhausted`). See
 
 ---
 
+## Release Signing Keys (auto-refresh)
+
+The terraform binary mirror verifies upstream SHA256SUMS files against ASCII-armored
+GPG keys for HashiCorp and OpenTofu. The repo ships embedded snapshots of those keys
+as an offline fallback, but every snapshot has a self-sig expiration — when it
+passes, every mirror sync fails GPG verification (see [#415][issue-415] for the
+incident). To prevent that, a background job re-fetches each tool's public key
+from its `.well-known/pgp-key.txt` endpoint on a schedule and caches it in the
+database. The mirror sync prefers the cached key over the embedded snapshot.
+
+New keys are accepted only if their parsed **primary fingerprint matches a
+hardcoded allow-list** in `internal/jobs`. A compromised TLS path can never
+substitute a different key — at worst it can serve a stale or denied response,
+and we fall back to the embedded snapshot.
+
+Rotating to a new fingerprint requires a reviewed code change to update the
+allow-list. There is intentionally no DB or config knob for that.
+
+[issue-415]: https://github.com/sethbacon/terraform-registry-backend/issues/415
+
+```yaml
+releases_gpg_keys:
+  enabled: true                  # set false for air-gapped deployments
+  refresh_interval_hours: 24
+  expiry_warning_days: 60
+  hashicorp_url: https://www.hashicorp.com/.well-known/pgp-key.txt
+  opentofu_url:  https://opentofu.org/.well-known/pgp-key.txt
+```
+
+| Variable                                          | Type   | Default                                              | Description                                                                                                            |
+| ------------------------------------------------- | ------ | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `TFR_RELEASES_GPG_KEYS_ENABLED`                   | bool   | `true`                                               | Master toggle. When `false`, the job never runs and mirror sync always uses the embedded snapshots.                    |
+| `TFR_RELEASES_GPG_KEYS_REFRESH_INTERVAL_HOURS`    | int    | `24`                                                 | How often the job re-fetches each upstream key.                                                                        |
+| `TFR_RELEASES_GPG_KEYS_EXPIRY_WARNING_DAYS`       | int    | `60`                                                 | Warning threshold. When the effective key (cache or embedded) is within this many days of expiry, the job logs a warn. |
+| `TFR_RELEASES_GPG_KEYS_HASHICORP_URL`             | string | `https://www.hashicorp.com/.well-known/pgp-key.txt`  | Override the HashiCorp upstream URL (e.g. when proxying through an internal mirror).                                   |
+| `TFR_RELEASES_GPG_KEYS_OPENTOFU_URL`              | string | `https://opentofu.org/.well-known/pgp-key.txt`       | Override the OpenTofu upstream URL.                                                                                    |
+
+The job emits two Prometheus metrics:
+
+- `terraform_registry_releases_key_refresh_total{tool, outcome}` (counter):
+  outcomes are `success`, `fingerprint_mismatch`, `fetch_failed`,
+  `parse_failed`, `db_failed`, `skipped_unchanged`. Any
+  `fingerprint_mismatch` should page on-call — it indicates either an
+  upstream key rotation we need to allow-list, or an attempted substitution.
+- `terraform_registry_releases_key_expires_seconds{tool, source}` (gauge):
+  seconds until the earliest signing-key expiry. `source` is `cache` or
+  `embedded`. Alert when `min by (tool) (...)` drops below your refresh SLA.
+
+See [Observability Reference](observability.md) for example PromQL alerts.
+
+---
+
 ## Notifications
 
 ```yaml


### PR DESCRIPTION
## Summary

Follow-up to #415 / #416. The embedded HashiCorp/OpenTofu release-signing snapshots ship in-repo so they work air-gapped, but every snapshot has a self-sig expiration. On 2026-04-18 we hit that in production and every terraform mirror sync silently failed GPG verification. The next expiry is 2030; this PR makes sure it doesn't recur.

Two new layers of defense:

1. **`ReleasesKeyRefreshJob`** fetches each tool's public key from its `.well-known/pgp-key.txt` endpoint on a schedule (default 24h) and caches it in a new `releases_gpg_keys` table. `gpgKeyForTool` now consults a package-level resolver before falling back to the embedded snapshot, so a successful refresh takes effect on the next sync tick with no extra DB round trips.
2. **Pre-expiry warning** via a new `terraform_registry_releases_key_expires_seconds{tool, source}` gauge plus warn/error logs once the effective key is within `ExpiryWarningDays` (default 60) of expiring.

## Trust model

New keys are accepted **only** if the parsed primary-key fingerprint matches a hardcoded allow-list:

- HashiCorp: `C874011F0AB405110D02105534365D9472D7468F` (literal)
- OpenTofu: derived from the embedded snapshot at job construction (so a future snapshot refresh updates both the constant and the pin in one edit)

A compromised TLS path can never substitute a different key. Rotating to a different primary fingerprint is intentionally **not** automated — it requires a reviewed code change to bump the allow-list. Persisted rows are re-checked against the pin during cache priming so even a manual DB edit can't poison the resolver.

Closes #418

## What's new

| File | Purpose |
| ---- | ------- |
| `internal/mirror/key_fetcher.go` | `FetchReleasesKey` (HTTP + parse + fingerprint pin) and `ParseReleasesKey` (parse-only inspector). |
| `internal/db/migrations/000036_releases_gpg_keys.*` | Reversible migration adding the cache table keyed by tool. |
| `internal/db/models/releases_gpg_key.go` + `repositories/releases_gpg_key_repository.go` | Get/Upsert against the new table. |
| `internal/jobs/releases_key_refresh_job.go` | Start/Stop background job mirroring the WebhookRetryJob pattern; implements `ReleasesKeyResolver` so it doubles as the in-process cache. |
| `internal/jobs/terraform_mirror_sync.go` | `gpgKeyForTool` now consults `releasesKeyResolver` before the embedded fallback. `SetReleasesKeyResolver` is the install hook. |
| `internal/config/config.go` | New `ReleasesGPGKeys` section with sensible defaults; `enabled: false` for air-gapped deployments. |
| `internal/telemetry/metrics.go` | `ReleasesKeyRefreshTotal{tool, outcome}` counter + `ReleasesKeyExpiresSeconds{tool, source}` gauge. |
| `internal/api/router.go` | Construct + wire job, install as resolver, `Stop()` on shutdown. |
| `docs/configuration.md` | Operator-facing config + observability docs. |
| `internal/db/migrations/README.md` | Index row for migration 036. |

## Config (with defaults)

```yaml
releases_gpg_keys:
  enabled: true
  refresh_interval_hours: 24
  expiry_warning_days: 60
  hashicorp_url: https://www.hashicorp.com/.well-known/pgp-key.txt
  opentofu_url:  https://opentofu.org/.well-known/pgp-key.txt
```

## Telemetry

- `terraform_registry_releases_key_refresh_total{tool, outcome}` — outcomes: `success`, `fingerprint_mismatch`, `fetch_failed`, `parse_failed`, `db_failed`, `skipped_unchanged`. **Alert on any `fingerprint_mismatch`.**
- `terraform_registry_releases_key_expires_seconds{tool, source}` — `source` ∈ `{cache, embedded}`. Alert when `min by (tool) (...) < 86400 * 30`.

## Test plan

- [x] `go fmt ./...` clean (one unrelated pre-existing drift in `mirror_test.go` left as-is)
- [x] `go vet ./...` clean
- [x] Repository tests (5/5 pass): get/upsert round-trip + error paths
- [x] Fetcher tests (10/10 pass): success, fingerprint mismatch, case-insensitive pin, HTTP error, malformed body, bad pin shape, empty armor
- [x] Refresh job tests (14/14 pass): disabled is no-op, success caches + upserts, fingerprint mismatch leaves cache untouched (no Upsert expected), fetch failure leaves cache untouched, skipped-unchanged dedupes, prime-cache loads persisted row, prime-cache rejects drift-fingerprint row, export gauges doesn't panic, nil-safe resolver/Stop, idempotent Stop, runCycle drives full path with one tool succeeding and one failing
- [x] Resolver hook tests (4/4 pass on top of existing `gpgKeyForTool` suite): resolver overrides embedded, resolver-empty falls back to embedded, nil resolver uses embedded
- [x] Telemetry tests (2 new pass): label sets stable, registration test extended
- [x] Embedded-key regression test from #416 refactored to use new `ParseReleasesKey` — covers both snapshots; passes
- [x] Full suite: `go test ./internal/... ./pkg/...` — all packages pass
- [x] Coverage filter: `total: 80.0%` (at threshold)
- [x] `gosec` baseline compare: **New: 0** (21 active vs. 24 baseline; same 3 unrelated resolved)
- [ ] Manual: deploy this build to dev, watch logs for `releases key refresh: cached upstream key`, confirm a row appears in `releases_gpg_keys`, and confirm the GPG column stays green on the next sync cycle even with a synthetically-expired embedded snapshot

## Notes for reviewers

- The package-level `releasesKeyResolver` var is a small piece of mutable global state. Justified vs. a constructor-injection refactor because every call site already lives behind `gpgKeyForTool`, and the only writer is `router.go` once at startup. Tests reset it via `t.Cleanup(func() { SetReleasesKeyResolver(nil) })`.
- `NewReleasesKeyRefreshJob` returns an error if it can't parse the embedded OpenTofu snapshot — fatal because we can't derive the pin. `router.go` logs that and continues without auto-refresh; the embedded fallback still works.
- I deliberately did not add an admin HTTP endpoint to inspect cache state. Operators can `SELECT * FROM releases_gpg_keys` and watch the metrics; adding an endpoint is a separate concern with its own auth/audit considerations.