### PR TITLE
fix(deps): bump Go to 1.26.4 to resolve stdlib advisories

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Terraform Registry Backend
 
 # Stage 1: Build the Go application
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-registry/terraform-registry
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/storage v1.62.2


### PR DESCRIPTION
Closes #466

## What
OSV-Scanner flagged **3 Go stdlib vulnerabilities** in 1.26.3 — `GO-2026-5037`, `GO-2026-5038`, `GO-2026-5039` — all **fixed in 1.26.4**. No third-party deps are affected (all Dependabot alerts are already in the `fixed` state).

## Fix
Bump the `go` directive in `backend/go.mod` 1.26.3 → 1.26.4. CI's `setup-go` uses `go-version-file: backend/go.mod`, so this is the only change needed — OSV reads the same directive and will no longer flag the stdlib.

## Verified
- go1.26.4 toolchain builds the module cleanly (`go build ./...` exit 0, `go vet` clean).