### PR TITLE
fix(auth): deprovision group-mapped roles when a user loses the IdP group

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -816,89 +816,26 @@ func (h *AuthHandlers) resolveGroupMappingConfig(ctx context.Context) (claimName
 	return h.cfg.Auth.OIDC.GroupClaimName, h.cfg.Auth.OIDC.GroupMappings, h.cfg.Auth.OIDC.DefaultRole
 }
 
-// applyGroupMappings resolves the user's IdP groups against the configured
-// group_mappings and upserts their org memberships accordingly.
-//
-// Logic per configured mapping:
-//   - If the user belongs to the mapped group → ensure they are a member of the
-//     mapped organization with the mapped role (insert or update).
-//   - Memberships created by a previous login are updated if the role changed.
-//
-// If no mapping matches any of the user's groups but default_role is set, the
-// user is added to (or kept in) the default organization with that role.
-//
-// Groups/orgs not mentioned in any mapping are left untouched so that manually
-// assigned memberships are not wiped by an unrelated login.
+// groupMapping is the provider-agnostic shape of a single group-to-role mapping.
+// OIDC (config.OIDCGroupMapping) and SAML (config.SAMLGroupMapping) both carry
+// the identical {Group, Organization, Role} triple, so the reconcile logic is
+// shared and adapts each provider's slice into this type.
+type groupMapping struct {
+	Group        string
+	Organization string
+	Role         string
+}
+
+// applyGroupMappings resolves the user's OIDC IdP groups against the configured
+// group_mappings and reconciles their org memberships. See
+// reconcileGroupMemberships for the full reconciliation semantics.
 func (h *AuthHandlers) applyGroupMappings(ctx context.Context, userID string, groups []string) error {
 	_, mappings, defaultRole := h.resolveGroupMappingConfig(ctx)
-	if len(mappings) == 0 && defaultRole == "" {
-		return nil
+	gm := make([]groupMapping, len(mappings))
+	for i, m := range mappings {
+		gm[i] = groupMapping{Group: m.Group, Organization: m.Organization, Role: m.Role}
 	}
-
-	// Build a set of the user's groups for O(1) lookup.
-	groupSet := make(map[string]struct{}, len(groups))
-	for _, g := range groups {
-		groupSet[g] = struct{}{}
-	}
-
-	matched := false
-
-	for _, mapping := range mappings {
-		if _, ok := groupSet[mapping.Group]; !ok {
-			continue
-		}
-		matched = true
-
-		org, err := h.orgRepo.GetByName(ctx, mapping.Organization)
-		if err != nil || org == nil {
-			slog.Warn("OIDC group mapping: organization not found", "org", mapping.Organization, "group", mapping.Group)
-			continue
-		}
-
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership org=%s user=%s: %w", org.ID, userID, err)
-		}
-
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("update member role org=%s user=%s role=%s: %w", org.ID, userID, mapping.Role, err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("add member org=%s user=%s role=%s: %w", org.ID, userID, mapping.Role, err)
-			}
-		}
-
-		slog.Info("OIDC group mapping applied", "user_id", userID, "group", mapping.Group, "org", mapping.Organization, "role", mapping.Role)
-	}
-
-	// Fall back to defaultRole in the default organization when nothing matched.
-	if !matched && defaultRole != "" {
-		org, err := h.orgRepo.GetDefaultOrganization(ctx)
-		if err != nil || org == nil {
-			return fmt.Errorf("default organization not found for default_role fallback: %w", err)
-		}
-
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership default org user=%s: %w", userID, err)
-		}
-
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("update default role user=%s role=%s: %w", userID, defaultRole, err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("add default member user=%s role=%s: %w", userID, defaultRole, err)
-			}
-		}
-
-		slog.Info("OIDC default role applied", "user_id", userID, "role", defaultRole)
-	}
-
-	return nil
+	return h.reconcileGroupMemberships(ctx, userID, groups, gm, defaultRole, "OIDC")
 }
 
 // applySAMLGroupMappings applies SAML group-to-role mappings for a user.
