### PR TITLE
feat(identity): identity-schema cutover behind a flag

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -235,11 +235,31 @@ func serve(cfg *config.Config) error {
 		}()
 	}
 
-	// Create router
-	router, bgServices := api.NewRouter(cfg, database)
+	// Determine the connection for identity data access. When the identity-schema
+	// cutover is enabled, open a dedicated pool whose search_path resolves identity
+	// tables against the shared identity schema (feature tables fall back to
+	// public). Otherwise identity data stays in the app's public schema.
+	identityDB := database
+	if identitySchemaEnabled() {
+		searchPath := identitySchemaName() + ",public"
+		idb, connErr := db.Connect(
+			cfg.Database.GetDSNWithSearchPath(searchPath),
+			cfg.Database.MaxConnections, cfg.Database.MinIdleConnections,
+		)
+		if connErr != nil {
+			return fmt.Errorf("failed to connect to identity schema: %w", connErr)
+		}
+		defer idb.Close()
+		identityDB = idb
+		slog.Info("identity schema cutover enabled", "search_path", searchPath)
+	}
 
-	// Start daily cleanup of expired JWT revocation entries
-	tokenRepo := repositories.NewTokenRepository(database)
+	// Create router
+	router, bgServices := api.NewRouter(cfg, database, identityDB)
+
+	// Start daily cleanup of expired JWT revocation entries (revoked_tokens is an
+	// identity table, so use the identity connection).
+	tokenRepo := repositories.NewTokenRepository(identityDB)
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
@@ -408,6 +428,23 @@ func handleSetupToken(repo *repositories.OIDCConfigRepository) error {
 // TFR_IDENTITY_MIGRATIONS_ENABLED=true. Additive and reversible.
 func identityMigrationsEnabled() bool {
 	return os.Getenv("TFR_IDENTITY_MIGRATIONS_ENABLED") == "true"
+}
+
+// identitySchemaEnabled reports whether identity data (users, organizations, API
+// keys, OIDC config, audit logs, role templates, revoked tokens) is read/written
+// from the dedicated shared identity schema instead of the app's public schema.
+// Off by default; enable with TFR_IDENTITY_SCHEMA_ENABLED=true. Requires the
+// identity migrations (TFR_IDENTITY_MIGRATIONS_ENABLED) to have run. Reversible.
+func identitySchemaEnabled() bool {
+	return os.Getenv("TFR_IDENTITY_SCHEMA_ENABLED") == "true"
+}
+
+// identitySchemaName returns the identity schema name (default "identity").
+func identitySchemaName() string {
+	if name := os.Getenv("TFR_IDENTITY_SCHEMA_NAME"); name != "" {
+		return name
+	}
+	return "identity"
 }
 
 func runMigrations(cfg *config.Config, direction string) error {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -140,7 +140,11 @@ var AppCryptoMode = "standard"
 
 // NewRouter creates and configures the Gin router.
 // coverage:skip:integration-only — wires all repos, jobs, and services together; tested via E2E
-func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices) {
+// identityDB backs identity data access (users, organizations, API keys, OIDC
+// config, audit logs, role templates, revoked tokens). It equals db unless the
+// identity-schema cutover is enabled, in which case it targets the shared
+// identity schema (feature tables fall back to public via search_path).
+func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *BackgroundServices) {
 	router := gin.New()
 
 	// Initialize storage backend
@@ -150,21 +154,25 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	}
 	log.Printf("Initialized storage backend: %s", cfg.Storage.DefaultBackend)
 
-	// Initialize repositories
-	userRepo := repositories.NewUserRepository(db)
-	apiKeyRepo := repositories.NewAPIKeyRepository(db)
+	// Identity repositories use identityDB so they follow the configured identity
+	// schema; feature repositories below stay on db (public schema).
+	userRepo := repositories.NewUserRepository(identityDB)
+	apiKeyRepo := repositories.NewAPIKeyRepository(identityDB)
 	moduleRepo := repositories.NewModuleRepository(db)
 	providerRepo := repositories.NewProviderRepository(db)
-	auditRepo := repositories.NewAuditRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
-	tokenRepo := repositories.NewTokenRepository(db)
+	auditRepo := repositories.NewAuditRepository(identityDB)
+	orgRepo := repositories.NewOrganizationRepository(identityDB)
+	tokenRepo := repositories.NewTokenRepository(identityDB)
 
-	// Wrap *sql.DB with sqlx for SCM and mirror repositories
+	// Wrap *sql.DB with sqlx for SCM and mirror repositories (public) and identity
+	// data access (the identity schema when the cutover is enabled).
 	sqlxDB := sqlx.NewDb(db, "postgres")
+	identitySqlxDB := sqlx.NewDb(identityDB, "postgres")
 	scmRepo := repositories.NewSCMRepository(sqlxDB)
 	mirrorRepo := repositories.NewMirrorRepository(sqlxDB)
 	storageConfigRepo := repositories.NewStorageConfigRepository(sqlxDB)
-	oidcConfigRepo := repositories.NewOIDCConfigRepository(sqlxDB)
+	// OIDC-config CRUD follows the identity schema; setup-wizard state stays public.
+	oidcConfigRepo := repositories.NewOIDCConfigRepositoryWithIdentity(sqlxDB, identitySqlxDB)
 
 	providerDocsRepo := repositories.NewProviderDocsRepository(db)
 	scanRepo := repositories.NewModuleScanRepository(db)
@@ -544,7 +552,7 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 	}
 
 	var authHandlers *admin.AuthHandlers
