### PR TITLE
feat!: repoint feature-table FKs to the identity schema

### DIFF
--- a/backend/internal/db/migrations/000038_feature_fk_to_identity.down.sql
+++ b/backend/internal/db/migrations/000038_feature_fk_to_identity.down.sql
@@ -1,0 +1,72 @@
+-- Revert feature-table foreign keys from identity.{users,organizations} back to
+-- public.{users,organizations}. No-op when the identity schema is absent.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.download_events DROP CONSTRAINT IF EXISTS download_events_user_id_fkey;
+    ALTER TABLE public.download_events ADD CONSTRAINT download_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_organization_id_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_requested_by_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_requested_by_fkey FOREIGN KEY (requested_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_reviewed_by_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_reviewed_by_fkey FOREIGN KEY (reviewed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_configurations DROP CONSTRAINT IF EXISTS mirror_configurations_created_by_fkey;
+    ALTER TABLE public.mirror_configurations ADD CONSTRAINT mirror_configurations_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_configurations DROP CONSTRAINT IF EXISTS mirror_configurations_organization_id_fkey;
+    ALTER TABLE public.mirror_configurations ADD CONSTRAINT mirror_configurations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.mirror_policies DROP CONSTRAINT IF EXISTS mirror_policies_created_by_fkey;
+    ALTER TABLE public.mirror_policies ADD CONSTRAINT mirror_policies_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_policies DROP CONSTRAINT IF EXISTS mirror_policies_organization_id_fkey;
+    ALTER TABLE public.mirror_policies ADD CONSTRAINT mirror_policies_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.module_versions DROP CONSTRAINT IF EXISTS module_versions_published_by_fkey;
+    ALTER TABLE public.module_versions ADD CONSTRAINT module_versions_published_by_fkey FOREIGN KEY (published_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.modules DROP CONSTRAINT IF EXISTS modules_created_by_fkey;
+    ALTER TABLE public.modules ADD CONSTRAINT modules_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.modules DROP CONSTRAINT IF EXISTS modules_organization_id_fkey;
+    ALTER TABLE public.modules ADD CONSTRAINT modules_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.provider_versions DROP CONSTRAINT IF EXISTS provider_versions_published_by_fkey;
+    ALTER TABLE public.provider_versions ADD CONSTRAINT provider_versions_published_by_fkey FOREIGN KEY (published_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_created_by_fkey;
+    ALTER TABLE public.providers ADD CONSTRAINT providers_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_organization_id_fkey;
+    ALTER TABLE public.providers ADD CONSTRAINT providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.scm_oauth_tokens DROP CONSTRAINT IF EXISTS scm_oauth_tokens_user_id_fkey;
+    ALTER TABLE public.scm_oauth_tokens ADD CONSTRAINT scm_oauth_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.scm_providers DROP CONSTRAINT IF EXISTS scm_providers_organization_id_fkey;
+    ALTER TABLE public.scm_providers ADD CONSTRAINT scm_providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.storage_config DROP CONSTRAINT IF EXISTS storage_config_created_by_fkey;
+    ALTER TABLE public.storage_config ADD CONSTRAINT storage_config_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.storage_config DROP CONSTRAINT IF EXISTS storage_config_updated_by_fkey;
+    ALTER TABLE public.storage_config ADD CONSTRAINT storage_config_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.storage_migrations DROP CONSTRAINT IF EXISTS storage_migrations_created_by_fkey;
+    ALTER TABLE public.storage_migrations ADD CONSTRAINT storage_migrations_created_by_fkey FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.system_settings DROP CONSTRAINT IF EXISTS system_settings_storage_configured_by_fkey;
+    ALTER TABLE public.system_settings ADD CONSTRAINT system_settings_storage_configured_by_fkey FOREIGN KEY (storage_configured_by) REFERENCES public.users(id);
+
+    ALTER TABLE public.version_approval_events DROP CONSTRAINT IF EXISTS version_approval_events_performed_by_fkey;
+    ALTER TABLE public.version_approval_events ADD CONSTRAINT version_approval_events_performed_by_fkey FOREIGN KEY (performed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.version_immutability_violations DROP CONSTRAINT IF EXISTS version_immutability_violations_resolved_by_fkey;
+    ALTER TABLE public.version_immutability_violations ADD CONSTRAINT version_immutability_violations_resolved_by_fkey FOREIGN KEY (resolved_by) REFERENCES public.users(id);
+  END IF;
+END $$;

--- a/backend/internal/db/migrations/000038_feature_fk_to_identity.up.sql
+++ b/backend/internal/db/migrations/000038_feature_fk_to_identity.up.sql
@@ -1,0 +1,74 @@
+-- Repoint feature-table foreign keys from public.{users,organizations} to
+-- identity.{users,organizations} so identities created after the identity-schema
+-- cutover can perform feature writes. No-op when the identity schema is absent
+-- (default, non-cutover deployments). See docs/identity-schema.md.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.download_events DROP CONSTRAINT IF EXISTS download_events_user_id_fkey;
+    ALTER TABLE public.download_events ADD CONSTRAINT download_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES identity.users(id);
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_organization_id_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_requested_by_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_requested_by_fkey FOREIGN KEY (requested_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_approval_requests DROP CONSTRAINT IF EXISTS mirror_approval_requests_reviewed_by_fkey;
+    ALTER TABLE public.mirror_approval_requests ADD CONSTRAINT mirror_approval_requests_reviewed_by_fkey FOREIGN KEY (reviewed_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_configurations DROP CONSTRAINT IF EXISTS mirror_configurations_created_by_fkey;
+    ALTER TABLE public.mirror_configurations ADD CONSTRAINT mirror_configurations_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_configurations DROP CONSTRAINT IF EXISTS mirror_configurations_organization_id_fkey;
+    ALTER TABLE public.mirror_configurations ADD CONSTRAINT mirror_configurations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.mirror_policies DROP CONSTRAINT IF EXISTS mirror_policies_created_by_fkey;
+    ALTER TABLE public.mirror_policies ADD CONSTRAINT mirror_policies_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.mirror_policies DROP CONSTRAINT IF EXISTS mirror_policies_organization_id_fkey;
+    ALTER TABLE public.mirror_policies ADD CONSTRAINT mirror_policies_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.module_versions DROP CONSTRAINT IF EXISTS module_versions_published_by_fkey;
+    ALTER TABLE public.module_versions ADD CONSTRAINT module_versions_published_by_fkey FOREIGN KEY (published_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.modules DROP CONSTRAINT IF EXISTS modules_created_by_fkey;
+    ALTER TABLE public.modules ADD CONSTRAINT modules_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.modules DROP CONSTRAINT IF EXISTS modules_organization_id_fkey;
+    ALTER TABLE public.modules ADD CONSTRAINT modules_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.provider_versions DROP CONSTRAINT IF EXISTS provider_versions_published_by_fkey;
+    ALTER TABLE public.provider_versions ADD CONSTRAINT provider_versions_published_by_fkey FOREIGN KEY (published_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_created_by_fkey;
+    ALTER TABLE public.providers ADD CONSTRAINT providers_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.providers DROP CONSTRAINT IF EXISTS providers_organization_id_fkey;
+    ALTER TABLE public.providers ADD CONSTRAINT providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.scm_oauth_tokens DROP CONSTRAINT IF EXISTS scm_oauth_tokens_user_id_fkey;
+    ALTER TABLE public.scm_oauth_tokens ADD CONSTRAINT scm_oauth_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES identity.users(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.scm_providers DROP CONSTRAINT IF EXISTS scm_providers_organization_id_fkey;
+    ALTER TABLE public.scm_providers ADD CONSTRAINT scm_providers_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.storage_config DROP CONSTRAINT IF EXISTS storage_config_created_by_fkey;
+    ALTER TABLE public.storage_config ADD CONSTRAINT storage_config_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.storage_config DROP CONSTRAINT IF EXISTS storage_config_updated_by_fkey;
+    ALTER TABLE public.storage_config ADD CONSTRAINT storage_config_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.storage_migrations DROP CONSTRAINT IF EXISTS storage_migrations_created_by_fkey;
+    ALTER TABLE public.storage_migrations ADD CONSTRAINT storage_migrations_created_by_fkey FOREIGN KEY (created_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.system_settings DROP CONSTRAINT IF EXISTS system_settings_storage_configured_by_fkey;
+    ALTER TABLE public.system_settings ADD CONSTRAINT system_settings_storage_configured_by_fkey FOREIGN KEY (storage_configured_by) REFERENCES identity.users(id);
+
+    ALTER TABLE public.version_approval_events DROP CONSTRAINT IF EXISTS version_approval_events_performed_by_fkey;
+    ALTER TABLE public.version_approval_events ADD CONSTRAINT version_approval_events_performed_by_fkey FOREIGN KEY (performed_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+
+    ALTER TABLE public.version_immutability_violations DROP CONSTRAINT IF EXISTS version_immutability_violations_resolved_by_fkey;
+    ALTER TABLE public.version_immutability_violations ADD CONSTRAINT version_immutability_violations_resolved_by_fkey FOREIGN KEY (resolved_by) REFERENCES identity.users(id);
+  END IF;
+END $$;

--- a/docs/identity-schema.md
+++ b/docs/identity-schema.md
@@ -23,11 +23,11 @@ separate service. There is nothing extra to deploy.
 
 Two environment flags gate the feature, **both default `false`**:
 
-| Variable | Default | Effect |
-| -------- | ------- | ------ |
-| `TFR_IDENTITY_MIGRATIONS_ENABLED` | `false` | Run the shared identity migrations at startup (create/update the `identity` schema). Additive and safe; does **not** change runtime behaviour on its own. |
-| `TFR_IDENTITY_SCHEMA_ENABLED` | `false` | Route identity reads/writes at the `identity` schema (`search_path=identity,public`). Requires the schema to exist. |
-| `TFR_IDENTITY_SCHEMA_NAME` | `identity` | The schema name. |
+| Variable                          | Default    | Effect                                                                                                                                                    |
+| --------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TFR_IDENTITY_MIGRATIONS_ENABLED` | `false`    | Run the shared identity migrations at startup (create/update the `identity` schema). Additive and safe; does **not** change runtime behaviour on its own. |
+| `TFR_IDENTITY_SCHEMA_ENABLED`     | `false`    | Route identity reads/writes at the `identity` schema (`search_path=identity,public`). Requires the schema to exist.                                       |
+| `TFR_IDENTITY_SCHEMA_NAME`        | `identity` | The schema name.                                                                                                                                          |
 
 Leaving both unset keeps the registry on `public` — the supported standalone path.
 
@@ -43,43 +43,34 @@ reversible — turning it off routes identity access back to `public`.
 
 ---
 
-## ⚠️ Known limitation — cross-schema foreign keys
+## Cross-schema foreign keys (resolved in backend 2.0)
 
 > **Read this before enabling the cutover on a registry with module/provider data.**
 
-The cutover routes **identity** data to the `identity` schema, but the registry's
-**feature** tables still reference identity by foreign key in `public`:
+The cutover routes **identity** data to the `identity` schema. In backend 2.0, migration
+`000038_feature_fk_to_identity` automatically repoints the registry's **feature**-table
+foreign keys from `public.{users,organizations}` to `identity.{users,organizations}`.
+This is guarded — it only executes when the `identity` schema exists (cutover deployments)
+and is a no-op otherwise. It is idempotent and fully reversible (the `.down.sql` repoints
+back to `public`).
 
-```
-modules.created_by      → public.users(id)
-modules.organization_id → public.organizations(id)
-providers.created_by    → public.users(id)
-providers.organization_id → public.organizations(id)
-... (and similar on version_approvals, etc.)
-```
+After the migration, feature writes by users/orgs created **after** the cutover work
+correctly — the FK now resolves against `identity.users` / `identity.organizations`
+where those rows live.
 
-After the cutover, a user or organization **created in the `identity` schema** does not
-exist in `public.users` / `public.organizations`. A feature write that references such a
-row (for example, a newly-onboarded user publishing their first module) will therefore
-fail its foreign-key check.
+### Caveats
 
-Consequences:
+1. **Non-default schema name.** If you set `TFR_IDENTITY_SCHEMA_NAME` to something other
+   than `identity`, the migration's hardcoded schema literal will not match. Edit the
+   `.up.sql` and `.down.sql` files to replace `identity.` with your custom schema name
+   before applying.
 
-- ✅ **Identity / auth flows work fully** — login, sessions, API keys, audit logs, role
-  templates, OIDC config. These are internal to the identity schema.
-- ✅ Feature writes by users/orgs that **existed before the cutover** (and were copied to
-  `identity`, so the same UUID is still present in `public`) continue to work.
-- ⚠️ Feature writes that reference a user/org **created after the cutover** fail.
-
-Making feature writes work for newly-created identity entities requires migrating the
-feature-table foreign keys to reference `identity.{users,organizations}`. That migration
-is **not** included here — it is planned as a fast-follow (backend 2.0). Until then, enable
-the cutover only where this is acceptable:
-
-- **new / greenfield deployments** evaluating the shared identity store, or
-- deployments where you have migrated the feature-table FKs yourself.
-
-For a standalone registry with active publishing, **stay on the default (`public`) schema.**
+2. **Identity enabled after initial migration.** If you enable
+   `TFR_IDENTITY_MIGRATIONS_ENABLED` on a deployment whose app migrations already ran
+   (i.e. migration 000038 already executed as a no-op), golang-migrate will not re-run
+   it. In this case, run the body of `000038_feature_fk_to_identity.up.sql` manually
+   against the database — the SQL is safe to execute by hand (idempotent
+   `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT`).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds migration `000038_feature_fk_to_identity` that repoints all feature-table foreign
keys from `public.{users,organizations}` to `identity.{users,organizations}`, resolving
the cross-schema FK limitation documented in `docs/identity-schema.md`.

- **Guarded**: only executes when the `identity` schema exists (cutover deployments);
  no-op on default/non-cutover deployments.
- **Idempotent**: `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT`.
- **Reversible**: `.down.sql` repoints back to `public`.
- **Preserves ON DELETE rules**: each constraint retains its original delete behavior
  (CASCADE, SET NULL, or NO ACTION).
- **22 constraints** repointed across 14 feature tables.

## UAT Results

- Non-cutover DB: migration is a verified no-op; up/down round-trips cleanly.
- Cutover DB: all feature-table FKs target `identity.{users,organizations}`.
- **Publish-after-cutover proven**: a user created *only* in `identity.users` (not in
  `public.users`) successfully inserts a module row — the exact FK violation that
  failed before this change now succeeds.

## Test Plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/... ./pkg/...` — all pass
- [x] Coverage >= 80% (80.1%)
- [x] `gosec` — 0 new findings
- [x] Swagger regeneration — no diff
- [x] `go mod tidy` — no diff
- [x] Migration up/down round-trip on non-cutover DB
- [x] Migration up/down round-trip on cutover DB
- [x] Post-cutover feature write UAT (FK violation before → success after)

Closes #450

BREAKING CHANGE: Cutover deployments have their feature-table FK targets changed from
public.{users,organizations} to identity.{users,organizations}. This drops and recreates
22 constraints. Non-cutover deployments are unaffected (migration is a no-op).