### PR TITLE
feat(suite): emit canonical host-alias set for the consumers join

### DIFF
--- a/backend/internal/api/host.go
+++ b/backend/internal/api/host.go
@@ -41,3 +41,32 @@ func canonicalHost(raw string) string {
 	}
 	return net.JoinHostPort(host, port)
 }
+
+// canonicalHostSet builds the de-duplicated set of canonical host identities
+// this registry presents for the suite "Consumed by" join: its public-URL host,
+// its base-URL host, and any operator-configured aliases (vanity CNAMEs,
+// split-horizon DNS, or a portless variant of a non-default-port public URL).
+// Empty/unparseable entries are dropped. Including both the public and base
+// hosts heals the common reverse-proxy case where authors still address the
+// base host even though public_url is set.
+func canonicalHostSet(publicURL, baseURL string, aliases []string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	add := func(raw string) {
+		ch := canonicalHost(raw)
+		if ch == "" {
+			return
+		}
+		if _, dup := seen[ch]; dup {
+			return
+		}
+		seen[ch] = struct{}{}
+		out = append(out, ch)
+	}
+	add(publicURL)
+	add(baseURL)
+	for _, a := range aliases {
+		add(a)
+	}
+	return out
+}

--- a/backend/internal/api/host_test.go
+++ b/backend/internal/api/host_test.go
@@ -42,3 +42,29 @@ func TestCanonicalHost_Idempotent(t *testing.T) {
 		}
 	}
 }