-	authHandlers, err = admin.NewAuthHandlers(cfg, db, oidcConfigRepo, tokenRepo, oidcStateStore)
+	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore)
 	if err != nil {
 		log.Fatalf("Failed to initialize auth handlers: %v", err)
 	}
@@ -576,10 +584,14 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 		}
 	}
 
-	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, db)
-	userHandlers := admin.NewUserHandlers(cfg, db)
-	orgHandlers := admin.NewOrganizationHandlers(cfg, db)
-	statsHandlers := admin.NewStatsHandler(sqlxDB, &cfg.Scanning)
+	// Identity-backed admin handlers use the identity connection (their internal
+	// identity repos / raw identity SQL then follow the identity schema). The org
+	// handler's namespace cascade and the stats handler's feature-table counts
+	// fall back to public via the identity connection's search_path.
+	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, identityDB)
+	userHandlers := admin.NewUserHandlers(cfg, identityDB)
+	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB)
+	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers
 
@@ -595,14 +607,15 @@ func NewRouter(cfg *config.Config, db *sql.DB) (*gin.Engine, *BackgroundServices
 
 	// GDPR data-subject handlers (Article 15/17/20). Registered under
 	// /api/v1/admin/users/:id/{export,erase} below.
-	userSvc := services.NewUserService(db)
+	userSvc := services.NewUserService(identityDB)
 	gdprHandlers := admin.NewGDPRHandlers(userSvc)
 
-	rbacRepo := repositories.NewRBACRepository(sqlxDB)
+	// Role-template CRUD follows the identity schema; mirror methods stay public.
+	rbacRepo := repositories.NewRBACRepositoryWithIdentity(sqlxDB, identitySqlxDB)
 	rbacHandlers := admin.NewRBACHandlers(rbacRepo)
 
 	// Initialize audit log handlers
-	auditLogHandlers := admin.NewAuditLogHandlers(db)
+	auditLogHandlers := admin.NewAuditLogHandlers(identityDB)
 
 	// Initialize SCM publisher service (needed by scmLinkingHandler)
 	scmPublisher := services.NewSCMPublisher(scmRepo, moduleRepo, storageBackend, tokenCipher).

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1087,6 +1087,14 @@ func (c *DatabaseConfig) GetDSN() string {
 	)
 }
 
+// GetDSNWithSearchPath returns the DSN with the connection's search_path set, so
+// unqualified table names resolve against the given schemas in order. Used to
+// route identity data access at the dedicated identity schema while feature
+// tables fall back to public.
+func (c *DatabaseConfig) GetDSNWithSearchPath(searchPath string) string {
+	return c.GetDSN() + fmt.Sprintf(" options='-c search_path=%s'", searchPath)
+}
+
 // GetAddress returns the server address in host:port format
 func (c *ServerConfig) GetAddress() string {
 	return fmt.Sprintf("%s:%d", c.Host, c.Port)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -64,6 +64,18 @@ func TestGetDSN(t *testing.T) {
 	}
 }
 
+func TestGetDSNWithSearchPath(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "disable",
+	}
+	got := cfg.GetDSNWithSearchPath("identity,public")
+	want := cfg.GetDSN() + " options='-c search_path=identity,public'"
+	if got != want {
+		t.Errorf("GetDSNWithSearchPath() = %q, want %q", got, want)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ServerConfig.GetAddress
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Final phase of the identity unification (R5c). Routes identity data access at the dedicated shared **identity schema** when `TFR_IDENTITY_SCHEMA_ENABLED=true`; off by default and reversible (mirrors TSM's cutover, PR #36).

## How it works
- `DatabaseConfig.GetDSNWithSearchPath` builds a DSN with `options='-c search_path=identity,public'` — identity tables resolve at the identity schema; feature tables fall back to public.
- `main.go` opens a dedicated identity pool when the flag is set (else reuses the primary pool), passes it to `NewRouter`, and uses it for the revoked-token cleanup job.
- `NewRouter(cfg, db, identityDB)` injects the identity connection into:
  - identity **repos**: user / api_key / audit / organization / token;
  - the **OIDC** and **RBAC** delegation wrappers (their identity half — OIDC-config CRUD and role-template CRUD — via the `*WithIdentity` constructors added in R5b);
  - identity **admin handlers** (auth, users, api-keys, orgs, audit, stats) + the **GDPR** user service.
  - The org handler's namespace cascade and the stats handler's feature counts fall back to public via the identity connection's `search_path`. Feature repos/handlers stay on the public connection.

## Notes
- Requires `TFR_IDENTITY_MIGRATIONS_ENABLED` to have run first (so `identity.*` exists).
- **Prod rollout** (not this PR): flipping the flag on a populated deployment needs a one-time data copy public→identity; the identity schema only seeds role templates + the default org.
- UAT against the live Keycloak+Postgres stack (with the flag on) is the first end-to-end validation of module migration `000003` — running next.