### PR TITLE
refactor(auth): delegate API key gen/validation to the identity module

### DIFF
--- a/backend/internal/auth/apikey.go
+++ b/backend/internal/auth/apikey.go
@@ -1,85 +1,36 @@
-// Package auth provides authentication primitives for the registry, including API key generation/validation and JWT creation/verification.
-// Two authentication methods are supported: JWTs (issued on OIDC/username login, stateless verification) and API keys (long-lived tokens with bcrypt hashing).
-// See internal/middleware/auth.go for the request-time authentication logic that uses these primitives.
+// Package auth - apikey.go delegates API key generation and validation to the
+// shared identity/auth package so all suite apps share one implementation.
 package auth
 
 import (
-	"crypto/rand"
-	"encoding/base64"
-	"errors"
-	"fmt"
-	"strings"
-
-	"golang.org/x/crypto/bcrypt"
+	identityauth "github.com/sethbacon/terraform-suite-identity/identity/auth"
 )
 
 const (
-	// APIKeyLength is the length of the random part of the API key in bytes
-	APIKeyLength = 32
+	// APIKeyLength is the length of the random part of the API key in bytes.
+	APIKeyLength = identityauth.APIKeyLength
 
-	// DisplayPrefixLength is the number of characters to show in displays
-	DisplayPrefixLength = 10
+	// DisplayPrefixLength is the number of characters to show in displays and
+	// used as the lookup prefix for stored keys.
+	DisplayPrefixLength = identityauth.DisplayPrefixLength
 
-	// BcryptCost is the cost factor for bcrypt hashing
-	BcryptCost = 12
+	// BcryptCost is the cost factor for bcrypt hashing.
+	BcryptCost = identityauth.BcryptCost
 )
 
-// GenerateAPIKey creates a new random API key with the given prefix
-// Returns: full key (to show once), bcrypt hash (to store), display prefix
+// GenerateAPIKey creates a new random API key with the given prefix.
+// Returns: full key (to show once), bcrypt hash (to store), display prefix.
 func GenerateAPIKey(prefix string) (key string, hash string, displayPrefix string, err error) {
-	// Generate random bytes
-	randomBytes := make([]byte, APIKeyLength)
-	_, err = rand.Read(randomBytes)
-	if err != nil {
-		return "", "", "", fmt.Errorf("failed to generate random bytes: %w", err)
-	}
-
-	// Encode to base64 (URL-safe)
-	randomPart := base64.RawURLEncoding.EncodeToString(randomBytes)
-
-	// Construct full key: prefix_randomPart
-	fullKey := fmt.Sprintf("%s_%s", prefix, randomPart)
-
-	// Hash the full key with bcrypt
-	hashBytes, err := bcrypt.GenerateFromPassword([]byte(fullKey), BcryptCost)
-	if err != nil {
-		return "", "", "", fmt.Errorf("failed to hash API key: %w", err)
-	}
-
-	// Generate display prefix (first N characters of full key)
-	displayPrefixStr := fullKey
-	if len(fullKey) > DisplayPrefixLength {
-		displayPrefixStr = fullKey[:DisplayPrefixLength]
-	}
-
-	return fullKey, string(hashBytes), displayPrefixStr, nil
+	return identityauth.GenerateAPIKey(prefix)
 }
 
-// ValidateAPIKey checks if a provided key matches the stored hash
+// ValidateAPIKey checks if a provided key matches the stored hash.
 func ValidateAPIKey(providedKey, storedHash string) bool {
-	err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(providedKey))
-	return err == nil
+	return identityauth.ValidateAPIKey(providedKey, storedHash)
 }
 
