### PR TITLE
fix(helm): allow disabling OIDC require_verified_email via values

### DIFF
--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -51,6 +51,8 @@ data:
   TFR_AUTH_API_KEYS_ENABLED: {{ .Values.auth.apiKeys.enabled | quote }}
   TFR_AUTH_API_KEYS_PREFIX: {{ .Values.auth.apiKeys.prefix | quote }}
   TFR_AUTH_OIDC_ENABLED: {{ .Values.auth.oidc.enabled | quote }}
+  # Shared verified-email gate (governs both OIDC and Azure AD callbacks)
+  TFR_AUTH_OIDC_REQUIRE_VERIFIED_EMAIL: {{ .Values.auth.oidc.requireVerifiedEmail | quote }}
   {{- if .Values.auth.oidc.enabled }}
   TFR_AUTH_OIDC_ISSUER_URL: {{ .Values.auth.oidc.issuerUrl | quote }}
   TFR_AUTH_OIDC_CLIENT_ID: {{ .Values.auth.oidc.clientId | quote }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -149,6 +149,11 @@ auth:
       - openid
       - email
       - profile
+    # -- Reject SSO logins whose token lacks email_verified (or sets it false).
+    # Governs BOTH oidc and azureAd callbacks. Default true for security. SET
+    # FALSE for Entra/Azure AD, which omits email_verified — otherwise login
+    # fails with email_not_verified.
+    requireVerifiedEmail: true
   azureAd:
     enabled: false
     tenantId: ""


### PR DESCRIPTION
## Problem
`auth.oidc.require_verified_email` defaults **true** (`config.go:888`) and governs **both** the OIDC and Azure AD callbacks (shared flag, `auth.go:402`); a missing `email_verified` claim is rejected. Azure AD / Entra ID tokens routinely **omit** `email_verified`, so a default Azure AD deploy fails the first login with `email_not_verified` and the chart offered no values-level override (configmap emitted no key).

Parity with the same fix in terraform-state-manager-backend.

## Change (chart-only, behavior-preserving)
- Add `auth.oidc.requireVerifiedEmail` to `values.yaml` (**default `true`**).
- Emit `TFR_AUTH_OIDC_REQUIRE_VERIFIED_EMAIL` **unconditionally** (so it applies to Azure AD-only deploys where `auth.oidc.enabled=false`).

## Verify
`helm lint` clean; default render emits `TFR_AUTH_OIDC_REQUIRE_VERIFIED_EMAIL: "true"` even with both providers off; `--set …requireVerifiedEmail=false` renders `"false"`. No Go changes — `auth.oidc.require_verified_email` is already bound (BindEnv list + Viper `TFR` prefix).