### PR TITLE
fix(mirror): surface OPA as unsigned-upstream, not a silent GPG skip (#509)

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -4699,7 +4699,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit \"none\" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own. Binaries whose upstream publishes no release signature (e.g. opa — checksum-only) are listed with an explicit \"none\" source and an \"unsigned\" status, so operators can see they are verified by checksum but not by signature (distinct from \"unknown\"). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -16869,7 +16869,7 @@
                         "type": "integer"
                     },
                     "status": {
-                        "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\"",
+                        "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\" | \"unsigned\"",
                         "type": "string"
                     },
                     "tool": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3751,7 +3751,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit \"none\" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
+                "description": "Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own. Binaries whose upstream publishes no release signature (e.g. opa — checksum-only) are listed with an explicit \"none\" source and an \"unsigned\" status, so operators can see they are verified by checksum but not by signature (distinct from \"unknown\"). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.",
                 "produces": [
                     "application/json"
                 ],
@@ -13808,7 +13808,7 @@
                     "type": "integer"
                 },
                 "status": {
-                    "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\"",
+                    "description": "\"ok\" | \"warn\" | \"expired\" | \"unknown\" | \"unsigned\"",
                     "type": "string"
                 },
                 "tool": {

--- a/backend/internal/api/admin/releases_gpg_keys.go
+++ b/backend/internal/api/admin/releases_gpg_keys.go
@@ -121,7 +121,7 @@ type ReleasesGPGKeyStatusView struct {
 	Embedded          *ReleasesGPGKeyEmbeddedView `json:"embedded"`
 	EffectiveSource   string                      `json:"effective_source"` // "cache" | "embedded"
 	ExpiryWarningDays int                         `json:"expiry_warning_days"`
-	Status            string                      `json:"status"` // "ok" | "warn" | "expired" | "unknown"
+	Status            string                      `json:"status"` // "ok" | "warn" | "expired" | "unknown" | "unsigned"
 }
 
 // ReleasesGPGKeysResponse is the top-level response envelope.
@@ -130,7 +130,7 @@ type ReleasesGPGKeysResponse struct {
 }
 
 // @Summary      Get release signing key cache + expiry state
-// @Description  Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own; binaries without a managed signing key (e.g. opa) are listed with an explicit "none" source. The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.
+// @Description  Returns the current cached upstream release-signing GPG key and embedded snapshot state for each configured binary mirror. Binaries that share the HashiCorp releases key (terraform, packer, sentinel) each report that key's state; opentofu reports its own. Binaries whose upstream publishes no release signature (e.g. opa — checksum-only) are listed with an explicit "none" source and an "unsigned" status, so operators can see they are verified by checksum but not by signature (distinct from "unknown"). The response includes the fingerprint, expiry, and a pre-computed status against the configured warning threshold so UIs can render a glance-level view without re-deriving the rules.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -180,6 +180,15 @@ func (h *ReleasesGPGKeysHandler) buildToolView(ctx context.Context, tool string,
 	// source and "unknown" status — there is no key to report on yet.
 	keyTool, hasManagedKey := releasesKeyFamily(tool)
 	if !hasManagedKey {
+		// OPA-style tools publish no release signature at all (only per-file
+		// SHA-256 checksums), so mirror sync verifies them by checksum and can't
+		// check authenticity. Mark them "unsigned" so the UI shows an intentional
+		// "unsigned upstream" state rather than "unknown" — which reads like
+		// missing data or a misconfiguration. Genuinely unclassified tools (no
+		// managed key and not known-unsigned) keep the default "unknown".
+		if mirror.IsUnsignedUpstreamTool(tool) {
+			view.Status = "unsigned"
+		}
 		return view, nil
 	}
 

--- a/backend/internal/api/admin/releases_gpg_keys_test.go
+++ b/backend/internal/api/admin/releases_gpg_keys_test.go
@@ -339,9 +339,11 @@ func TestReleasesGPGKeys_SharedHashiCorpKeyPerBinary(t *testing.T) {
 	}
 }
 
