### PR TITLE
feat: add packer, sentinel, and OPA binary mirror support

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -17574,6 +17574,9 @@
                         "enum": [
                             "terraform",
                             "opentofu",
+                            "packer",
+                            "sentinel",
+                            "opa",
                             "custom"
                         ]
                     },
@@ -19054,6 +19057,9 @@
                         "enum": [
                             "terraform",
                             "opentofu",
+                            "packer",
+                            "sentinel",
+                            "opa",
                             "custom"
                         ]
                     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -14524,6 +14524,9 @@
                     "enum": [
                         "terraform",
                         "opentofu",
+                        "packer",
+                        "sentinel",
+                        "opa",
                         "custom"
                     ]
                 },
@@ -16004,6 +16007,9 @@
                     "enum": [
                         "terraform",
                         "opentofu",
+                        "packer",
+                        "sentinel",
+                        "opa",
                         "custom"
                     ]
                 },

--- a/backend/internal/cve/matcher.go
+++ b/backend/internal/cve/matcher.go
@@ -36,6 +36,8 @@ var scannerPackage = map[string][2]string{
 var binaryRepoURL = map[string]string{
 	"terraform": "https://github.com/hashicorp/terraform",
 	"opentofu":  "https://github.com/opentofu/opentofu",
+	"packer":    "https://github.com/hashicorp/packer",
+	"opa":       "https://github.com/open-policy-agent/opa",
 }
 
 // batchSize is the maximum number of queries per OSV /v1/querybatch call.

--- a/backend/internal/db/migrations/000039_add_packer_sentinel_opa_tools.down.sql
+++ b/backend/internal/db/migrations/000039_add_packer_sentinel_opa_tools.down.sql
@@ -1,0 +1,8 @@
+-- Revert to original tool CHECK constraint (will fail if rows with packer/sentinel/opa exist).
+ALTER TABLE terraform_mirror_configs
+    DROP CONSTRAINT IF EXISTS terraform_mirror_configs_tool_check;
+
+ALTER TABLE terraform_mirror_configs
+    ADD CONSTRAINT terraform_mirror_configs_tool_check CHECK (
+        tool IN ('terraform', 'opentofu', 'custom')
+    );

--- a/backend/internal/db/migrations/000039_add_packer_sentinel_opa_tools.up.sql
+++ b/backend/internal/db/migrations/000039_add_packer_sentinel_opa_tools.up.sql
@@ -1,0 +1,8 @@
+-- Expand the tool CHECK constraint to include packer, sentinel, and opa.
+ALTER TABLE terraform_mirror_configs
+    DROP CONSTRAINT IF EXISTS terraform_mirror_configs_tool_check;
+
+ALTER TABLE terraform_mirror_configs
+    ADD CONSTRAINT terraform_mirror_configs_tool_check CHECK (
+        tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa', 'custom')
+    );

--- a/backend/internal/db/models/terraform_mirror.go
+++ b/backend/internal/db/models/terraform_mirror.go
@@ -105,7 +105,7 @@ type TerraformSyncHistory struct {
 type CreateTerraformMirrorConfigRequest struct {
 	Name              string   `json:"name" binding:"required,min=1,max=255"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              string   `json:"tool" binding:"required,oneof=terraform opentofu custom"`
+	Tool              string   `json:"tool" binding:"required,oneof=terraform opentofu packer sentinel opa custom"`
 	UpstreamURL       string   `json:"upstream_url" binding:"required,url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
@@ -121,7 +121,7 @@ type CreateTerraformMirrorConfigRequest struct {
 type UpdateTerraformMirrorConfigRequest struct {
 	Name              *string  `json:"name,omitempty" binding:"omitempty,min=1,max=255"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              *string  `json:"tool,omitempty" binding:"omitempty,oneof=terraform opentofu custom"`
+	Tool              *string  `json:"tool,omitempty" binding:"omitempty,oneof=terraform opentofu packer sentinel opa custom"`
 	UpstreamURL       *string  `json:"upstream_url,omitempty" binding:"omitempty,url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`

--- a/backend/internal/db/repositories/cve_repository.go
+++ b/backend/internal/db/repositories/cve_repository.go
@@ -284,7 +284,7 @@ func (r *CVERepository) ListAllBinaryCandidates(ctx context.Context) ([]BinaryCa
 		FROM terraform_versions tv
 		JOIN terraform_mirror_configs c ON c.id = tv.config_id
 		WHERE c.enabled = true
-		  AND c.tool IN ('terraform', 'opentofu')
+		  AND c.tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa')
 		  AND tv.is_deprecated = false
 		  AND tv.sync_status = 'synced'
 		ORDER BY c.tool, tv.version

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -951,6 +951,12 @@ func productNameForTool(tool string) string {
 	switch strings.ToLower(tool) {
 	case "opentofu":
 		return "opentofu"
+	case "packer":
+		return "packer"
+	case "sentinel":
+		return "sentinel"
+	case "opa":
+		return "opa"
 	default:
 		return "terraform"
 	}
@@ -988,7 +994,7 @@ func gpgKeyForTool(tool string) string {
 		}
 	}
 	switch strings.ToLower(tool) {
-	case "terraform":
+	case "terraform", "packer", "sentinel":
 		return mirror.HashiCorpReleasesGPGKey
 	case "opentofu":
 		return mirror.OpenTofuReleasesGPGKey

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -125,6 +125,17 @@ func NewGitHubReleasesClient(upstreamURL, productName string) (*GitHubReleasesCl
 // e.g. opentofu_1.9.0_linux_amd64.zip
 var binaryZipRE = regexp.MustCompile(`^(.+?)_([^_]+)_([^_]+)_([^_]+)\.zip$`)
 
+// bareBinaryRE matches bare binaries without version in filename:
+//
+//	{product}_{os}_{arch}       e.g. opa_linux_amd64
+//	{product}_{os}_{arch}.exe   e.g. opa_windows_amd64.exe
+//
+// Used by projects like OPA that publish unversioned binaries per release.
+var bareBinaryRE = regexp.MustCompile(`^(.+?)_([a-z]+)_([a-z0-9]+?)(?:_static)?(?:\.exe)?$`)
+
+// perFileSHA256RE matches per-file SHA256 sidecar files: {filename}.sha256
+var perFileSHA256RE = regexp.MustCompile(`^(.+)\.sha256$`)
+
 // sha256sumsRE matches: {product}_{version}_SHA256SUMS (no extension)
 var sha256sumsRE = regexp.MustCompile(`^(.+?)_([^_]+)_SHA256SUMS$`)
 
@@ -212,6 +223,8 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 	var builds []TerraformReleaseBuild
 	var sha256sumsURL string
 	var sha256sumsSigURL string
+	// perFileSHAs maps binary filename → download URL for its .sha256 sidecar.
+	perFileSHAs := make(map[string]string)
 
 	for _, asset := range rel.Assets {
 		name := asset.Name
@@ -220,7 +233,6 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 		// Binary zip?
 		if m := binaryZipRE.FindStringSubmatch(name); m != nil {
 			product, _, osName, arch := m[1], m[2], m[3], m[4]
-			// Only accept assets belonging to our product (e.g. "opentofu_…")
 			if !strings.EqualFold(product, c.ProductName) {
 				continue
 			}
@@ -232,6 +244,12 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 				Filename: name,
 				URL:      url,
 			})
+			continue
+		}
+
+		// Per-file .sha256 sidecar? (e.g. opa_linux_amd64.sha256)
+		if m := perFileSHA256RE.FindStringSubmatch(name); m != nil {
+			perFileSHAs[m[1]] = url
 			continue
 		}
 
@@ -250,39 +268,109 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 			}
 			continue
 		}
+
+		// Bare binary? (e.g. opa_linux_amd64, opa_windows_amd64.exe)
+		if m := bareBinaryRE.FindStringSubmatch(name); m != nil {
+			product, osName, arch := m[1], m[2], m[3]
+			if !strings.EqualFold(product, c.ProductName) {
+				continue
+			}
+			builds = append(builds, TerraformReleaseBuild{
+				Name:     product,
+				Version:  version,
+				OS:       osName,
+				Arch:     arch,
+				Filename: name,
+				URL:      url,
+			})
+			continue
+		}
 	}
 
 	if len(builds) == 0 {
 		return TerraformVersionInfo{}, false
 	}
 
-	return TerraformVersionInfo{
+	vi := TerraformVersionInfo{
 		Version:          version,
 		SHASumsURL:       sha256sumsURL,
 		SHASumsSignature: sha256sumsSigURL,
 		Builds:           builds,
-	}, true
+	}
+	// Attach per-file SHA URLs so FetchSHASums can fall back to them.
+	if len(perFileSHAs) > 0 && sha256sumsURL == "" {
+		vi.PerFileSHAURLs = perFileSHAs
+	}
+
+	return vi, true
 }
 
 // ----- FetchSHASums ---------------------------------------------------------
 
 // FetchSHASums downloads the SHA256SUMS asset for a specific version from
 // GitHub and returns parsed filename→sha256 map plus the raw bytes.
-// It first calls ListVersions to locate the asset URL for the given version.
+// If no combined SHA256SUMS file exists (e.g. OPA), it falls back to fetching
+// individual .sha256 sidecar files for each binary asset.
 func (c *GitHubReleasesClient) FetchSHASums(ctx context.Context, version string) (map[string]string, []byte, error) {
 	sumsURL, err := c.findSHA256SumsURL(ctx, version)
 	if err != nil {
 		return nil, nil, err
 	}
-	if sumsURL == "" {
-		return nil, nil, fmt.Errorf("no SHA256SUMS asset found for version %s in %s/%s", version, c.Owner, c.Repo)
+
+	// Combined SHA256SUMS file found — use it directly.
+	if sumsURL != "" {
+		raw, fetchErr := c.fetchURL(ctx, sumsURL, 1<<20) // 1 MB cap
+		if fetchErr != nil {
+			return nil, nil, fmt.Errorf("failed to fetch SHA256SUMS for %s: %w", version, fetchErr)
+		}
+		return ParseSHASums(raw), raw, nil
 	}
 
-	raw, err := c.fetchURL(ctx, sumsURL, 1<<20) // 1 MB cap
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch SHA256SUMS for %s: %w", version, err)
+	// No combined file — try per-file .sha256 sidecars (OPA pattern).
+	return c.fetchPerFileSHASums(ctx, version)
+}
+
+// fetchPerFileSHASums fetches individual .sha256 sidecar files for a release
+// and synthesizes a combined filename→sha256 map.
+func (c *GitHubReleasesClient) fetchPerFileSHASums(ctx context.Context, version string) (map[string]string, []byte, error) {
+	// Fetch the release to find .sha256 assets.
+	var rel gitHubRelease
+	var found bool
+	for _, tag := range []string{"v" + version, version} {
+		r, fetchErr := c.fetchReleaseByTag(ctx, tag)
+		if fetchErr == nil {
+			rel = r
+			found = true
+			break
+		}
 	}
-	return ParseSHASums(raw), raw, nil
+	if !found {
+		return nil, nil, fmt.Errorf("no release found for version %s in %s/%s", version, c.Owner, c.Repo)
+	}
+
+	sums := make(map[string]string)
+	var combined strings.Builder
+
+	for _, asset := range rel.Assets {
+		m := perFileSHA256RE.FindStringSubmatch(asset.Name)
+		if m == nil {
+			continue
+		}
+		binaryFilename := m[1]
+		raw, fetchErr := c.fetchURL(ctx, asset.BrowserDownloadURL, 256)
+		if fetchErr != nil {
+			continue
+		}
+		hash := strings.TrimSpace(strings.Fields(string(raw))[0])
+		sums[binaryFilename] = hash
+		combined.WriteString(hash + "  " + binaryFilename + "\n")
+	}
+
+	if len(sums) == 0 {
+		return nil, nil, fmt.Errorf("no SHA256SUMS or .sha256 sidecar files found for version %s in %s/%s", version, c.Owner, c.Repo)
+	}
+
+	return sums, []byte(combined.String()), nil
 }
 
 // FetchSHASumsSignature downloads the GPG signature for the SHA256SUMS file

--- a/backend/internal/mirror/github_releases_test.go
+++ b/backend/internal/mirror/github_releases_test.go
@@ -626,3 +626,172 @@ func TestGitHubDownloadBinaryStream_NonOKStatus(t *testing.T) {
 		t.Fatal("expected error for non-200 response, got nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Bare binary regex (OPA-style assets)
+// ---------------------------------------------------------------------------
+
+func TestBareBinaryRE(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		match   bool
+		product string
+		os      string
+		arch    string
+	}{
+		{"opa linux amd64", "opa_linux_amd64", true, "opa", "linux", "amd64"},
+		{"opa darwin arm64", "opa_darwin_arm64", true, "opa", "darwin", "arm64"},
+		{"opa windows exe", "opa_windows_amd64.exe", true, "opa", "windows", "amd64"},
+		{"opa static variant skipped", "opa_linux_amd64_static", true, "opa", "linux", "amd64"},
+		{"zip file should not match", "opentofu_1.9.0_linux_amd64.zip", false, "", "", ""},
+		{"sha256sums should not match", "opa_0.70.0_SHA256SUMS", false, "", "", ""},
+		{"sidecar sha should not match", "opa_linux_amd64.sha256", false, "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := bareBinaryRE.FindStringSubmatch(tt.input)
+			got := m != nil
+			if got != tt.match {
+				t.Errorf("bareBinaryRE.MatchString(%q) = %v, want %v", tt.input, got, tt.match)
+				return
+			}
+			if got && tt.product != "" {
+				if m[1] != tt.product {
+					t.Errorf("product = %q, want %q", m[1], tt.product)
+				}
+				if m[2] != tt.os {
+					t.Errorf("os = %q, want %q", m[2], tt.os)
+				}
+				if m[3] != tt.arch {
+					t.Errorf("arch = %q, want %q", m[3], tt.arch)
+				}
+			}
+		})
+	}
+}
+
+func TestPerFileSHA256RE(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		match    bool
+		basename string
+	}{
+		{"opa sidecar", "opa_linux_amd64.sha256", true, "opa_linux_amd64"},
+		{"opa exe sidecar", "opa_windows_amd64.exe.sha256", true, "opa_windows_amd64.exe"},
+		{"not a sidecar", "opa_linux_amd64", false, ""},
+		{"zip file", "opentofu_1.9.0_linux_amd64.zip", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := perFileSHA256RE.FindStringSubmatch(tt.input)
+			got := m != nil
+			if got != tt.match {
+				t.Errorf("perFileSHA256RE.MatchString(%q) = %v, want %v", tt.input, got, tt.match)
+				return
+			}
+			if got && tt.basename != "" {
+				if m[1] != tt.basename {
+					t.Errorf("basename = %q, want %q", m[1], tt.basename)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseRelease with bare binaries (OPA-style)
+// ---------------------------------------------------------------------------
+
+func TestParseRelease_BareBinaries(t *testing.T) {
+	c := &GitHubReleasesClient{
+		Owner:       "open-policy-agent",
+		Repo:        "opa",
+		ProductName: "opa",
+	}
+
+	rel := gitHubRelease{
+		TagName: "v0.70.0",
+		Assets: []gitHubAsset{
+			{Name: "opa_linux_amd64", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_linux_amd64"},
+			{Name: "opa_darwin_arm64", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_darwin_arm64"},
+			{Name: "opa_windows_amd64.exe", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_windows_amd64.exe"},
+			{Name: "opa_linux_amd64.sha256", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_linux_amd64.sha256"},
+			{Name: "opa_darwin_arm64.sha256", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_darwin_arm64.sha256"},
+			{Name: "opa_windows_amd64.exe.sha256", BrowserDownloadURL: "https://github.com/open-policy-agent/opa/releases/download/v0.70.0/opa_windows_amd64.exe.sha256"},
+		},
+	}
+
+	vi, ok := c.parseRelease(rel)
+	if !ok {
+		t.Fatal("parseRelease returned ok=false for OPA release")
+	}
+	if vi.Version != "0.70.0" {
+		t.Errorf("Version = %q, want 0.70.0", vi.Version)
+	}
+	if len(vi.Builds) != 3 {
+		t.Errorf("Builds count = %d, want 3", len(vi.Builds))
+	}
+	if vi.SHASumsURL != "" {
+		t.Errorf("SHASumsURL = %q, want empty (OPA has no combined file)", vi.SHASumsURL)
+	}
+	if len(vi.PerFileSHAURLs) != 3 {
+		t.Errorf("PerFileSHAURLs count = %d, want 3", len(vi.PerFileSHAURLs))
+	}
+	if _, ok := vi.PerFileSHAURLs["opa_linux_amd64"]; !ok {
+		t.Error("PerFileSHAURLs missing entry for opa_linux_amd64")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchSHASums fallback to per-file .sha256 sidecars
+// ---------------------------------------------------------------------------
+
+func TestGitHubFetchSHASums_PerFileFallback(t *testing.T) {
+	const product = "opa"
+	const version = "0.70.0"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/releases/tags/") {
+			rel := gitHubRelease{
+				TagName: "v" + version,
+				Assets: []gitHubAsset{
+					{Name: "opa_linux_amd64", BrowserDownloadURL: "https://example.com/opa_linux_amd64"},
+					{Name: "opa_darwin_arm64", BrowserDownloadURL: "https://example.com/opa_darwin_arm64"},
+					{Name: "opa_linux_amd64.sha256", BrowserDownloadURL: "https://example.com/opa_linux_amd64.sha256"},
+					{Name: "opa_darwin_arm64.sha256", BrowserDownloadURL: "https://example.com/opa_darwin_arm64.sha256"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(rel)
+			return
+		}
+		// Serve .sha256 sidecar content
+		if strings.HasSuffix(r.URL.Path, "opa_linux_amd64.sha256") {
+			_, _ = w.Write([]byte("aabbccdd11223344  opa_linux_amd64\n"))
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "opa_darwin_arm64.sha256") {
+			_, _ = w.Write([]byte("eeff009988776655  opa_darwin_arm64\n"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := newTestGitHubClient(ts, "open-policy-agent", "opa", product)
+	parsed, raw, err := client.FetchSHASums(context.Background(), version)
+	if err != nil {
+		t.Fatalf("FetchSHASums error: %v", err)
+	}
+	if len(parsed) != 2 {
+		t.Errorf("parsed map size = %d, want 2", len(parsed))
+	}
+	if parsed["opa_linux_amd64"] != "aabbccdd11223344" {
+		t.Errorf("parsed[opa_linux_amd64] = %q, want aabbccdd11223344", parsed["opa_linux_amd64"])
+	}
+	if len(raw) == 0 {
+		t.Error("raw bytes should not be empty")
+	}
+}

--- a/backend/internal/mirror/terraform_releases.go
+++ b/backend/internal/mirror/terraform_releases.go
@@ -265,6 +265,10 @@ type TerraformVersionInfo struct {
 	SHASumsSignature  string
 	SHASumsSignatures []string
 	Builds            []TerraformReleaseBuild
+	// PerFileSHAURLs maps binary filename → .sha256 sidecar download URL.
+	// Populated by GitHubReleasesClient for projects (like OPA) that publish
+	// individual .sha256 files instead of a combined SHA256SUMS.
+	PerFileSHAURLs map[string]string
 }
 
 // ----- Index fetching -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add first-class support for HashiCorp Packer, HashiCorp Sentinel, and Open Policy Agent (OPA) binaries in the mirror system
- Database migration widens the `tool` CHECK constraint to accept `packer`, `sentinel`, `opa`
- Sync job handles HashiCorp releases (Packer/Sentinel) and GitHub bare-binary releases (OPA)
- CVE polling extended to cover Packer and OPA (Sentinel is closed-source, no public CVE data)

## Changes
- **Migration 000039**: Widen `terraform_mirror_configs.tool` CHECK constraint
- **Models**: Update `oneof` binding tags to include new tools
- **Sync job**: Extend `productNameForTool()` and `gpgKeyForTool()` for new tools
- **GitHub releases client**: Add bare-binary regex and per-file `.sha256` sidecar support (OPA pattern)
- **CVE matcher**: Add `packer` and `opa` to `binaryRepoURL` map
- **CVE repository**: Widen SQL filter to include new tool types

Closes #474

## Test plan
- [ ] `go test ./...` passes
- [ ] Create mirror config with `tool: "packer"`, upstream `https://releases.hashicorp.com` — trigger sync
- [ ] Create mirror config with `tool: "opa"`, upstream `https://github.com/open-policy-agent/opa` — trigger sync, verify bare binaries fetched
- [ ] Create mirror config with `tool: "sentinel"` — trigger sync via HashiCorp releases
- [ ] Verify CVE polling picks up Packer and OPA advisories from OSV.dev