### PR TITLE
feat(identity): seed app role scopes into identity schema on cutover

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -61,6 +61,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"golang.org/x/crypto/bcrypt"
@@ -252,6 +253,18 @@ func serve(cfg *config.Config) error {
 		defer idb.Close()
 		identityDB = idb
 		slog.Info("identity schema cutover enabled", "search_path", searchPath)
+
+		// The shared identity schema seeds role templates with identity-core
+		// scopes only (admin wildcard + cross-cutting reads). Layer the registry's
+		// own domain scopes onto the system roles so non-admin roles behave the
+		// same as in the default public-schema configuration ("identity-core +
+		// app-extended"). Idempotent; no-op on steady-state restarts.
+		if err := repositories.SeedSystemRoleTemplates(
+			context.Background(), identityDB, models.PredefinedRoleTemplates(),
+		); err != nil {
+			return fmt.Errorf("failed to seed system role templates: %w", err)
+		}
+		slog.Info("system role templates seeded into identity schema")
 	}
 
 	// Create router

--- a/backend/internal/db/repositories/role_template_seed.go
+++ b/backend/internal/db/repositories/role_template_seed.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// systemRoleTemplateExecer is the minimal database surface SeedSystemRoleTemplates
+// needs. *sql.DB satisfies it; tests substitute a fake.
+type systemRoleTemplateExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// upsertSystemRoleTemplateQuery idempotently inserts or updates a system role
+// template by its (unique) name. The conflict update only fires when something
+// actually changed, so steady-state restarts perform no writes.
+//
+// This deliberately bypasses the identity module's RoleTemplateRepository.Update,
+// which refuses to modify is_system rows (`WHERE is_system = false`). Seeding the
+// system role→scope mapping is a privileged bootstrap write owned by the app, not
+// a user-facing edit, so it must reach the protected system rows directly.
+const upsertSystemRoleTemplateQuery = `
+INSERT INTO role_templates (id, name, display_name, description, scopes, is_system, created_at, updated_at)
+VALUES (gen_random_uuid(), $1, $2, $3, $4, true, NOW(), NOW())
+ON CONFLICT (name) DO UPDATE SET
+    display_name = EXCLUDED.display_name,
+    description  = EXCLUDED.description,
+    scopes       = EXCLUDED.scopes,
+    is_system    = true,
+    updated_at   = NOW()
+WHERE role_templates.scopes       IS DISTINCT FROM EXCLUDED.scopes
+   OR role_templates.display_name IS DISTINCT FROM EXCLUDED.display_name
+   OR role_templates.description  IS DISTINCT FROM EXCLUDED.description
+   OR role_templates.is_system    IS DISTINCT FROM true`
+
+// SeedSystemRoleTemplates idempotently upserts the given system role templates by
+// name against the supplied connection.
+//
+// It is used under the identity-schema cutover (TFR_IDENTITY_SCHEMA_ENABLED): the
+// shared identity module seeds these roles with identity-core scopes only, so the
+// registry layers its own domain scopes onto them here ("identity-core +
+// app-extended"). In the default public-schema configuration the role templates
+// are already seeded with the full app scopes by migration 000001, so this is not
+// invoked.
+//
+// The connection's search_path determines which schema is written: under cutover
+// it resolves the unqualified role_templates to the shared identity schema.
+func SeedSystemRoleTemplates(ctx context.Context, db systemRoleTemplateExecer, templates []models.RoleTemplate) error {
+	for i := range templates {
+		t := templates[i]
+		scopesJSON, err := json.Marshal(t.Scopes)
+		if err != nil {
+			return fmt.Errorf("marshal scopes for role template %q: %w", t.Name, err)
+		}
+		if _, err := db.ExecContext(ctx, upsertSystemRoleTemplateQuery,
+			t.Name, t.DisplayName, t.Description, scopesJSON); err != nil {
+			return fmt.Errorf("upsert role template %q: %w", t.Name, err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/db/repositories/role_template_seed_test.go
+++ b/backend/internal/db/repositories/role_template_seed_test.go
@@ -1,0 +1,157 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// fakeExecer records ExecContext calls and returns a configurable error. It
+// satisfies systemRoleTemplateExecer without a live database.
+type fakeExecer struct {
+	calls []seedExecCall
+	err   error
+}
+
+type seedExecCall struct {
+	query string
+	args  []any
+}
+
+func (f *fakeExecer) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	f.calls = append(f.calls, seedExecCall{query: query, args: args})
+	return nil, f.err
+}
+
+func TestSeedSystemRoleTemplates_UpsertsEachTemplate(t *testing.T) {
+	desc := "Can upload and manage modules and providers"
+	templates := []models.RoleTemplate{
+		{Name: "admin", DisplayName: "Administrator", Scopes: []string{"admin"}},
+		{Name: "publisher", DisplayName: "Publisher", Description: &desc, Scopes: []string{"modules:read", "modules:write"}},
+	}
+
+	f := &fakeExecer{}
+	if err := SeedSystemRoleTemplates(context.Background(), f, templates); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(f.calls) != len(templates) {
+		t.Fatalf("expected %d Exec calls, got %d", len(templates), len(f.calls))
+	}
+	for i, call := range f.calls {
+		if call.query != upsertSystemRoleTemplateQuery {
+			t.Errorf("call %d: query did not match the upsert statement", i)
+		}
+		if len(call.args) != 4 {
+			t.Fatalf("call %d: expected 4 args, got %d", i, len(call.args))
+		}
+		if call.args[0] != templates[i].Name {
+			t.Errorf("call %d: name arg = %v, want %v", i, call.args[0], templates[i].Name)
+		}
+		if call.args[1] != templates[i].DisplayName {
+			t.Errorf("call %d: display_name arg = %v, want %v", i, call.args[1], templates[i].DisplayName)
+		}
+		// Description (*string) passes through by pointer.
+		if call.args[2] != templates[i].Description {
+			t.Errorf("call %d: description arg did not pass through", i)
+		}
+		// Scopes are JSON-encoded for the JSONB column.
+		scopesJSON, ok := call.args[3].([]byte)
+		if !ok {
+			t.Fatalf("call %d: scopes arg is %T, want []byte", i, call.args[3])
+		}
+		var gotScopes []string
+		if err := json.Unmarshal(scopesJSON, &gotScopes); err != nil {
+			t.Fatalf("call %d: scopes arg is not valid JSON: %v", i, err)
+		}
+		if !reflect.DeepEqual(gotScopes, templates[i].Scopes) {
+			t.Errorf("call %d: scopes = %v, want %v", i, gotScopes, templates[i].Scopes)
+		}
+	}
+}
+
+// TestSeedSystemRoleTemplates_GuardedUpsertSQL locks the shape of the bootstrap
+// write: it must be a guarded ON CONFLICT upsert that reaches is_system rows and
+// no-ops when nothing changed.
+func TestSeedSystemRoleTemplates_GuardedUpsertSQL(t *testing.T) {
+	q := upsertSystemRoleTemplateQuery
+	for _, want := range []string{
+		"INSERT INTO role_templates",
+		"ON CONFLICT (name) DO UPDATE SET",
+		"is_system    = true",
+		"IS DISTINCT FROM",
+	} {
+		if !strings.Contains(q, want) {
+			t.Errorf("upsert query is missing %q", want)
+		}
+	}
+}
+
+func TestSeedSystemRoleTemplates_PropagatesError(t *testing.T) {
+	f := &fakeExecer{err: errors.New("db unavailable")}
+	templates := []models.RoleTemplate{{Name: "viewer", Scopes: []string{"modules:read"}}}
+
+	err := SeedSystemRoleTemplates(context.Background(), f, templates)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "viewer") {
+		t.Errorf("error should name the failing role template, got: %v", err)
+	}
+}
+
+func TestSeedSystemRoleTemplates_EmptyTemplates(t *testing.T) {
+	f := &fakeExecer{}
+	if err := SeedSystemRoleTemplates(context.Background(), f, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("expected no Exec calls for empty templates, got %d", len(f.calls))
+	}
+}
+
+// TestSeedSystemRoleTemplates_Idempotent_NoOpReRun drives a real *sql.DB via
+// sqlmock to assert the seed executes the guarded upsert once per template, and
+// that a same-value re-run is a no-op: the guarded ON CONFLICT update affects 0
+// rows (Postgres "INSERT 0 0"), which the seed tolerates without error.
+func TestSeedSystemRoleTemplates_Idempotent_NoOpReRun(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	templates := models.PredefinedRoleTemplates()
+
+	// First run: every template upsert inserts a row (RowsAffected = 1).
+	for range templates {
+		mock.ExpectExec("INSERT INTO role_templates").
+			WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+	// Second run with identical values: the guarded WHERE suppresses every write,
+	// so each upsert reports 0 rows affected — the steady-state no-op.
+	for range templates {
+		mock.ExpectExec("INSERT INTO role_templates").
+			WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+
+	if err := SeedSystemRoleTemplates(context.Background(), db, templates); err != nil {
+		t.Fatalf("first seed run: unexpected error: %v", err)
+	}
+	if err := SeedSystemRoleTemplates(context.Background(), db, templates); err != nil {
+		t.Fatalf("re-run seed: unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #461

## What

Under the identity-schema cutover (`TFR_IDENTITY_SCHEMA_ENABLED=true`), the registry opens a dedicated identity DB pool but never seeded its app-specific role->scope templates into the identity schema. The shared `terraform-suite-identity` module seeds `role_templates` with identity-core scopes only (admin wildcard + cross-cutting reads), so under cutover the registry's non-admin roles (viewer/publisher/devops/auditor/user_manager) would lose their domain scopes.

This adds an idempotent startup seed that layers the registry's own role->scope mapping (`models.PredefinedRoleTemplates()`) onto the identity-schema system role templates, mirroring the public-schema seed in migration `000001` so a role grants the same access in either schema ("identity-core + app-extended").

## Why

`models.PredefinedRoleTemplates()` already existed but was never written to the identity schema at startup. This closes the parity gap so the cutover is behaviourally equivalent to the default public-schema deployment.

## How

- **`internal/db/repositories/role_template_seed.go`** — new `SeedSystemRoleTemplates(ctx, db, templates)` doing a guarded raw upsert by `name`:

  ```sql
  INSERT INTO role_templates (id, name, display_name, description, scopes, is_system, created_at, updated_at)
  VALUES (gen_random_uuid(), $1, $2, $3, $4, true, NOW(), NOW())
  ON CONFLICT (name) DO UPDATE SET
      display_name = EXCLUDED.display_name,
      description  = EXCLUDED.description,
      scopes       = EXCLUDED.scopes,
      is_system    = true,
      updated_at   = NOW()
  WHERE role_templates.scopes       IS DISTINCT FROM EXCLUDED.scopes
     OR role_templates.display_name IS DISTINCT FROM EXCLUDED.display_name
     OR role_templates.description  IS DISTINCT FROM EXCLUDED.description
     OR role_templates.is_system    IS DISTINCT FROM true
  ```

  The guarded `WHERE ... IS DISTINCT FROM ...` makes a same-value re-run a no-op (`INSERT 0 0`, no restart churn). It deliberately bypasses the module's `RoleTemplateRepository.Update`, which guards `WHERE is_system = false` and would silently no-op on these `is_system = true` rows — seeding the system role->scope mapping is a privileged bootstrap write owned by the app, not a user edit.

- **`cmd/server/main.go`** — call the seed right after the identity pool is opened, **gated on `TFR_IDENTITY_SCHEMA_ENABLED`**, so the default public-schema deployment is untouched.

- **`internal/db/repositories/role_template_seed_test.go`** — unit tests: per-template upsert with exact SQL + JSON-encoded scopes (fake execer), guarded-SQL shape assertion, error propagation, empty input, and a **sqlmock idempotency test** proving a same-value re-run is a no-op (each upsert returns `RowsAffected = 0`).

## Deviations from the state-manager mirror (commit 7b12322)

- The registry **already had** `models.PredefinedRoleTemplates()` with full tests in `models_test.go`, so this PR only adds the seed + wiring + seed tests (TSM also added the model half).
- The registry's cutover flag is **env-only** (`TFR_IDENTITY_SCHEMA_ENABLED`) with no `identity_schema` block in `config.example.yaml`, so there was no config doc to update (TSM had a YAML key to annotate).

## Testing

Run from `backend/`:

- `go fmt ./...` / `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./internal/db/repositories/...` — pass; package coverage 90.7% (well above the 80% floor); `SeedSystemRoleTemplates` at 87.5% (only the unreachable `json.Marshal([]string)` error branch is uncovered)
- `go mod tidy` — no change to `go.mod`/`go.sum`
- gosec baseline compare — **New: 0** (no new findings introduced)

Notes:
- `-race` was not run locally (cgo is unavailable on the Windows dev host) — relying on the CI race gate.
- Pre-existing, unrelated failures in `internal/middleware` (API key `Scan` column-count drift + setup-token SQL mismatch) reproduce on a clean `origin/main` with this change stashed, so they are not introduced here. They will, however, make this PR's CI red until fixed separately.

Full flag-ON live verification against a running registry stack can follow if/when the identity-schema cutover is rolled out; this PR's bar is CI green + the idempotency unit test (the cutover is default-off and not in rollout).
