### PR TITLE
test(auth): cover the Redis OIDC state store with miniredis

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.7.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/ProtonMail/go-crypto v1.4.1
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.17
@@ -144,6 +145,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -58,6 +58,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
@@ -407,6 +409,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM=
 github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/backend/internal/auth/statestore_redis.go
+++ b/backend/internal/auth/statestore_redis.go
@@ -23,7 +23,6 @@ type RedisStateStore struct {
 }
 
 // NewRedisStateStore creates a Redis-backed state store.
-// coverage:skip:requires-redis-connection
 func NewRedisStateStore(cfg *config.RedisConfig) (*RedisStateStore, error) {
 	opts := &redis.Options{
 		Addr:        fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
@@ -51,7 +50,6 @@ func NewRedisStateStore(cfg *config.RedisConfig) (*RedisStateStore, error) {
 }
 
 // Save stores session state as JSON in Redis with the given TTL.
-// coverage:skip:requires-redis-connection
 func (s *RedisStateStore) Save(ctx context.Context, state string, data *SessionState, ttl time.Duration) error {
 	payload, err := json.Marshal(data)
 	if err != nil {
@@ -71,7 +69,6 @@ return val
 
 // Load retrieves and atomically deletes the session state (single-use token).
 // Returns nil, nil when the key does not exist.
-// coverage:skip:requires-redis-connection
 func (s *RedisStateStore) Load(ctx context.Context, state string) (*SessionState, error) {
 	key := stateKeyPrefix + state
 	result, err := getAndDeleteScript.Run(ctx, s.client, []string{key}).Result()
@@ -90,13 +87,11 @@ func (s *RedisStateStore) Load(ctx context.Context, state string) (*SessionState
 }
 
 // Delete removes a session state entry from Redis.
-// coverage:skip:requires-redis-connection
 func (s *RedisStateStore) Delete(ctx context.Context, state string) error {
 	return s.client.Del(ctx, stateKeyPrefix+state).Err()
 }
 
 // Close shuts down the Redis connection.
-// coverage:skip:requires-redis-connection
 func (s *RedisStateStore) Close() error {
 	return s.client.Close()
 }

--- a/backend/internal/auth/statestore_redis_test.go
+++ b/backend/internal/auth/statestore_redis_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// newTestRedisStore starts an in-process miniredis and returns a RedisStateStore
+// wired to it. The store and miniredis are cleaned up via t.Cleanup.
+func newTestRedisStore(t *testing.T) (*RedisStateStore, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	port, err := strconv.Atoi(mr.Port())
+	if err != nil {
+		t.Fatalf("parse miniredis port: %v", err)
+	}
+	store, err := NewRedisStateStore(&config.RedisConfig{Host: mr.Host(), Port: port})
+	if err != nil {
+		t.Fatalf("NewRedisStateStore: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+		mr.Close()
+	})
+	return store, mr
+}
+
+func TestRedisStateStore_SaveLoadSingleUse(t *testing.T) {
+	store, _ := newTestRedisStore(t)
+	ctx := context.Background()
+
+	in := &SessionState{
+		State:        "abc",
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+		RedirectURL:  "/dashboard",
+		ProviderType: "oidc",
+	}
+	if err := store.Save(ctx, "abc", in, time.Minute); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Load(ctx, "abc")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Load returned nil for a saved state")
+	}
+	if got.RedirectURL != "/dashboard" || got.ProviderType != "oidc" || got.State != "abc" {
+		t.Errorf("Load mismatch: %+v", got)
+	}
+
+	// Load is single-use (atomic get+delete): a second Load must return nil.
+	again, err := store.Load(ctx, "abc")
+	if err != nil {
+		t.Fatalf("second Load: %v", err)
+	}
+	if again != nil {
+		t.Errorf("expected nil on second Load (single-use), got %+v", again)
+	}
+}
+
+func TestRedisStateStore_LoadNonExistent(t *testing.T) {
+	store, _ := newTestRedisStore(t)
+	got, err := store.Load(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for a missing key, got %+v", got)
+	}
+}
+
+func TestRedisStateStore_Delete(t *testing.T) {
+	store, _ := newTestRedisStore(t)
+	ctx := context.Background()
+
+	if err := store.Save(ctx, "d1", &SessionState{State: "d1"}, time.Minute); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, "d1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, err := store.Load(ctx, "d1")
+	if err != nil {
+		t.Fatalf("Load after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil after Delete, got %+v", got)
+	}
+
+	// Deleting a non-existent key is a no-op (no error).
+	if err := store.Delete(ctx, "never-existed"); err != nil {
+		t.Errorf("Delete of missing key should be a no-op, got: %v", err)
+	}
+}
+
+func TestRedisStateStore_SaveTTLExpiry(t *testing.T) {
+	store, mr := newTestRedisStore(t)
+	ctx := context.Background()
+
+	if err := store.Save(ctx, "ttl", &SessionState{State: "ttl"}, time.Minute); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Advance miniredis' clock past the TTL; the entry should be gone.
+	mr.FastForward(2 * time.Minute)
+
+	got, err := store.Load(ctx, "ttl")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil after TTL expiry, got %+v", got)
+	}
+}
+
+func TestNewRedisStateStore_ConnectionError(t *testing.T) {
+	// Point at a port with nothing listening; the constructor's Ping must fail.
+	_, err := NewRedisStateStore(&config.RedisConfig{
+		Host:        "127.0.0.1",
+		Port:        1, // unused, refused
+		DialTimeout: time.Second,
+	})
+	if err == nil {
+		t.Error("expected a connection error from NewRedisStateStore")
+	}
+}


### PR DESCRIPTION
Backfills real unit tests for `RedisStateStore` (previously 0%-covered — it needs a live Redis, so it was only marked `coverage:skip`). Uses an in-process **miniredis** so the Save/Load (single-use, atomic get+delete), Delete, TTL-expiry, and connection-error paths are genuinely exercised.

## Why
As the auth primitives are delegated to the shared `terraform-suite-identity` module, the registry's `internal/auth` package thins out — which exposed the 0%-covered Redis store and dropped the package under its **79% per-package floor**. Backfilling these tests raises `internal/auth` from ~78% → **89.5%**, restoring headroom for the remaining JWT/OIDC delegations. The stale `coverage:skip:requires-redis-connection` markers are removed since the functions are now tested.

## Verification
- `go build ./...`, `go vet ./internal/auth/...` → clean
- `scripts/check_package_coverage.sh` → auth **89.5%**, middleware 88.0% (both ≥ 79%)
- `go mod tidy` idempotent; adds `alicebob/miniredis/v2` (test-only)