### PR TITLE
fix: show release signing-key rows per configured binary mirror

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -4699,7 +4699,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit \"none\" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
                 "tags": [
                     "Terraform Mirror"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3751,7 +3751,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit \"none\" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
                 "produces": [
                     "application/json"
                 ],

--- a/backend/internal/api/admin/releases_gpg_keys.go
+++ b/backend/internal/api/admin/releases_gpg_keys.go
@@ -14,6 +14,8 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -29,23 +31,66 @@ type releasesGPGKeyRepo interface {
 	Get(ctx context.Context, tool string) (*models.ReleasesGPGKey, error)
 }
 
+// mirrorConfigLister is the subset of the Terraform mirror repository used to
+// discover which binaries are actually configured, so the endpoint only
+// surfaces signing-key rows for those binaries.
+type mirrorConfigLister interface {
+	ListAll(ctx context.Context) ([]models.TerraformMirrorConfig, error)
+}
+
 // ReleasesGPGKeysHandler exposes the GET /api/v1/admin/releases-gpg-keys
 // endpoint. It mirrors the embedded snapshot + cache lookup logic from
 // ReleasesKeyRefreshJob, but as a pure read so the UI can show the same
 // effective state the mirror sync uses.
 type ReleasesGPGKeysHandler struct {
-	repo releasesGPGKeyRepo
-	cfg  config.ReleasesGPGKeysConfig
+	repo    releasesGPGKeyRepo
+	mirrors mirrorConfigLister
+	cfg     config.ReleasesGPGKeysConfig
 }
 
 // NewReleasesGPGKeysHandler constructs a ReleasesGPGKeysHandler.
-func NewReleasesGPGKeysHandler(repo releasesGPGKeyRepo, cfg config.ReleasesGPGKeysConfig) *ReleasesGPGKeysHandler {
-	return &ReleasesGPGKeysHandler{repo: repo, cfg: cfg}
+func NewReleasesGPGKeysHandler(repo releasesGPGKeyRepo, mirrors mirrorConfigLister, cfg config.ReleasesGPGKeysConfig) *ReleasesGPGKeysHandler {
+	return &ReleasesGPGKeysHandler{repo: repo, mirrors: mirrors, cfg: cfg}
 }
 
-// supportedReleasesGPGTools is the canonical iteration order — keep stable so
-// API consumers can rely on the ordering of the response array.
-var supportedReleasesGPGTools = []string{"terraform", "opentofu"}
+// releasesKeyFamily maps a configured binary tool to the signing-key "family"
+// it verifies against: the cache/embedded lookup key, and whether a managed key
+// exists at all. terraform, packer and sentinel are all signed by the same
+// HashiCorp releases key, so they share the "terraform" cache/embedded entry;
+// opentofu has its own key. Everything else (e.g. opa, custom) has no managed
+// signing key yet, so its row is surfaced with an explicit "none" source.
+func releasesKeyFamily(tool string) (keyTool string, hasManagedKey bool) {
+	switch strings.ToLower(tool) {
+	case "terraform", "packer", "sentinel":
+		return "terraform", true
+	case "opentofu":
+		return "opentofu", true
+	default:
+		return "", false
+	}
+}
+
+// configuredTools returns the distinct configured binary tools in a
+// deterministic (sorted) order. Two mirrors for the same tool collapse to one
+// signing-key row, since the key is per-tool, not per-config.
+func (h *ReleasesGPGKeysHandler) configuredTools(ctx context.Context) ([]string, error) {
+	configs, err := h.mirrors.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(configs))
+	tools := make([]string, 0, len(configs))
+	for _, cfg := range configs {
+		tool := strings.ToLower(strings.TrimSpace(cfg.Tool))
+		if tool == "" || seen[tool] {
+			continue
+		}
+		seen[tool] = true
+		tools = append(tools, tool)
+	}
+	sort.Strings(tools)
+	return tools, nil
+}
 
 // ReleasesGPGKeyCacheView is the cache-side block in the response. Embedded
 // in the per-tool object; nil when no row has been persisted yet.
@@ -85,7 +130,7 @@ type ReleasesGPGKeysResponse struct {
 }
 
 // @Summary      Get release signing key cache + expiry state
-// @Description  Returns the current cached upstream release-signing GPG key and embedded snapshot state for each supported tool (terraform, opentofu). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.
+// @Description  Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit "none" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -101,8 +146,14 @@ func (h *ReleasesGPGKeysHandler) GetReleasesGPGKeys(c *gin.Context) {
 		warningDays = 60
 	}
 
