### PR TITLE
docs(suite): document audit federation to the State Manager

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -198,3 +198,31 @@ cve:
   poll_binaries: true
   poll_providers: true
   poll_scanner: true
+
+# Audit logging — records security-relevant write operations (uploads, deletes,
+# permission changes). Always written to the database; optionally SHIPPED to
+# external destinations (SIEM / log aggregator) or FEDERATED to a sibling suite
+# app. Shippers are a structured list, so they live here in config.yaml (env
+# vars cannot express a list of structs).
+audit:
+  enabled: true
+  # log_read_operations: false   # also log GETs (verbose)
+  # log_failed_requests: false   # also log 4xx/5xx responses
+  shippers: []
+  # Suite audit federation: ship each entry to a sibling Terraform State Manager
+  # so its admin Audit Log shows a unified, cross-app trail. Requires a SHARED
+  # identity store (TSM accepts federation only under sharedStore — its
+  # audit.ingest.v1 capability) and the same shared suite token on both apps
+  # (this app's TFR_SUITE_SIBLING_TOKEN == TSM's TSM_SUITE_SERVICE_TOKEN).
+  # No code change — this reuses the built-in webhook shipper. Replace the empty
+  # list above with: see docs/suite-audit-federation.md.
+  #  - enabled: true
+  #    type: webhook   # webhook | syslog | file
+  #    webhook:
+  #      url: https://tsm.example.com/api/v1/audit/ingest
+  #      headers:
+  #        X-Suite-Service-Token: ${TFR_SUITE_SIBLING_TOKEN}
+  #        X-Suite-Source-App: terraform-registry
+  #      timeout_secs: 5
+  #      batch_size: 0           # 0 = ship each entry immediately (no batching)
+  #      flush_interval_secs: 0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -632,6 +632,30 @@ over config file values and supports runtime changes without restart.
 
 ---
 
+## Audit Log Shipping
+
+Beyond the database trail, the backend can ship each audit entry to external
+destinations (SIEM, log aggregator) or **federate** it to a sibling Terraform
+State Manager so both apps share one unified Audit Log. Shippers are a structured
+list, configured in `config.yaml` (environment variables cannot express a list of
+structs):
+
+```yaml
+audit:
+  enabled: true
+  shippers:
+    - enabled: true
+      type: webhook   # webhook | syslog | file
+      webhook:
+        url: https://siem.example.com/ingest
+        headers: { Authorization: "Bearer ${SIEM_TOKEN}" }
+```
+
+For the suite cross-app unified audit trail, see
+[Suite Audit Federation](suite-audit-federation.md).
+
+---
+
 ## Audit Log Retention
 
 The backend can automatically delete audit log entries older than a configurable

