### PR TITLE
chore: gofmt mirror and models files

### DIFF
--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -32,7 +32,8 @@ var mirrorProvCols = []string{
 
 // Column ordering mirrors the production SELECT in provider_repository.go
 // (gpg_public_key, shasums_url, shasums_signature_url,
-//  shasum_storage_key, shasum_signature_storage_key, published_by, ...).
+//
+//	shasum_storage_key, shasum_signature_storage_key, published_by, ...).
 var mirrorVersionCols = []string{
 	"id", "provider_id", "version", "protocols",
 	"gpg_public_key", "shasums_url", "shasums_signature_url",

--- a/backend/internal/db/models/mirror.go
+++ b/backend/internal/db/models/mirror.go
@@ -83,8 +83,8 @@ type CreateMirrorConfigRequest struct {
 	PlatformFilter           []string `json:"platform_filter,omitempty"`                                        // List of "os/arch" strings (e.g. ["linux/amd64", "windows/amd64"])
 	Enabled                  *bool    `json:"enabled,omitempty"`                                                // Default: true
 	SyncIntervalHours        *int     `json:"sync_interval_hours,omitempty" binding:"omitempty,min=1"`          // Default: 24
-	RequiresApproval         *bool    `json:"requires_approval,omitempty"`                                     // Default: false
-	AutoApproveRules         *string  `json:"auto_approve_rules,omitempty"`                                    // JSON: AutoApproveRules
+	RequiresApproval         *bool    `json:"requires_approval,omitempty"`                                      // Default: false
+	AutoApproveRules         *string  `json:"auto_approve_rules,omitempty"`                                     // JSON: AutoApproveRules
 	PullThroughEnabled       *bool    `json:"pull_through_enabled,omitempty"`                                   // Default: false
 	PullThroughCacheTTLHours *int     `json:"pull_through_cache_ttl_hours,omitempty" binding:"omitempty,min=1"` // Default: 24
 }

--- a/backend/internal/db/models/terraform_mirror.go
+++ b/backend/internal/db/models/terraform_mirror.go
@@ -26,7 +26,7 @@ type TerraformMirrorConfig struct {
 	GPGVerify         bool       `json:"gpg_verify" db:"gpg_verify"`
 	StableOnly        bool       `json:"stable_only" db:"stable_only"` // exclude pre-release versions when true
 	SyncIntervalHours int        `json:"sync_interval_hours" db:"sync_interval_hours"`
-	RequiresApproval  bool       `json:"requires_approval" db:"requires_approval"`            // Gate newly synced versions behind admin approval
+	RequiresApproval  bool       `json:"requires_approval" db:"requires_approval"`             // Gate newly synced versions behind admin approval
 	AutoApproveRules  *string    `json:"auto_approve_rules,omitempty" db:"auto_approve_rules"` // JSONB: AutoApproveRules; NULL = manual approval only
 	LastSyncAt        *time.Time `json:"last_sync_at,omitempty" db:"last_sync_at"`
 	LastSyncStatus    *string    `json:"last_sync_status,omitempty" db:"last_sync_status"`
@@ -39,18 +39,18 @@ type TerraformMirrorConfig struct {
 
 // TerraformVersion represents a single Terraform/OpenTofu release version within a mirror config.
 type TerraformVersion struct {
-	ID           uuid.UUID  `json:"id" db:"id"`
-	ConfigID     uuid.UUID  `json:"config_id" db:"config_id"`
-	Version      string     `json:"version" db:"version"`
-	IsLatest     bool       `json:"is_latest" db:"is_latest"`
-	IsDeprecated bool       `json:"is_deprecated" db:"is_deprecated"`
-	ReleaseDate  *time.Time `json:"release_date,omitempty" db:"release_date"`
-	SyncStatus   string     `json:"sync_status" db:"sync_status"` // pending|syncing|synced|failed|partial
-	SyncError    *string    `json:"sync_error,omitempty" db:"sync_error"`
-	SyncedAt     *time.Time `json:"synced_at,omitempty" db:"synced_at"`
-	ApprovalStatus *string  `json:"approval_status,omitempty" db:"approval_status"` // NULL|pending_approval|approved|rejected
-	CreatedAt    time.Time  `json:"created_at" db:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at" db:"updated_at"`
+	ID             uuid.UUID  `json:"id" db:"id"`
+	ConfigID       uuid.UUID  `json:"config_id" db:"config_id"`
+	Version        string     `json:"version" db:"version"`
+	IsLatest       bool       `json:"is_latest" db:"is_latest"`
+	IsDeprecated   bool       `json:"is_deprecated" db:"is_deprecated"`
+	ReleaseDate    *time.Time `json:"release_date,omitempty" db:"release_date"`
+	SyncStatus     string     `json:"sync_status" db:"sync_status"` // pending|syncing|synced|failed|partial
+	SyncError      *string    `json:"sync_error,omitempty" db:"sync_error"`
+	SyncedAt       *time.Time `json:"synced_at,omitempty" db:"synced_at"`
+	ApprovalStatus *string    `json:"approval_status,omitempty" db:"approval_status"` // NULL|pending_approval|approved|rejected
+	CreatedAt      time.Time  `json:"created_at" db:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at" db:"updated_at"`
 
 	// Storage keys for the per-version GPG-verified SHA256SUMS file and its
 	// detached signature. NULL until the sync job has uploaded them. Used by

--- a/backend/internal/db/models/version_approval.go
+++ b/backend/internal/db/models/version_approval.go
@@ -69,7 +69,7 @@ type AutoApproveRules struct {
 // row's own UUID (mirrored_provider_versions.id or terraform_versions.id).
 type VersionApproval struct {
 	ID                uuid.UUID `json:"id" db:"id"`
-	Type              string    `json:"type" db:"type"`             // provider | terraform
+	Type              string    `json:"type" db:"type"` // provider | terraform
 	Version           string    `json:"version" db:"version"`
 	ApprovalStatus    string    `json:"approval_status" db:"approval_status"`
 	ProviderNamespace *string   `json:"provider_namespace,omitempty" db:"provider_namespace"`


### PR DESCRIPTION
gofmt-only formatting of 4 files (no logic change):

- backend/internal/api/mirror/mirror_test.go
- backend/internal/db/models/mirror.go
- backend/internal/db/models/terraform_mirror.go
- backend/internal/db/models/version_approval.go

Changes are pure gofmt output (struct-tag/comment alignment and comment-block reindentation). These files are not touched by the open security PRs #485/#487, so there is no conflict risk.