### PR TITLE
feat(suite): server-proxy module consumers for the Consumed-by panel

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -847,6 +847,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			authenticatedGroup.POST("/auth/refresh", authHandlers.RefreshHandler())
 			authenticatedGroup.GET("/auth/me", authHandlers.MeHandler())
 
+			// Suite coupling: "Consumed by" — which sibling-app states use this
+			// module. Server-proxied to the sibling (2s timeout, [] on any failure),
+			// auth-required so internal state/source names aren't exposed anonymously.
+			// Namespaced under /suite to avoid the /modules/:version wildcard.
+			authenticatedGroup.GET("/suite/modules/:namespace/:name/:system/consumers",
+				moduleConsumersHandler(func() *suite.DiscoveryClient { return suiteClient }, cfg))
+
 			// Stats endpoints (require auth)
 			authenticatedGroup.GET("/admin/stats/dashboard", statsHandlers.GetDashboardStats)
 

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -2,7 +2,11 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
@@ -11,6 +15,11 @@ import (
 )
 
 const suiteIssuer = "terraform-registry"
+
+// suiteServiceTokenHeader is the header the sibling expects for server-to-server
+// cross-app reads (it gates the sibling's /consumers). Defined locally so this
+// package needs no dependency on the sibling's middleware package.
+const suiteServiceTokenHeader = "X-Suite-Service-Token" // #nosec G101 -- HTTP header name, not a credential
 
 func buildSuiteManifest(cfg *config.Config) suite.Manifest {
 	pub := cfg.Server.PublicURL
@@ -70,4 +79,71 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 	dc := suite.NewDiscoveryClient(cfg.Suite.SiblingURL, buildSuiteManifest(cfg), cfg.Suite.PollInterval)
 	go dc.Start(context.Background())
 	return dc
+}
+
+// moduleConsumersHandler server-proxies the "Consumed by" lookup to the sibling
+// Suite app (TSM): which states consume this registry module. It returns an empty
+// list whenever the sibling is absent/unreachable, the sibling token is
+// unconfigured, or anything fails — so the panel simply hides and the registry
+// stays fully standalone. 2s timeout; never blocks the page.
+func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config) gin.HandlerFunc {
+	// registryHost is THIS registry's own public host — the key the sibling matches
+	// "consumed by" on, so it never false-joins against public-registry modules.
+	registryHost := ""
+	if u, err := url.Parse(cfg.Server.GetPublicURL()); err == nil {
+		registryHost = u.Host
+	}
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+
+	return func(c *gin.Context) {
+		empty := gin.H{"consumers": []any{}, "total": 0}
+		dc := getClient()
+		if dc == nil || registryHost == "" || cfg.Suite.SiblingToken == "" {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		state, m := dc.Snapshot()
+		if state != suite.StateActive || m == nil || m.PublicURL == "" {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+
+		moduleAddr := c.Param("namespace") + "/" + c.Param("name") + "/" + c.Param("system")
+		target := strings.TrimRight(m.PublicURL, "/") +
+			"/api/v1/consumers?host=" + url.QueryEscape(registryHost) +
+			"&module=" + url.QueryEscape(moduleAddr)
+
+		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, target, nil)
+		if err != nil {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		req.Header.Set(suiteServiceTokenHeader, cfg.Suite.SiblingToken)
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+
+		// Forward the sibling's rows opaquely (RawMessage) — the registry does not
+		// reinterpret TSM's consumer shape.
+		var body struct {
+			Consumers []json.RawMessage `json:"consumers"`
+			Total     int               `json:"total"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		if body.Consumers == nil {
+			body.Consumers = []json.RawMessage{}
+		}
+		c.JSON(http.StatusOK, gin.H{"consumers": body.Consumers, "total": body.Total})
+	}
 }

--- a/backend/internal/api/suite_consumers_test.go
+++ b/backend/internal/api/suite_consumers_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sethbacon/terraform-suite-identity/identity/suite"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+func mountConsumers(cfg *config.Config, dc *suite.DiscoveryClient) *gin.Engine {
+	r := gin.New()
+	r.GET("/api/v1/suite/modules/:namespace/:name/:system/consumers",
+		moduleConsumersHandler(func() *suite.DiscoveryClient { return dc }, cfg))
+	return r
+}
+
+func getConsumers(r *gin.Engine) (int, map[string]any) {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/suite/modules/acme/vpc/aws/consumers", nil))
+	var out map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	return w.Code, out
+}
+
+// activeClient builds a DiscoveryClient polling url and waits for it to go active.
+func activeClient(t *testing.T, url string) *suite.DiscoveryClient {
+	t.Helper()
+	self := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-registry"}
+	dc := suite.NewDiscoveryClient(url, self, time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	go dc.Start(ctx)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, _ := dc.Snapshot(); st == suite.StateActive {
+			return dc
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("discovery client did not become active")
+	return nil
+}
+
+func TestModuleConsumers_StandaloneReturnsEmpty(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "tok"
+	code, out := getConsumers(mountConsumers(cfg, nil)) // no sibling
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if c, _ := out["consumers"].([]any); len(c) != 0 || out["total"].(float64) != 0 {
+		t.Errorf("standalone must be empty: %v", out)
+	}
+}
+
+func TestModuleConsumers_NoTokenReturnsEmpty(t *testing.T) {
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com" // SiblingToken empty → inert
+	_, out := getConsumers(mountConsumers(cfg, dc))
+	if c, _ := out["consumers"].([]any); len(c) != 0 {
+		t.Errorf("no sibling token must yield empty: %v", out)
+	}
+}
+
+func TestModuleConsumers_ProxiesActiveSibling(t *testing.T) {
+	var gotToken, gotHost, gotModule string
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			gotToken = r.Header.Get("X-Suite-Service-Token")
+			gotHost = r.URL.Query().Get("host")
+			gotModule = r.URL.Query().Get("module")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"consumers": []map[string]any{{"source_id": "s1", "source_name": "prod", "state_key": "app.tfstate"}},
+				"total":     1,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest) // discovery poll
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "s3cr3t"
+	code, out := getConsumers(mountConsumers(cfg, dc))
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if out["total"].(float64) != 1 {
+		t.Errorf("total = %v, want 1", out["total"])
+	}
+	if c, _ := out["consumers"].([]any); len(c) != 1 {
+		t.Errorf("consumers = %v, want 1 row", out["consumers"])
+	}
+	if gotToken != "s3cr3t" {
+		t.Errorf("service token not forwarded to sibling: %q", gotToken)
+	}
+	if gotModule != "acme/vpc/aws" {
+		t.Errorf("module param = %q, want acme/vpc/aws", gotModule)
+	}
+	if gotHost != "registry.example.com" {
+		t.Errorf("host param = %q, want registry.example.com (the registry's own host)", gotHost)
+	}
+}
+
+func TestModuleConsumers_SiblingErrorReturnsEmpty(t *testing.T) {
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			w.WriteHeader(http.StatusUnauthorized) // e.g. wrong/absent token at the sibling
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "s3cr3t"
+	_, out := getConsumers(mountConsumers(cfg, dc))
+	if c, _ := out["consumers"].([]any); len(c) != 0 {
+		t.Errorf("sibling error must yield empty (graceful): %v", out)
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -231,6 +231,11 @@ type SuiteConfig struct {
 	// the "you may need to sign in" hint only when both this app AND the sibling
 	// assert it. Default false. Env: TFR_SUITE_IDENTITY_SHARED_STORE.
 	IdentitySharedStore bool `mapstructure:"identity_shared_store"`
+	// SiblingToken is the shared secret sent (X-Suite-Service-Token) when this app
+	// server-proxies a cross-app read to the sibling (the "Consumed by" panel calls
+	// the sibling TSM's /consumers). Empty (default) leaves the proxy inert; set it
+	// to the SAME value as the sibling's TSM_SUITE_SERVICE_TOKEN.
+	SiblingToken string `mapstructure:"sibling_token"` // TFR_SUITE_SIBLING_TOKEN
 }
 
 // ShouldSeedRoles reports whether this app (identified by app, e.g. "registry")
@@ -808,6 +813,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"suite.poll_interval",
 		"suite.role_seed_owner",
 		"suite.identity_shared_store",
+		"suite.sibling_token",
 	}
 	for _, key := range keys {
 		if err := v.BindEnv(key); err != nil {
@@ -1018,6 +1024,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("suite.poll_interval", 60*time.Second)
 	v.SetDefault("suite.role_seed_owner", "self")
 	v.SetDefault("suite.identity_shared_store", false)
+	v.SetDefault("suite.sibling_token", "")
 }
 
 // expandEnv expands environment variables in the format ${VAR_NAME}


### PR DESCRIPTION
## What (Phase 2 slice 4a — registry side)
Adds **`GET /api/v1/suite/modules/:namespace/:name/:system/consumers`** — a server-side proxy to the sibling TSM's `/consumers`, listing which states consume this registry module (powers a 'Consumed by' panel).

- **`suite.sibling_token`** config (`TFR_SUITE_SIBLING_TOKEN`, default ""); sent as `X-Suite-Service-Token` so TSM authorizes the server-to-server read (matches [tsm-backend#103](https://github.com/sethbacon/terraform-state-manager-backend/pull/103)). Empty ⇒ proxy inert.
- Returns **`[]` on any failure** (sibling absent/degraded, token unset, timeout, non-200) — 2s timeout, never blocks the page; registry stays fully standalone.
- Passes the registry's **own public host** as the join key so it never false-joins against public-registry modules.
- Mounted on the **authenticated group** (auth required) so internal state/source names aren't exposed to anonymous module-page visitors. Namespaced under `/suite` to avoid the existing `/modules/:version` wildcard collision.

## Tests
`TestModuleConsumers_*`: standalone→[], no-token→[], active sibling→proxies + forwards `{consumers,total}` + asserts the token/host/module passed to the sibling, sibling-error→[]. gofmt/vet/golangci-lint/gosec clean.

**Operational:** lights up only when `TFR_SUITE_SIBLING_TOKEN` == the sibling's `TSM_SUITE_SERVICE_TOKEN` (both default empty = off). The FE 'Consumed by' panel is the final piece (slice 4b).