-// ExtractAPIKeyFromHeader extracts the API key from an Authorization header
-// Expected format: "Bearer tfr_abc123xyz..."
+// ExtractAPIKeyFromHeader extracts the API key from an Authorization header.
+// Expected format: "Bearer tfr_abc123xyz...".
 func ExtractAPIKeyFromHeader(header string) (string, error) {
-	if header == "" {
-		return "", errors.New("authorization header is empty")
-	}
-
-	// Check if it starts with "Bearer "
-	if !strings.HasPrefix(header, "Bearer ") {
-		return "", errors.New("authorization header must start with 'Bearer '")
-	}
-
-	// Extract the key (remove "Bearer " prefix)
-	key := strings.TrimPrefix(header, "Bearer ")
-	key = strings.TrimSpace(key)
-
-	if key == "" {
-		return "", errors.New("API key is empty after Bearer prefix")
-	}
-
-	return key, nil
+	return identityauth.ExtractAPIKeyFromHeader(header)
 }

--- a/backend/scripts/uat-oidc.sh
+++ b/backend/scripts/uat-oidc.sh
@@ -56,4 +56,26 @@ echo "== 7. /auth/me without token rejected =="
 CODE=$(curl -sk $R -o /dev/null -w '%{http_code}' "$BE/api/v1/auth/me")
 [[ "$CODE" == "401" ]] && pass "no token -> 401" || fail "no token -> $CODE (expected 401)"
 
+echo "== 8. resolve org id via authenticated API =="
+ORGS=$(curl -sk $R "$BE/api/v1/organizations" -H "Authorization: Bearer $JWT")
+ORG=$(printf '%s' "$ORGS" | grep -o '"id":"[^"]*"' | head -1 | sed 's/.*"id":"//; s/"$//')
+[[ -n "$ORG" ]] || fail "could not resolve an org id from the API (resp: ${ORGS:0:120})"
+pass "org id: $ORG"
+
+echo "== 9. create API key (POST /api/v1/apikeys) =="
+CREATE=$(curl -sk $R -X POST "$BE/api/v1/apikeys" \
+  -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
+  -d "{\"name\":\"uat-r4\",\"organization_id\":\"$ORG\",\"scopes\":[\"organizations:read\"]}")
+APIKEY=$(printf '%s' "$CREATE" | grep -o '"key":"[^"]*"' | head -1 | sed 's/.*"key":"//; s/"$//')
+[[ "$APIKEY" == *_* ]] || fail "no key returned (resp: ${CREATE:0:160})"
+pass "API key created: ${APIKEY:0:10}..."
+
+echo "== 10. authenticate with the API key (scope-gated route) =="
+CODE=$(curl -sk $R -o /dev/null -w '%{http_code}' "$BE/api/v1/organizations" -H "Authorization: Bearer $APIKEY")
+[[ "$CODE" == "200" ]] && pass "valid API key -> 200" || fail "valid API key -> $CODE (expected 200)"
+
+echo "== 11. bogus API key rejected =="
+CODE=$(curl -sk $R -o /dev/null -w '%{http_code}' "$BE/api/v1/organizations" -H "Authorization: Bearer tfr_bogusbogusbogus")
+[[ "$CODE" == "401" ]] && pass "bogus API key -> 401" || fail "bogus API key -> $CODE (expected 401)"
+
 echo "ALL REGISTRY AUTH UAT CHECKS PASSED"


### PR DESCRIPTION
Registry mirror, R4 (2/4). Replaces the registry's local API-key primitives with thin delegations to the shared `identity/auth` package (module v0.10.0, already adopted in the scopes PR). The implementations were byte-identical, so this is a clean 1:1 delegation — same bcrypt cost (12), `prefix_<random>` format, and 10-char display/lookup prefix; no call-site changes.

Also extends `scripts/uat-oidc.sh` with API-key create + authenticate checks.

## Verification
- `go build ./...`, `go vet ./internal/auth/...` → clean
- `go test ./internal/auth/...` → pass
- `go mod tidy` idempotent (no dep change)
- **Live UAT (Keycloak stack):** OIDC login → JWT → create `tfr_` key → authenticate on a scope-gated route (organizations:read) **200** (exercises delegated ValidateAPIKey + HasScope), bogus key **401**.