+
+func TestCanonicalHostSet(t *testing.T) {
+	got := canonicalHostSet(
+		"https://registry.example.com",                         // public
+		"http://registry.internal:8080",                        // base (distinct host)
+		[]string{"tf.example.com", "REGISTRY.example.com", ""}, // alias + dup-of-public + empty
+	)
+	want := []string{"registry.example.com", "registry.internal:8080", "tf.example.com"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (order: public, base, aliases; deduped; empties dropped)", got, want)
+		}
+	}
+}
+
+// TestCanonicalHostSet_PublicOnly: the default deploy (public_url empty → base
+// used; no aliases) yields exactly one host and never an empty set.
+func TestCanonicalHostSet_PublicOnly(t *testing.T) {
+	got := canonicalHostSet("http://localhost:8080", "http://localhost:8080", nil)
+	if len(got) != 1 || got[0] != "localhost:8080" {
+		t.Fatalf("got %v, want [localhost:8080]", got)
+	}
+}

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -99,20 +99,18 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 // @Failure      401  {object}  map[string]interface{}  "Authentication required"
 // @Router       /api/v1/suite/modules/{namespace}/{name}/{system}/consumers [get]
 func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config) gin.HandlerFunc {
-	// registryHost is THIS registry's own public host — the key the sibling matches
-	// "consumed by" on, so it never false-joins against public-registry modules.
-	// Canonicalized so it compares like-for-like against the host TSM captured
-	// from the module source address (case/port/trailing-dot folded).
-	registryHost := ""
-	if u, err := url.Parse(cfg.Server.GetPublicURL()); err == nil {
-		registryHost = canonicalHost(u.Host)
-	}
+	// hosts is THIS registry's set of canonical host identities the sibling
+	// matches "consumed by" on: its public host, its base/discovery host, and any
+	// operator-configured aliases (TFR_SERVER_HOST_ALIASES) for vanity-CNAME or
+	// port-asymmetry deployments. Canonicalized + de-duped so the join compares
+	// like-for-like against the host TSM captured from the module source address.
+	hosts := canonicalHostSet(cfg.Server.GetPublicURL(), cfg.Server.BaseURL, cfg.Server.HostAliases)
 	httpClient := &http.Client{Timeout: 2 * time.Second}
 
 	return func(c *gin.Context) {
 		empty := gin.H{"consumers": []any{}, "total": 0}
 		dc := getClient()
-		if dc == nil || registryHost == "" || cfg.Suite.SiblingToken == "" {
+		if dc == nil || len(hosts) == 0 || cfg.Suite.SiblingToken == "" {
 			c.JSON(http.StatusOK, empty)
 			return
 		}
@@ -123,9 +121,17 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 		}
 
 		moduleAddr := c.Param("namespace") + "/" + c.Param("name") + "/" + c.Param("system")
-		target := strings.TrimRight(m.PublicURL, "/") +
-			"/api/v1/consumers?host=" + url.QueryEscape(registryHost) +
-			"&module=" + url.QueryEscape(moduleAddr)
+		// Emit every acceptable host as a repeated &host= param; the sibling
+		// matches a state if its captured host is any of them.
+		var sb strings.Builder
+		sb.WriteString(strings.TrimRight(m.PublicURL, "/"))
+		sb.WriteString("/api/v1/consumers?module=")
+		sb.WriteString(url.QueryEscape(moduleAddr))
+		for _, h := range hosts {
+			sb.WriteString("&host=")
+			sb.WriteString(url.QueryEscape(h))
+		}
+		target := sb.String()
 
 		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, target, nil)
 		if err != nil {

--- a/backend/internal/api/suite_consumers_test.go
+++ b/backend/internal/api/suite_consumers_test.go
@@ -123,6 +123,45 @@ func TestModuleConsumers_ProxiesActiveSibling(t *testing.T) {
 	}
 }
 
+// TestModuleConsumers_EmitsHostAliasSet proves the registry forwards its full
+// canonical host-identity set (public host + base host + operator aliases,
+// de-duped) as repeated &host= params so a vanity-CNAME / split-horizon
+// deployment still joins.
+func TestModuleConsumers_EmitsHostAliasSet(t *testing.T) {
+	var gotHosts []string
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			gotHosts = r.URL.Query()["host"]
+			_ = json.NewEncoder(w).Encode(map[string]any{"consumers": []map[string]any{}, "total": 0})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Server.BaseURL = "http://registry.internal:8080"
+	cfg.Server.HostAliases = []string{"tf.example.com", "REGISTRY.example.com"} // alias + dup-of-public
+	cfg.Suite.SiblingToken = "s3cr3t"
+	if code, _ := getConsumers(mountConsumers(cfg, dc)); code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+
+	want := map[string]bool{"registry.example.com": true, "registry.internal:8080": true, "tf.example.com": true}
+	if len(gotHosts) != len(want) {
+		t.Fatalf("emitted hosts = %v, want the 3-host deduped set %v", gotHosts, want)
+	}
+	for _, h := range gotHosts {
+		if !want[h] {
+			t.Errorf("unexpected emitted host %q (set %v)", h, gotHosts)
+		}
+	}
+}
+
 func TestModuleConsumers_SiblingErrorReturnsEmpty(t *testing.T) {
 	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -213,6 +213,13 @@ type ServerConfig struct {
 	// TrustedProxies lists CIDRs/IPs of reverse proxies allowed to set
 	// X-Forwarded-For. Empty (default) = trust no proxy.
 	TrustedProxies []string `mapstructure:"trusted_proxies"`
+	// HostAliases lists additional hostnames this registry is reachable under
+	// (e.g. a vanity CNAME, or a portless variant of a non-default-port
+	// public_url) beyond public_url/base_url. Used only to widen the suite
+	// "Consumed by" join key set so states that reference an alias still match.
+	// Empty (default) = just public_url + base_url. TFR_SERVER_HOST_ALIASES,
+	// comma-separated.
+	HostAliases []string `mapstructure:"host_aliases"`
 }
 
 // SuiteConfig configures optional runtime coupling to the sibling Suite app.
@@ -695,6 +702,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"server.write_timeout",
 		"server.default_language",
 		"server.trusted_proxies",
+		"server.host_aliases",
 
 		// Storage
 		"storage.default_backend",
@@ -901,6 +909,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("server.write_timeout", "30s")
 	v.SetDefault("server.default_language", "en")
 	v.SetDefault("server.trusted_proxies", []string{})
+	v.SetDefault("server.host_aliases", []string{})
 
 	// Redis defaults (empty host = disabled, in-memory fallback used)
 	v.SetDefault("redis.host", "")


### PR DESCRIPTION
## Summary

Registry side of Stage 2's alias matching — pairs with [tsm-backend #106](https://github.com/sethbacon/terraform-state-manager-backend/pull/106) (which made the State Manager match `registry_host_canon = ANY(...)`).

The "Consumed by" proxy emitted a **single** host (the public-URL host) as the join key. A registry can be reachable under more than one identity — its public host, its base/discovery host, or a vanity CNAME / split-horizon name — so a state that referenced an *alias* would silently fail to join.

## Changes

- **`canonicalHostSet`** ([host.go](backend/internal/api/host.go)) builds the de-duped canonical set: public-URL host ∪ base-URL host ∪ operator aliases. Including the base host heals the common reverse-proxy case (authors still address `base_url` even when `public_url` is set).
- **`moduleConsumersHandler`** ([suite.go](backend/internal/api/suite.go)) emits the set as **repeated `&host=` params**; dormancy gate is now `len(hosts) == 0`.
- **`TFR_SERVER_HOST_ALIASES`** ([config.go](backend/internal/config/config.go)) — comma-separated, default empty, **not** required by `Validate()` (modeled on the existing `trusted_proxies` slice). Viper's default decoder comma-splits it.

## Standalone safety

The proxy stays dormant without a sibling + service token; `HostAliases` defaults empty. A single-host deployment emits exactly one `host=` — **unchanged behavior** (existing `ProxiesActiveSibling` test still asserts the single-host case).

## Verification

- `gofmt` clean (changed files) · `go build` + `vet` OK · `gosec` 0 · `golangci-lint` exit 0
- New tests: `TestCanonicalHostSet` (order/dedup/empty-drop), `TestCanonicalHostSet_PublicOnly`, `TestModuleConsumers_EmitsHostAliasSet` (3-host deduped set forwarded)

## Follow-up

Shared `suite.CanonicalHost` adoption (replacing the local `canonicalHost` copy used here) rides [identity #42](https://github.com/sethbacon/terraform-suite-identity/pull/42) once released.