### PR TITLE
feat(mirror): admin endpoint for release signing key state

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -4692,6 +4692,65 @@
                 }
             }
         },
+        "/api/v1/admin/terraform-mirrors/releases-gpg-keys": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "tags": [
+                    "Terraform Mirror"
+                ],
+                "summary": "Get release signing key cache + expiry state",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.ReleasesGPGKeysResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Missing required scope",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/terraform-mirrors/{id}": {
             "get": {
                 "security": [
@@ -16255,6 +16314,79 @@
                     },
                     "token": {
                         "type": "string"
+                    }
+                }
+            },
+            "admin.ReleasesGPGKeyCacheView": {
+                "type": "object",
+                "properties": {
+                    "armored_present": {
+                        "type": "boolean"
+                    },
+                    "days_until_expiry": {
+                        "type": "integer"
+                    },
+                    "fetched_at": {
+                        "type": "string"
+                    },
+                    "fingerprint": {
+                        "type": "string"
+                    },
+                    "key_expires_at": {
+                        "type": "string"
+                    },
+                    "source_url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "admin.ReleasesGPGKeyEmbeddedView": {
+                "type": "object",
+                "properties": {
+                    "days_until_expiry": {
+                        "type": "integer"
+                    },
+                    "fingerprint": {
+                        "type": "string"
+                    },
+                    "key_expires_at": {
+                        "type": "string"
+                    }
+                }
+            },
+            "admin.ReleasesGPGKeyStatusView": {
+                "type": "object",
+                "properties": {
+                    "cache": {
+                        "$ref": "#/components/schemas/admin.ReleasesGPGKeyCacheView"
+                    },
+                    "effective_source": {
+                        "description": "\"cache\" | \"embedded\"",
+                        "type": "string"
+                    },
+                    "embedded": {
+                        "$ref": "#/components/schemas/admin.ReleasesGPGKeyEmbeddedView"
+                    },
+                    "expiry_warning_days": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\"",
+                        "type": "string"
+                    },
+                    "tool": {
+                        "type": "string"
+                    }
+                }
+            },
+            "admin.ReleasesGPGKeysResponse": {
+                "type": "object",
+                "properties": {
+                    "keys": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/admin.ReleasesGPGKeyStatusView"
+                        }
                     }
                 }
             },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3744,6 +3744,52 @@
                 }
             }
         },
