### PR TITLE
feat(identity): support a separable identity database DSN

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -166,9 +166,22 @@ func serve(cfg *config.Config) error {
 	// until explicitly enabled; mirrors the TFR_SECURITY_TLS_ENABLED env flag.
 	if identityMigrationsEnabled() {
 		log.Println("Running identity schema migrations...")
-		if err := identity.RunMigrations(database, "up"); err != nil {
+		// Run against the identity database (defaults to the app DB). Identity
+		// migrations are schema-qualified (identity.*), so a plain connection
+		// suffices; a dedicated connection lets identity live in a separate database
+		// (TFR_IDENTITY_DATABASE_*) without coupling to the app pool.
+		identityMigrateDB, mErr := db.Connect(
+			cfg.IdentityDatabase.GetDSN(),
+			cfg.IdentityDatabase.MaxConnections, cfg.IdentityDatabase.MinIdleConnections,
+		)
+		if mErr != nil {
+			return fmt.Errorf("failed to connect to identity database: %w", mErr)
+		}
+		if err := identity.RunMigrations(identityMigrateDB, "up"); err != nil {
+			_ = identityMigrateDB.Close()
 			return fmt.Errorf("failed to run identity migrations: %w", err)
 		}
+		_ = identityMigrateDB.Close()
 		log.Println("Identity schema migrations completed successfully")
 	}
 
@@ -244,8 +257,8 @@ func serve(cfg *config.Config) error {
 	if identitySchemaEnabled() {
 		searchPath := identitySchemaName() + ",public"
 		idb, connErr := db.Connect(
-			cfg.Database.GetDSNWithSearchPath(searchPath),
-			cfg.Database.MaxConnections, cfg.Database.MinIdleConnections,
+			cfg.IdentityDatabase.GetDSNWithSearchPath(searchPath),
+			cfg.IdentityDatabase.MaxConnections, cfg.IdentityDatabase.MinIdleConnections,
 		)
 		if connErr != nil {
 			return fmt.Errorf("failed to connect to identity schema: %w", connErr)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -24,9 +24,14 @@ import (
 type Config struct {
 	Server   ServerConfig   `mapstructure:"server"`
 	Database DatabaseConfig `mapstructure:"database"`
-	Redis    RedisConfig    `mapstructure:"redis"`
-	Storage  StorageConfig  `mapstructure:"storage"`
-	Auth     AuthConfig     `mapstructure:"auth"`
+	// IdentityDatabase optionally points the identity schema at a separate/shared
+	// database. Any unset field falls back to Database, so fully unset = the app
+	// database (standalone default). Set TFR_IDENTITY_DATABASE_* to share one
+	// identity store across the suite.
+	IdentityDatabase DatabaseConfig `mapstructure:"identity_database"`
+	Redis            RedisConfig    `mapstructure:"redis"`
+	Storage          StorageConfig  `mapstructure:"storage"`
+	Auth             AuthConfig     `mapstructure:"auth"`
 	// ApiDocs holds OpenAPI/Swagger metadata that can be overridden at deploy-time
 	ApiDocs         ApiDocsConfig         `mapstructure:"api_docs"`
 	MultiTenancy    MultiTenancyConfig    `mapstructure:"multi_tenancy"`
@@ -662,6 +667,14 @@ func bindEnvVars(v *viper.Viper) error {
 		"database.ssl_mode",
 		"database.max_connections",
 		"database.min_idle_connections",
+		"identity_database.host",
+		"identity_database.port",
+		"identity_database.name",
+		"identity_database.user",
+		"identity_database.password",
+		"identity_database.ssl_mode",
+		"identity_database.max_connections",
+		"identity_database.min_idle_connections",
 
 		// Server
 		"server.host",
@@ -844,6 +857,7 @@ func Load(configPath string) (*Config, error) {
 
 	// Expand environment variables in sensitive fields
 	cfg.Database.Password = expandEnv(cfg.Database.Password)
+	cfg.IdentityDatabase.Password = expandEnv(cfg.IdentityDatabase.Password)
 	cfg.Redis.Password = expandEnv(cfg.Redis.Password)
 	cfg.Storage.Azure.AccountKey = expandEnv(cfg.Storage.Azure.AccountKey)
 	cfg.Storage.S3.AccessKeyID = expandEnv(cfg.Storage.S3.AccessKeyID)
@@ -851,6 +865,10 @@ func Load(configPath string) (*Config, error) {
 	cfg.Auth.OIDC.ClientSecret = expandEnv(cfg.Auth.OIDC.ClientSecret)
 	cfg.Auth.AzureAD.ClientSecret = expandEnv(cfg.Auth.AzureAD.ClientSecret)
 	cfg.Notifications.SMTP.Password = expandEnv(cfg.Notifications.SMTP.Password)
+
+	// Identity database inherits any unset field from the app database. Runs after
+	// expandEnv so an inherited password is the expanded value.
+	cfg.resolveIdentityDatabase()
 
 	// Validate configuration
 	if err := cfg.Validate(); err != nil {
@@ -889,6 +907,17 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.ssl_mode", "require")
 	v.SetDefault("database.max_connections", 25)
 	v.SetDefault("database.min_idle_connections", 5)
+
+	// Identity database — empty defaults so each field falls back to the app
+	// database (above) unless TFR_IDENTITY_DATABASE_* overrides it.
+	v.SetDefault("identity_database.host", "")
+	v.SetDefault("identity_database.port", 0)
+	v.SetDefault("identity_database.name", "")
+	v.SetDefault("identity_database.user", "")
+	v.SetDefault("identity_database.password", "")
+	v.SetDefault("identity_database.ssl_mode", "")
+	v.SetDefault("identity_database.max_connections", 0)
+	v.SetDefault("identity_database.min_idle_connections", 0)
 
 	// Storage defaults
 	v.SetDefault("storage.default_backend", "local")
@@ -1133,6 +1162,38 @@ func (c *DatabaseConfig) GetDSN() string {
 // tables fall back to public.
 func (c *DatabaseConfig) GetDSNWithSearchPath(searchPath string) string {
 	return c.GetDSN() + fmt.Sprintf(" options='-c search_path=%s'", searchPath)
+}
+
+// resolveIdentityDatabase fills any unset IdentityDatabase field from the primary
+// Database, so an operator can point identity at a different host or database name
+// while inheriting the rest (port, user, password, ssl_mode, pool sizing). Fully
+// unset → identical to Database (the standalone default).
+func (c *Config) resolveIdentityDatabase() {
+	id := &c.IdentityDatabase
+	if id.Host == "" {
+		id.Host = c.Database.Host
+	}
+	if id.Port == 0 {
+		id.Port = c.Database.Port
+	}
+	if id.Name == "" {
+		id.Name = c.Database.Name
+	}
+	if id.User == "" {
+		id.User = c.Database.User
+	}
+	if id.Password == "" {
+		id.Password = c.Database.Password
+	}
+	if id.SSLMode == "" {
+		id.SSLMode = c.Database.SSLMode
+	}
+	if id.MaxConnections == 0 {
+		id.MaxConnections = c.Database.MaxConnections
+	}
+	if id.MinIdleConnections == 0 {
+		id.MinIdleConnections = c.Database.MinIdleConnections
+	}
 }
 
 // GetAddress returns the server address in host:port format

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -667,3 +667,61 @@ func TestLoad_RoleSeedOwnerEnvOverride(t *testing.T) {
 		t.Errorf("Suite.RoleSeedOwner = %q, want registry (TFR_SUITE_ROLE_SEED_OWNER override)", cfg.Suite.RoleSeedOwner)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// IdentityDatabase fallback
+// ---------------------------------------------------------------------------
+
+func TestLoad_IdentityDatabaseDefaultsToAppDB(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Unset → the identity database is byte-for-byte the app database.
+	if cfg.IdentityDatabase != cfg.Database {
+		t.Errorf("IdentityDatabase = %+v, want == Database %+v", cfg.IdentityDatabase, cfg.Database)
+	}
+}
+
+func TestLoad_IdentityDatabasePartialOverride(t *testing.T) {
+	// Override only host + database name; everything else inherits the app DB —
+	// the common "shared identity DB on the same server" case.
+	t.Setenv("TFR_IDENTITY_DATABASE_HOST", "identity.db.internal")
+	t.Setenv("TFR_IDENTITY_DATABASE_NAME", "terraform_suite_identity")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.IdentityDatabase.Host != "identity.db.internal" {
+		t.Errorf("IdentityDatabase.Host = %q, want identity.db.internal", cfg.IdentityDatabase.Host)
+	}
+	if cfg.IdentityDatabase.Name != "terraform_suite_identity" {
+		t.Errorf("IdentityDatabase.Name = %q, want terraform_suite_identity", cfg.IdentityDatabase.Name)
+	}
+	if cfg.IdentityDatabase.User != cfg.Database.User {
+		t.Errorf("IdentityDatabase.User = %q, want inherited %q", cfg.IdentityDatabase.User, cfg.Database.User)
+	}
+	if cfg.IdentityDatabase.Port != cfg.Database.Port {
+		t.Errorf("IdentityDatabase.Port = %d, want inherited %d", cfg.IdentityDatabase.Port, cfg.Database.Port)
+	}
+	if cfg.IdentityDatabase.SSLMode != cfg.Database.SSLMode {
+		t.Errorf("IdentityDatabase.SSLMode = %q, want inherited %q", cfg.IdentityDatabase.SSLMode, cfg.Database.SSLMode)
+	}
+}
+
+func TestLoad_IdentityDatabasePasswordFallbackExpanded(t *testing.T) {
+	// The fallback runs AFTER expandEnv, so an inherited password is the expanded
+	// value (not the literal ${VAR}).
+	t.Setenv("REG_CONFIG_TEST_DBPASS", "s3cr3t-pw")
+	t.Setenv("TFR_DATABASE_PASSWORD", "${REG_CONFIG_TEST_DBPASS}")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Database.Password != "s3cr3t-pw" {
+		t.Fatalf("Database.Password = %q, want expanded s3cr3t-pw", cfg.Database.Password)
+	}
+	if cfg.IdentityDatabase.Password != "s3cr3t-pw" {
+		t.Errorf("IdentityDatabase.Password = %q, want inherited+expanded s3cr3t-pw", cfg.IdentityDatabase.Password)
+	}
+}


### PR DESCRIPTION
## What
Adds an optional `IdentityDatabase` config so the identity schema can live in a **separate/shared** database — the mechanism for a shared `terraform_suite_identity` store across the suite (coupling **Phase 1**). Parity with [tsm-backend#97](https://github.com/sethbacon/terraform-state-manager-backend/pull/97).

- New `identity_database.*` config (+ `bindEnvVars` + `setDefaults`); **any unset field falls back to the app `Database`**, resolved **after `expandEnv`** so an inherited password is the expanded value. Fully unset == app DB (standalone byte-for-byte unchanged).
- Both identity entry points now use `cfg.IdentityDatabase`: the `TFR_IDENTITY_MIGRATIONS_ENABLED` path (dedicated connection — migrations are schema-qualified `identity.*`, so equivalent to the app pool when the DBs coincide) and the `TFR_IDENTITY_SCHEMA_ENABLED` search_path pool. App pool + app migrations untouched; both flags keep their independent semantics.

## Tests
`TestLoad_IdentityDatabaseDefaultsToAppDB` (unset → `==Database`), `...PartialOverride` (host/name override, rest inherit), `...PasswordFallbackExpanded` (guards the expandEnv-then-resolve ordering). gofmt/vet/golangci-lint/gosec clean.

## ⚠ Stacked PR
Based on **`fix/role-seed-owner`** ([#491](https://github.com/sethbacon/terraform-registry-backend/pull/491)), not main — both edit `config.go` + `main.go`'s identity block. **Merge #491 first**, then I'll rebase onto main. Diff shown is slice-4 only.