### PR TITLE
fix(mirror): persist requires_approval and auto_approve_rules from API

### DIFF
--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -161,6 +161,11 @@ func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 		pullThroughTTL = *req.PullThroughCacheTTLHours
 	}
 
+	requiresApproval := false
+	if req.RequiresApproval != nil {
+		requiresApproval = *req.RequiresApproval
+	}
+
 	config := &models.MirrorConfiguration{
 		ID:                       uuid.New(),
 		Name:                     req.Name,
@@ -173,6 +178,8 @@ func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 		PlatformFilter:           platformFilter,
 		Enabled:                  enabled,
 		SyncIntervalHours:        syncInterval,
+		RequiresApproval:         requiresApproval,
+		AutoApproveRules:         req.AutoApproveRules,
 		PullThroughEnabled:       pullThroughEnabled,
 		PullThroughCacheTTLHours: pullThroughTTL,
 		CreatedAt:                time.Now(),
@@ -396,6 +403,14 @@ func (h *MirrorHandler) UpdateMirrorConfig(c *gin.Context) {
 
 	if req.PullThroughCacheTTLHours != nil {
 		config.PullThroughCacheTTLHours = *req.PullThroughCacheTTLHours
+	}
+
+	if req.RequiresApproval != nil {
+		config.RequiresApproval = *req.RequiresApproval
+	}
+
+	if req.AutoApproveRules != nil {
+		config.AutoApproveRules = req.AutoApproveRules
 	}
 
 	if err := h.mirrorRepo.Update(c.Request.Context(), config); err != nil {

--- a/backend/internal/api/admin/mirror_test.go
+++ b/backend/internal/api/admin/mirror_test.go
@@ -170,6 +170,31 @@ func TestMirrorCreate_Success(t *testing.T) {
 	}
 }
 
+func TestMirrorCreate_RequiresApprovalPersisted(t *testing.T) {
+	mock, r := newMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE name").
+		WillReturnRows(sqlmock.NewRows(mirrorCfgCols))
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}))
+	mock.ExpectExec("INSERT INTO mirror_configurations").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors",
+		jsonBody(map[string]interface{}{
+			"name":                  "gated-mirror",
+			"upstream_registry_url": "https://registry.terraform.io",
+			"requires_approval":     true,
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if got := getJSON(w)["requires_approval"]; got != true {
+		t.Errorf("requires_approval = %v, want true (toggle dropped by handler)", got)
+	}
+}
+
 func TestMirrorCreate_InsertDBError(t *testing.T) {
 	mock, r := newMirrorRouter(t)
 	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE name").
@@ -325,6 +350,25 @@ func TestMirrorUpdate_Success(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMirrorUpdate_RequiresApprovalPersisted(t *testing.T) {
+	mock, r := newMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE id").
+		WillReturnRows(sampleMirrorCfgRow())
+	mock.ExpectExec("UPDATE mirror_configurations SET name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/mirrors/"+knownUUID,
+		jsonBody(map[string]interface{}{"requires_approval": true})))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if got := getJSON(w)["requires_approval"]; got != true {
+		t.Errorf("requires_approval = %v, want true (toggle dropped by handler)", got)
 	}
 }
 

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -95,6 +95,11 @@ func (h *TerraformMirrorHandler) CreateConfig(c *gin.Context) {
 		return
 	}
 
+	requiresApproval := false
+	if req.RequiresApproval != nil {
+		requiresApproval = *req.RequiresApproval
+	}
+
 	cfg := &models.TerraformMirrorConfig{
 		Name:              req.Name,
 		Description:       req.Description,
@@ -106,6 +111,8 @@ func (h *TerraformMirrorHandler) CreateConfig(c *gin.Context) {
 		GPGVerify:         gpgVerify,
 		StableOnly:        stableOnly,
 		SyncIntervalHours: syncIntervalHours,
+		RequiresApproval:  requiresApproval,
+		AutoApproveRules:  req.AutoApproveRules,
 	}
 
 	if createErr := h.repo.Create(c.Request.Context(), cfg); createErr != nil {
@@ -305,6 +312,12 @@ func (h *TerraformMirrorHandler) UpdateConfig(c *gin.Context) {
 	}
 	if req.VersionFilter != nil {
 		cfg.VersionFilter = req.VersionFilter
+	}
+	if req.RequiresApproval != nil {
+		cfg.RequiresApproval = *req.RequiresApproval
+	}
+	if req.AutoApproveRules != nil {
+		cfg.AutoApproveRules = req.AutoApproveRules
 	}
 
 	if updateErr := h.repo.Update(c.Request.Context(), cfg); updateErr != nil {

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -570,6 +570,25 @@ func TestTMUpdateConfig_Success(t *testing.T) {
 	}
 }
 
+func TestTMUpdateConfig_RequiresApprovalPersisted(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE id").
+		WillReturnRows(sampleTMCRow())
+	mock.ExpectExec("UPDATE terraform_mirror_configs SET").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/terraform-mirrors/"+knownUUID,
+		jsonBody(map[string]interface{}{"requires_approval": true})))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if got := getJSON(w)["requires_approval"]; got != true {
+		t.Errorf("requires_approval = %v, want true (toggle dropped by handler)", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetStatus success test
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Enabling **Require approval for new versions** on a provider or Terraform binary mirror had no effect. Versions synced after enabling the toggle were auto-approved and immediately visible to clients — nothing landed in the Version Approvals queue.

Reproduced on the AKS UAT deployment: a new `hashicorp/archive` provider mirror was created with approval enabled and manually synced; all 3 versions synced and were immediately served via `/v1/providers/hashicorp/archive/versions`, with `version-approvals?status=pending_approval` empty.

## Root cause

The mirror create/update handlers built the configuration struct without copying `RequiresApproval` or `AutoApproveRules` from the request body:

- `CreateMirrorConfig` / `UpdateMirrorConfig` (`mirror.go`)
- `CreateConfig` / `UpdateConfig` (`terraform_mirror.go`)

The request structs carry the fields, the repositories persist them, and the sync job honors them (`resolveProviderApproval` returns `approved` when `!config.RequiresApproval`). Only the handler layer was dropping the value, defaulting it to `false`.

This passed CI because the e2e test only asserted the toggle *renders*, and handler unit tests never asserted the persisted value.

## Fix

- Wire `requires_approval` and `auto_approve_rules` through create and update for both the provider and Terraform binary mirror handlers.
- Add handler tests asserting `requires_approval` round-trips on create and update (provider create/update, terraform update).

## Note for existing deployments

Any mirror created before this fix has `requires_approval = false` stored regardless of what the UI showed. After deploying, re-apply the toggle (edit + save, or recreate the mirror) so the value is written correctly. Versions already synced as approved stay approved.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/admin/ ./internal/jobs/ ./internal/db/repositories/`
- [x] New tests fail without the handler change, pass with it