### PR TITLE
docs(suite): document module consumers route in swagger

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -12915,6 +12915,73 @@
                 }
             }
         },
+        "/api/v1/suite/modules/{namespace}/{name}/{system}/consumers": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Server-proxies a \"Consumed by\" lookup to the sibling Suite app (Terraform State Manager): which managed states reference this module. Returns an empty list when the sibling is unconfigured, unreachable, or the shared suite service token is unset, so the registry stays fully standalone. Always responds 200.",
+                "tags": [
+                    "Suite"
+                ],
+                "summary": "List module consumers (suite)",
+                "parameters": [
+                    {
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Target system (e.g. aws, azurerm)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Consuming states (rows forwarded opaquely from the sibling) and total count",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/ui/theme": {
             "get": {
                 "description": "Returns the white-label theme configuration consumed by the frontend ThemeContext. Public — no authentication required so the login page can brand itself before sign-in. Returns 404 when nothing has been configured; the frontend then falls back to its built-in defaults.",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -10446,6 +10446,62 @@
                 }
             }
         },
+        "/api/v1/suite/modules/{namespace}/{name}/{system}/consumers": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Server-proxies a \"Consumed by\" lookup to the sibling Suite app (Terraform State Manager): which managed states reference this module. Returns an empty list when the sibling is unconfigured, unreachable, or the shared suite service token is unset, so the registry stays fully standalone. Always responds 200.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Suite"
+                ],
+                "summary": "List module consumers (suite)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Module namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Module name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target system (e.g. aws, azurerm)",
+                        "name": "system",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Consuming states (rows forwarded opaquely from the sibling) and total count",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication required",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/ui/theme": {
             "get": {
                 "description": "Returns the white-label theme configuration consumed by the frontend ThemeContext. Public — no authentication required so the login page can brand itself before sign-in. Returns 404 when nothing has been configured; the frontend then falls back to its built-in defaults.",

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -86,6 +86,18 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 // list whenever the sibling is absent/unreachable, the sibling token is
 // unconfigured, or anything fails — so the panel simply hides and the registry
 // stays fully standalone. 2s timeout; never blocks the page.
+//
+// @Summary      List module consumers (suite)
+// @Description  Server-proxies a "Consumed by" lookup to the sibling Suite app (Terraform State Manager): which managed states reference this module. Returns an empty list when the sibling is unconfigured, unreachable, or the shared suite service token is unset, so the registry stays fully standalone. Always responds 200.
+// @Tags         Suite
+// @Security     Bearer
+// @Produce      json
+// @Param        namespace  path  string  true  "Module namespace"
+// @Param        name       path  string  true  "Module name"
+// @Param        system     path  string  true  "Target system (e.g. aws, azurerm)"
+// @Success      200  {object}  map[string]interface{}  "Consuming states (rows forwarded opaquely from the sibling) and total count"
+// @Failure      401  {object}  map[string]interface{}  "Authentication required"
+// @Router       /api/v1/suite/modules/{namespace}/{name}/{system}/consumers [get]
 func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config) gin.HandlerFunc {
 	// registryHost is THIS registry's own public host — the key the sibling matches
 	// "consumed by" on, so it never false-joins against public-registry modules.


### PR DESCRIPTION
## Summary

`moduleConsumersHandler` — the suite **"Consumed by"** proxy added in #495 — served `GET /api/v1/suite/modules/{namespace}/{name}/{system}/consumers` **without swagger annotations**, so the route was absent from `docs/swagger.json`. That forced the registry frontend to add an allowlist entry in its contract check ([terraform-registry-frontend#385](https://github.com/sethbacon/terraform-registry-frontend/pull/385)), since the check diffs frontend API calls against this backend's swagger.

This PR documents the route so the spec is complete and the frontend contract check can **verify** it rather than skip it.

## Changes

- Added swag annotations to `moduleConsumersHandler` (`@Summary` / `@Description` / `@Tags Suite` / `@Security Bearer` / `@Param` × 3 / `@Success 200` / `@Failure 401` / `@Router`), modeled on the documented `Get module` handler.
- Regenerated `docs/swagger.json` and `docs/openapi3.json` (`swag init` + `swagger2openapi`, matching CI). Both diffs are **purely additive** (only the new route).

## Note on the `@Router` path

I used the full-prefix form `/api/v1/suite/modules/{namespace}/{name}/{system}/consumers` (not the bare `/suite/...` the originating task suggested). This repo's existing annotations carry the `/api/v1/` prefix (e.g. `Get module` is `/api/v1/modules/{namespace}/{name}/{system}`), and the frontend contract check matches `spec.paths` keys **literally** — so the prefix is required for the route to line up with the frontend's `/api/v1/suite/modules/{}/{}/{}/consumers` call.

## Follow-up (not in this PR)

Once this releases and the frontend's `deployments/docker-compose.contract-check.yml` backend image is bumped to a tag containing the route, the frontend allowlist entry should be removed — the contract check auto-flags it stale once the route exists in swagger.

## Verification

- `gofmt -l` clean · `go build ./...` + `go vet` OK
- `golangci-lint run ./internal/api/...` exit 0
- `gosec ./internal/api/...` — **0 issues**
- Confirmed swagger path key normalizes to `/api/v1/suite/modules/{}/{}/{}/consumers` (exact match to the frontend call).