-	out := make([]ReleasesGPGKeyStatusView, 0, len(supportedReleasesGPGTools))
-	for _, tool := range supportedReleasesGPGTools {
+	tools, err := h.configuredTools(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list configured mirrors: " + err.Error()})
+		return
+	}
+
+	out := make([]ReleasesGPGKeyStatusView, 0, len(tools))
+	for _, tool := range tools {
 		view, err := h.buildToolView(c.Request.Context(), tool, now, warningDays)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load releases key state: " + err.Error()})
@@ -121,9 +172,18 @@ func (h *ReleasesGPGKeysHandler) buildToolView(ctx context.Context, tool string,
 		Tool:              tool,
 		ExpiryWarningDays: warningDays,
 		Status:            "unknown",
+		EffectiveSource:   "none",
 	}
 
-	cacheRow, err := h.repo.Get(ctx, tool)
+	// Binaries without a managed signing key (e.g. opa, custom) are still listed
+	// so operators can see they are configured, but with an explicit "none"
+	// source and "unknown" status — there is no key to report on yet.
+	keyTool, hasManagedKey := releasesKeyFamily(tool)
+	if !hasManagedKey {
+		return view, nil
+	}
+
+	cacheRow, err := h.repo.Get(ctx, keyTool)
 	if err != nil {
 		return view, err
 	}
@@ -141,7 +201,7 @@ func (h *ReleasesGPGKeysHandler) buildToolView(ctx context.Context, tool string,
 		}
 	}
 
-	embedded := embeddedKeyArmoredForTool(tool)
+	embedded := embeddedKeyArmoredForTool(keyTool)
 	if embedded != "" {
 		if info, parseErr := mirror.ParseReleasesKey(embedded); parseErr == nil {
 			view.Embedded = &ReleasesGPGKeyEmbeddedView{

--- a/backend/internal/api/admin/releases_gpg_keys_test.go
+++ b/backend/internal/api/admin/releases_gpg_keys_test.go
@@ -28,9 +28,41 @@ func (s *stubReleasesRepo) Get(_ context.Context, tool string) (*models.Releases
 	return s.rows[tool], nil
 }
 
+// stubMirrorLister is a configurable test double for mirrorConfigLister.
+type stubMirrorLister struct {
+	configs []models.TerraformMirrorConfig
+	err     error
+}
+
+func (s *stubMirrorLister) ListAll(_ context.Context) ([]models.TerraformMirrorConfig, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.configs, nil
+}
+
+// mirrorListerForTools builds a stub lister with one config per named tool.
+func mirrorListerForTools(tools ...string) *stubMirrorLister {
+	configs := make([]models.TerraformMirrorConfig, 0, len(tools))
+	for _, tool := range tools {
+		configs = append(configs, models.TerraformMirrorConfig{Tool: tool})
+	}
+	return &stubMirrorLister{configs: configs}
+}
+
+// defaultMirrorLister lists terraform + opentofu, matching the historical
+// always-on pair so existing tests exercise both signing-key rows.
+func defaultMirrorLister() *stubMirrorLister {
+	return mirrorListerForTools("terraform", "opentofu")
+}
+
 func newReleasesGPGRouter(t *testing.T, repo releasesGPGKeyRepo, cfg config.ReleasesGPGKeysConfig) *gin.Engine {
+	return newReleasesGPGRouterWithMirrors(t, repo, defaultMirrorLister(), cfg)
+}
+
+func newReleasesGPGRouterWithMirrors(t *testing.T, repo releasesGPGKeyRepo, mirrors mirrorConfigLister, cfg config.ReleasesGPGKeysConfig) *gin.Engine {
 	t.Helper()
-	h := NewReleasesGPGKeysHandler(repo, cfg)
+	h := NewReleasesGPGKeysHandler(repo, mirrors, cfg)
 	r := gin.New()
 	r.GET("/admin/terraform-mirrors/releases-gpg-keys", h.GetReleasesGPGKeys)
 	return r
@@ -249,7 +281,9 @@ func TestReleasesGPGKeys_DBError_Returns500(t *testing.T) {
 	}
 }
 
-func TestReleasesGPGKeys_BothToolsAlwaysReturned(t *testing.T) {
+// When terraform and opentofu are both configured, both signing-key rows are
+// returned. Rows now follow the configured binaries rather than a fixed list.
+func TestReleasesGPGKeys_ConfiguredToolsReturned(t *testing.T) {
 	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
 	r := newReleasesGPGRouter(t, repo, defaultReleasesCfg())
 
@@ -260,6 +294,108 @@ func TestReleasesGPGKeys_BothToolsAlwaysReturned(t *testing.T) {
 	}
 	if !seen["terraform"] || !seen["opentofu"] {
 		t.Errorf("expected both terraform and opentofu in response, got %+v", seen)
+	}
+}
+
+// Only binaries that are actually configured produce a row.
+func TestReleasesGPGKeys_OnlyConfiguredBinariesReturned(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools("opentofu"), defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	if len(body.Keys) != 1 {
+		t.Fatalf("expected 1 key (opentofu only), got %d: %+v", len(body.Keys), body.Keys)
+	}
+	if body.Keys[0].Tool != "opentofu" {
+		t.Errorf("tool = %q, want opentofu", body.Keys[0].Tool)
+	}
+}
+
+// terraform, packer and sentinel all verify against the HashiCorp releases key,
+// so each configured one gets its own row backed by that same embedded key.
+func TestReleasesGPGKeys_SharedHashiCorpKeyPerBinary(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools("packer", "sentinel"), defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	if len(body.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(body.Keys))
+	}
+	hcInfo, err := mirror.ParseReleasesKey(mirror.HashiCorpReleasesGPGKey)
+	if err != nil {
+		t.Fatalf("parse embedded: %v", err)
+	}
+	for _, tool := range []string{"packer", "sentinel"} {
+		row := findTool(t, body, tool)
+		if row.Embedded == nil {
+			t.Fatalf("%s: expected embedded HashiCorp key block", tool)
+		}
+		if row.Embedded.Fingerprint != hcInfo.PrimaryFingerprint {
+			t.Errorf("%s: fingerprint = %q, want HashiCorp %q", tool, row.Embedded.Fingerprint, hcInfo.PrimaryFingerprint)
+		}
+		if row.EffectiveSource != "embedded" {
+			t.Errorf("%s: effective source = %q, want embedded", tool, row.EffectiveSource)
+		}
+	}
+}
+
+// opa has no managed signing key yet: it is still listed (it is configured) but
+// with an explicit "none" source and "unknown" status, and no key blocks.
+func TestReleasesGPGKeys_UnmanagedBinaryHasNoneSource(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools("opa"), defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	if len(body.Keys) != 1 {
+		t.Fatalf("expected 1 key (opa), got %d", len(body.Keys))
+	}
+	opa := findTool(t, body, "opa")
+	if opa.EffectiveSource != "none" {
+		t.Errorf("effective source = %q, want none", opa.EffectiveSource)
+	}
+	if opa.Status != "unknown" {
+		t.Errorf("status = %q, want unknown", opa.Status)
+	}
+	if opa.Cache != nil || opa.Embedded != nil {
+		t.Errorf("expected no cache/embedded for opa, got cache=%v embedded=%v", opa.Cache, opa.Embedded)
+	}
+}
+
+// Nothing configured => empty response (the UI shows its no-data state).
+func TestReleasesGPGKeys_NoConfiguredBinaries_EmptyResponse(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools(), defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	if len(body.Keys) != 0 {
+		t.Fatalf("expected 0 keys when nothing configured, got %d", len(body.Keys))
+	}
+}
+
+// Two mirrors for the same tool collapse to a single signing-key row.
+func TestReleasesGPGKeys_DuplicateToolDeduped(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	lister := &stubMirrorLister{configs: []models.TerraformMirrorConfig{
+		{Tool: "terraform"}, {Tool: "terraform"},
+	}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, lister, defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	if len(body.Keys) != 1 {
+		t.Fatalf("expected 1 deduped terraform row, got %d", len(body.Keys))
+	}
+}
+
+// A failure listing configured mirrors surfaces as a 500.
+func TestReleasesGPGKeys_MirrorListError_Returns500(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	lister := &stubMirrorLister{err: errors.New("db down")}
+	r := newReleasesGPGRouterWithMirrors(t, repo, lister, defaultReleasesCfg())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/terraform-mirrors/releases-gpg-keys", nil))
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -602,7 +602,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize Terraform binary mirror admin handler
 	tfMirrorAdminHandler := admin.NewTerraformMirrorHandler(tfMirrorRepo)
 	tfMirrorAdminHandler.SetSyncJob(tfMirrorSyncJob)
-	releasesGPGKeysAdminHandler := admin.NewReleasesGPGKeysHandler(releasesKeyRepo, cfg.ReleasesGPGKeys)
+	releasesGPGKeysAdminHandler := admin.NewReleasesGPGKeysHandler(releasesKeyRepo, tfMirrorRepo, cfg.ReleasesGPGKeys)
 	versionApprovalHandler := admin.NewVersionApprovalHandler(repositories.NewVersionApprovalRepository(sqlxDB))
 	providerAdminHandlers := admin.NewProviderAdminHandlers(db, storageBackend, cfg)
 	moduleAdminHandlers := admin.NewModuleAdminHandlers(db, storageBackend, cfg).


### PR DESCRIPTION
## Summary

The releases-gpg-keys admin endpoint returned a fixed `terraform` + `opentofu` pair regardless of what was actually configured. It now **enumerates the configured binary mirrors** and emits one signing-key row per configured binary.

- `terraform`, `packer`, and `sentinel` each report the shared **HashiCorp** releases key.
- `opentofu` reports its own key.
- Binaries without a managed signing key yet (e.g. `opa`) are listed with an explicit `effective_source: "none"` and `status: "unknown"`, so the gap is visible rather than hidden.
- Tools are de-duplicated (two mirrors of the same tool → one row) and sorted for stable output.

## Changes

- `internal/api/admin/releases_gpg_keys.go`: replace the hardcoded tool list with `configuredTools()` (via `ListAll`), add `releasesKeyFamily()` to map a binary to its key family, and surface unmanaged binaries with a `none` source.
- `internal/api/router.go`: inject the Terraform mirror repo into the handler.

## Test plan

- Added per-binary tests: only-configured-returned, shared-HashiCorp-key (packer/sentinel), unmanaged `none`/`unknown` (opa), empty response, dedupe, and mirror-list error → 500.
- `go test ./internal/api/admin/` green (16 tests); `go vet ./internal/api/...` + `go build ./...` clean.

## Companion

Frontend type update (adds `none` to the `effective_source` union): sethbacon/terraform-registry-frontend `fix/signing-keys-per-binary`.

Closes #507