--- a/docs/suite-audit-federation.md
+++ b/docs/suite-audit-federation.md
@@ -1,0 +1,81 @@
+# Suite Audit Federation
+
+When the Terraform Registry is deployed alongside the Terraform State Manager
+(TSM) as a coupled suite, the registry can **federate its audit trail to TSM** so
+TSM's admin Audit Log page shows a single, unified record of write operations
+across both apps. This is an optional, operator-enabled feature; it requires no
+code change on either side.
+
+## How it works
+
+The registry already writes every audited action to its own database and can
+*ship* a copy of each entry to external destinations via the built-in audit
+**webhook shipper** (`internal/audit/shipper.go`). Federation is just a webhook
+shipper whose destination is TSM's ingest endpoint:
+
+```
+registry audit middleware ──ship──▶ POST {tsm}/api/v1/audit/ingest ──▶ identity.audit_logs
+```
+
+TSM records the entry in the shared `identity.audit_logs` table — the same trail
+its Audit Log page reads — tagging it `federated: true` (plus `source_app` and the
+original `source_timestamp`, `auth_method`, and `status_code` in metadata).
+
+## Preconditions
+
+Federation is only **coherent under a shared identity store**, and TSM enforces
+this — it accepts entries only when `sharedStore` is asserted (advertised as the
+`audit.ingest.v1` manifest capability) and rejects them otherwise:
+
+1. **Shared identity store.** Both apps point at one physical identity database
+   (one host + one database name). Only then do the registry's `user_id` /
+   `organization_id` resolve in TSM's identity tables; otherwise a merged
+   timeline would mis-attribute actors and the `audit_logs` foreign key would
+   reject the row. Set `identity.sharedStore: true` (TSM `TSM_SUITE_IDENTITY_SHARED_STORE=true`).
+2. **Shared suite service token.** The header token this app sends must equal
+   TSM's `TSM_SUITE_SERVICE_TOKEN`. Reuse the same value already used to gate the
+   "Consumed by" read — i.e. this app's `TFR_SUITE_SIBLING_TOKEN`.
+3. **Reachability.** The registry pods must be able to reach TSM's public URL.
+
+If any precondition is unmet, leave federation off. The registry continues to
+record its own audit trail locally; only the cross-app unified view is absent.
+
+## Configuration
+
+Audit shippers are a structured list, so they are configured in `config.yaml`
+(not via environment variables). Add a `webhook` shipper to `audit.shippers`:
+
+```yaml
+audit:
+  enabled: true
+  shippers:
+    - enabled: true
+      type: webhook
+      webhook:
+        url: https://tsm.example.com/api/v1/audit/ingest
+        headers:
+          # Must equal TSM's TSM_SUITE_SERVICE_TOKEN.
+          X-Suite-Service-Token: ${TFR_SUITE_SIBLING_TOKEN}
+          # Optional — labels the federated rows in TSM's trail.
+          X-Suite-Source-App: terraform-registry
+        timeout_secs: 5
+        batch_size: 0           # 0 = ship each entry immediately
+        flush_interval_secs: 0
+```
+
+`${TFR_SUITE_SIBLING_TOKEN}` is expanded from the environment, so the token
+itself stays in a secret and never appears in the config file.
+
+> **Note on the Helm chart.** The chart configures the backend through
+> environment variables, which cannot express a structured shipper list. To use
+> federation in a chart deployment, mount a `config.yaml` containing the
+> `audit.shippers` block above (e.g. via a ConfigMap/Secret volume) — the backend
+> auto-discovers `config.yaml` in the standard locations. A first-class chart
+> value for this can be added if there is demand.
+
+## Verifying
+
+After enabling, perform an audited action in the registry (e.g. publish or delete
+a module) and confirm it appears in TSM's admin Audit Log marked as federated.
+Shipping is best-effort and asynchronous: delivery failures are logged on the
+registry side (`failed to ship audit log`) and never block the original request.


### PR DESCRIPTION
## What

Documents how to **federate the registry's audit trail to a sibling Terraform State Manager** so TSM's admin Audit Log shows a unified, cross-app record. This is the registry-side half of suite audit federation (P2-7); the TSM ingest endpoint is [terraform-state-manager-backend#117](https://github.com/sethbacon/terraform-state-manager-backend/pull/117).

**Zero registry code** — federation reuses the built-in audit **webhook shipper**, which already supports custom headers. So this PR is purely documentation/config.

## Changes

- **`config.example.yaml`** — adds an `audit:` block (previously absent) with a commented webhook-federation shipper. The `shippers` list is a structured type, so it's documented as `config.yaml`-only (env vars can't express a list of structs).
- **`docs/suite-audit-federation.md`** — new focused page: how it works, preconditions (shared identity store + shared suite token + reachability), the `config.yaml` shipper config, the Helm `config.yaml`-mount note, and how TSM records/labels federated entries (`federated: true`, original `source_timestamp`/`auth_method`/`status_code` in metadata).
- **`docs/configuration.md`** — new "Audit Log Shipping" section (the docs previously covered only retention), linking the federation page.

## Notes

- Federation is gated on a **shared identity store** on the TSM side (its `audit.ingest.v1` capability) — only then do the registry's user/org IDs resolve in TSM's identity tables. The docs state this precondition prominently.
- The header token must equal TSM's `TSM_SUITE_SERVICE_TOKEN` (reuse this app's `TFR_SUITE_SIBLING_TOKEN`). The example uses `${VAR}` expansion so the token stays in a secret.
- A first-class Helm value for the federation shipper is noted as a possible follow-up if there's demand (the chart is env-var based today).