### PR TITLE
fix(server): restrict trusted proxies to prevent X-Forwarded-For spoofing

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -146,6 +146,9 @@ var AppCryptoMode = "standard"
 // identity schema (feature tables fall back to public via search_path).
 func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *BackgroundServices) {
 	router := gin.New()
+	if err := router.SetTrustedProxies(cfg.Server.TrustedProxies); err != nil {
+		log.Fatalf("invalid trusted_proxies config: %v", err)
+	}
 
 	// Initialize storage backend
 	storageBackend, err := storage.NewStorage(cfg)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -204,6 +204,9 @@ type ServerConfig struct {
 	ReadTimeout     time.Duration `mapstructure:"read_timeout"`
 	WriteTimeout    time.Duration `mapstructure:"write_timeout"`
 	DefaultLanguage string        `mapstructure:"default_language"`
+	// TrustedProxies lists CIDRs/IPs of reverse proxies allowed to set
+	// X-Forwarded-For. Empty (default) = trust no proxy.
+	TrustedProxies []string `mapstructure:"trusted_proxies"`
 }
 
 // GetPublicURL returns the public-facing URL used for OAuth callbacks and external redirects.
@@ -645,6 +648,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"server.read_timeout",
 		"server.write_timeout",
 		"server.default_language",
+		"server.trusted_proxies",
 
 		// Storage
 		"storage.default_backend",
@@ -837,6 +841,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "30s")
 	v.SetDefault("server.default_language", "en")
+	v.SetDefault("server.trusted_proxies", []string{})
 
 	// Redis defaults (empty host = disabled, in-memory fallback used)
 	v.SetDefault("redis.host", "")


### PR DESCRIPTION
## Summary

- Adds `server.trusted_proxies` config field (`TF_REG_SERVER_TRUSTED_PROXIES` env var) accepting a list of CIDRs/IPs
- Calls `gin.Engine.SetTrustedProxies()` at router init so only listed proxies may set `X-Forwarded-For`
- Default empty = trust no proxy (safe-by-default); matches Gin's recommended hardened configuration

Without this, any client can spoof `X-Forwarded-For`, poisoning `c.ClientIP()` used in audit logs, rate limiting, and binary mirror IP allowlists.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/...` passes
- [x] Pre-existing vet failures (`log_redaction_test.go`, `auth_email_hardening_test.go`) are contract tests for future fixes, not regressions
- [ ] CI gates (coverage, gosec)