+        "/api/v1/admin/terraform-mirrors/releases-gpg-keys": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Terraform Mirror"
+                ],
+                "summary": "Get release signing key cache + expiry state",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ReleasesGPGKeysResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Missing required scope",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/terraform-mirrors/{id}": {
             "get": {
                 "security": [
@@ -13272,6 +13318,79 @@
                 },
                 "token": {
                     "type": "string"
+                }
+            }
+        },
+        "admin.ReleasesGPGKeyCacheView": {
+            "type": "object",
+            "properties": {
+                "armored_present": {
+                    "type": "boolean"
+                },
+                "days_until_expiry": {
+                    "type": "integer"
+                },
+                "fetched_at": {
+                    "type": "string"
+                },
+                "fingerprint": {
+                    "type": "string"
+                },
+                "key_expires_at": {
+                    "type": "string"
+                },
+                "source_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ReleasesGPGKeyEmbeddedView": {
+            "type": "object",
+            "properties": {
+                "days_until_expiry": {
+                    "type": "integer"
+                },
+                "fingerprint": {
+                    "type": "string"
+                },
+                "key_expires_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ReleasesGPGKeyStatusView": {
+            "type": "object",
+            "properties": {
+                "cache": {
+                    "$ref": "#/definitions/admin.ReleasesGPGKeyCacheView"
+                },
+                "effective_source": {
+                    "description": "\"cache\" | \"embedded\"",
+                    "type": "string"
+                },
+                "embedded": {
+                    "$ref": "#/definitions/admin.ReleasesGPGKeyEmbeddedView"
+                },
+                "expiry_warning_days": {
+                    "type": "integer"
+                },
+                "status": {
+                    "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\"",
+                    "type": "string"
+                },
+                "tool": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.ReleasesGPGKeysResponse": {
+            "type": "object",
+            "properties": {
+                "keys": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.ReleasesGPGKeyStatusView"
+                    }
                 }
             }
         },

--- a/backend/internal/api/admin/releases_gpg_keys.go
+++ b/backend/internal/api/admin/releases_gpg_keys.go
@@ -1,0 +1,218 @@
+// releases_gpg_keys.go implements the admin read-only endpoint that surfaces
+// the state of the upstream-key refresh feature. The mirror admin page and the
+// admin dashboard tile consume it to show a glance-level view of whether the
+// GPG keys mirror sync uses are fresh, where they came from (cache vs
+// embedded), and how close they are to expiry.
+//
+// All computation here is pure: read the cached row, parse the embedded
+// snapshot, derive expiry math and status from the configured warning
+// threshold. No writes, no upstream fetches — those belong to
+// ReleasesKeyRefreshJob.
+package admin
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+)
+
+// releasesGPGKeyRepo is the subset of ReleasesGPGKeyRepository used by this
+// handler. Defining it locally keeps the handler testable without dragging
+// the full repository into the mock surface.
+type releasesGPGKeyRepo interface {
+	Get(ctx context.Context, tool string) (*models.ReleasesGPGKey, error)
+}
+
+// ReleasesGPGKeysHandler exposes the GET /api/v1/admin/releases-gpg-keys
+// endpoint. It mirrors the embedded snapshot + cache lookup logic from
+// ReleasesKeyRefreshJob, but as a pure read so the UI can show the same
+// effective state the mirror sync uses.
+type ReleasesGPGKeysHandler struct {
+	repo releasesGPGKeyRepo
+	cfg  config.ReleasesGPGKeysConfig
+}
+
+// NewReleasesGPGKeysHandler constructs a ReleasesGPGKeysHandler.
+func NewReleasesGPGKeysHandler(repo releasesGPGKeyRepo, cfg config.ReleasesGPGKeysConfig) *ReleasesGPGKeysHandler {
+	return &ReleasesGPGKeysHandler{repo: repo, cfg: cfg}
+}
+
+// supportedReleasesGPGTools is the canonical iteration order — keep stable so
+// API consumers can rely on the ordering of the response array.
+var supportedReleasesGPGTools = []string{"terraform", "opentofu"}
+
+// ReleasesGPGKeyCacheView is the cache-side block in the response. Embedded
+// in the per-tool object; nil when no row has been persisted yet.
+type ReleasesGPGKeyCacheView struct {
+	ArmoredPresent  bool       `json:"armored_present"`
+	Fingerprint     string     `json:"fingerprint"`
+	FetchedAt       time.Time  `json:"fetched_at"`
+	SourceURL       string     `json:"source_url"`
+	KeyExpiresAt    *time.Time `json:"key_expires_at,omitempty"`
+	DaysUntilExpiry *int       `json:"days_until_expiry,omitempty"`
+}
+
+// ReleasesGPGKeyEmbeddedView is the embedded-snapshot block. Always present
+// because the snapshot is compiled in.
+type ReleasesGPGKeyEmbeddedView struct {
+	Fingerprint     string     `json:"fingerprint"`
+	KeyExpiresAt    *time.Time `json:"key_expires_at,omitempty"`
+	DaysUntilExpiry *int       `json:"days_until_expiry,omitempty"`
+}
+
+// ReleasesGPGKeyStatusView is one tool's row in the response. Status is
+// pre-computed against ExpiryWarningDays so the UI doesn't have to re-derive
+// the threshold; effective_source mirrors gpgKeyForTool so the UI shows the
+// same source the mirror sync actually uses.
+type ReleasesGPGKeyStatusView struct {
+	Tool              string                      `json:"tool"`
+	Cache             *ReleasesGPGKeyCacheView    `json:"cache"`
+	Embedded          *ReleasesGPGKeyEmbeddedView `json:"embedded"`
+	EffectiveSource   string                      `json:"effective_source"` // "cache" | "embedded"
+	ExpiryWarningDays int                         `json:"expiry_warning_days"`
+	Status            string                      `json:"status"` // "ok" | "warn" | "expired" | "unknown"
+}
+
+// ReleasesGPGKeysResponse is the top-level response envelope.
+type ReleasesGPGKeysResponse struct {
+	Keys []ReleasesGPGKeyStatusView `json:"keys"`
+}
+
+// @Summary      Get release signing key cache + expiry state
+// @Description  Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.
+// @Tags         Terraform Mirror
+// @Security     Bearer
+// @Produce      json
+// @Success      200  {object}  admin.ReleasesGPGKeysResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "Missing required scope"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/terraform-mirrors/releases-gpg-keys [get]
+func (h *ReleasesGPGKeysHandler) GetReleasesGPGKeys(c *gin.Context) {
+	now := time.Now()
+	warningDays := h.cfg.ExpiryWarningDays
+	if warningDays <= 0 {
+		warningDays = 60
+	}
+
+	out := make([]ReleasesGPGKeyStatusView, 0, len(supportedReleasesGPGTools))
+	for _, tool := range supportedReleasesGPGTools {
+		view, err := h.buildToolView(c.Request.Context(), tool, now, warningDays)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load releases key state: " + err.Error()})
+			return
+		}
+		out = append(out, view)
+	}
+
+	c.JSON(http.StatusOK, ReleasesGPGKeysResponse{Keys: out})
+}
+
+// buildToolView assembles one tool's row. Splits cache + embedded loading,
+// derives expiry math, and chooses effective source + status.
+func (h *ReleasesGPGKeysHandler) buildToolView(ctx context.Context, tool string, now time.Time, warningDays int) (ReleasesGPGKeyStatusView, error) {
+	view := ReleasesGPGKeyStatusView{
+		Tool:              tool,
+		ExpiryWarningDays: warningDays,
+		Status:            "unknown",
+	}
+
+	cacheRow, err := h.repo.Get(ctx, tool)
+	if err != nil {
+		return view, err
+	}
+	if cacheRow != nil {
+		view.Cache = &ReleasesGPGKeyCacheView{
+			ArmoredPresent: cacheRow.ArmoredKey != "",
+			Fingerprint:    cacheRow.PrimaryFingerprint,
+			FetchedAt:      cacheRow.FetchedAt,
+			SourceURL:      cacheRow.SourceURL,
+			KeyExpiresAt:   cacheRow.KeyExpiresAt,
+		}
+		if cacheRow.KeyExpiresAt != nil {
+			d := daysBetween(now, *cacheRow.KeyExpiresAt)
+			view.Cache.DaysUntilExpiry = &d
+		}
+	}
+
+	embedded := embeddedKeyArmoredForTool(tool)
+	if embedded != "" {
+		if info, parseErr := mirror.ParseReleasesKey(embedded); parseErr == nil {
+			view.Embedded = &ReleasesGPGKeyEmbeddedView{
+				Fingerprint: info.PrimaryFingerprint,
+			}
+			if !info.LatestSigningExpiry.IsZero() {
+				expiry := info.LatestSigningExpiry
+				view.Embedded.KeyExpiresAt = &expiry
+				d := daysBetween(now, expiry)
+				view.Embedded.DaysUntilExpiry = &d
+			}
+		}
+	}
+
+	// Effective source: prefer cache only when its fingerprint matches the
+	// embedded one. A drifted cache row (manual DB edit, future allow-list
+	// rotation) is reported as effective=embedded so the UI shows what the
+	// mirror sync actually uses — the refresh job's cache-prime check
+	// ignores drift-fingerprint rows for the same reason.
+	view.EffectiveSource = "embedded"
+	if view.Cache != nil && view.Embedded != nil && view.Cache.Fingerprint == view.Embedded.Fingerprint {
+		view.EffectiveSource = "cache"
+	}
+
+	// Status is derived against the effective source's expiry so the UI
+	// shows the same risk operators would actually face.
+	view.Status = computeStatus(view, warningDays)
+	return view, nil
+}
+
+// computeStatus returns "ok", "warn", "expired", or "unknown" against the
+// effective source's days-until-expiry.
+func computeStatus(view ReleasesGPGKeyStatusView, warningDays int) string {
+	var days *int
+	if view.EffectiveSource == "cache" && view.Cache != nil {
+		days = view.Cache.DaysUntilExpiry
+	} else if view.Embedded != nil {
+		days = view.Embedded.DaysUntilExpiry
+	}
+	if days == nil {
+		return "unknown"
+	}
+	switch {
+	case *days < 0:
+		return "expired"
+	case *days < warningDays:
+		return "warn"
+	default:
+		return "ok"
+	}
+}
+
+// daysBetween returns ceil((to - from) in days). Negative when 'to' is past.
+func daysBetween(from, to time.Time) int {
+	diff := to.Sub(from).Hours() / 24
+	if diff >= 0 {
+		return int(math.Ceil(diff))
+	}
+	return int(math.Floor(diff))
+}
+
+// embeddedKeyArmoredForTool returns the compiled-in snapshot. Defined here
+// (rather than reaching across packages into jobs.embeddedKeyForTool which
+// is unexported) so this handler stays self-contained.
+func embeddedKeyArmoredForTool(tool string) string {
+	switch tool {
+	case "terraform":
+		return mirror.HashiCorpReleasesGPGKey
+	case "opentofu":
+		return mirror.OpenTofuReleasesGPGKey
+	default:
+		return ""
+	}
+}

--- a/backend/internal/api/admin/releases_gpg_keys_test.go
+++ b/backend/internal/api/admin/releases_gpg_keys_test.go
@@ -1,0 +1,287 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+)
+
+// stubReleasesRepo is a configurable test double for releasesGPGKeyRepo.
+type stubReleasesRepo struct {
+	rows map[string]*models.ReleasesGPGKey
+	err  error
+}
+
+func (s *stubReleasesRepo) Get(_ context.Context, tool string) (*models.ReleasesGPGKey, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.rows[tool], nil
+}
+
+func newReleasesGPGRouter(t *testing.T, repo releasesGPGKeyRepo, cfg config.ReleasesGPGKeysConfig) *gin.Engine {
+	t.Helper()
+	h := NewReleasesGPGKeysHandler(repo, cfg)
+	r := gin.New()
+	r.GET("/admin/terraform-mirrors/releases-gpg-keys", h.GetReleasesGPGKeys)
+	return r
+}
+
+// defaultCfg returns a config equivalent to the production defaults so
+// status-threshold tests reflect real behaviour.
+func defaultReleasesCfg() config.ReleasesGPGKeysConfig {
+	return config.ReleasesGPGKeysConfig{
+		Enabled:              true,
+		RefreshIntervalHours: 24,
+		ExpiryWarningDays:    60,
+		HashiCorpURL:         "https://www.hashicorp.com/.well-known/pgp-key.txt",
+		OpenTofuURL:          "https://opentofu.org/.well-known/pgp-key.txt",
+	}
+}
+
+// invokeAndDecode runs a GET and returns the decoded response or fails the test.
+func invokeAndDecode(t *testing.T, r *gin.Engine) (int, ReleasesGPGKeysResponse) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/terraform-mirrors/releases-gpg-keys", nil))
+	if w.Code != http.StatusOK {
+		return w.Code, ReleasesGPGKeysResponse{}
+	}
+	var body ReleasesGPGKeysResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return w.Code, body
+}
+
+// findTool returns the per-tool view from a response, failing the test if absent.
+func findTool(t *testing.T, body ReleasesGPGKeysResponse, tool string) ReleasesGPGKeyStatusView {
+	t.Helper()
+	for _, k := range body.Keys {
+		if k.Tool == tool {
+			return k
+		}
+	}
+	t.Fatalf("tool %q not found in response", tool)
+	return ReleasesGPGKeyStatusView{}
+}
+
+func TestReleasesGPGKeys_NoCacheRows_EmbeddedFallback(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	code, body := invokeAndDecode(t, r)
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if len(body.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(body.Keys))
+	}
+
+	tf := findTool(t, body, "terraform")
+	if tf.Cache != nil {
+		t.Error("terraform: expected nil Cache when no row")
+	}
+	if tf.Embedded == nil {
+		t.Fatal("terraform: expected Embedded block to be populated")
+	}
+	if tf.EffectiveSource != "embedded" {
+		t.Errorf("terraform: EffectiveSource = %q, want embedded", tf.EffectiveSource)
+	}
+	if tf.Status == "unknown" {
+		// The embedded snapshot has a known expiry; status should not be unknown.
+		t.Error("terraform: expected status to be derived from embedded expiry, got unknown")
+	}
+}
+
+func TestReleasesGPGKeys_CacheRowMatchesEmbedded_EffectiveSourceCache(t *testing.T) {
+	// Parse the embedded snapshot so the test cache row has a matching fingerprint.
+	info, err := mirror.ParseReleasesKey(mirror.HashiCorpReleasesGPGKey)
+	if err != nil {
+		t.Fatalf("parse embedded: %v", err)
+	}
+	expiry := time.Now().Add(365 * 24 * time.Hour)
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{
+		"terraform": {
+			Tool:               "terraform",
+			ArmoredKey:         mirror.HashiCorpReleasesGPGKey,
+			PrimaryFingerprint: info.PrimaryFingerprint,
+			KeyExpiresAt:       &expiry,
+			SourceURL:          "https://www.hashicorp.com/.well-known/pgp-key.txt",
+			FetchedAt:          time.Now().Add(-2 * time.Hour),
+		},
+	}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	tf := findTool(t, body, "terraform")
+
+	if tf.Cache == nil {
+		t.Fatal("expected Cache block to be populated")
+	}
+	if !tf.Cache.ArmoredPresent {
+		t.Error("ArmoredPresent = false, want true (row has armored bytes)")
+	}
+	if tf.Cache.Fingerprint != info.PrimaryFingerprint {
+		t.Errorf("cache fingerprint = %q, want %q", tf.Cache.Fingerprint, info.PrimaryFingerprint)
+	}
+	if tf.EffectiveSource != "cache" {
+		t.Errorf("EffectiveSource = %q, want cache", tf.EffectiveSource)
+	}
+	if tf.Status != "ok" {
+		t.Errorf("Status = %q, want ok for 365-day expiry", tf.Status)
+	}
+	if tf.Cache.DaysUntilExpiry == nil {
+		t.Error("DaysUntilExpiry should be set when KeyExpiresAt is non-nil")
+	} else if *tf.Cache.DaysUntilExpiry < 360 || *tf.Cache.DaysUntilExpiry > 366 {
+		t.Errorf("DaysUntilExpiry = %d, want ~365", *tf.Cache.DaysUntilExpiry)
+	}
+}
+
+func TestReleasesGPGKeys_CacheFingerprintDrift_EffectiveSourceEmbedded(t *testing.T) {
+	// Cache row exists but has a different fingerprint (e.g. allow-list bumped
+	// and a stale row left behind). Effective source must report embedded so
+	// the UI shows what the mirror sync actually uses.
+	expiry := time.Now().Add(365 * 24 * time.Hour)
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{
+		"terraform": {
+			Tool:               "terraform",
+			ArmoredKey:         "ARMORED-WITH-WRONG-FPR",
+			PrimaryFingerprint: "0000000000000000000000000000000000000000",
+			KeyExpiresAt:       &expiry,
+			SourceURL:          "https://example.com",
+			FetchedAt:          time.Now(),
+		},
+	}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	tf := findTool(t, body, "terraform")
+	if tf.EffectiveSource != "embedded" {
+		t.Errorf("EffectiveSource = %q, want embedded (cache fpr does not match embedded)", tf.EffectiveSource)
+	}
+}
+
+func TestReleasesGPGKeys_Status_Expired(t *testing.T) {
+	// Cache row matches embedded fingerprint but expired yesterday.
+	info, _ := mirror.ParseReleasesKey(mirror.HashiCorpReleasesGPGKey)
+	expired := time.Now().Add(-24 * time.Hour)
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{
+		"terraform": {
+			Tool:               "terraform",
+			ArmoredKey:         mirror.HashiCorpReleasesGPGKey,
+			PrimaryFingerprint: info.PrimaryFingerprint,
+			KeyExpiresAt:       &expired,
+			SourceURL:          "https://example.com",
+			FetchedAt:          time.Now(),
+		},
+	}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	tf := findTool(t, body, "terraform")
+	if tf.Status != "expired" {
+		t.Errorf("Status = %q, want expired", tf.Status)
+	}
+	if tf.Cache == nil || tf.Cache.DaysUntilExpiry == nil {
+		t.Fatal("expected DaysUntilExpiry to be set on cache view")
+	}
+	if *tf.Cache.DaysUntilExpiry >= 0 {
+		t.Errorf("expected negative days, got %d", *tf.Cache.DaysUntilExpiry)
+	}
+}
+
+func TestReleasesGPGKeys_Status_Warn(t *testing.T) {
+	info, _ := mirror.ParseReleasesKey(mirror.HashiCorpReleasesGPGKey)
+	// Effective key expires in 30 days — inside the default 60-day warning window.
+	soon := time.Now().Add(30 * 24 * time.Hour)
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{
+		"terraform": {
+			Tool:               "terraform",
+			ArmoredKey:         mirror.HashiCorpReleasesGPGKey,
+			PrimaryFingerprint: info.PrimaryFingerprint,
+			KeyExpiresAt:       &soon,
+			SourceURL:          "https://example.com",
+			FetchedAt:          time.Now(),
+		},
+	}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	tf := findTool(t, body, "terraform")
+	if tf.Status != "warn" {
+		t.Errorf("Status = %q, want warn for 30d expiry with 60d threshold", tf.Status)
+	}
+}
+
+func TestReleasesGPGKeys_DefaultWarningDays_AppliedWhenConfigZero(t *testing.T) {
+	// Cfg with ExpiryWarningDays = 0 must fall back to 60.
+	cfg := defaultReleasesCfg()
+	cfg.ExpiryWarningDays = 0
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouter(t, repo, cfg)
+
+	_, body := invokeAndDecode(t, r)
+	for _, k := range body.Keys {
+		if k.ExpiryWarningDays != 60 {
+			t.Errorf("%s: ExpiryWarningDays = %d, want 60 (default)", k.Tool, k.ExpiryWarningDays)
+		}
+	}
+}
+
+func TestReleasesGPGKeys_DBError_Returns500(t *testing.T) {
+	repo := &stubReleasesRepo{err: errors.New("db down")}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/terraform-mirrors/releases-gpg-keys", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestReleasesGPGKeys_BothToolsAlwaysReturned(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	seen := map[string]bool{}
+	for _, k := range body.Keys {
+		seen[k.Tool] = true
+	}
+	if !seen["terraform"] || !seen["opentofu"] {
+		t.Errorf("expected both terraform and opentofu in response, got %+v", seen)
+	}
+}
+
+func TestDaysBetween_Symmetry(t *testing.T) {
+	// Future: positive days.
+	if got := daysBetween(time.Unix(0, 0), time.Unix(86400*10, 0)); got != 10 {
+		t.Errorf("daysBetween(+10d) = %d, want 10", got)
+	}
+	// Past: negative days.
+	if got := daysBetween(time.Unix(86400*10, 0), time.Unix(0, 0)); got >= 0 {
+		t.Errorf("daysBetween(-10d) = %d, want negative", got)
+	}
+}
+
+func TestEmbeddedKeyArmoredForTool(t *testing.T) {
+	if embeddedKeyArmoredForTool("terraform") == "" {
+		t.Error("expected non-empty terraform key")
+	}
+	if embeddedKeyArmoredForTool("opentofu") == "" {
+		t.Error("expected non-empty opentofu key")
+	}
+	if embeddedKeyArmoredForTool("nope") != "" {
+		t.Error("expected empty for unknown tool")
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -585,6 +585,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	// Initialize Terraform binary mirror admin handler
 	tfMirrorAdminHandler := admin.NewTerraformMirrorHandler(tfMirrorRepo)
 	tfMirrorAdminHandler.SetSyncJob(tfMirrorSyncJob)
+	releasesGPGKeysAdminHandler := admin.NewReleasesGPGKeysHandler(releasesKeyRepo, cfg.ReleasesGPGKeys)
 	providerAdminHandlers := admin.NewProviderAdminHandlers(db, storageBackend, cfg)
 	moduleAdminHandlers := admin.NewModuleAdminHandlers(db, storageBackend, cfg).
 		WithModuleDocs(moduleDocsRepo).
@@ -1055,6 +1056,9 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 			// Read operations require mirrors:read scope; management requires mirrors:manage
 			tfMirrorGroup := authenticatedGroup.Group("/admin/terraform-mirrors")
 			{
+				// Release-signing GPG key cache + expiry state (read-only).
+				// Registered before /:id routes so the static path takes priority.
+				tfMirrorGroup.GET("/releases-gpg-keys", middleware.RequireScope(auth.ScopeMirrorsRead), releasesGPGKeysAdminHandler.GetReleasesGPGKeys)
 				// Config CRUD
 				tfMirrorGroup.GET("", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListConfigs)
 				tfMirrorGroup.POST("", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.CreateConfig)

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -200,9 +200,10 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `POST /api/v1/admin/mirrors/:id/sync` - Trigger mirror sync
 - [x] `GET /terraform/providers/:hostname/:namespace/:type/index.json` - Mirror index (public)
 - [x] `GET /terraform/providers/:hostname/:namespace/:type/:versionfile` - Mirror version file (public)
+- [x] `GET /api/v1/admin/terraform-mirrors/releases-gpg-keys` - Release signing key cache + expiry state
 
-**Files**: `backend/internal/api/admin/mirror.go`, `backend/internal/api/mirror/index.go`, `backend/internal/api/mirror/platform_index.go`
-**Progress**: 9/9 annotated ✅
+**Files**: `backend/internal/api/admin/mirror.go`, `backend/internal/api/mirror/index.go`, `backend/internal/api/mirror/platform_index.go`, `backend/internal/api/admin/releases_gpg_keys.go`
+**Progress**: 10/10 annotated ✅
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the small admin endpoint planned in #420 so the upcoming frontend panel (#340) and dashboard tile (#341) can render a glance view of the release-signing key state introduced in #419 — without operators having to read Prometheus or query the DB.

`GET /api/v1/admin/terraform-mirrors/releases-gpg-keys` (scope: `mirrors:read`) returns the cached upstream key + embedded snapshot state for each supported tool with the effective source and a pre-computed status against the configured warning threshold.

Closes #420

## Response shape

```json
{
  "keys": [
    {
      "tool": "terraform",
      "cache": {
        "armored_present": true,
        "fingerprint": "C874011F0AB405110D02105534365D9472D7468F",
        "fetched_at": "2026-05-28T17:20:51Z",
        "source_url": "https://www.hashicorp.com/.well-known/pgp-key.txt",
        "key_expires_at": "2030-03-01T00:00:00Z",
        "days_until_expiry": 1373
      },
      "embedded": {
        "fingerprint": "C874011F0AB405110D02105534365D9472D7468F",
        "key_expires_at": "2030-03-01T00:00:00Z",
        "days_until_expiry": 1373
      },
      "effective_source": "cache",
      "expiry_warning_days": 60,
      "status": "ok"
    },
    {
      "tool": "opentofu",
      "cache": null,
      "embedded": { "...": "..." },
      "effective_source": "embedded",
      "expiry_warning_days": 60,
      "status": "ok"
    }
  ]
}
```

Both tools are **always** returned even when no cache row exists, so the UI doesn't have to handle 404 vs partial responses.

## Trust-model parity with the refresh job

The endpoint mirrors `gpgKeyForTool`'s effective-source logic so the response describes what the mirror sync actually uses:

- `effective_source = \"cache\"` only when `cache.fingerprint == embedded.fingerprint`.
- A drifted cache row (manual DB edit, future allow-list rotation) reports as `effective_source = \"embedded\"`. This matches `ReleasesKeyRefreshJob.primeCacheFromDB`'s conservative drop-on-drift behaviour from #419.

`status` is derived against the *effective* source's `days_until_expiry`:
- `\"expired\"` when the effective expiry is in the past
- `\"warn\"` when within `expiry_warning_days` of expiring (default 60, falls back to 60 when the config value is 0)
- `\"ok\"` otherwise
- `\"unknown\"` when no expiry data is available (defensive — shouldn't happen with the embedded snapshot present)

## What's new

| File | Purpose |
| ---- | ------- |
| `internal/api/admin/releases_gpg_keys.go` | New handler. Pure read; no writes, no upstream fetches. |
| `internal/api/admin/releases_gpg_keys_test.go` | 10 tests (see below). |
| `internal/api/router.go` | Construct + register route inside the `/admin/terraform-mirrors` group, before `/:id` so the static path wins the Gin radix tree. Scope `mirrors:read`. |
| `backend/docs/swagger.json` | Regenerated from annotations. |
| `docs/SWAGGER_ANNOTATION_CHECKLIST.md` | New row in Phase 6. |

## Test plan

- [x] `go fmt ./...` clean (pre-existing `mirror_test.go` fmt drift left untouched)
- [x] `go vet ./...` clean
- [x] Handler unit tests (10/10 pass):
  - No cache rows → embedded fallback for both tools
  - Cache row matches embedded fingerprint → effective_source=cache, status=ok, days_until_expiry populated
  - Cache fingerprint drift → effective_source=embedded (conservative)
  - Status=expired when effective expiry is past
  - Status=warn when effective expiry is within threshold
  - Default warning days applied when config value is 0
  - DB error → 500
  - Both tools always returned even when no cache rows exist
  - `daysBetween` symmetric for past/future
  - `embeddedKeyArmoredForTool` switch arms covered
- [x] Full suite: all packages pass
- [x] Coverage filter: `total: 80.1%` (above threshold)
- [x] `gosec` baseline compare: **New: 0**
- [x] Swagger regenerated; new endpoint appears at `/api/v1/admin/terraform-mirrors/releases-gpg-keys`
- [ ] Manual: after deploy, hit the endpoint with an admin token and confirm both tools return — cache populated after first refresh tick, embedded-only before that

## Notes for reviewers

- I used a local `releasesGPGKeyRepo` interface (just `Get`) instead of the concrete repository so the handler test can use a plain struct stub. No additional production wiring needed.
- The route is registered **before** `/:id` deliberately. Gin's radix tree actually prioritizes static segments anyway, but the ordering makes the intent obvious in the diff.
- I did not add a manual-refresh `POST` endpoint. Today operators wait at most `refresh_interval_hours`; if anyone needs that, it's a separate backend + frontend pair worth its own design discussion.