### PR TITLE
fix(suite): align service discovery with the consumers join host

### DIFF
--- a/backend/internal/api/host.go
+++ b/backend/internal/api/host.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+// canonicalHost normalizes a registry host so the suite "Consumed by" join
+// compares like-for-like across apps. Terraform module source addresses, the
+// service-discovery host, and this registry's own public host can differ only
+// in case, a default port, a trailing FQDN dot, or an accidental scheme prefix;
+// folding those away makes the exact-match join robust to such variants.
+//
+// It strips any scheme, lowercases the host, removes a trailing dot, and drops
+// a default port (:80/:443) while preserving any non-default port. IDN/punycode
+// folding is intentionally NOT done here — it is deferred to the shared helper.
+//
+// TODO(stage2): replace with the shared suite.CanonicalHost helper once the
+// terraform-suite-identity module exposes it (a byte-identical copy lives in
+// terraform-state-manager-backend internal/services/driftingest).
+func canonicalHost(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// If a scheme slipped in (e.g. the value came from a full URL), keep only
+	// the authority component.
+	if strings.Contains(raw, "://") {
+		if u, err := url.Parse(raw); err == nil && u.Host != "" {
+			raw = u.Host
+		}
+	}
+	host, port := raw, ""
+	if h, p, err := net.SplitHostPort(raw); err == nil {
+		host, port = h, p
+	}
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if port == "" || port == "80" || port == "443" {
+		return host
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/backend/internal/api/host_test.go
+++ b/backend/internal/api/host_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestCanonicalHost(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain", "reg.example.com", "reg.example.com"},
+		{"uppercase", "REG.Example.COM", "reg.example.com"},
+		{"trailing dot", "reg.example.com.", "reg.example.com"},
+		{"default https port stripped", "reg.example.com:443", "reg.example.com"},
+		{"default http port stripped", "reg.example.com:80", "reg.example.com"},
+		{"non-default port preserved", "reg.example.com:8443", "reg.example.com:8443"},
+		{"scheme stripped", "https://reg.example.com/", "reg.example.com"},
+		{"scheme + default port", "https://REG.Example.com.:443/v1/modules/", "reg.example.com"},
+		{"scheme + non-default port", "http://reg.example.com:8080", "reg.example.com:8080"},
+		{"surrounding whitespace", "  reg.example.com  ", "reg.example.com"},
+		{"ipv4", "10.0.0.5", "10.0.0.5"},
+		{"ipv4 with port", "10.0.0.5:8443", "10.0.0.5:8443"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalHost(tc.in); got != tc.want {
+				t.Errorf("canonicalHost(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalHost_Idempotent guards the join invariant: applying the function
+// twice must equal applying it once, so re-canonicalizing an already-stored host
+// never drifts.
+func TestCanonicalHost_Idempotent(t *testing.T) {
+	for _, in := range []string{"reg.example.com", "REG.Example.com:443", "https://reg.example.com:8080"} {
+		once := canonicalHost(in)
+		if twice := canonicalHost(once); twice != once {
+			t.Errorf("not idempotent: canonicalHost(%q)=%q then %q", in, once, twice)
+		}
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -1367,13 +1367,21 @@ func readinessHandler(db *sql.DB, storageBackend storage.Storage) gin.HandlerFun
 // @Produce      json
 // @Success      200  {object}  api.ServiceDiscoveryResponse
 // @Router       /.well-known/terraform.json [get]
-// serviceDiscoveryHandler implements Terraform service discovery
+// serviceDiscoveryHandler implements Terraform service discovery.
+//
+// The endpoint URLs are built from GetPublicURL() (public_url, falling back to
+// base_url) rather than base_url directly. This is the host Terraform resolves
+// "source = HOST/ns/name/system" against and that the State Manager captures for
+// the suite "Consumed by" join, so it must match the join key the suite proxy
+// emits (also GetPublicURL-derived). In the default deploy public_url is empty
+// and this is byte-for-byte identical to the previous base_url output.
 func serviceDiscoveryHandler(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		publicURL := cfg.Server.GetPublicURL()
 		c.JSON(http.StatusOK, gin.H{
-			"modules.v1":   cfg.Server.BaseURL + "/v1/modules/",
-			"providers.v1": cfg.Server.BaseURL + "/v1/providers/",
-			"oci.v1":       cfg.Server.BaseURL + "/v2/",
+			"modules.v1":   publicURL + "/v1/modules/",
+			"providers.v1": publicURL + "/v1/providers/",
+			"oci.v1":       publicURL + "/v2/",
 		})
 	}
 }

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -208,6 +208,35 @@ func TestServiceDiscoveryHandler(t *testing.T) {
 	}
 }
 
+// TestServiceDiscoveryHandler_UsesPublicURL is a load-bearing regression guard:
+// in a reverse-proxied deploy (public_url != base_url) service discovery MUST
+// advertise the public_url host, because that is the host Terraform resolves
+// "source = HOST/..." against and that the suite "Consumed by" join keys on. If
+// this ever reverts to base_url, the join silently returns empty with no error
+// in proxied deployments. Do not "simplify" this back to cfg.Server.BaseURL.
+func TestServiceDiscoveryHandler_UsesPublicURL(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Server.BaseURL = "http://registry.internal:8080" // internal listen address
+	cfg.Server.PublicURL = "https://registry.example.com" // externally reachable URL
+
+	r := gin.New()
+	r.GET("/.well-known/terraform.json", serviceDiscoveryHandler(cfg))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/.well-known/terraform.json", nil))
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["modules.v1"] != "https://registry.example.com/v1/modules/" {
+		t.Errorf("modules.v1 = %v, want the public_url host (not base_url)", body["modules.v1"])
+	}
+	if body["providers.v1"] != "https://registry.example.com/v1/providers/" {
+		t.Errorf("providers.v1 = %v, want the public_url host (not base_url)", body["providers.v1"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // versionHandler
 // ---------------------------------------------------------------------------

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -101,9 +101,11 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config) gin.HandlerFunc {
 	// registryHost is THIS registry's own public host — the key the sibling matches
 	// "consumed by" on, so it never false-joins against public-registry modules.
+	// Canonicalized so it compares like-for-like against the host TSM captured
+	// from the module source address (case/port/trailing-dot folded).
 	registryHost := ""
 	if u, err := url.Parse(cfg.Server.GetPublicURL()); err == nil {
-		registryHost = u.Host
+		registryHost = canonicalHost(u.Host)
 	}
 	httpClient := &http.Client{Timeout: 2 * time.Second}
 


### PR DESCRIPTION
## Summary

Stage 1 of the canonical-host resolution: fixes a latent **silent false-negative** in the suite "Consumed by" join.

Service discovery advertised `modules.v1`/`providers.v1`/`oci.v1` from `server.base_url` ([router.go:1374-1376](backend/internal/api/router.go)), while the suite join key is derived from `GetPublicURL()` (`public_url`, falling back to `base_url`) in [suite.go](backend/internal/api/suite.go). In a reverse-proxied deploy where `public_url != base_url`, the host Terraform resolves `source = "HOST/ns/name/system"` against (and that State Manager captures into `state_module_refs.registry_host`) **diverged** from the join key — so the join returned empty with no error.

## Changes

- **Discovery now builds its URLs from `GetPublicURL()`** so the discovery host and the join key are one identity. `GetPublicURL()` falls back to `base_url` when `public_url` is empty, so **default/standalone deploys are byte-for-byte unchanged**.
- **`canonicalHost` helper** (new [host.go](backend/internal/api/host.go)) folds case, default port (`:80`/`:443`), and a trailing FQDN dot; the join key is run through it so it compares like-for-like against the captured host.
- **Load-bearing regression test** `TestServiceDiscoveryHandler_UsesPublicURL` (asserts discovery uses `public_url`, not `base_url`) with a comment warning against reverting — the fix is invisible in default deploys.

## Scope / follow-ups (not here)

This is the per-repo, no-lockstep Stage 1. The matching State Manager change (canonicalize on capture + read) ships in its own PR. **Stage 2** extracts a shared `suite.CanonicalHost` into `terraform-suite-identity` (replacing this local copy — see the `TODO(stage2)`), adds a generated-column-backed join + IDN folding + an operator host-alias set. **Standalone-safe:** no new config; the join path stays dormant without a sibling + token.

## Verification

- `gofmt` clean · `go build ./...` + `go vet` OK
- `go test ./internal/api/` — canonicalizer table + idempotency, both discovery tests, all 4 ModuleConsumers tests pass
- `golangci-lint` exit 0 · `gosec` 0 issues