### PR TITLE
fix(auth): deprovision LDAP group-mapped roles when a user loses the group DN

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1285,61 +1285,38 @@ func (h *AuthHandlers) LDAPLoginHandler() gin.HandlerFunc {
 	}
 }
 
-// applyLDAPGroupMappings applies LDAP group DN-to-role mappings for a user.
+// applyLDAPGroupMappings reconciles a user's organization memberships against
+// their LDAP group DNs. LDAP group DNs are matched case-insensitively against the
+// configured mappings (see ldappkg.MatchGroupMappings); every org referenced by a
+// mapping is treated as IdP-authoritative, so losing the mapped group DN
+// deprovisions the corresponding membership.
+//
+// It adapts LDAP's {GroupDN, Organization, Role} mappings into the
+// provider-agnostic groupMapping shape and delegates to reconcileGroupMemberships
+// for the shared revoke/upsert and first-login-only default_role semantics. The
+// canonical (config-cased) GroupDNs of the matched mappings are passed as the
+// user's "current groups" and every mapping is keyed by its GroupDN, so the
+// reconciler's exact-match comparison lines up while preserving LDAP's
+// case-insensitive DN matching.
 func (h *AuthHandlers) applyLDAPGroupMappings(ctx context.Context, userID string, groupDNs []string) error {
-	matched := ldappkg.MatchGroupMappings(groupDNs, h.cfg.Auth.LDAP.GroupMappings)
+	ldapMappings := h.cfg.Auth.LDAP.GroupMappings
 	defaultRole := h.cfg.Auth.LDAP.DefaultRole
-	if len(matched) == 0 && defaultRole == "" {
-		return nil
+
+	// Resolve which configured mappings the user's group DNs match. Matching is
+	// case-insensitive on the DN, so the matched entries carry the canonical
+	// (config-cased) GroupDN — feed those as the reconciler's "current groups".
+	matched := ldappkg.MatchGroupMappings(groupDNs, ldapMappings)
+	currentGroups := make([]string, 0, len(matched))
+	for _, m := range matched {
+		currentGroups = append(currentGroups, m.GroupDN)
 	}
 
-	anyMatched := false
-	for _, mapping := range matched {
-		anyMatched = true
-		org, err := h.orgRepo.GetByName(ctx, mapping.Organization)
-		if err != nil || org == nil {
-			slog.Warn("LDAP group mapping: organization not found", "org", mapping.Organization, "group_dn", mapping.GroupDN)
-			continue
-		}
-
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership org=%s user=%s: %w", org.ID, userID, err)
-		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("update member role: %w", err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("add member: %w", err)
-			}
-		}
-		slog.Info("LDAP group mapping applied", "user_id", userID, "group_dn", mapping.GroupDN, "org", mapping.Organization, "role", mapping.Role)
+	gm := make([]groupMapping, len(ldapMappings))
+	for i, m := range ldapMappings {
+		gm[i] = groupMapping{Group: m.GroupDN, Organization: m.Organization, Role: m.Role}
 	}
 
-	if !anyMatched && defaultRole != "" {
-		org, err := h.orgRepo.GetDefaultOrganization(ctx)
-		if err != nil || org == nil {
-			return fmt.Errorf("default organization not found for LDAP default_role fallback: %w", err)
-		}
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership default org user=%s: %w", userID, err)
-		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("update default role: %w", err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("add default member: %w", err)
-			}
-		}
-		slog.Info("LDAP default role applied", "user_id", userID, "role", defaultRole)
-	}
-
-	return nil
+	return h.reconcileGroupMemberships(ctx, userID, currentGroups, gm, defaultRole, "LDAP")
 }
 
 // @Summary      Identity group mappings

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -1944,3 +1944,151 @@ func TestApplySAMLGroupMappings_NothingConfigured(t *testing.T) {
 		t.Errorf("expected nil error, got %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// LDAP entry point — same reconcile semantics via applyLDAPGroupMappings, but
+// mappings are keyed by case-insensitive group DN (issue #467 follow-up).
+// ---------------------------------------------------------------------------
+
+const ldapAdminDN = "cn=admins,ou=groups,dc=example,dc=com"
+
+// LDAP: user loses their only mapped group DN → membership REVOKED.
+func TestApplyLDAPGroupMappings_LosesGroup_Revokes(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: ldapAdminDN, Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// Managed org acme: user is currently a member but no longer carries the DN.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{"cn=other,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: user keeps the group DN → membership upserted with the mapped role.
+func TestApplyLDAPGroupMappings_KeepsGroup_Upserts(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: ldapAdminDN, Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{ldapAdminDN})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: group DNs are matched case-insensitively — a differently-cased DN on the
+// user still resolves to the configured mapping and upserts the membership. This
+// guards the adapter that feeds the matched (config-cased) DNs into the shared
+// reconciler.
+func TestApplyLDAPGroupMappings_CaseInsensitiveDN_Upserts(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// Config DN is mixed-case; the user's DN is lower-case.
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "CN=Admins,OU=Groups,DC=example,DC=com", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{"cn=admins,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: manual membership in an UNMANAGED org (no mapping references it) is
+// PRESERVED — only the managed org is queried, so the unmanaged one is never
+// touched.
+func TestApplyLDAPGroupMappings_UnmanagedOrg_Preserved(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: ldapAdminDN, Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// Only the managed org "acme" is reconciled; user has no matching DN and is
+	// not a member → no-op. No query is issued for any unmanaged org.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{"cn=unrelated,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: default_role is first-login-only — an existing member's manually-set role
+// is never overwritten.
+func TestApplyLDAPGroupMappings_DefaultRole_FirstLoginOnly(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// No mappings → default org is unmanaged.
+	cfg.Auth.LDAP.DefaultRole = "viewer"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	// GetDefaultOrganization → found; user is already a member → no write at all.
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-manual")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{"cn=anything,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: nothing configured → no-op (no DB calls).
+func TestApplyLDAPGroupMappings_NothingConfigured(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	if err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{"cn=x,dc=example,dc=com"}); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #471

## Problem

`applyLDAPGroupMappings` carried the same two security flaws that #470 fixed for OIDC and SAML (issue #467):

1. **No deprovisioning** — it only upserted memberships for LDAP group DNs the user currently held; it never revoked a mapped membership when the user lost the corresponding LDAP group DN. A user removed from a privileged LDAP group kept their mapped role.
2. **`default_role` overwrote manual grants** — the `!anyMatched && defaultRole != ""` fallback called `UpdateMemberRole` on existing members, silently overwriting a manually-granted role.

## Fix

Migrate `applyLDAPGroupMappings` onto the shared `reconcileGroupMemberships` helper introduced in #470. Every org referenced by a configured mapping is now treated as IdP-authoritative and reconciled on each login: upsert when a current group DN maps to the org, **revoke** (`RemoveMember`) when none does, leave unmanaged orgs untouched, and apply `default_role` first-login-only (skipped when the default org is itself managed).

### LDAP-specific adaptation

LDAP differs from OIDC/SAML: mappings are keyed by `GroupDN` and matched **case-insensitively** via `ldappkg.MatchGroupMappings`. To reuse the generic helper (which compares `groupMapping.Group` against the current-groups set by exact match), the adapter:

- runs `MatchGroupMappings` to resolve which mappings the user's DNs match — these carry the canonical, config-cased `GroupDN`;
- feeds those matched GroupDNs as the helper's "current groups";
- maps every configured `LDAPGroupMapping` into the generic `groupMapping` shape keyed by `GroupDN`.

The exact-match comparison inside the helper then lines up, while case-insensitivity is preserved (resolved up front by `MatchGroupMappings`). Trust model and log style are unchanged — group DNs come only from the authenticated LDAP bind, mappings are admin-configured, and the helper logs `"LDAP group mapping applied/revoked"` consistent with OIDC/SAML.

## Tests

Added LDAP entry-point tests in `auth_test.go` following the existing `TestReconcile_*` / `TestApplySAMLGroupMappings_*` sqlmock patterns:

- loses LDAP group DN → **revoked**
- keeps group DN → membership upserted (preserved)
- case-insensitive DN → still matched and upserted (guards the adapter)
- unmanaged org → preserved (never queried)
- `default_role` first-login-only (existing member not overwritten)
- nothing configured → no-op

## Quality gate (run from `backend/`)

- `go build ./...` ✓
- `go vet ./...` ✓
- `golangci-lint run ./...` ✓ (clean)
- `go test ./internal/... ./pkg/...` ✓ (CI adds `-race`)
- `gosec ./...` ✓ — 0 new findings vs baseline
- `internal/api/admin` coverage **79.9%** (≥ prior baseline)