-// opa has no managed signing key yet: it is still listed (it is configured) but
-// with an explicit "none" source and "unknown" status, and no key blocks.
-func TestReleasesGPGKeys_UnmanagedBinaryHasNoneSource(t *testing.T) {
+// opa publishes no release signature (checksum-only). It is still listed (it is
+// configured) with an explicit "none" source, no key blocks, and an "unsigned"
+// status — so operators see it is verified by checksum but not by signature,
+// distinct from a missing-data "unknown".
+func TestReleasesGPGKeys_UnsignedUpstreamBinaryHasUnsignedStatus(t *testing.T) {
 	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
 	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools("opa"), defaultReleasesCfg())
 
@@ -353,11 +355,28 @@ func TestReleasesGPGKeys_UnmanagedBinaryHasNoneSource(t *testing.T) {
 	if opa.EffectiveSource != "none" {
 		t.Errorf("effective source = %q, want none", opa.EffectiveSource)
 	}
-	if opa.Status != "unknown" {
-		t.Errorf("status = %q, want unknown", opa.Status)
+	if opa.Status != "unsigned" {
+		t.Errorf("status = %q, want unsigned", opa.Status)
 	}
 	if opa.Cache != nil || opa.Embedded != nil {
 		t.Errorf("expected no cache/embedded for opa, got cache=%v embedded=%v", opa.Cache, opa.Embedded)
+	}
+}
+
+// A configured tool that is neither key-managed nor known-unsigned keeps the
+// default "unknown" status — the "unsigned" marker is reserved for tools we know
+// publish no signature (opa), not for unclassified ones.
+func TestReleasesGPGKeys_UnclassifiedToolIsUnknown(t *testing.T) {
+	repo := &stubReleasesRepo{rows: map[string]*models.ReleasesGPGKey{}}
+	r := newReleasesGPGRouterWithMirrors(t, repo, mirrorListerForTools("futuretool"), defaultReleasesCfg())
+
+	_, body := invokeAndDecode(t, r)
+	row := findTool(t, body, "futuretool")
+	if row.EffectiveSource != "none" {
+		t.Errorf("effective source = %q, want none", row.EffectiveSource)
+	}
+	if row.Status != "unknown" {
+		t.Errorf("status = %q, want unknown", row.Status)
 	}
 }
 

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -477,7 +477,16 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 				}
 			}
 		} else {
-			log.Printf("[terraform-mirror] GPG verify enabled but no key for tool %q — skipping GPG check", cfg.Tool)
+			if mirror.IsUnsignedUpstreamTool(cfg.Tool) {
+				// OPA (and any other unsigned-upstream tool) publishes no release
+				// signature — only per-file SHA-256 checksums, already fetched into
+				// `sums` and checked per binary below. Integrity is verified;
+				// authenticity cannot be. Surface this honestly rather than as a
+				// missing-key warning (the admin signing-keys view shows the same).
+				log.Printf("[terraform-mirror] %s publishes no release signature; verifying %s by checksum only (no GPG)", cfg.Tool, version)
+			} else {
+				log.Printf("[terraform-mirror] GPG verify enabled but no key for tool %q — skipping GPG check", cfg.Tool)
+			}
 		}
 	}
 

