### PR TITLE
fix(auth): deprovision LDAP group-mapped roles when a user loses the group

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1285,61 +1285,21 @@ func (h *AuthHandlers) LDAPLoginHandler() gin.HandlerFunc {
 	}
 }
 
-// applyLDAPGroupMappings applies LDAP group DN-to-role mappings for a user.
+// applyLDAPGroupMappings reconciles LDAP group DN-to-role mappings for a user,
+// delegating to the shared reconcileGroupMemberships. LDAP DNs are matched
+// case-insensitively (matching ldappkg.MatchGroupMappings), so DNs are
+// lowercased into the provider-agnostic groupMapping before reconciliation.
 func (h *AuthHandlers) applyLDAPGroupMappings(ctx context.Context, userID string, groupDNs []string) error {
-	matched := ldappkg.MatchGroupMappings(groupDNs, h.cfg.Auth.LDAP.GroupMappings)
-	defaultRole := h.cfg.Auth.LDAP.DefaultRole
-	if len(matched) == 0 && defaultRole == "" {
-		return nil
+	mappings := h.cfg.Auth.LDAP.GroupMappings
+	gm := make([]groupMapping, len(mappings))
+	for i, m := range mappings {
+		gm[i] = groupMapping{Group: strings.ToLower(m.GroupDN), Organization: m.Organization, Role: m.Role}
 	}
-
-	anyMatched := false
-	for _, mapping := range matched {
-		anyMatched = true
-		org, err := h.orgRepo.GetByName(ctx, mapping.Organization)
-		if err != nil || org == nil {
-			slog.Warn("LDAP group mapping: organization not found", "org", mapping.Organization, "group_dn", mapping.GroupDN)
-			continue
-		}
-
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership org=%s user=%s: %w", org.ID, userID, err)
-		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("update member role: %w", err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, mapping.Role); err != nil {
-				return fmt.Errorf("add member: %w", err)
-			}
-		}
-		slog.Info("LDAP group mapping applied", "user_id", userID, "group_dn", mapping.GroupDN, "org", mapping.Organization, "role", mapping.Role)
+	groups := make([]string, len(groupDNs))
+	for i, dn := range groupDNs {
+		groups[i] = strings.ToLower(dn)
 	}
-
-	if !anyMatched && defaultRole != "" {
-		org, err := h.orgRepo.GetDefaultOrganization(ctx)
-		if err != nil || org == nil {
-			return fmt.Errorf("default organization not found for LDAP default_role fallback: %w", err)
-		}
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID)
-		if err != nil {
-			return fmt.Errorf("check membership default org user=%s: %w", userID, err)
-		}
-		if isMember {
-			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("update default role: %w", err)
-			}
-		} else {
-			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, defaultRole); err != nil {
-				return fmt.Errorf("add default member: %w", err)
-			}
-		}
-		slog.Info("LDAP default role applied", "user_id", userID, "role", defaultRole)
-	}
-
-	return nil
+	return h.reconcileGroupMemberships(ctx, userID, groups, gm, h.cfg.Auth.LDAP.DefaultRole, "LDAP")
 }
 
 // @Summary      Identity group mappings

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -1941,6 +1942,229 @@ func TestApplySAMLGroupMappings_NothingConfigured(t *testing.T) {
 	}
 
 	if err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"x"}); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LDAP entry point — same reconcile semantics via applyLDAPGroupMappings.
