### PR TITLE
feat(api-test): report live-spec endpoint coverage

### DIFF
--- a/backend/cmd/api-test/coverage.go
+++ b/backend/cmd/api-test/coverage.go
@@ -1,0 +1,160 @@
+// coverage.go adds spec-coverage reporting to the integration runner. Every
+// endpoint the runner touches (via record/skipTest) is recorded; at the end we
+// fetch the live OpenAPI spec, match each spec path+method against the touched
+// set, and report the endpoints that have no integration coverage.
+//
+// This keeps the runner honest as the API grows: when a new endpoint ships, it
+// shows up as uncovered here instead of silently going untested. Matching is
+// template-aware so a touched concrete path like /admin/mirrors/<uuid> (or the
+// literal /admin/mirrors/{id} used in skip lists) counts as covering the spec
+// template /admin/mirrors/{id}.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// httpMethods is the set of keys under a spec path object that denote operations.
+var httpMethods = map[string]bool{
+	"get": true, "post": true, "put": true, "patch": true,
+	"delete": true, "head": true, "options": true,
+}
+
+// endpoint is a method+path-template pair from the OpenAPI spec.
+type endpoint struct {
+	Method   string // upper-case (GET, POST, …)
+	Template string // e.g. /api/v1/admin/mirrors/{id}
+}
+
+// touchedEndpoint is a method+concrete-path the runner exercised.
+type touchedEndpoint struct {
+	Method string
+	Path   string // concrete path as called (query string already stripped)
+}
+
+// touched accumulates every endpoint the runner hits. Populated from record()
+// and skipTest() so both executed and intentionally-skipped endpoints count as
+// "covered" — a skip still means the runner knows the endpoint exists.
+var touched []touchedEndpoint
+
+// markTouched records that the runner exercised method+path. The query string
+// is stripped so /x?status=y collapses to /x.
+func markTouched(method, path string) {
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+	touched = append(touched, touchedEndpoint{Method: strings.ToUpper(method), Path: path})
+}
+
+// loadSpecEndpoints parses the "paths" object of an OpenAPI 2.0/3.0 spec (both
+// share the path→method→operation shape) into a flat, sorted endpoint list.
+func loadSpecEndpoints(spec map[string]interface{}) []endpoint {
+	pathsRaw, ok := spec["paths"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	var out []endpoint
+	for path, v := range pathsRaw {
+		ops, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for method := range ops {
+			if httpMethods[strings.ToLower(method)] {
+				out = append(out, endpoint{Method: strings.ToUpper(method), Template: path})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Template != out[j].Template {
+			return out[i].Template < out[j].Template
+		}
+		return out[i].Method < out[j].Method
+	})
+	return out
+}
+
+// pathMatchesTemplate reports whether a concrete path matches a spec template.
+// Segments must align one-to-one; a template parameter segment ({id}) matches
+// any non-empty concrete segment, and a concrete segment that is itself a
+// placeholder ({id}) matches a template parameter segment.
+func pathMatchesTemplate(concrete, template string) bool {
+	cs := strings.Split(strings.Trim(concrete, "/"), "/")
+	ts := strings.Split(strings.Trim(template, "/"), "/")
+	if len(cs) != len(ts) {
+		return false
+	}
+	for i := range ts {
+		tParam := strings.HasPrefix(ts[i], "{") && strings.HasSuffix(ts[i], "}")
+		cParam := strings.HasPrefix(cs[i], "{") && strings.HasSuffix(cs[i], "}")
+		if tParam {
+			if cs[i] == "" {
+				return false
+			}
+			continue // any concrete value (or placeholder) covers a param segment
+		}
+		if cParam {
+			// A literal-placeholder concrete segment can only match a param
+			// template segment, which is handled above; against a literal
+			// template segment it does not match.
+			return false
+		}
+		if cs[i] != ts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// reportCoverage fetches the live OpenAPI spec, diffs it against the touched
+// endpoints, prints a coverage summary, and returns the number of uncovered
+// endpoints. A spec that cannot be loaded is reported but not treated as a
+// failure (returns 0) so the coverage check never masks real test results.
+func reportCoverage() int {
+	r := doJSON("GET", "/swagger.json", nil, false)
+	fmt.Println("\n--- API Coverage ---")
+	if r.Code != 200 || r.Object == nil {
+		fmt.Println("  spec unavailable (GET /swagger.json did not return a JSON object); skipping coverage check")
+		return 0
+	}
+
+	spec := loadSpecEndpoints(r.Object)
+	if len(spec) == 0 {
+		fmt.Println("  no paths found in spec; skipping coverage check")
+		return 0
+	}
+
+	missing := uncoveredEndpoints(spec, touched)
+	covered := len(spec) - len(missing)
+	fmt.Printf("  %d/%d spec endpoints exercised (%.0f%%)\n",
+		covered, len(spec), float64(covered)/float64(len(spec))*100)
+
+	if len(missing) > 0 {
+		fmt.Printf("  %d endpoint(s) with no integration coverage:\n", len(missing))
+		for _, ep := range missing {
+			fmt.Printf("    %-7s %s\n", ep.Method, ep.Template)
+		}
+	}
+	return len(missing)
+}
+
+// uncoveredEndpoints returns spec endpoints with no matching touched endpoint,
+// sorted for stable output.
+func uncoveredEndpoints(spec []endpoint, hits []touchedEndpoint) []endpoint {
+	var missing []endpoint
+	for _, ep := range spec {
+		covered := false
+		for _, h := range hits {
+			if h.Method == ep.Method && pathMatchesTemplate(h.Path, ep.Template) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			missing = append(missing, ep)
+		}
+	}
+	return missing
+}

--- a/backend/cmd/api-test/coverage_test.go
+++ b/backend/cmd/api-test/coverage_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPathMatchesTemplate(t *testing.T) {
+	cases := []struct {
+		concrete string
+		template string
+		want     bool
+	}{
+		{"/api/v1/admin/mirrors", "/api/v1/admin/mirrors", true},
+		{"/api/v1/admin/mirrors/abc-123", "/api/v1/admin/mirrors/{id}", true},
+		{"/api/v1/admin/mirrors/{id}", "/api/v1/admin/mirrors/{id}", true}, // literal placeholder from skip lists
+		{"/v1/providers/hashicorp/aws/versions", "/v1/providers/{namespace}/{type}/versions", true},
+		{"/v1/providers/hashicorp/aws/1.0.0/download/linux/amd64", "/v1/providers/{namespace}/{type}/{version}/download/{os}/{arch}", true},
+		// negatives
+		{"/api/v1/admin/mirrors", "/api/v1/admin/mirrors/{id}", false},               // segment count
+		{"/api/v1/admin/mirrors/abc", "/api/v1/admin/terraform-mirrors/{id}", false}, // literal mismatch
+		{"/api/v1/admin/{id}", "/api/v1/admin/mirrors", false},                       // placeholder vs literal
+		{"/v1/providers/hashicorp/aws", "/v1/providers/{namespace}/{type}/versions", false},
+	}
+	for _, c := range cases {
+		if got := pathMatchesTemplate(c.concrete, c.template); got != c.want {
+			t.Errorf("pathMatchesTemplate(%q,%q)=%v want %v", c.concrete, c.template, got, c.want)
+		}
+	}
+}
+
+func TestLoadSpecEndpoints(t *testing.T) {
+	raw := `{
+	  "paths": {
+	    "/api/v1/admin/mirrors": {
+	      "get": {"summary": "list"},
+	      "post": {"summary": "create"},
+	      "parameters": []
+	    },
+	    "/api/v1/admin/mirrors/{id}": {
+	      "get": {}, "put": {}, "delete": {}
+	    }
+	  }
+	}`
+	var spec map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	eps := loadSpecEndpoints(spec)
+	// 2 + 3 = 5 operations; the non-method "parameters" key is ignored.
+	if len(eps) != 5 {
+		t.Fatalf("expected 5 endpoints, got %d: %+v", len(eps), eps)
+	}
+	// Sorted: path then method.
+	if eps[0].Template != "/api/v1/admin/mirrors" || eps[0].Method != "GET" {
+		t.Fatalf("unexpected first endpoint: %+v", eps[0])
+	}
+}
+
+func TestLoadSpecEndpoints_NoPaths(t *testing.T) {
+	if eps := loadSpecEndpoints(map[string]interface{}{}); eps != nil {
+		t.Fatalf("expected nil for spec without paths, got %+v", eps)
+	}
+}
+
+func TestUncoveredEndpoints(t *testing.T) {
+	spec := []endpoint{
+		{Method: "GET", Template: "/api/v1/admin/mirrors"},
+		{Method: "POST", Template: "/api/v1/admin/mirrors"},
+		{Method: "GET", Template: "/api/v1/admin/mirrors/{id}"},
+		{Method: "DELETE", Template: "/api/v1/admin/mirrors/{id}"},
+		{Method: "GET", Template: "/api/v1/admin/version-approvals"},
+	}
+	hits := []touchedEndpoint{
+		{Method: "GET", Path: "/api/v1/admin/mirrors"},
+		{Method: "POST", Path: "/api/v1/admin/mirrors"},
+		{Method: "GET", Path: "/api/v1/admin/mirrors/abc-123"}, // covers the {id} GET
+	}
+
+	missing := uncoveredEndpoints(spec, hits)
+	// DELETE /mirrors/{id} and GET /version-approvals are uncovered.
+	if len(missing) != 2 {
+		t.Fatalf("expected 2 uncovered, got %d: %+v", len(missing), missing)
+	}
+	wantUncovered := map[string]bool{
+		"DELETE /api/v1/admin/mirrors/{id}":   true,
+		"GET /api/v1/admin/version-approvals": true,
+	}
+	for _, ep := range missing {
+		if !wantUncovered[ep.Method+" "+ep.Template] {
+			t.Errorf("unexpected uncovered endpoint: %s %s", ep.Method, ep.Template)
+		}
+	}
+}
+
+func TestMarkTouched_StripsQueryString(t *testing.T) {
+	saved := touched
+	t.Cleanup(func() { touched = saved })
+	touched = nil
+
+	markTouched("GET", "/api/v1/admin/version-approvals?status=pending_approval&type=provider")
+	if len(touched) != 1 {
+		t.Fatalf("expected 1 touched entry, got %d", len(touched))
+	}
+	if touched[0].Path != "/api/v1/admin/version-approvals" {
+		t.Fatalf("query string not stripped: %q", touched[0].Path)
+	}
+	if touched[0].Method != "GET" {
+		t.Fatalf("method not normalised: %q", touched[0].Method)
+	}
+}

--- a/backend/cmd/api-test/main.go
+++ b/backend/cmd/api-test/main.go
@@ -2,10 +2,16 @@
 // Runs ~170 tests across 23 phases, cleans up everything it creates, and
 // reports any remaining swagger/spec discrepancies separately from failures.
 //
+// After the phases run it fetches the live OpenAPI spec and prints an API
+// coverage report: every spec path+method the runner never touched is listed
+// so new endpoints can't ship untested. Coverage is informational by default;
+// pass -strict-coverage to fail the run when uncovered endpoints exist.
+//
 // Usage:
 //
 //	go run ./cmd/api-test/ -key <api-key>
 //	go run ./cmd/api-test/ -url http://registry.local:8080 -key <api-key>
+//	go run ./cmd/api-test/ -key <api-key> -strict-coverage
 //	./api-test.exe -key <api-key>
 package main
 
@@ -199,6 +205,7 @@ func nested(m map[string]interface{}, key string) map[string]interface{} {
 }
 
 func record(method, path string, got int, want []int, elapsed time.Duration, note string) bool {
+	markTouched(method, path)
 	label := ""
 	if note != "" {
 		label = " | " + note
@@ -221,6 +228,7 @@ func record(method, path string, got int, want []int, elapsed time.Duration, not
 }
 
 func skipTest(method, path, reason string) {
+	markTouched(method, path)
 	skipped++
 	skippedTests = append(skippedTests, fmt.Sprintf("#%-3d %-7s %s → %s", passed+failed+skipped, method, path, reason))
 	fmt.Printf("[SKIP] #%-3d %-7s %-72s → %s\n", passed+failed+skipped, method, path, reason)
@@ -1507,6 +1515,7 @@ func main() {
 	urlFlag := flag.String("url", "http://registry.local:8080", "Base URL of the registry API")
 	keyFlag := flag.String("key", "", "API key for authenticated requests") // #nosec G101 -- integration test credential
 	delayFlag := flag.Int("delay", 750, "Milliseconds to wait before each request (use 0 for local, 750+ for rate-limited environments)")
+	strictCoverage := flag.Bool("strict-coverage", false, "Exit non-zero if the live spec contains endpoints the runner never touches")
 	flag.Parse()
 
 	baseURL = *urlFlag
@@ -1588,6 +1597,8 @@ func main() {
 		}
 	}
 
+	uncovered := reportCoverage()
+
 	if len(skippedTests) > 0 {
 		fmt.Println("\n--- Skipped Tests ---")
 		for _, s := range skippedTests {
@@ -1606,5 +1617,10 @@ func main() {
 		// non-zero exit so CI can detect failures
 		fmt.Println()
 		panic("test failures")
+	}
+
+	if *strictCoverage && uncovered > 0 {
+		fmt.Println()
+		panic("uncovered API endpoints (run without -strict-coverage to list only)")
 	}
 }


### PR DESCRIPTION
## Summary

Makes the `cmd/api-test` integration runner **self-auditing** so new endpoints can't ship untested — the gap that let the version-approval endpoints exist without an api-test phase.

After the phases run, the tool fetches the live OpenAPI spec (`GET /swagger.json`), template-matches every spec path+method against the set of endpoints the runner actually touched, and prints an **API Coverage** report listing anything with no integration coverage.

## Why a hybrid (not a full contract-test rewrite)

A pure spec-driven walker can't replace the hand-written phases: mutating endpoints need *valid* bodies and real path IDs (created by prior steps), correct ordering, and cleanup — none of which a generic walker can synthesize, and blindly firing every POST/DELETE at a live backend is unsafe. So this keeps the existing stateful flows and adds spec **coverage awareness** on top, which is the piece that actually solves the "is it up to date?" maintenance problem.

## Behaviour

- Every `record(...)` and `skipTest(...)` call registers the endpoint as touched (a skip still counts — the runner knows the endpoint exists).
- Matching is template-aware: a touched `/admin/mirrors/<uuid>` — or the literal `/admin/mirrors/{id}` used in skip lists — covers the spec template `/admin/mirrors/{id}`. Query strings are stripped.
- Coverage is **informational by default** (prints `N/M spec endpoints exercised` + the uncovered list). Pass `-strict-coverage` to exit non-zero when uncovered endpoints exist, so CI can gate on it once the suite reaches the desired surface.
- A spec that can't be loaded is reported but never fails the run, so the coverage check can't mask real test results.

## Testing

`go build`, `go vet`, and `go test ./cmd/api-test/` pass. New unit tests cover the path-template matcher (positives + negatives), spec parsing (ignoring non-method keys like `parameters`), the uncovered-diff, and query-string stripping — all without needing a live backend.

> Note: ships independently of the version-approval feature branch; that branch adds its own api-test phase, and once both merge this report will show those endpoints as covered.