### PR TITLE
fix(mirror): resolve expired GPG keys for verification and backfill gpg_verified

### DIFF
--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -551,6 +551,18 @@ func (r *MirrorRepository) CreateMirroredProviderVersion(ctx context.Context, mp
 	return nil
 }
 
+// UpdateMirroredProviderVersionGPGStatus sets gpg_verified on a mirrored provider version.
+func (r *MirrorRepository) UpdateMirroredProviderVersionGPGStatus(ctx context.Context, id uuid.UUID, gpgVerified bool) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE mirrored_provider_versions SET gpg_verified = $2 WHERE id = $1`,
+		id, gpgVerified,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update mirrored provider version GPG status: %w", err)
+	}
+	return nil
+}
+
 // GetMirroredProviderVersion retrieves a specific mirrored version
 func (r *MirrorRepository) GetMirroredProviderVersion(ctx context.Context, mirroredProviderID uuid.UUID, version string) (*models.MirroredProviderVersion, error) {
 	query := `

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -538,7 +538,7 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 				}
 			}
 
-			// Backfill GPG key if the stored value is empty or expired.
+			// Backfill GPG key and re-verify signature if the stored key is empty or expired.
 			if existingVersion.GPGPublicKey == "" || !mirror.HasUsableGPGKey(existingVersion.GPGPublicKey) {
 				if len(version.Platforms) > 0 {
 					p0 := version.Platforms[0]
@@ -550,6 +550,30 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 									log.Printf("Warning: failed to backfill GPG key for %s/%s@%s: %v", namespace, providerName, version.Version, err)
 								} else {
 									log.Printf("Backfilled GPG key for %s/%s@%s", namespace, providerName, version.Version)
+								}
+							}
+						}
+
+						// Re-verify GPG signature and update the tracking record.
+						if mirroredProvider != nil {
+							versionUUID, _ := uuid.Parse(existingVersion.ID)
+							if tracking, tErr := j.mirrorRepo.GetMirroredProviderVersionByVersionID(ctx, versionUUID); tErr == nil && tracking != nil && !tracking.GPGVerified {
+								shasumContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsURL)
+								sigContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsSignatureURL)
+								if len(shasumContent) > 0 && len(sigContent) > 0 {
+									var resolvedKeys []string
+									for _, gpgKey := range pkgInfo.SigningKeys.GPGPublicKeys {
+										if gpgKey.ASCIIArmor != "" {
+											resolvedKeys = append(resolvedKeys, mirror.ResolveExpiredGPGKey(gpgKey.ASCIIArmor))
+										}
+									}
+									if result := verifyGPGSignature(shasumContent, sigContent, resolvedKeys); result.Verified {
+										if err := j.mirrorRepo.UpdateMirroredProviderVersionGPGStatus(ctx, tracking.ID, true); err != nil {
+											log.Printf("Warning: failed to update gpg_verified for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+										} else {
+											log.Printf("Backfilled gpg_verified for %s/%s@%s", namespace, providerName, version.Version)
+										}
+									}
 								}
 							}
 						}
@@ -741,11 +765,12 @@ func (j *MirrorSyncJob) syncProviderVersion(
 		if err != nil {
 			log.Printf("Warning: failed to download SHASUM signature: %v", err)
 		} else {
-			// Collect all GPG keys from the package
+			// Collect all GPG keys from the package, resolving any expired
+			// keys so that verification uses the refreshed snapshot.
 			var publicKeys []string
 			for _, gpgKey := range packageInfo.SigningKeys.GPGPublicKeys {
 				if gpgKey.ASCIIArmor != "" {
-					publicKeys = append(publicKeys, gpgKey.ASCIIArmor)
+					publicKeys = append(publicKeys, mirror.ResolveExpiredGPGKey(gpgKey.ASCIIArmor))
 				}
 			}
 


### PR DESCRIPTION
## Summary

- GPG signature verification during provider sync was using original upstream keys (expired) instead of the resolved refreshed keys, causing `gpg_verified` to remain `false` even though the signature is valid
- Uses `ResolveExpiredGPGKey` on each upstream key before passing to `verifyGPGSignature`
- Backfill path now also re-verifies the GPG signature and updates `gpg_verified` on `mirrored_provider_versions` for existing versions
- Adds `UpdateMirroredProviderVersionGPGStatus` repository method

Follows up on #423 (download-time substitution) and #425 (GPG key backfill). This is the missing piece that fixes the UI showing unverified GPG status for all post-expiry versions.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/jobs/ ./internal/mirror/ ./internal/db/repositories/` passes
- [ ] Deploy → trigger sync → all versions show green GPG checkmark