### PR TITLE
fix: default new binary mirrors to stable-only and requires-approval

### DIFF
--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -76,7 +76,9 @@ func (h *TerraformMirrorHandler) CreateConfig(c *gin.Context) {
 	if req.GPGVerify != nil {
 		gpgVerify = *req.GPGVerify
 	}
-	stableOnly := false
+	// Default new mirrors to stable-only so pre-release (alpha/beta/rc) versions
+	// are excluded unless an operator opts in. Explicit false in the request is honored.
+	stableOnly := true
 	if req.StableOnly != nil {
 		stableOnly = *req.StableOnly
 	}
@@ -95,7 +97,9 @@ func (h *TerraformMirrorHandler) CreateConfig(c *gin.Context) {
 		return
 	}
 
-	requiresApproval := false
+	// Default new mirrors to require approval so newly synced versions enter
+	// pending_approval until reviewed. Explicit false in the request is honored.
+	requiresApproval := true
 	if req.RequiresApproval != nil {
 		requiresApproval = *req.RequiresApproval
 	}

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -206,6 +206,93 @@ func TestTMCreateConfig_Success(t *testing.T) {
 	}
 }
 
+// When stable_only and requires_approval are omitted from the request, the
+// handler must default both to true (safe-by-default new mirrors). The INSERT
+// arg positions are $10 = stable_only and $12 = requires_approval.
+func TestTMCreateConfig_DefaultsStableOnlyAndApproval(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE name").
+		WillReturnRows(emptyTMCRows())
+	mock.ExpectQuery("INSERT INTO terraform_mirror_configs").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			sqlmock.AnyArg(), // name
+			sqlmock.AnyArg(), // description
+			sqlmock.AnyArg(), // tool
+			sqlmock.AnyArg(), // enabled
+			sqlmock.AnyArg(), // upstream_url
+			sqlmock.AnyArg(), // platform_filter
+			sqlmock.AnyArg(), // version_filter
+			sqlmock.AnyArg(), // gpg_verify
+			true,             // stable_only -> default true
+			sqlmock.AnyArg(), // sync_interval_hours
+			true,             // requires_approval -> default true
+			sqlmock.AnyArg(), // auto_approve_rules
+			sqlmock.AnyArg(), // created_at
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnRows(sampleTMCRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors",
+		jsonBody(map[string]interface{}{
+			"name":         "my-mirror",
+			"tool":         "terraform",
+			"upstream_url": "https://releases.hashicorp.com",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations (defaults not applied?): %v", err)
+	}
+}
+
+// An explicit stable_only=false / requires_approval=false in the request must
+// be honored and not overridden by the new defaults.
+func TestTMCreateConfig_ExplicitFalseOverridesDefaults(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE name").
+		WillReturnRows(emptyTMCRows())
+	mock.ExpectQuery("INSERT INTO terraform_mirror_configs").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			sqlmock.AnyArg(), // name
+			sqlmock.AnyArg(), // description
+			sqlmock.AnyArg(), // tool
+			sqlmock.AnyArg(), // enabled
+			sqlmock.AnyArg(), // upstream_url
+			sqlmock.AnyArg(), // platform_filter
+			sqlmock.AnyArg(), // version_filter
+			sqlmock.AnyArg(), // gpg_verify
+			false,            // stable_only -> explicit false honored
+			sqlmock.AnyArg(), // sync_interval_hours
+			false,            // requires_approval -> explicit false honored
+			sqlmock.AnyArg(), // auto_approve_rules
+			sqlmock.AnyArg(), // created_at
+			sqlmock.AnyArg(), // updated_at
+		).
+		WillReturnRows(sampleTMCRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors",
+		jsonBody(map[string]interface{}{
+			"name":              "my-mirror",
+			"tool":              "terraform",
+			"upstream_url":      "https://releases.hashicorp.com",
+			"stable_only":       false,
+			"requires_approval": false,
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations (explicit false not honored?): %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ListConfigs tests
 // ---------------------------------------------------------------------------

--- a/backend/internal/db/migrations/000040_terraform_mirror_default_stable_approval.down.sql
+++ b/backend/internal/db/migrations/000040_terraform_mirror_default_stable_approval.down.sql
@@ -1,0 +1,6 @@
+-- Migration 000040 (down): Revert terraform_mirror_configs column defaults to
+-- their original false values. Existing rows are not modified.
+
+ALTER TABLE terraform_mirror_configs
+    ALTER COLUMN stable_only       SET DEFAULT false,
+    ALTER COLUMN requires_approval SET DEFAULT false;

--- a/backend/internal/db/migrations/000040_terraform_mirror_default_stable_approval.up.sql
+++ b/backend/internal/db/migrations/000040_terraform_mirror_default_stable_approval.up.sql
@@ -1,0 +1,15 @@
+-- Migration 000040: Default new terraform_mirror_configs to stable-only and
+-- requires-approval.
+--
+-- New binary mirrors should be safe-by-default: only stable releases are synced
+-- and newly synced versions wait for approval before becoming visible. The API
+-- handler already applies these defaults when the request omits the fields; this
+-- migration aligns the column DEFAULT clauses so direct SQL inserts behave the
+-- same way.
+--
+-- Only the DEFAULT for future inserts changes. Existing rows keep their current
+-- stable_only / requires_approval values.
+
+ALTER TABLE terraform_mirror_configs
+    ALTER COLUMN stable_only       SET DEFAULT true,
+    ALTER COLUMN requires_approval SET DEFAULT true;


### PR DESCRIPTION
## Summary

New Terraform binary mirror configs now default to **stable-only** and **requires-approval** so newly created mirrors are safe-by-default:

- Only stable releases sync (pre-release alpha/beta/rc are excluded).
- Newly synced versions enter `pending_approval` and stay hidden from clients until reviewed.

An explicit `false` in the create request is still honored (the fields are `*bool` pointers, so only an *omitted* field picks up the new default).

## Changes

- `internal/api/admin/terraform_mirror.go`: create handler defaults `stable_only` and `requires_approval` to `true` when omitted.
- `internal/db/migrations/000040_*`: aligns the `terraform_mirror_configs` column `DEFAULT` clauses with the new API behavior so direct SQL inserts match. **Existing rows are not modified.**

## Test plan

- Added `TestTMCreateConfig_DefaultsStableOnlyAndApproval` (omitted → both `true`) and `TestTMCreateConfig_ExplicitFalseOverridesDefaults` (explicit `false` honored).
- `go test ./internal/api/admin/` green; `go vet` + `go build ./...` clean.

Closes #508
