### PR TITLE
fix(identity): gate system-role seeding on suite.role_seed_owner

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -259,12 +259,20 @@ func serve(cfg *config.Config) error {
 		// own domain scopes onto the system roles so non-admin roles behave the
 		// same as in the default public-schema configuration ("identity-core +
 		// app-extended"). Idempotent; no-op on steady-state restarts.
-		if err := repositories.SeedSystemRoleTemplates(
-			context.Background(), identityDB, models.PredefinedRoleTemplates(),
-		); err != nil {
-			return fmt.Errorf("failed to seed system role templates: %w", err)
+		// Under a shared identity database, exactly one app must own role-template
+		// seeding (suite.role_seed_owner) or the apps overwrite each other's role
+		// scopes on restart. Default "self" preserves standalone behavior.
+		if cfg.Suite.ShouldSeedRoles("registry") {
+			if err := repositories.SeedSystemRoleTemplates(
+				context.Background(), identityDB, models.PredefinedRoleTemplates(),
+			); err != nil {
+				return fmt.Errorf("failed to seed system role templates: %w", err)
+			}
+			slog.Info("system role templates seeded into identity schema")
+		} else {
+			slog.Info("skipping system role template seeding; another app owns it",
+				"role_seed_owner", cfg.Suite.RoleSeedOwner)
 		}
-		slog.Info("system role templates seeded into identity schema")
 	}
 
 	// Create router

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -215,6 +215,20 @@ type ServerConfig struct {
 type SuiteConfig struct {
 	SiblingURL   string        `mapstructure:"sibling_url"`   // TFR_SUITE_SIBLING_URL, e.g. https://tfstate.brunswick.com
 	PollInterval time.Duration `mapstructure:"poll_interval"` // TFR_SUITE_POLL_INTERVAL, default 60s
+	// RoleSeedOwner controls which app seeds the shared identity schema's system
+	// role templates. "self" (default) = this app seeds its own store, matching
+	// standalone behavior. When two apps share one identity database, exactly one
+	// must own the seed ("registry" or "tsm"); otherwise they overwrite each
+	// other's role scopes on every restart.
+	RoleSeedOwner string `mapstructure:"role_seed_owner"` // TFR_SUITE_ROLE_SEED_OWNER: self|registry|tsm
+}
+
+// ShouldSeedRoles reports whether this app (identified by app, e.g. "registry")
+// should seed system role templates given the configured RoleSeedOwner. "self"
+// (the default) means every app seeds its own store; otherwise only the named
+// owner seeds, so a shared identity database is written by exactly one app.
+func (s SuiteConfig) ShouldSeedRoles(app string) bool {
+	return s.RoleSeedOwner == "self" || s.RoleSeedOwner == app
 }
 
 // GetPublicURL returns the public-facing URL used for OAuth callbacks and external redirects.
@@ -774,6 +788,7 @@ func bindEnvVars(v *viper.Viper) error {
 		// Suite
 		"suite.sibling_url",
 		"suite.poll_interval",
+		"suite.role_seed_owner",
 	}
 	for _, key := range keys {
 		if err := v.BindEnv(key); err != nil {
@@ -966,6 +981,7 @@ func setDefaults(v *viper.Viper) {
 	// Suite runtime discovery
 	v.SetDefault("suite.sibling_url", "")
 	v.SetDefault("suite.poll_interval", 60*time.Second)
+	v.SetDefault("suite.role_seed_owner", "self")
 }
 
 // expandEnv expands environment variables in the format ${VAR_NAME}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -621,3 +621,49 @@ func TestScanningConfig_DefaultInstallDir(t *testing.T) {
 		t.Errorf("Scanning.InstallDir = %q, want /app/scanners", cfg.Scanning.InstallDir)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// SuiteConfig.RoleSeedOwner / ShouldSeedRoles
+// ---------------------------------------------------------------------------
+
+func TestSuiteConfig_ShouldSeedRoles(t *testing.T) {
+	cases := []struct {
+		owner string
+		app   string
+		want  bool
+	}{
+		{"self", "registry", true},     // standalone default: every app seeds its own
+		{"registry", "registry", true}, // this app is the designated owner
+		{"tsm", "registry", false},     // sibling owns the shared seed → skip
+		{"self", "tsm", true},          // "self" is app-agnostic
+		{"", "registry", false},        // unset (shouldn't happen post-default) → not owner
+	}
+	for _, c := range cases {
+		if got := (SuiteConfig{RoleSeedOwner: c.owner}).ShouldSeedRoles(c.app); got != c.want {
+			t.Errorf("ShouldSeedRoles(owner=%q, app=%q) = %v, want %v", c.owner, c.app, got, c.want)
+		}
+	}
+}
+
+func TestLoad_RoleSeedOwnerDefault(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Suite.RoleSeedOwner != "self" {
+		t.Errorf("default Suite.RoleSeedOwner = %q, want self", cfg.Suite.RoleSeedOwner)
+	}
+}
+
+func TestLoad_RoleSeedOwnerEnvOverride(t *testing.T) {
+	// Proves suite.role_seed_owner is in the bindEnvVars whitelist — without that
+	// entry registry's explicit-bind loader would not pick up the env var.
+	t.Setenv("TFR_SUITE_ROLE_SEED_OWNER", "registry")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Suite.RoleSeedOwner != "registry" {
+		t.Errorf("Suite.RoleSeedOwner = %q, want registry (TFR_SUITE_ROLE_SEED_OWNER override)", cfg.Suite.RoleSeedOwner)
+	}
+}


### PR DESCRIPTION
## Problem
Under a **shared identity database**, registry and TSM both seed the same system role templates (`admin`/`viewer`/`operator`) with **different scope arrays**. Registry's `viewer`=`[modules:read,…]` vs TSM's `viewer`=`[state:read]`; TSM's seeder (`bootstrap.go:40`) is an *unconditional* `ON CONFLICT … DO UPDATE`, so each restart silently overwrites the other app's role scopes. This is the verified data-correctness blocker for the suite's shared-identity north star.

## Change
- Add `suite.role_seed_owner` (`self`|`registry`|`tsm`, **default `self`**) to `SuiteConfig` + `bindEnvVars` + `setDefaults`.
- Add `SuiteConfig.ShouldSeedRoles(app)` (`self` ⇒ true; else only the named owner).
- Gate the `SeedSystemRoleTemplates` call (`main.go`, inside the existing identity-schema-cutover block) on `cfg.Suite.ShouldSeedRoles("registry")`.

**Default `self` = current behavior** (every app seeds its own store), so standalone / per-app-DB deploys are unaffected. Under a shared identity DB, set exactly one owner.

## Tests
`TestSuiteConfig_ShouldSeedRoles` (truth table) + `TestLoad_RoleSeedOwnerDefault` + `TestLoad_RoleSeedOwnerEnvOverride` (the override proves the `bindEnvVars` whitelist entry). gofmt/vet/golangci-lint clean.

Part of suite-coupling **Phase 1**; the TSM-side gate is a parallel PR. No identity-module change (seeding is per-app).