### PR TITLE
refactor(auth): delegate JWT to the identity TokenManager

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-ldap/ldap/v3 v3.4.13
 	github.com/go-redis/redis_rate/v10 v10.0.1
-	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.9.0
@@ -97,6 +96,7 @@ require (
 	github.com/goccy/go-json v0.10.6 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -29,17 +30,28 @@ const jwtIssuer = "terraform-registry"
 type Claims = identityauth.Claims
 
 var (
-	// jwtSecret holds the current effective signing secret (env or file). It is
-	// kept in sync with the TokenManager's current secret so GetJWTSecret can
-	// report it for diagnostics and tests.
-	jwtSecret     string
 	jwtSecretOnce sync.Once
 	jwtSecretErr  error
+
+	// currentSecret holds the current effective signing secret (env or file). It
+	// is accessed atomically because the file watch updates it from a goroutine
+	// while requests read it via GetJWTSecret. Kept in sync with the
+	// TokenManager's current secret for diagnostics and tests.
+	currentSecret atomic.Pointer[string]
 
 	// tokenManager performs the actual signing/validation. Constructed once the
 	// secret is resolved; the file watch swaps its secret via RotateSecret.
 	tokenManager *identityauth.TokenManager
 )
+
+func storeSecret(s string) { currentSecret.Store(&s) }
+
+func loadSecret() string {
+	if p := currentSecret.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
 
 // isDevMode checks if we're in development mode (duplicated here to avoid import cycle)
 func isDevMode() bool {
@@ -67,6 +79,7 @@ func generateRandomSecret() (string, error) {
 func ValidateJWTSecret() error {
 	jwtSecretOnce.Do(func() {
 		secret := os.Getenv("TFR_JWT_SECRET")
+		var resolved string
 
 		if secret == "" {
 			if isDevMode() {
@@ -78,7 +91,7 @@ func ValidateJWTSecret() error {
 					jwtSecretErr = err
 					return
 				}
-				jwtSecret = randomSecret
+				resolved = randomSecret
 				log.Printf("WARNING: TFR_JWT_SECRET not set. Using auto-generated secret for development.")
 				log.Printf("WARNING: Sessions will not persist across restarts. Set TFR_JWT_SECRET for persistent sessions.")
 			} else {
@@ -92,10 +105,11 @@ func ValidateJWTSecret() error {
 			if len(secret) < 32 {
 				log.Printf("WARNING: TFR_JWT_SECRET is shorter than recommended 32 characters. Consider using a longer secret.")
 			}
-			jwtSecret = secret
+			resolved = secret
 		}
 
-		tokenManager = identityauth.NewTokenManager(jwtSecret, jwtIssuer)
+		storeSecret(resolved)
+		tokenManager = identityauth.NewTokenManager(resolved, jwtIssuer)
 	})
 
 	return jwtSecretErr
@@ -104,12 +118,12 @@ func ValidateJWTSecret() error {
 // GetJWTSecret retrieves the current effective JWT secret, validating lazily if
 // ValidateJWTSecret has not been called.
 func GetJWTSecret() string {
-	if jwtSecret == "" {
+	if loadSecret() == "" {
 		if err := ValidateJWTSecret(); err != nil {
 			panic(err)
 		}
 	}
-	return jwtSecret
+	return loadSecret()
 }
 
 // GenerateJWT creates a JWT for an authenticated user, delegating to the shared
@@ -139,8 +153,11 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 		overlapDuration = 5 * time.Minute
 	}
 
-	// Ensure the TokenManager exists (constructed from the env/dev secret).
+	// Ensure the TokenManager exists (constructed from the env/dev secret), then
+	// capture it so the watcher goroutine does not read the package-level
+	// pointer (which test resets may swap).
 	_ = GetJWTSecret()
+	tm := tokenManager
 
 	// Read the initial secret and make the file the source of truth. The env
 	// secret is dropped as a valid previous key (no tokens were signed with it
@@ -150,9 +167,9 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 		return nil, fmt.Errorf("failed to read JWT secret file %q: %w", secretFilePath, err)
 	}
 	secret := trimSecretBytes(data)
-	tokenManager.RotateSecret(secret)
-	tokenManager.ClearPreviousSecret()
-	jwtSecret = string(secret)
+	tm.RotateSecret(secret)
+	tm.ClearPreviousSecret()
+	storeSecret(string(secret))
 	slog.Info("JWT secret loaded from file", "path", secretFilePath, "length", len(secret))
 
 	watcher, err := fsnotify.NewWatcher()
@@ -186,15 +203,15 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 					}
 
 					// Skip if unchanged (fsnotify may fire multiple events per write).
-					if string(newSecret) == jwtSecret {
+					if string(newSecret) == loadSecret() {
 						continue
 					}
 
 					// Rotate: the outgoing secret stays valid for the overlap window.
-					tokenManager.RotateSecret(newSecret)
-					jwtSecret = string(newSecret)
+					tm.RotateSecret(newSecret)
+					storeSecret(string(newSecret))
 					time.AfterFunc(overlapDuration, func() {
-						tokenManager.ClearPreviousSecret()
+						tm.ClearPreviousSecret()
 						slog.Info("JWT previous secret cleared after overlap period")
 					})
 					slog.Info("JWT secret reloaded from file", "path", secretFilePath, "length", len(newSecret))

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,9 +1,11 @@
-// Package auth - jwt.go handles JWT token creation, signing, and verification
-// using a shared secret, including lazy secret initialization and claims parsing.
+// Package auth - jwt.go resolves the JWT signing secret (from the environment or
+// a watched file) and delegates token creation/validation to the shared identity
+// TokenManager. The TokenManager owns signing, validation, JTI stamping and the
+// previous-key overlap during rotation; this file keeps the registry-specific
+// secret resolution and the fsnotify file watch that drives rotation.
 package auth
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -12,39 +14,32 @@ import (
 	"log/slog"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/uuid"
+
+	identityauth "github.com/sethbacon/terraform-suite-identity/identity/auth"
 )
 
+// jwtIssuer stamps the iss claim on tokens this service generates.
+const jwtIssuer = "terraform-registry"
+
+// Claims is the suite identity JWT claims type, re-exported so existing call
+// sites keep referring to auth.Claims. It carries a JTI used for revocation.
+type Claims = identityauth.Claims
+
 var (
-	// jwtSecret holds the validated JWT secret
+	// jwtSecret holds the current effective signing secret (env or file). It is
+	// kept in sync with the TokenManager's current secret so GetJWTSecret can
+	// report it for diagnostics and tests.
 	jwtSecret     string
 	jwtSecretOnce sync.Once
 	jwtSecretErr  error
 
-	// jwtSecretPtr is the atomically-swappable signing key used when
-	// TFR_JWT_SECRET_FILE is configured.  When non-nil, GenerateJWT and
-	// ValidateJWT use this instead of the static jwtSecret.
-	jwtSecretPtr atomic.Pointer[[]byte]
-
-	// jwtPreviousSecretPtr holds the previous signing key during the overlap
-	// period of a key rotation.  ValidateJWT tries the current key first,
-	// then falls back to this key if verification fails.
-	jwtPreviousSecretPtr atomic.Pointer[[]byte]
+	// tokenManager performs the actual signing/validation. Constructed once the
+	// secret is resolved; the file watch swaps its secret via RotateSecret.
+	tokenManager *identityauth.TokenManager
 )
-
-// Claims represents the JWT claims structure
-type Claims struct {
-	UserID string   `json:"user_id"`
-	Email  string   `json:"email"`
-	Scopes []string `json:"scopes,omitempty"`
-	JTI    string   `json:"jti"`
-	jwt.RegisteredClaims
-}
 
 // isDevMode checks if we're in development mode (duplicated here to avoid import cycle)
 func isDevMode() bool {
@@ -65,9 +60,9 @@ func generateRandomSecret() (string, error) {
 	return hex.EncodeToString(bytes), nil
 }
 
-// ValidateJWTSecret checks that the JWT secret is properly configured.
-// In production, this will fail if TFR_JWT_SECRET is not set.
-// In dev mode, it will generate a random secret and log a warning.
+// ValidateJWTSecret checks that the JWT secret is properly configured and
+// constructs the shared TokenManager. In production it fails if TFR_JWT_SECRET
+// is not set; in dev mode it generates a random ephemeral secret and warns.
 // Call this at application startup.
 func ValidateJWTSecret() error {
 	jwtSecretOnce.Do(func() {
@@ -90,30 +85,26 @@ func ValidateJWTSecret() error {
 				// In production, fail fast
 				jwtSecretErr = errors.New("SECURITY ERROR: TFR_JWT_SECRET environment variable is required in production. " +
 					"Generate a secure secret with: openssl rand -hex 32")
+				return
 			}
-			return
+		} else {
+			// Validate secret length (minimum 32 characters recommended)
+			if len(secret) < 32 {
+				log.Printf("WARNING: TFR_JWT_SECRET is shorter than recommended 32 characters. Consider using a longer secret.")
+			}
+			jwtSecret = secret
 		}
 
-		// Validate secret length (minimum 32 characters recommended)
-		if len(secret) < 32 {
-			log.Printf("WARNING: TFR_JWT_SECRET is shorter than recommended 32 characters. Consider using a longer secret.")
-		}
-
-		jwtSecret = secret
+		tokenManager = identityauth.NewTokenManager(jwtSecret, jwtIssuer)
 	})
 
 	return jwtSecretErr
 }
 
-// GetJWTSecret retrieves the validated JWT secret.
-// Panics if ValidateJWTSecret() hasn't been called or failed.
+// GetJWTSecret retrieves the current effective JWT secret, validating lazily if
+// ValidateJWTSecret has not been called.
 func GetJWTSecret() string {
-	// If a file-watched secret is active, use that
-	if ptr := jwtSecretPtr.Load(); ptr != nil {
-		return string(*ptr)
-	}
 	if jwtSecret == "" {
-		// If ValidateJWTSecret wasn't called, try to validate now
 		if err := ValidateJWTSecret(); err != nil {
 			panic(err)
 		}
@@ -121,25 +112,47 @@ func GetJWTSecret() string {
 	return jwtSecret
 }
 
-// StartJWTSecretFileWatch begins watching the file at secretFilePath for
-// changes.  When the file is modified, the signing key is atomically swapped.
-// The previous key is kept for overlapDuration to allow in-flight tokens
-// signed with the old key to still validate.
+// GenerateJWT creates a JWT for an authenticated user, delegating to the shared
+// identity TokenManager. Scopes are embedded so the auth middleware can
+// authorize without a database round-trip; a unique JTI is stamped for revocation.
+func GenerateJWT(userID, email string, scopes []string, expiresIn time.Duration) (string, error) {
+	_ = GetJWTSecret() // ensure the secret is validated and the TokenManager exists
+	return tokenManager.Generate(userID, email, scopes, expiresIn)
+}
+
+// ValidateJWT parses and validates a JWT via the shared identity TokenManager.
+// During a key rotation overlap the TokenManager also tries the previous secret.
+func ValidateJWT(tokenString string) (*Claims, error) {
+	_ = GetJWTSecret()
+	return tokenManager.Validate(tokenString)
+}
+
+// StartJWTSecretFileWatch begins watching the file at secretFilePath for changes.
+// When the file is modified, the signing secret is rotated on the TokenManager;
+// the previous key remains valid for overlapDuration so in-flight tokens signed
+// with the old key still validate.
 //
-// This function should be called once at startup when TFR_JWT_SECRET_FILE is set.
-// It returns a stop function that should be called during shutdown.
+// Call this once at startup when TFR_JWT_SECRET_FILE is set. It returns a stop
+// function that should be called during shutdown.
 func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duration) (stop func(), err error) {
 	if overlapDuration <= 0 {
 		overlapDuration = 5 * time.Minute
 	}
 
-	// Read the initial secret
+	// Ensure the TokenManager exists (constructed from the env/dev secret).
+	_ = GetJWTSecret()
+
+	// Read the initial secret and make the file the source of truth. The env
+	// secret is dropped as a valid previous key (no tokens were signed with it
+	// before the file loaded).
 	data, err := os.ReadFile(secretFilePath) // #nosec G304 -- path comes from server config, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to read JWT secret file %q: %w", secretFilePath, err)
 	}
 	secret := trimSecretBytes(data)
-	jwtSecretPtr.Store(&secret)
+	tokenManager.RotateSecret(secret)
+	tokenManager.ClearPreviousSecret()
+	jwtSecret = string(secret)
 	slog.Info("JWT secret loaded from file", "path", secretFilePath, "length", len(secret))
 
 	watcher, err := fsnotify.NewWatcher()
@@ -172,24 +185,18 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 						continue
 					}
 
-					// Skip if the new secret is identical to the current one
-					// (fsnotify may fire multiple events for a single write)
-					current := jwtSecretPtr.Load()
-					if current != nil && bytes.Equal(*current, newSecret) {
+					// Skip if unchanged (fsnotify may fire multiple events per write).
+					if string(newSecret) == jwtSecret {
 						continue
 					}
 
-					// Save current as previous for the overlap period
-					if current != nil {
-						jwtPreviousSecretPtr.Store(current)
-						// Schedule clearing the previous secret after the overlap
-						time.AfterFunc(overlapDuration, func() {
-							jwtPreviousSecretPtr.Store(nil)
-							slog.Info("JWT previous secret cleared after overlap period")
-						})
-					}
-
-					jwtSecretPtr.Store(&newSecret)
+					// Rotate: the outgoing secret stays valid for the overlap window.
+					tokenManager.RotateSecret(newSecret)
+					jwtSecret = string(newSecret)
+					time.AfterFunc(overlapDuration, func() {
+						tokenManager.ClearPreviousSecret()
+						slog.Info("JWT previous secret cleared after overlap period")
+					})
 					slog.Info("JWT secret reloaded from file", "path", secretFilePath, "length", len(newSecret))
 				}
 			case watchErr, ok := <-watcher.Errors:
@@ -217,85 +224,4 @@ func trimSecretBytes(data []byte) []byte {
 	result := make([]byte, end)
 	copy(result, data[:end])
 	return result
-}
-
-// GenerateJWT creates a JWT token for an authenticated user.
-// Scopes are embedded in the token so the auth middleware can authorize
-// requests without a database round-trip on every request.
-func GenerateJWT(userID, email string, scopes []string, expiresIn time.Duration) (string, error) {
-	if expiresIn == 0 {
-		expiresIn = 1 * time.Hour // Default to 1 hour
-	}
-
-	claims := &Claims{
-		UserID: userID,
-		Email:  email,
-		Scopes: scopes,
-		JTI:    uuid.New().String(),
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiresIn)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Issuer:    "terraform-registry",
-			Subject:   userID,
-			ID:        uuid.New().String(),
-		},
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	secret := GetJWTSecret()
-
-	tokenString, err := token.SignedString([]byte(secret))
-	if err != nil {
-		return "", err
-	}
-
-	return tokenString, nil
-}
-
-// ValidateJWT parses and validates a JWT token.
-// When a previous key is available (during key rotation overlap), validation
-// tries the current key first, then falls back to the previous key.
-func ValidateJWT(tokenString string) (*Claims, error) {
-	secret := GetJWTSecret()
-
-	claims, err := validateJWTWithSecret(tokenString, secret)
-	if err == nil {
-		return claims, nil
-	}
-
-	// Try previous secret during overlap period
-	if prevPtr := jwtPreviousSecretPtr.Load(); prevPtr != nil {
-		prevClaims, prevErr := validateJWTWithSecret(tokenString, string(*prevPtr))
-		if prevErr == nil {
-			return prevClaims, nil
-		}
-	}
-
-	return nil, err
-}
-
-// validateJWTWithSecret validates a JWT token against a specific secret.
-func validateJWTWithSecret(tokenString, secret string) (*Claims, error) {
-	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
-		// Validate signing method
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, errors.New("unexpected signing method")
-		}
-		return []byte(secret), nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if !token.Valid {
-		return nil, errors.New("invalid token")
-	}
-
-	claims, ok := token.Claims.(*Claims)
-	if !ok {
-		return nil, errors.New("invalid claims type")
-	}
-
-	return claims, nil
 }

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/golang-jwt/jwt/v5"
 )
 
 // resetJWTSecret resets the package-level sync.Once so tests can set a fresh secret.
@@ -16,8 +14,7 @@ func resetJWTSecret() {
 	jwtSecret = ""
 	jwtSecretOnce = sync.Once{}
 	jwtSecretErr = nil
-	jwtSecretPtr.Store(nil)
-	jwtPreviousSecretPtr.Store(nil)
+	tokenManager = nil
 }
 
 func TestMain(m *testing.M) {
@@ -184,47 +181,6 @@ func TestTrimSecretBytes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// validateJWTWithSecret (direct)
-// ---------------------------------------------------------------------------
-
-func TestValidateJWTWithSecret(t *testing.T) {
-	resetJWTSecret()
-	t.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars-!")
-
-	token, err := GenerateJWT("user-1", "a@b.com", []string{"modules:read"}, time.Hour)
-	if err != nil {
-		t.Fatalf("GenerateJWT() error: %v", err)
-	}
-
-	t.Run("correct secret succeeds", func(t *testing.T) {
-		claims, err := validateJWTWithSecret(token, "test-jwt-secret-that-is-32-chars-!")
-		if err != nil {
-			t.Fatalf("validateJWTWithSecret() error: %v", err)
-		}
-		if claims.UserID != "user-1" {
-			t.Errorf("claims.UserID = %q, want %q", claims.UserID, "user-1")
-		}
-		if len(claims.Scopes) != 1 || claims.Scopes[0] != "modules:read" {
-			t.Errorf("claims.Scopes = %v, want [modules:read]", claims.Scopes)
-		}
-	})
-
-	t.Run("wrong secret fails", func(t *testing.T) {
-		_, err := validateJWTWithSecret(token, "wrong-secret-wrong-secret-wrong!")
-		if err == nil {
-			t.Error("validateJWTWithSecret() expected error with wrong secret")
-		}
-	})
-
-	t.Run("empty token fails", func(t *testing.T) {
-		_, err := validateJWTWithSecret("", "test-jwt-secret-that-is-32-chars-!")
-		if err == nil {
-			t.Error("validateJWTWithSecret() expected error with empty token")
-		}
-	})
-}
-
-// ---------------------------------------------------------------------------
 // StartJWTSecretFileWatch
 // ---------------------------------------------------------------------------
 
@@ -337,109 +293,6 @@ func TestStartJWTSecretFileWatch(t *testing.T) {
 			t.Errorf("GetJWTSecret() after empty update = %q, want original", got)
 		}
 	})
-}
-
-// ---------------------------------------------------------------------------
-// ValidateJWT with previous key fallback (manual atomic pointer setup)
-// ---------------------------------------------------------------------------
-
-func TestValidateJWT_PreviousKeyFallback(t *testing.T) {
-	resetJWTSecret()
-	t.Setenv("TFR_JWT_SECRET", "")
-
-	// Set up current key via atomic pointer
-	currentKey := []byte("current-secret-32-chars-exactly!")
-	jwtSecretPtr.Store(&currentKey)
-
-	// Generate a token with a different (previous) secret
-	prevKey := []byte("previous-secret-32-chars-exact!!")
-	jwtPreviousSecretPtr.Store(&prevKey)
-
-	// Manually create a token signed with the previous key
-	prevSecret := string(prevKey)
-	jwtSecretPtr.Store(&prevKey) // temporarily use prev key to sign
-	token, err := GenerateJWT("fallback-user", "fb@test.com", nil, time.Hour)
-	if err != nil {
-		t.Fatalf("GenerateJWT() error: %v", err)
-	}
-
-	// Now switch to current key, keeping previous
-	jwtSecretPtr.Store(&currentKey)
-	jwtPreviousSecretPtr.Store(&prevKey)
-	_ = prevSecret
-
-	// Token signed with previous key should validate via fallback
-	claims, err := ValidateJWT(token)
-	if err != nil {
-		t.Fatalf("ValidateJWT() with previous key fallback: %v", err)
-	}
-	if claims.UserID != "fallback-user" {
-		t.Errorf("claims.UserID = %q, want %q", claims.UserID, "fallback-user")
-	}
-
-	// Clear previous — now the old token should fail
-	jwtPreviousSecretPtr.Store(nil)
-	_, err = ValidateJWT(token)
-	if err == nil {
-		t.Error("ValidateJWT() expected error after previous key cleared")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// GetJWTSecret with file-watched key
-// ---------------------------------------------------------------------------
-
-func TestGetJWTSecret_FileWatchedKeyTakesPrecedence(t *testing.T) {
-	resetJWTSecret()
-	t.Setenv("TFR_JWT_SECRET", "env-secret-that-is-32-chars-ok!!")
-
-	// Without file watch, should use env
-	if err := ValidateJWTSecret(); err != nil {
-		t.Fatalf("ValidateJWTSecret() error: %v", err)
-	}
-	if got := GetJWTSecret(); got != "env-secret-that-is-32-chars-ok!!" {
-		t.Errorf("GetJWTSecret() = %q, want env secret", got)
-	}
-
-	// Set file-watched key — should take precedence
-	fileKey := []byte("file-watched-secret-32-chars-ok!")
-	jwtSecretPtr.Store(&fileKey)
-
-	if got := GetJWTSecret(); got != "file-watched-secret-32-chars-ok!" {
-		t.Errorf("GetJWTSecret() = %q, want file-watched secret", got)
-	}
-
-	// Clear file-watched key — should fall back to env
-	jwtSecretPtr.Store(nil)
-	if got := GetJWTSecret(); got != "env-secret-that-is-32-chars-ok!!" {
-		t.Errorf("GetJWTSecret() = %q, want env secret after clearing file ptr", got)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// validateJWTWithSecret edge cases
-// ---------------------------------------------------------------------------
-
-func TestValidateJWTWithSecret_WrongSigningMethod(t *testing.T) {
-	// Create a token signed with RSA (not HMAC) — the parser should reject it
-	token := jwt.NewWithClaims(jwt.SigningMethodNone, &Claims{
-		UserID: "user-1",
-		Email:  "a@b.com",
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-		},
-	})
-	// jwt.SigningMethodNone requires jwt.UnsafeAllowNoneSignatureType
-	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
-	if err != nil {
-		t.Fatalf("SignedString() error: %v", err)
-	}
-
-	_, err = validateJWTWithSecret(tokenString, "any-secret-32-chars-exactly-ok!!")
-	if err == nil {
-		t.Error("validateJWTWithSecret() expected error for none signing method")
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -11,7 +11,7 @@ import (
 // resetJWTSecret resets the package-level sync.Once so tests can set a fresh secret.
 // This is only safe to call from test code.
 func resetJWTSecret() {
-	jwtSecret = ""
+	currentSecret.Store(nil)
 	jwtSecretOnce = sync.Once{}
 	jwtSecretErr = nil
 	tokenManager = nil


### PR DESCRIPTION
Registry mirror, R4 (3/4). Replaces the registry's local JWT implementation with delegation to the shared identity `TokenManager` (module v0.10.0, enriched in R1 with `JTI` + secret rotation).

## What changed
- `GenerateJWT`/`ValidateJWT` delegate to the `TokenManager`; `Claims` is aliased to the module's (carries the `JTI` the revocation middleware checks).
- `StartJWTSecretFileWatch` is kept (fsnotify is app orchestration) but now drives the manager via `RotateSecret`/`ClearPreviousSecret` instead of local atomic pointers.
- Env/dev secret resolution (`ValidateJWTSecret`/`GetJWTSecret`) and `trimSecretBytes` unchanged.
- Removed the now-internal `jwtSecretPtr`/`jwtPreviousSecretPtr` and `validateJWTWithSecret`; the previous-key overlap + HMAC-only enforcement are covered by the module's `TokenManager` tests. `golang-jwt/jwt/v5` becomes indirect.

Token revocation is unaffected — the module stamps a unique `JTI` and the middleware's `IsTokenRevoked(claims.JTI)` check + `TokenRepository` stay app-side (revocation repo moves to the module in R5).

## Verification
- `go build ./...`, `go vet ./internal/auth/...` → clean
- `go test ./internal/auth/...` → pass
- `scripts/check_package_coverage.sh` → auth **89.5%**, middleware 88.0% (≥79%)
- `go mod tidy` idempotent
- **Live UAT (Keycloak stack):** OIDC login → JWT (issued by the module's TokenManager) → `/auth/me` 200, no-token 401; API-key create + scope-gated auth 200, bogus 401.