### PR TITLE
feat(suite): advertise and forward the identity shared-store signal

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -817,7 +817,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 
 			// Suite runtime discovery (Phase 0)
 			publicGroup.GET("/suite/manifest", suiteManifestHandler(cfg))
-			publicGroup.GET("/ui/config", uiConfigHandler(func() *suite.DiscoveryClient { return suiteClient }))
+			publicGroup.GET("/ui/config", uiConfigHandler(cfg, func() *suite.DiscoveryClient { return suiteClient }))
 		}
 		suiteClient = startSuiteDiscovery(cfg)
 

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -23,7 +23,7 @@ func buildSuiteManifest(cfg *config.Config) suite.Manifest {
 		Version:       AppVersion,
 		BuildDate:     AppBuildDate,
 		PublicURL:     pub,
-		Identity:      suite.IdentityInfo{Issuer: suiteIssuer, SharedStore: false, Schema: "identity"},
+		Identity:      suite.IdentityInfo{Issuer: suiteIssuer, SharedStore: cfg.Suite.IdentitySharedStore, Schema: "identity"},
 		Capabilities: []suite.Capability{
 			{ID: "modules.v1"}, {ID: "providers.v1"}, {ID: "mirror.v1"}, {ID: "oci.v1"},
 		},
@@ -39,14 +39,21 @@ func suiteManifestHandler(cfg *config.Config) gin.HandlerFunc {
 	}
 }
 
