### PR TITLE
fix(mirror): backfill GPG key for existing provider versions on re-sync

### DIFF
--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -514,6 +514,18 @@ func (r *ProviderRepository) UpdateVersionSignatureStorage(ctx context.Context, 
 	return nil
 }
 
+// UpdateVersionGPGKey sets the gpg_public_key for an existing provider version.
+func (r *ProviderRepository) UpdateVersionGPGKey(ctx context.Context, versionID string, gpgKey string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE provider_versions SET gpg_public_key = $2 WHERE id = $1`,
+		versionID, gpgKey,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update provider version GPG key: %w", err)
+	}
+	return nil
+}
+
 // UndeprecateVersion removes the deprecated status from a provider version
 func (r *ProviderRepository) UndeprecateVersion(ctx context.Context, versionID string) error {
 	query := `

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -538,6 +538,25 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 				}
 			}
 
+			// Backfill GPG key if the stored value is empty or expired.
+			if existingVersion.GPGPublicKey == "" || !mirror.HasUsableGPGKey(existingVersion.GPGPublicKey) {
+				if len(version.Platforms) > 0 {
+					p0 := version.Platforms[0]
+					if pkgInfo, pkgErr := upstreamClient.GetProviderPackage(ctx, namespace, providerName, version.Version, p0.OS, p0.Arch); pkgErr == nil {
+						if len(pkgInfo.SigningKeys.GPGPublicKeys) > 0 {
+							resolved := mirror.ResolveExpiredGPGKey(pkgInfo.SigningKeys.GPGPublicKeys[0].ASCIIArmor)
+							if resolved != "" {
+								if err := j.providerRepo.UpdateVersionGPGKey(ctx, existingVersion.ID, resolved); err != nil {
+									log.Printf("Warning: failed to backfill GPG key for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+								} else {
+									log.Printf("Backfilled GPG key for %s/%s@%s", namespace, providerName, version.Version)
+								}
+							}
+						}
+					}
+				}
+			}
+
 			// Check for missing platforms — the user may have deleted individual
 			// platform records. Build a set of platforms already in the DB for this version.
 			existingPlatforms, err := j.providerRepo.ListPlatforms(ctx, existingVersion.ID)

--- a/backend/internal/mirror/gpg_resolve.go
+++ b/backend/internal/mirror/gpg_resolve.go
@@ -4,6 +4,16 @@ import "errors"
 
 const hashiCorpFingerprint = "C874011F0AB405110D02105534365D9472D7468F"
 
+// HasUsableGPGKey reports whether the armored key contains at least one
+// non-expired signing subkey or primary key.
+func HasUsableGPGKey(armored string) bool {
+	info, err := ParseReleasesKey(armored)
+	if err != nil {
+		return false
+	}
+	return info.HasUsableSigningKey
+}
+
 // ResolveExpiredGPGKey checks if an armored GPG key is expired and, if its
 // primary fingerprint matches a known releases key, returns the refreshed
 // embedded snapshot. If the key is valid, unparseable, or has an unknown

--- a/backend/internal/mirror/gpg_resolve_test.go
+++ b/backend/internal/mirror/gpg_resolve_test.go
@@ -166,3 +166,21 @@ func TestResolveExpiredGPGKey_UnknownExpiredKey_ReturnsUnchanged(t *testing.T) {
 		t.Error("expected non-HashiCorp key to be returned unchanged")
 	}
 }
+
+func TestHasUsableGPGKey_ValidKey(t *testing.T) {
+	if !HasUsableGPGKey(HashiCorpReleasesGPGKey) {
+		t.Error("expected current HashiCorp key to be usable")
+	}
+}
+
+func TestHasUsableGPGKey_ExpiredKey(t *testing.T) {
+	if HasUsableGPGKey(expiredHashiCorpKey) {
+		t.Error("expected expired key to be not usable")
+	}
+}
+
+func TestHasUsableGPGKey_Empty(t *testing.T) {
+	if HasUsableGPGKey("") {
+		t.Error("expected empty string to be not usable")
+	}
+}


### PR DESCRIPTION
## Summary

- Existing provider versions in the DB with empty or expired `gpg_public_key` were never updated on re-sync because the sync skips already-complete versions
- Adds `UpdateVersionGPGKey` repository method to update just the GPG key column
- Adds `HasUsableGPGKey` helper to check if a stored key is still valid
- During re-sync, if the stored GPG key is missing or expired, fetches the upstream key, resolves it through the fingerprint-pinned substitution, and persists it

This is the missing piece from #423 — that fix only handled new versions and download-time substitution, but existing versions with empty `gpg_public_key` were never backfilled.

## Test plan

- [x] `TestHasUsableGPGKey_ValidKey` — current key returns true
- [x] `TestHasUsableGPGKey_ExpiredKey` — expired key returns false
- [x] `TestHasUsableGPGKey_Empty` — empty string returns false
- [x] Full test suite passes (`go test ./...`)
- [ ] Deploy → trigger provider sync → verify GPG keys appear for existing providers