@@ -906,63 +843,134 @@ func (h *AuthHandlers) applyGroupMappings(ctx context.Context, userID string, gr
 func (h *AuthHandlers) applySAMLGroupMappings(ctx context.Context, userID string, groups []string) error {
 	mappings := h.cfg.Auth.SAML.GroupMappings
 	defaultRole := h.cfg.Auth.SAML.DefaultRole
+	gm := make([]groupMapping, len(mappings))
+	for i, m := range mappings {
+		gm[i] = groupMapping{Group: m.Group, Organization: m.Organization, Role: m.Role}
+	}
+	return h.reconcileGroupMemberships(ctx, userID, groups, gm, defaultRole, "SAML")
+}
+
+// reconcileGroupMemberships reconciles a user's organization memberships against
+// the IdP groups carried by their signature-verified login token. It is shared
+// by the OIDC and SAML callback paths; provider names the log source ("OIDC" or
+// "SAML").
+//
+// Every organization referenced by a configured mapping is treated as
+// IdP-authoritative and is reconciled on every login:
+//
+//  1. The desired role per managed org is computed from the user's *current*
+//     groups. When several current groups map to the same org, the first
+//     matching mapping in configuration order wins (deterministic).
+//  2. For each managed org: if a current group maps to it the membership is
+//     upserted (added if absent, role updated if changed); if no current group
+//     maps to it the membership is REVOKED (removed) when the user is currently
+//     a member — this is the deprovisioning step.
+//  3. Organizations not referenced by any mapping are left untouched, so
+//     manually granted memberships in unmanaged orgs persist across logins.
+//  4. The default_role fallback is first-login-only: the user is added to the
+//     default org with default_role only when they are not already a member
+//     (existing roles are never overwritten). It is skipped entirely when the
+//     default org is itself IdP-managed (already reconciled in step 2).
+//
+// Groups originate solely from the verified token and mappings are
+// admin-configured, preserving the existing trust model.
+func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID string, groups []string, mappings []groupMapping, defaultRole, provider string) error {
 	if len(mappings) == 0 && defaultRole == "" {
 		return nil
 	}
 
+	// Set of the user's current groups for O(1) lookup.
 	groupSet := make(map[string]struct{}, len(groups))
 	for _, g := range groups {
 		groupSet[g] = struct{}{}
 	}
 
-	matched := false
-	for _, mapping := range mappings {
-		if _, ok := groupSet[mapping.Group]; !ok {
-			continue
-		}
-		matched = true
+	// Compute the desired role per managed org from current groups, and the full
+	// set of managed orgs. A "managed org" is any org named in a mapping; it is
+	// reconciled (and possibly revoked) below even when no current group maps to
+	// it. Iterating mappings in configuration order makes the desired-role choice
+	// deterministic: the first mapping for an org whose group the user currently
+	// has wins.
+	managedOrgs := make([]string, 0, len(mappings)) // preserves config order, deduped
+	seenManaged := make(map[string]struct{}, len(mappings))
+	desiredRole := make(map[string]string, len(mappings)) // org name -> role
 
-		org, err := h.orgRepo.GetByName(ctx, mapping.Organization)
-		if err != nil || org == nil {
-			slog.Warn("SAML group mapping: organization not found", "org", mapping.Organization, "group", mapping.Group)
+	for _, m := range mappings {
+		if _, ok := seenManaged[m.Organization]; !ok {
+			seenManaged[m.Organization] = struct{}{}
+			managedOrgs = append(managedOrgs, m.Organization)
+		}
+		if _, hasGroup := groupSet[m.Group]; !hasGroup {
 			continue
 		}
+		// First matching mapping (config order) sets the desired role for the org.
+		if _, already := desiredRole[m.Organization]; !already {
+			desiredRole[m.Organization] = m.Role
+		}
+	}
+
+	// Reconcile each managed org. Track resolved org IDs so the default-role
+	// fallback can detect when the default org is itself IdP-managed.
+	managedOrgIDs := make(map[string]struct{}, len(managedOrgs))
+
+	for _, orgName := range managedOrgs {
+		org, err := h.orgRepo.GetByName(ctx, orgName)
+		if err != nil || org == nil {
+			slog.Warn(provider+" group mapping: organization not found", "org", orgName)
+			continue
+		}
+		managedOrgIDs[org.ID] = struct{}{}
 
 		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
 		if err != nil {
 			return fmt.Errorf("check membership org=%s user=%s: %w", org.ID, userID, err)
 		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("update member role org=%s user=%s role=%s: %w", org.ID, userID, mapping.Role, err)
+
+		role, wanted := desiredRole[orgName]
+		switch {
+		case wanted && isMember:
+			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, role); err != nil {
+				return fmt.Errorf("update member role org=%s user=%s role=%s: %w", org.ID, userID, role, err)
 			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("add member org=%s user=%s role=%s: %w", org.ID, userID, mapping.Role, err)
+			slog.Info(provider+" group mapping applied", "user_id", userID, "org", orgName, "role", role)
+		case wanted && !isMember:
+			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, role); err != nil {
+				return fmt.Errorf("add member org=%s user=%s role=%s: %w", org.ID, userID, role, err)
 			}
+			slog.Info(provider+" group mapping applied", "user_id", userID, "org", orgName, "role", role)
+		case !wanted && isMember:
+			// No current group maps to this managed org → deprovision.
+			if err := h.orgRepo.RemoveMember(ctx, org.ID, userID); err != nil {
+				return fmt.Errorf("revoke member org=%s user=%s: %w", org.ID, userID, err)
+			}
+			slog.Info(provider+" group mapping revoked", "user_id", userID, "org", orgName)
+		default:
+			// Not wanted and not a member → nothing to do.
 		}
-		slog.Info("SAML group mapping applied", "user_id", userID, "group", mapping.Group, "org", mapping.Organization, "role", mapping.Role)
 	}
 
-	if !matched && defaultRole != "" {
+	// default_role fallback — first-login-only. Add the user to the default org
+	// with default_role only if they are not already a member. Skip entirely when
+	// the default org is itself IdP-managed (already reconciled above).
+	if defaultRole != "" {
 		org, err := h.orgRepo.GetDefaultOrganization(ctx)
 		if err != nil || org == nil {
-			return fmt.Errorf("default organization not found for SAML default_role fallback: %w", err)
+			return fmt.Errorf("default organization not found for default_role fallback: %w", err)
 		}
+		if _, isManaged := managedOrgIDs[org.ID]; isManaged {
+			return nil
+		}
+
 		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
 		if err != nil {
 			return fmt.Errorf("check membership default org user=%s: %w", userID, err)
 		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("update default role user=%s role=%s: %w", userID, defaultRole, err)
-			}
-		} else {
+		if !isMember {
 			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, defaultRole); err != nil {
 				return fmt.Errorf("add default member user=%s role=%s: %w", userID, defaultRole, err)
 			}
+			slog.Info(provider+" default role applied", "user_id", userID, "role", defaultRole)
 		}
-		slog.Info("SAML default role applied", "user_id", userID, "role", defaultRole)
 	}
 
 	return nil

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -889,7 +889,18 @@ func TestApplyGroupMappings_DefaultRoleFallback(t *testing.T) {
 	cfg.Auth.OIDC.DefaultRole = "viewer"
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
-	// No group matches → falls through to default role
+	// No current group matches → managed org "acme" is reconciled (user is not a
+	// member, so it is a no-op), then the default-role fallback adds the user to
+	// the unmanaged default org.
+
+	// Managed org reconcile: GetByName("acme") → found
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+		WithArgs("acme").
+		WillReturnRows(sqlmock.NewRows(authOrgCols).
+			AddRow("org-acme", "acme", "Acme Corp", nil, nil, time.Now(), time.Now()))
+	// CheckMembership(acme) → not a member → nothing to revoke
+	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+		WillReturnRows(sqlmock.NewRows(authMemberCols))
 
 	// GetDefaultOrganization → GetByName("default") → found
 	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
@@ -897,7 +908,7 @@ func TestApplyGroupMappings_DefaultRoleFallback(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(authOrgCols).
 			AddRow("org-default", "default", "Default Org", nil, nil, time.Now(), time.Now()))
 
-	// CheckMembership → GetMember → not found
+	// CheckMembership(default) → not found
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols))
 
@@ -1107,8 +1118,9 @@ func TestApplyGroupMappings_DefaultRole_OrgNotFound(t *testing.T) {
 	}
 }
 
-func TestApplyGroupMappings_DefaultRole_UpdateMember(t *testing.T) {
-	// Existing member → UpdateMemberRole path in default-role fallback
+func TestApplyGroupMappings_DefaultRole_ExistingMemberNotOverwritten(t *testing.T) {
+	// First-login-only default_role: an existing member's manually-granted role
+	// must NOT be overwritten by the default-role fallback on subsequent logins.
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
 
@@ -1122,19 +1134,12 @@ func TestApplyGroupMappings_DefaultRole_UpdateMember(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(authOrgCols).
 			AddRow("org-default", "default", "Default", nil, nil, time.Now(), time.Now()))
 
-	// CheckMembership → is member (returns a row)
+	// CheckMembership → is member (returns a row) → fallback is a no-op.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
-			AddRow("org-default", "user-1", "rt-1", time.Now()))
+			AddRow("org-default", "user-1", "rt-manual", time.Now()))
 
-	// UpdateMemberRole → role template lookup
-	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
-		WithArgs("editor").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-editor"))
-
-	// UpdateMemberRole → UPDATE
-	mock.ExpectExec("UPDATE organization_members").
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	// No role-template lookup and no UPDATE/INSERT must follow.
 
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"other"})
 	if err != nil {
@@ -1518,5 +1523,424 @@ func TestExchangeTokenHandler_ValidCookie(t *testing.T) {
 		if c.Name == "tfr_auth_token" && c.MaxAge != -1 {
 			t.Errorf("cookie MaxAge = %d, want -1 (cleared)", c.MaxAge)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// reconcileGroupMemberships — deprovisioning & first-login default-role
+// (issue #467). Exercised through both the OIDC (applyGroupMappings) and SAML
+// (applySAMLGroupMappings) entry points.
+// ---------------------------------------------------------------------------
+
+// expectOrgByName queues a GetByName lookup that returns a single org row.
+func expectOrgByName(mock sqlmock.Sqlmock, name, orgID string) {
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+		WithArgs(name).
+		WillReturnRows(sqlmock.NewRows(authOrgCols).
+			AddRow(orgID, name, name, nil, nil, time.Now(), time.Now()))
+}
+
+// expectIsMember queues a CheckMembership lookup that reports the user as a member.
+func expectIsMember(mock sqlmock.Sqlmock, orgID, userID, roleID string) {
+	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+		WillReturnRows(sqlmock.NewRows(authMemberCols).
+			AddRow(orgID, userID, roleID, time.Now()))
+}
+
+// expectNotMember queues a CheckMembership lookup that reports no membership.
+func expectNotMember(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+		WillReturnRows(sqlmock.NewRows(authMemberCols))
+}
+
+// expectAddMember queues the role-template lookup + INSERT done by AddMemberWithParams.
+func expectAddMember(mock sqlmock.Sqlmock, roleName, roleID string) {
+	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+		WithArgs(roleName).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(roleID))
+	mock.ExpectExec("INSERT INTO organization_members").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// expectUpdateMember queues the role-template lookup + UPDATE done by UpdateMemberRole.
+func expectUpdateMember(mock sqlmock.Sqlmock, roleName, roleID string) {
+	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+		WithArgs(roleName).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(roleID))
+	mock.ExpectExec("UPDATE organization_members").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+// expectRemoveMember queues the DELETE done by RemoveMember (deprovisioning).
+func expectRemoveMember(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("DELETE FROM organization_members").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+// User loses their only mapped group → membership is REVOKED from that org.
+func TestReconcile_LosesGroup_RevokesMembership(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// Managed org acme: user is currently a member but no longer has the group.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	// User now has an unrelated group that maps to nothing.
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"some-other-group"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// User's group changes to one mapping a different role in the same org → role UPDATED.
+func TestReconcile_GroupChanges_UpdatesRole(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "viewers", Organization: "acme", Role: "viewer"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// acme is managed; the user now has "viewers" (was "admins") → desired role viewer.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectUpdateMember(mock, "viewer", "rt-viewer")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"viewers"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// User keeps the group → membership preserved with the correct role (UPDATE to same role).
+func TestReconcile_KeepsGroup_PreservesMembership(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectUpdateMember(mock, "admin", "rt-admin")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Manual membership in an UNMANAGED org (no mapping references it) → PRESERVED.
+// The only mapping references "acme"; the user's manual membership in "other-org"
+// must never be touched, so the reconcile only queries the managed org.
+func TestReconcile_UnmanagedOrg_Preserved(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// Only the managed org "acme" is reconciled. The user is not a member and has
+	// no matching group → no-op. No query is ever issued for the unmanaged org,
+	// so a manual membership there cannot be revoked.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"unrelated"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// default_role does NOT overwrite an existing member's manually-set role
+// (first-login-only) when the default org is unmanaged.
+func TestReconcile_DefaultRole_FirstLoginOnly(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// No mappings → default org is unmanaged.
+	cfg.Auth.OIDC.DefaultRole = "viewer"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// GetDefaultOrganization → found; user is already a member → no write at all.
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-manual")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"whatever"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// default_role is applied on first login (user not yet a member of default org).
+func TestReconcile_DefaultRole_FirstLoginAdds(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.DefaultRole = "viewer"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "default", "org-default")
+	expectNotMember(mock)
+	expectAddMember(mock, "viewer", "rt-viewer")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"whatever"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// default_role is SKIPPED when the default org is itself IdP-managed (referenced
+// by a mapping). The managed reconcile is the single source of truth for it.
+func TestReconcile_DefaultRole_SkippedWhenDefaultOrgManaged(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// A mapping references the "default" org, making it IdP-managed.
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "default", Role: "admin"},
+	}
+	cfg.Auth.OIDC.DefaultRole = "viewer"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// Managed reconcile of "default": user currently a member, no matching group
+	// → REVOKE.
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	// The default-role fallback resolves the default org, recognises it as
+	// IdP-managed, and returns WITHOUT re-adding the user (no membership check,
+	// no INSERT/UPDATE). The org row resolves to the same ID reconciled above.
+	expectOrgByName(mock, "default", "org-default")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"not-admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Multiple groups mapping to the SAME org → deterministic single desired role.
+// The first mapping in config order whose group the user has wins.
+func TestReconcile_MultipleGroupsSameOrg_Deterministic(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "devs", Organization: "acme", Role: "editor"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// User has BOTH groups. First config mapping (admins → admin) must win.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"devs", "admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Multiple managed orgs reconciled in a single login: one upserted, one revoked.
+func TestReconcile_MultipleManagedOrgs_MixedActions(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "ops", Organization: "platform", Role: "operator"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// acme: has group → add member.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+	// platform: no group, currently a member → revoke.
+	expectOrgByName(mock, "platform", "org-platform")
+	expectIsMember(mock, "org-platform", "user-1", "rt-operator")
+	expectRemoveMember(mock)
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// RemoveMember DB error during deprovisioning is surfaced.
+func TestReconcile_RevokeError_Surfaced(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	mock.ExpectExec("DELETE FROM organization_members").WillReturnError(errDB)
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"not-admins"})
+	if err == nil {
+		t.Error("expected error from RemoveMember failure, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SAML entry point — same reconcile semantics via applySAMLGroupMappings.
+// ---------------------------------------------------------------------------
+
+// SAML: user loses their only mapped group → membership REVOKED.
+func TestApplySAMLGroupMappings_LosesGroup_Revokes(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.SAML.GroupMappings = []config.SAMLGroupMapping{
+		{Group: "saml-admins", Organization: "acme", Role: "admin"},
+	}
+	h := &AuthHandlers{
+		cfg:        cfg,
+		db:         db,
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		stateStore: auth.NewMemoryStateStore(time.Hour),
+	}
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"unrelated"})
+	if err != nil {
+		t.Fatalf("applySAMLGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// SAML: user keeps the group → membership upserted with the mapped role.
+func TestApplySAMLGroupMappings_KeepsGroup_Upserts(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.SAML.GroupMappings = []config.SAMLGroupMapping{
+		{Group: "saml-admins", Organization: "acme", Role: "admin"},
+	}
+	h := &AuthHandlers{
+		cfg:        cfg,
+		db:         db,
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		stateStore: auth.NewMemoryStateStore(time.Hour),
+	}
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"saml-admins"})
+	if err != nil {
+		t.Fatalf("applySAMLGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// SAML: default_role first-login-only — existing member not overwritten.
+func TestApplySAMLGroupMappings_DefaultRole_FirstLoginOnly(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.SAML.DefaultRole = "viewer"
+	h := &AuthHandlers{
+		cfg:        cfg,
+		db:         db,
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		stateStore: auth.NewMemoryStateStore(time.Hour),
+	}
+
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-manual")
+
+	err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"anything"})
+	if err != nil {
+		t.Fatalf("applySAMLGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// SAML: nothing configured → no-op (no DB calls).
+func TestApplySAMLGroupMappings_NothingConfigured(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	h := &AuthHandlers{
+		cfg:        cfg,
+		db:         db,
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		stateStore: auth.NewMemoryStateStore(time.Hour),
+	}
+
+	if err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"x"}); err != nil {
+		t.Errorf("expected nil error, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #467

## The two flaws

`applyGroupMappings` (OIDC) and `applySAMLGroupMappings` (SAML) in `backend/internal/api/admin/auth.go` shared the same bugs:

1. **No deprovisioning.** They only ever *upserted* memberships for groups the user currently had; a mapped membership was never revoked when the user lost the corresponding IdP group. A user removed from an `admins` group at the IdP kept their mapped `admin` role until an operator manually removed it — defeating IdP-driven off-boarding/least-privilege (the issue's medium–high severity concern).
2. **`default_role` overwrote manual grants.** The unmatched-login fallback called `UpdateMemberRole` on *every* login, silently replacing a manually-granted role with the default.

## The fix — shared reconcile helper

Both paths now adapt their provider-specific `{Group, Organization, Role}` mappings into a common `groupMapping` shape and delegate to a single `reconcileGroupMemberships(ctx, userID, groups, mappings, defaultRole, provider)` helper. Every org referenced by a mapping is treated as **IdP-authoritative** and reconciled on each login:

1. **Compute the desired role per managed org** from the user's *current* verified groups. When several current groups map to the same org, the **first mapping in configuration order wins** (deterministic).
2. **For each managed org:** upsert the membership when a current group maps to it (add if absent, update if the role changed); **revoke** via `orgRepo.RemoveMember` when no current group does.
3. **Orgs not referenced by any mapping are left untouched**, so manual grants in unmanaged orgs persist across logins.
4. **`default_role` fallback is first-login-only:** add the user to the default org only if they are *not already a member* (never `UpdateMemberRole` on an existing member), and **skip it entirely when the default org is itself IdP-managed** (already reconciled in step 2).

The trust model is unchanged: groups come only from the signature-verified token; mappings are admin-configured.

## Behavior change

Mapping-referenced orgs are now IdP-authoritative — memberships are reconciled, **including revocation**, on every login. Unmanaged orgs and the first-login default-role grant are unaffected.

## Tests

Added thorough unit tests (sqlmock over the real `OrganizationRepository`, matching the existing `auth_test.go` patterns), covering both the OIDC and SAML entry points:

- user loses their only mapped group → membership **revoked**
- user's group changes to one mapping a different role → role **updated**
- user keeps the group → membership preserved with the correct role
- manual membership in an **unmanaged** org → preserved (never queried/revoked)
- `default_role` does **not** overwrite an existing member's role (first-login-only); and is applied on genuine first login
- `default_role` **skipped** when the default org is IdP-managed
- multiple groups mapping to the same org → deterministic single desired role
- multiple managed orgs in one login → mixed add + revoke
- `RemoveMember` DB error surfaced
- SAML: revoke / upsert / default-role-first-login-only / no-op when unconfigured

One pre-existing test (`TestApplyGroupMappings_DefaultRole_UpdateMember`) asserted the *buggy* overwrite behavior; it was rewritten to assert first-login-only semantics.

## Gate results (run from `backend/`)

- `go build ./...` — pass
- `go vet ./...` — pass
- `golangci-lint run ./...` — pass (0 findings)
- `go test ./internal/... ./pkg/...` — pass (run without `-race` locally; **CI runs `-race`**)
- coverage: `internal/api/admin` **78.3% → 79.2%**; filtered global **80.3%** (≥ 80% floor); per-package floors `internal/auth` 89.9%, `internal/middleware` 88.0% (≥ 79%)
- `gosec ./...` — **0 new findings** vs baseline (only changed file `admin/auth.go` has 0 findings)
- swagger: no handler signature/route change → `swag init` produces no diff (verified)