--- a/backend/internal/mirror/signing.go
+++ b/backend/internal/mirror/signing.go
@@ -1,0 +1,25 @@
+package mirror
+
+import "strings"
+
+// unsignedUpstreamTools lists tools whose upstream publishes release binaries
+// WITHOUT any cryptographic signature — only SHA-256 checksums (per-file
+// .sha256 sidecars). For these, mirror sync verifies integrity via those
+// checksums but cannot verify authenticity: there is simply no signature to
+// check. This is an intentional, documented state — distinct from a tool that
+// SHOULD be signed but has no key configured, which is a likely misconfiguration.
+//
+// OPA (open-policy-agent/opa) is the canonical case: its GitHub releases ship
+// opa_<os>_<arch> binaries each with a sibling opa_<os>_<arch>.sha256, and no
+// .sig / SHA256SUMS / cosign artifacts.
+var unsignedUpstreamTools = map[string]bool{
+	"opa": true,
+}
+
+// IsUnsignedUpstreamTool reports whether the given tool's upstream publishes no
+// release signatures (checksum-only verification is the best available). Used so
+// the mirror sync and the admin signing-keys view can present OPA honestly as
+// "unsigned upstream" rather than as a missing-key error or a silent skip.
+func IsUnsignedUpstreamTool(tool string) bool {
+	return unsignedUpstreamTools[strings.ToLower(strings.TrimSpace(tool))]
+}

--- a/backend/internal/mirror/signing_test.go
+++ b/backend/internal/mirror/signing_test.go
@@ -1,0 +1,18 @@
+package mirror
+
+import "testing"
+
+func TestIsUnsignedUpstreamTool(t *testing.T) {
+	// OPA is unsigned upstream; matching is case-insensitive and trims space.
+	for _, tool := range []string{"opa", "OPA", "Opa", " opa "} {
+		if !IsUnsignedUpstreamTool(tool) {
+			t.Errorf("IsUnsignedUpstreamTool(%q) = false, want true", tool)
+		}
+	}
+	// Key-managed tools and unclassified/empty values are not unsigned-upstream.
+	for _, tool := range []string{"terraform", "opentofu", "packer", "sentinel", "custom", ""} {
+		if IsUnsignedUpstreamTool(tool) {
+			t.Errorf("IsUnsignedUpstreamTool(%q) = true, want false", tool)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #509 (backend half).

## Finding

OPA publishes **no release signatures** — only per-binary `.sha256` checksums (verified against v1.17.1: `opa_<os>_<arch>` + `opa_<os>_<arch>.sha256`; no `.sig`, no `SHA256SUMS`, no cosign). So OPA **cannot** be signature-verified upstream — this is the issue's **option 3** (make the skip explicit + surfaced), not options 1/2.

OPA binaries **are already integrity-checked** (the `GitHubReleasesClient` `FetchSHASums` per-file `.sha256` fallback). The defect is *honesty*: the gap was presented as if it were a bug —
- `gpgKeyForTool`'s generic `default: return ""` → sync logged *"no key — skipping"* (sounds like a misconfiguration), and
- the admin signing-keys view showed OPA as `status: "unknown"` (reads like missing data).

## Change

One source of truth + honest surfacing (no behavior change to verification — checksum integrity already runs):

- **`mirror.IsUnsignedUpstreamTool(tool)`** — `opa` today; documents *unsigned-upstream-by-design* vs *missing key*.
- **Sync log** (`terraform_mirror_sync.go`): unsigned-upstream + no key → *"OPA publishes no release signature; verifying <ver> by checksum only (no GPG)"*. A genuinely missing key for a tool that *should* be signed is still warned.
- **Admin view** (`releases_gpg_keys.go`): unsigned-upstream tools report `status: "unsigned"` (source stays `"none"`) — distinct from `"unknown"` (unclassified). Doc updated.

## Acceptance criteria

- ✅ Skipping is **explicit + surfaced** (honest log + `"unsigned"` status), not silent.
- ✅ OPA's **actual** mechanism (per-file `.sha256` checksum) is used — not assumed to match the HashiCorp `SHA256SUMS`+GPG flow.
- ✅ Tests: helper, the `"unsigned"` view status for opa, and that an unclassified tool stays `"unknown"`.

## Verification

`gofmt`/`build`/`vet` clean; new tests pass; `gosec` introduces no new findings (additions are a map/helper/log/string); `swagger.json` regenerated.

The frontend "unsigned upstream — checksum only" chip follows in terraform-registry-frontend.