+// LDAP group DNs are matched case-insensitively (matching
+// ldappkg.MatchGroupMappings); the adapter lowercases both the configured
+// GroupDNs and the user's DNs before delegating to reconcileGroupMemberships.
+// ---------------------------------------------------------------------------
+
+// newLDAPHandler builds an AuthHandlers wired only with what the LDAP group
+// reconcile needs, avoiding NewProvider (no live LDAP server in tests).
+func newLDAPHandler(db *sql.DB, cfg *config.Config) *AuthHandlers {
+	return &AuthHandlers{
+		cfg:        cfg,
+		db:         db,
+		orgRepo:    repositories.NewOrganizationRepository(db),
+		stateStore: auth.NewMemoryStateStore(time.Hour),
+	}
+}
+
+// LDAP: user loses their only mapped group DN → membership REVOKED.
+func TestApplyLDAPGroupMappings_LosesGroup_Revokes(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+	}
+	h := newLDAPHandler(db, cfg)
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	// User now has an unrelated DN that maps to nothing.
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=unrelated,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: user's DN changes to one mapping a different role in the same org → role UPDATED.
+func TestApplyLDAPGroupMappings_GroupChanges_UpdatesRole(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+		{GroupDN: "cn=viewers,ou=groups,dc=example,dc=com", Organization: "acme", Role: "viewer"},
+	}
+	h := newLDAPHandler(db, cfg)
+
+	// User now has the viewers DN (was admins) → desired role viewer.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
+	expectUpdateMember(mock, "viewer", "rt-viewer")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=viewers,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: case-insensitive DN matching — a differently-cased DN still matches the
+// configured mapping (reproducing ldappkg.MatchGroupMappings) and upserts.
+func TestApplyLDAPGroupMappings_CaseInsensitiveDN_Matches(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// Configured DN uses lowercase; the user presents a mixed/upper-case DN.
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+	}
+	h := newLDAPHandler(db, cfg)
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"CN=Admins,OU=Groups,DC=Example,DC=Com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: manual membership in an UNMANAGED org → PRESERVED. Only the managed org
+// is ever queried, so a manual membership elsewhere cannot be revoked.
+func TestApplyLDAPGroupMappings_UnmanagedOrg_Preserved(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+	}
+	h := newLDAPHandler(db, cfg)
+
+	// Only managed org "acme" reconciled; user not a member, no matching DN → no-op.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=unrelated,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: default_role first-login-only — existing member not overwritten.
+func TestApplyLDAPGroupMappings_DefaultRole_FirstLoginOnly(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.DefaultRole = "viewer"
+	h := newLDAPHandler(db, cfg)
+
+	// GetDefaultOrganization → found; user is already a member → no write at all.
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-manual")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=anything,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: default_role SKIPPED when the default org is itself IdP-managed.
+func TestApplyLDAPGroupMappings_DefaultRole_SkippedWhenDefaultOrgManaged(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	// A mapping references the "default" org, making it IdP-managed.
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "default", Role: "admin"},
+	}
+	cfg.Auth.LDAP.DefaultRole = "viewer"
+	h := newLDAPHandler(db, cfg)
+
+	// Managed reconcile of "default": user currently a member, no matching DN → REVOKE.
+	expectOrgByName(mock, "default", "org-default")
+	expectIsMember(mock, "org-default", "user-1", "rt-admin")
+	expectRemoveMember(mock)
+
+	// default-role fallback resolves the default org, recognises it as IdP-managed,
+	// and returns WITHOUT re-adding the user (no membership check, no INSERT/UPDATE).
+	expectOrgByName(mock, "default", "org-default")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=not-admins,ou=groups,dc=example,dc=com"})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: multiple DNs mapping to the SAME org → deterministic single desired role.
+// The first mapping in config order whose DN the user has wins.
+func TestApplyLDAPGroupMappings_MultipleDNsSameOrg_Deterministic(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+		{GroupDN: "cn=devs,ou=groups,dc=example,dc=com", Organization: "acme", Role: "editor"},
+	}
+	h := newLDAPHandler(db, cfg)
+
+	// User has BOTH DNs. First config mapping (admins → admin) must win.
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	expectAddMember(mock, "admin", "rt-admin")
+
+	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{
+		"cn=devs,ou=groups,dc=example,dc=com",
+		"cn=admins,ou=groups,dc=example,dc=com",
+	})
+	if err != nil {
+		t.Fatalf("applyLDAPGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// LDAP: nothing configured → no-op (no DB calls).
+func TestApplyLDAPGroupMappings_NothingConfigured(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	h := newLDAPHandler(db, cfg)
+
+	if err := h.applyLDAPGroupMappings(context.Background(), "user-1",
+		[]string{"cn=x,ou=groups,dc=example,dc=com"}); err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
 }


### PR DESCRIPTION
Applies the same reconcile fix as #470 (follow-up to #467) to the third auth path: LDAP. There is no GitHub issue open specifically for LDAP; this closes the remaining instance of the #467 deprovisioning gap.

## Problem
`applyLDAPGroupMappings` still used the old **upsert-only** pattern via `ldappkg.MatchGroupMappings`, carrying the same two flaws #470 fixed for OIDC and SAML:
1. A user who **lost** an LDAP group DN kept any org role that DN had granted (no deprovisioning).
2. `default_role` could overwrite an existing member's manually-set role on every login.

## Fix
Rewrite `applyLDAPGroupMappings` to delegate to the shared `reconcileGroupMemberships` helper introduced in #470. The helper treats every mapping-referenced org as IdP-authoritative — upserts when a current group maps to it, **revokes (RemoveMember) when none does** — leaves unmanaged orgs untouched, and keeps `default_role` first-login-only (skipped for an IdP-managed default org).

**Case-insensitive DN matching is preserved.** `ldappkg.MatchGroupMappings` matched DNs only via `strings.ToLower` (no other canonicalization). The adapter lowercases both the configured `GroupDN`s and the user's DNs into the provider-agnostic `groupMapping` before reconciliation, so the helper's exact-match lookup reproduces the previous case-insensitive behaviour exactly. `ldappkg.MatchGroupMappings` itself is left in place (still exported). The `ldappkg` import remains (used by `ldapProvider`/`NewProvider`/`SetLDAPProvider`).

## Tests
Added `applyLDAPGroupMappings` reconcile tests mirroring the OIDC/SAML coverage (same `go-sqlmock` orgRepo style):
- DN-group loss -> membership **REVOKED**
- role change -> **UPDATED**
- **case-insensitive** DN (`CN=Admins,...` vs configured `cn=admins,...`) still matches
- manual membership in an **unmanaged** org -> **PRESERVED**
- `default_role` first-login-only (existing member not overwritten) + skipped when default org is IdP-managed
- multiple DNs -> same org resolves a deterministic role (config order wins)
- nothing configured -> no-op

## Quality gate (from `backend/`)
- `go build ./...` / `go vet ./...` — pass
- `golangci-lint run ./internal/api/admin/` — clean
- `go test ./...` — pass (run without `-race` locally; cgo unavailable on Windows. CI runs `-race`.)
- `internal/api/admin` coverage 79.9%; `applyLDAPGroupMappings` 100%. `scripts/check_package_coverage.sh` passes (auth 89.9%, middleware 88.0% >= 79%).
- gosec on `internal/api/admin/` — 0 issues
- `swag init` — no diff in `docs/swagger.json` (no route/handler-signature change)