### PR TITLE
test(middleware): add expiry_notification_sent_at to API key auth mocks

### DIFF
--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -241,10 +241,10 @@ func newTestAPIKeyRepo(t *testing.T) (*repositories.APIKeyRepository, sqlmock.Sq
 	return repositories.NewAPIKeyRepository(db), mock
 }
 
-// GetAPIKeysByPrefix uses 11 columns (no user_name join)
+// GetAPIKeysByPrefix uses 12 columns (no user_name join)
 var apiKeyPrefixCols = []string{
 	"id", "user_id", "organization_id", "name", "description",
-	"key_hash", "key_prefix", "scopes", "expires_at", "last_used_at", "created_at",
+	"key_hash", "key_prefix", "scopes", "expires_at", "last_used_at", "expiry_notification_sent_at", "created_at",
 }
 
 func TestAuthenticateAPIKey_DBError(t *testing.T) {
@@ -282,7 +282,7 @@ func TestAuthenticateAPIKey_KeyDoesNotMatch(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-1", "user-1", "org-1", "Test Key", nil, badHash, "prefix",
-			[]byte(`["read"]`), nil, nil, time.Now(),
+			[]byte(`["read"]`), nil, nil, nil, time.Now(),
 		))
 
 	key, err := authenticateAPIKey(context.Background(), "some-key", "prefix", repo)
@@ -313,7 +313,7 @@ func TestAuthenticateAPIKey_KeyMatches(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-1", "user-1", "org-1", "Test Key", nil, validHash, "prefix",
-			[]byte(`["read"]`), nil, nil, time.Now(),
+			[]byte(`["read"]`), nil, nil, nil, time.Now(),
 		))
 
 	key, err := authenticateAPIKey(context.Background(), providedKey, "prefix", repo)
@@ -384,7 +384,7 @@ func TestAuthMiddleware_ExpiredAPIKey(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-1", "user-1", "org-1", "Test Key", nil, validHash, "tfr_test_",
-			[]byte(`["read"]`), &expiredAt, nil, time.Now(),
+			[]byte(`["read"]`), &expiredAt, nil, nil, time.Now(),
 		))
 
 	w := httptest.NewRecorder()
@@ -525,7 +525,7 @@ func TestAuthMiddleware_APIKeyWithUser(t *testing.T) {
 	apiKeyMock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-1", &userID, "org-1", "Test Key", nil, validHash, "tfr_apikey",
-			[]byte(`["modules:read"]`), nil, nil, time.Now(),
+			[]byte(`["modules:read"]`), nil, nil, nil, time.Now(),
 		))
 
 	// userRepo.GetUserByID loads the user linked to the API key
@@ -620,7 +620,7 @@ func TestOptionalAuthMiddleware_APIKey_Valid_SetsContext(t *testing.T) {
 	apiKeyMock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-2", &userID, "org-1", "CI Key", nil, validHash, "tfr_optio",
-			[]byte(`["modules:read"]`), nil, nil, time.Now(),
+			[]byte(`["modules:read"]`), nil, nil, nil, time.Now(),
 		))
 
 	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
@@ -655,7 +655,7 @@ func TestOptionalAuthMiddleware_APIKey_Expired_PassesThrough(t *testing.T) {
 	apiKeyMock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
 		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
 			"key-3", &userID, "org-1", "Expired Key", nil, validHash, "tfr_expir",
-			[]byte(`["modules:read"]`), &expiredAt, nil, time.Now(),
+			[]byte(`["modules:read"]`), &expiredAt, nil, nil, time.Now(),
 		))
 
 	w := httptest.NewRecorder()


### PR DESCRIPTION
@
## Summary

Fixes the `internal/middleware` test suite, which fails on `main` (clean tree) with:

```
--- FAIL: TestAuthenticateAPIKey_KeyDoesNotMatch  (sql: expected 11 destination arguments in Scan, not 12)
--- FAIL: TestAuthenticateAPIKey_KeyMatches       (sql: expected 11 destination arguments in Scan, not 12)
--- FAIL: TestAuthMiddleware_ExpiredAPIKey        (status 500, want 401)
--- FAIL: TestAuthMiddleware_APIKeyWithUser       (status 500, want 200)
```

## Root cause

`48c0706` ("feat(api-key): include expiry_notification_sent_at in API key responses") added the
`expiry_notification_sent_at` column to `APIKeyRepository.GetAPIKeysByPrefix`, which now scans 12
columns. The sqlmock rows in `internal/middleware/auth_test.go` (`apiKeyPrefixCols`) still declared 11,
so `Scan` failed. In `AuthMiddleware` that surfaced as HTTP 500; in `OptionalAuthMiddleware` it was
swallowed (those tests assert 200 regardless, so they passed but no longer exercised the key path).

## Change

Test-only. Added `expiry_notification_sent_at` to `apiKeyPrefixCols` and every `AddRow` that uses it,
positioned between `last_used_at` and `created_at` to match the production query column order. The 2
`OptionalAuth` rows were updated too — once the column count changed they would otherwise panic in
`AddRow`. No production code changed; the query/struct are correct.

## Note on setup middleware

All `TestSetupMiddleware_*` tests already pass. The `could not match actual sql` log lines are expected
noise from `TestSetupMiddleware_RateLimitExceeded` (it intentionally queues only `setup_completed`
expectations), not failures, so that test was left untouched.

## Verification (local)

- `gofmt -l` clean
- `go build ./...` OK
- `go vet ./...` OK
- `go test ./internal/middleware/...` **ok** (was FAIL)

`golangci-lint` and the `-race` gate (cgo unavailable on this Windows host) are left to CI.

Closes #463
@