-func uiConfigHandler(getClient func() *suite.DiscoveryClient) gin.HandlerFunc {
+func uiConfigHandler(cfg *config.Config, getClient func() *suite.DiscoveryClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		out := gin.H{"sibling": nil}
 		if dc := getClient(); dc != nil {
 			if state, m := dc.Snapshot(); state == suite.StateActive && m != nil {
+				// Single sign-on is seamless only when BOTH apps assert the shared
+				// identity store; otherwise the SPA keeps its "you may need to sign
+				// in" hint. issuer is informational (which app minted the sibling's
+				// tokens). Forwarded only on the active branch so a stale identity
+				// block can't leak during degraded/unreachable windows.
 				out["sibling"] = gin.H{
 					"app": m.App, "state": string(state),
 					"publicUrl": m.PublicURL, "links": m.Links,
+					"issuer":      m.Identity.Issuer,
+					"sharedStore": cfg.Suite.IdentitySharedStore && m.Identity.SharedStore,
 				}
 			} else {
 				out["sibling"] = gin.H{"state": string(state)}

--- a/backend/internal/api/suite_test.go
+++ b/backend/internal/api/suite_test.go
@@ -72,7 +72,7 @@ func TestSuiteManifestHandler_PublicURLFallsBackToBaseURL(t *testing.T) {
 
 func TestUIConfigHandler_NoSibling(t *testing.T) {
 	r := gin.New()
-	r.GET("/api/v1/ui/config", uiConfigHandler(func() *suite.DiscoveryClient { return nil }))
+	r.GET("/api/v1/ui/config", uiConfigHandler(&config.Config{}, func() *suite.DiscoveryClient { return nil }))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ui/config", nil))
@@ -116,7 +116,7 @@ func TestUIConfigHandler_ActiveSibling(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.GET("/api/v1/ui/config", uiConfigHandler(func() *suite.DiscoveryClient { return dc }))
+	r.GET("/api/v1/ui/config", uiConfigHandler(&config.Config{}, func() *suite.DiscoveryClient { return dc }))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ui/config", nil))
@@ -154,7 +154,7 @@ func TestUIConfigHandler_UnreachableSibling(t *testing.T) {
 	dc.Start(ctxThatCancelsImmediately())
 
 	r := gin.New()
-	r.GET("/api/v1/ui/config", uiConfigHandler(func() *suite.DiscoveryClient { return dc }))
+	r.GET("/api/v1/ui/config", uiConfigHandler(&config.Config{}, func() *suite.DiscoveryClient { return dc }))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ui/config", nil))
@@ -179,6 +179,63 @@ func TestStartSuiteDiscovery_NilWhenNoSiblingURL(t *testing.T) {
 	cfg := &config.Config{}
 	if dc := startSuiteDiscovery(cfg); dc != nil {
 		t.Error("expected nil when SiblingURL is empty")
+	}
+}
+
+func TestUIConfigHandler_ForwardsIdentityBlock(t *testing.T) {
+	sibling := suite.Manifest{
+		SchemaVersion: suite.SchemaVersionV1,
+		App:           "terraform-state-manager",
+		PublicURL:     "https://tfstate.example.com",
+		Identity:      suite.IdentityInfo{Issuer: "terraform-state-manager", SharedStore: true, Schema: "identity"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(sibling)
+	}))
+	defer srv.Close()
+
+	self := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-registry"}
+	dc := suite.NewDiscoveryClient(srv.URL, self, time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go dc.Start(ctx)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, _ := dc.Snapshot(); st == suite.StateActive {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	decodeSibling := func(cfg *config.Config) map[string]any {
+		r := gin.New()
+		r.GET("/api/v1/ui/config", uiConfigHandler(cfg, func() *suite.DiscoveryClient { return dc }))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/ui/config", nil))
+		var resp struct {
+			Sibling map[string]any `json:"sibling"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return resp.Sibling
+	}
+
+	// issuer is always forwarded; sharedStore is true only when THIS app also
+	// asserts the shared store (seamless SSO).
+	shared := decodeSibling(&config.Config{Suite: config.SuiteConfig{IdentitySharedStore: true}})
+	if shared["issuer"] != "terraform-state-manager" {
+		t.Errorf("issuer = %v, want terraform-state-manager", shared["issuer"])
+	}
+	if shared["sharedStore"] != true {
+		t.Errorf("sharedStore = %v, want true (both apps assert it)", shared["sharedStore"])
+	}
+
+	// This app does NOT assert the shared store → keep the hint even though the
+	// sibling claims one (the AND).
+	notShared := decodeSibling(&config.Config{})
+	if notShared["sharedStore"] != false {
+		t.Errorf("sharedStore = %v, want false (this app does not assert it)", notShared["sharedStore"])
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -226,6 +226,11 @@ type SuiteConfig struct {
 	// must own the seed ("registry" or "tsm"); otherwise they overwrite each
 	// other's role scopes on every restart.
 	RoleSeedOwner string `mapstructure:"role_seed_owner"` // TFR_SUITE_ROLE_SEED_OWNER: self|registry|tsm
+	// IdentitySharedStore is an operator assertion that THIS app uses the shared
+	// identity store + single IdP. It is advertised in the manifest; the SPA drops
+	// the "you may need to sign in" hint only when both this app AND the sibling
+	// assert it. Default false. Env: TFR_SUITE_IDENTITY_SHARED_STORE.
+	IdentitySharedStore bool `mapstructure:"identity_shared_store"`
 }
 
 // ShouldSeedRoles reports whether this app (identified by app, e.g. "registry")
@@ -802,6 +807,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"suite.sibling_url",
 		"suite.poll_interval",
 		"suite.role_seed_owner",
+		"suite.identity_shared_store",
 	}
 	for _, key := range keys {
 		if err := v.BindEnv(key); err != nil {
@@ -1011,6 +1017,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("suite.sibling_url", "")
 	v.SetDefault("suite.poll_interval", 60*time.Second)
 	v.SetDefault("suite.role_seed_owner", "self")
+	v.SetDefault("suite.identity_shared_store", false)
 }
 
 // expandEnv expands environment variables in the format ${VAR_NAME}


### PR DESCRIPTION
## What
Backend half of the Phase 1 SSO-honesty UX (the frontend half shipped in [registry-frontend#383](https://github.com/sethbacon/terraform-registry-frontend/pull/383)).

- New `suite.identity_shared_store` config (operator assertion that this app uses the shared identity store + single IdP; **default false**). Advertised in the manifest's `identity` block (was hardcoded `false`).
- `uiConfigHandler` now forwards the sibling's `issuer` and a `sharedStore` signal = **(this app asserts it) AND (sibling asserts it)** — so the SPA drops its "may need to sign in" hint only when SSO is genuinely seamless from this app's side (forwarding the sibling's value alone would wrongly claim seamless from a non-shared app). Active-branch only, so a stale identity block can't leak during degraded/unreachable windows.

Default false everywhere ⇒ current behavior (hint always shown). It lights up only when an operator sets the flag true on **both** apps.

## Tests
`TestUIConfigHandler_ForwardsIdentityBlock` (issuer forwarded; `sharedStore` true only when both assert it, false when this app doesn't — the AND). Existing suite tests updated for the new handler signature. gofmt/vet/golangci-lint clean; 7/7 suite tests pass.