### PR TITLE
fix(audit): log binary-mirror admin actions as binary_mirror (#506)

### DIFF
--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -193,9 +193,15 @@ func getResourceType(c *gin.Context) string {
 		return "scanning"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/approvals"):
 		return "approval"
-	case strings.HasPrefix(fullPath, "/api/v1/admin/terraform-mirror"):
-		return "terraform_mirror"
-	case strings.HasPrefix(fullPath, "/api/v1/admin/binary-mirror"):
+	// The hosted binary-mirror admin API lives under /admin/terraform-mirror*
+	// (the original route prefix) but mirrors ALL binaries — terraform, opentofu,
+	// opa, packer, sentinel — so its audit resource_type reads "binary_mirror".
+	// The /admin/binary-mirror prefix is folded in for forward-compat (no such
+	// route is mounted today). Historical rows already written as
+	// "terraform_mirror" are intentionally left as-is for audit-trail integrity;
+	// only go-forward labels change.
+	case strings.HasPrefix(fullPath, "/api/v1/admin/terraform-mirror"),
+		strings.HasPrefix(fullPath, "/api/v1/admin/binary-mirror"):
 		return "binary_mirror"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/policies"):
 		return "policy"

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -176,6 +176,10 @@ func TestAuditMiddleware_ResourceTypeDetection(t *testing.T) {
 		{"/api/v1/organizations/some-id", "organization"},
 		{"/api/v1/organizations/some-id/members", "organization"},
 		{"/api/v1/admin/mirrors/y", "mirror"},
+		// The hosted binary-mirror admin API (mounted under /admin/terraform-mirror*)
+		// and the forward-compat /admin/binary-mirror prefix both audit as "binary_mirror".
+		{"/api/v1/admin/terraform-mirrors/some-id", "binary_mirror"},
+		{"/api/v1/admin/binary-mirror/x", "binary_mirror"},
 		{"/other/z", "unknown"},
 	}
 


### PR DESCRIPTION
Closes #506.

## Why

Audit entries for the hosted binary-mirror admin API recorded `resource_type = "terraform_mirror"`, but the feature mirrors **all** binaries (terraform, opentofu, opa, packer, sentinel) — misleading per UAT.

## Change

`getResourceType` now maps `/admin/terraform-mirror*` (the live route prefix) to **`binary_mirror`**, matching the "binary mirror" terminology the recent UX PRs adopted. The forward-compat `/admin/binary-mirror` prefix folds into the same case.

## Resolving the issue's open questions

- **Taxonomy / collision:** no real collision — there is **no `/admin/binary-mirror` route mounted** (only `/admin/terraform-mirrors`), so the prior separate `binary_mirror` case was **dead code**. Consolidated both prefixes to one `binary_mirror` type.
- **Historical rows:** left **as-is** (audit-trail integrity) — only go-forward labels change. Documented in a code comment.
- **UI/filters:** verified nothing queries `resource_type = 'terraform_mirror'` (every other `terraform_mirror` hit is the unrelated `terraform_mirror_configs` DB table or comments — out of scope).

## Acceptance criteria

- ✅ New audit entries use `binary_mirror`.
- ✅ No collision/ambiguity (the dead `binary_mirror` case is consolidated).
- ✅ Historical-rows decision recorded (leave as-is).
- ✅ No UI/filter consumers of the old value.

## Verification

`gofmt`/`build`/`vet` clean; the audit resource-type table test now covers both prefixes → `binary_mirror`. No swagger annotations touched (so no regen-bot `[skip ci]` follow-up — this PR's head gets real checks).