### PR TITLE
fix(mirror): run gpg_verified backfill independently of key backfill

### DIFF
--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -538,42 +538,49 @@ func (j *MirrorSyncJob) syncProvider(ctx context.Context, upstreamClient mirror.
 				}
 			}
 
-			// Backfill GPG key and re-verify signature if the stored key is empty or expired.
-			if existingVersion.GPGPublicKey == "" || !mirror.HasUsableGPGKey(existingVersion.GPGPublicKey) {
-				if len(version.Platforms) > 0 {
-					p0 := version.Platforms[0]
-					if pkgInfo, pkgErr := upstreamClient.GetProviderPackage(ctx, namespace, providerName, version.Version, p0.OS, p0.Arch); pkgErr == nil {
-						if len(pkgInfo.SigningKeys.GPGPublicKeys) > 0 {
-							resolved := mirror.ResolveExpiredGPGKey(pkgInfo.SigningKeys.GPGPublicKeys[0].ASCIIArmor)
-							if resolved != "" {
-								if err := j.providerRepo.UpdateVersionGPGKey(ctx, existingVersion.ID, resolved); err != nil {
-									log.Printf("Warning: failed to backfill GPG key for %s/%s@%s: %v", namespace, providerName, version.Version, err)
-								} else {
-									log.Printf("Backfilled GPG key for %s/%s@%s", namespace, providerName, version.Version)
-								}
+			// Backfill GPG key if the stored value is empty or expired.
+			needsGPGKeyBackfill := existingVersion.GPGPublicKey == "" || !mirror.HasUsableGPGKey(existingVersion.GPGPublicKey)
+
+			// Check if gpg_verified needs backfilling.
+			needsGPGVerifyBackfill := false
+			var trackingRecord *models.MirroredProviderVersion
+			if mirroredProvider != nil {
+				versionUUID, _ := uuid.Parse(existingVersion.ID)
+				if t, tErr := j.mirrorRepo.GetMirroredProviderVersionByVersionID(ctx, versionUUID); tErr == nil && t != nil && !t.GPGVerified {
+					needsGPGVerifyBackfill = true
+					trackingRecord = t
+				}
+			}
+
+			if (needsGPGKeyBackfill || needsGPGVerifyBackfill) && len(version.Platforms) > 0 {
+				p0 := version.Platforms[0]
+				if pkgInfo, pkgErr := upstreamClient.GetProviderPackage(ctx, namespace, providerName, version.Version, p0.OS, p0.Arch); pkgErr == nil {
+					if needsGPGKeyBackfill && len(pkgInfo.SigningKeys.GPGPublicKeys) > 0 {
+						resolved := mirror.ResolveExpiredGPGKey(pkgInfo.SigningKeys.GPGPublicKeys[0].ASCIIArmor)
+						if resolved != "" {
+							if err := j.providerRepo.UpdateVersionGPGKey(ctx, existingVersion.ID, resolved); err != nil {
+								log.Printf("Warning: failed to backfill GPG key for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+							} else {
+								log.Printf("Backfilled GPG key for %s/%s@%s", namespace, providerName, version.Version)
 							}
 						}
+					}
 
-						// Re-verify GPG signature and update the tracking record.
-						if mirroredProvider != nil {
-							versionUUID, _ := uuid.Parse(existingVersion.ID)
-							if tracking, tErr := j.mirrorRepo.GetMirroredProviderVersionByVersionID(ctx, versionUUID); tErr == nil && tracking != nil && !tracking.GPGVerified {
-								shasumContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsURL)
-								sigContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsSignatureURL)
-								if len(shasumContent) > 0 && len(sigContent) > 0 {
-									var resolvedKeys []string
-									for _, gpgKey := range pkgInfo.SigningKeys.GPGPublicKeys {
-										if gpgKey.ASCIIArmor != "" {
-											resolvedKeys = append(resolvedKeys, mirror.ResolveExpiredGPGKey(gpgKey.ASCIIArmor))
-										}
-									}
-									if result := verifyGPGSignature(shasumContent, sigContent, resolvedKeys); result.Verified {
-										if err := j.mirrorRepo.UpdateMirroredProviderVersionGPGStatus(ctx, tracking.ID, true); err != nil {
-											log.Printf("Warning: failed to update gpg_verified for %s/%s@%s: %v", namespace, providerName, version.Version, err)
-										} else {
-											log.Printf("Backfilled gpg_verified for %s/%s@%s", namespace, providerName, version.Version)
-										}
-									}
+					if needsGPGVerifyBackfill && trackingRecord != nil {
+						shasumContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsURL)
+						sigContent, _ := upstreamClient.DownloadFile(ctx, pkgInfo.SHASumsSignatureURL)
+						if len(shasumContent) > 0 && len(sigContent) > 0 {
+							var resolvedKeys []string
+							for _, gpgKey := range pkgInfo.SigningKeys.GPGPublicKeys {
+								if gpgKey.ASCIIArmor != "" {
+									resolvedKeys = append(resolvedKeys, mirror.ResolveExpiredGPGKey(gpgKey.ASCIIArmor))
+								}
+							}
+							if result := verifyGPGSignature(shasumContent, sigContent, resolvedKeys); result.Verified {
+								if err := j.mirrorRepo.UpdateMirroredProviderVersionGPGStatus(ctx, trackingRecord.ID, true); err != nil {
+									log.Printf("Warning: failed to update gpg_verified for %s/%s@%s: %v", namespace, providerName, version.Version, err)
+								} else {
+									log.Printf("Backfilled gpg_verified for %s/%s@%s", namespace, providerName, version.Version)
 								}
 							}
 						}


### PR DESCRIPTION
## Summary

The `gpg_verified` re-verification was nested inside the GPG key backfill condition (`gpgPublicKey == "" || !HasUsableGPGKey(...)`). After v1.3.2 backfilled the key column, the outer condition became false (key is now usable), so the `gpg_verified` backfill was skipped entirely.

This fix separates the two concerns:
- `needsGPGKeyBackfill`: checks if `gpg_public_key` needs updating
- `needsGPGVerifyBackfill`: checks if `gpg_verified` is false on the tracking record

Either condition triggers fetching upstream package info. Each backfill runs independently based on its own condition.

## Root cause

v1.3.2 (#425) backfilled `provider_versions.gpg_public_key` with the refreshed key. v1.3.3 (#427) added GPG re-verification but nested it inside the key-backfill `if` block. Since the key was already good, the `if` was false and the verification never ran.

## Test plan

- [x] `go build ./...`, `go vet ./...` pass
- [x] `go test ./internal/jobs/ ./internal/mirror/` pass
- [ ] Deploy → sync → versions 6.42–6.47 show green GPG checkmark