### PR TITLE
fix: align backend docs with the code, fix EKS/GKE authMethod, wire up upgrade preflight

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Then rebuild the binary (the spec is embedded at compile time). Add or update th
 ## Database Migrations
 
 - **Never edit existing migration files.** The migration system treats file content as immutable.
-- Create a new numbered pair: `000029_description.up.sql` and `000029_description.down.sql`.
+- Create a new numbered pair using the next sequential number after the highest existing migration: `0000NN_description.up.sql` and `0000NN_description.down.sql`.
 - The down migration must fully reverse the up migration.
 - Test both directions before submitting:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains the backend API, database migrations, and deployment in
 ### Authentication & Authorization
 
 - **API Key Authentication** — Secure token-based access with scoped permissions
+- **Cookie-based JWT sessions** — Browser auth uses an HttpOnly `tfr_auth_token` cookie (never exposed to page JavaScript), protected by a `tfr_csrf` double-submit CSRF token
 - **OIDC Integration** — Generic OIDC provider support for SSO
 - **Azure AD / Entra ID** — Native Azure Active Directory integration
 - **Role-Based Access Control (RBAC)** — Fine-grained permissions with organization roles
@@ -74,7 +75,7 @@ the full matrix, recommended targets, and step-by-step instructions.
 
 ### Observability & CI/CD
 
-- **Prometheus Metrics** — Eleven named application metrics on a dedicated scrape port (default 9090)
+- **Prometheus Metrics** — A suite of named application metrics on a dedicated scrape port (default 9090); see [docs/observability.md](docs/observability.md) for the authoritative catalogue
 - **Structured Logging** — stdlib `slog` with JSON (production) and text (development) formats
 - **pprof Profiling** — Opt-in profiling server on a configurable port
 - **GitHub Actions CI/CD** — Build, vet, race-detector tests, gosec security scan, Docker build, multi-platform releases
@@ -88,11 +89,11 @@ the full matrix, recommended targets, and step-by-step instructions.
 | HTTP framework  | Gin                                                         |
 | Database        | PostgreSQL 14+ (16 recommended)                             |
 | Migrations      | `golang-migrate` (file-based, immutable numbered pairs)     |
-| Auth            | JWT (HS256), API keys, OIDC, Azure AD                       |
+| Auth            | HttpOnly cookie JWT sessions (HS256) + CSRF double-submit, API keys, OIDC, Azure AD |
 | Storage         | Local FS, Azure Blob, AWS S3 (+compatible), Google Cloud    |
 | SCM             | GitHub, Azure DevOps, GitLab, Bitbucket Data Center         |
 | Observability   | Prometheus metrics, `slog` JSON logs, pprof                 |
-| API docs        | Swagger 2.0 (swag annotations) → served at `/swagger`       |
+| API docs        | Swagger 2.0 (swag annotations) → UI at `/api-docs/` (spec at `/swagger.json`) |
 | Build / release | GoReleaser, GitHub Actions, cosign keyless, SLSA, syft SBOM |
 
 ## Architecture
@@ -134,7 +135,7 @@ cd terraform-registry-backend
 
 # Start all services (backend + postgres; frontend served separately)
 cd deployments
-docker-compose up -d
+docker compose up -d
 
 # Backend API: http://localhost:8080
 # PostgreSQL:  localhost:5432
@@ -223,7 +224,7 @@ curl -s http://localhost:9090/metrics | grep '^http_requests_total'
 
 ```bash
 cd deployments
-docker-compose --profile monitoring up -d
+docker compose --profile monitoring up -d
 # Prometheus UI: http://localhost:9091
 # Grafana:       http://localhost:3001  (admin / admin)
 ```
@@ -293,6 +294,7 @@ go build -o terraform-registry cmd/server/main.go
 ## Documentation
 
 - [Getting Started](docs/getting-started.md) — Quick-start tutorial for new users
+- [Initial Setup](docs/initial-setup.md) — First-run setup wizard (OIDC/LDAP, storage, admin)
 - [Architecture](docs/architecture.md) — System design and component interactions
 - [Architecture Decision Records](docs/adr/) — Key design decisions and rationale
 - [API Reference](docs/api-reference.md) — API documentation guide
@@ -300,6 +302,8 @@ go build -o terraform-registry cmd/server/main.go
 - [Configuration Reference](docs/configuration.md) — All `TFR_*` environment variables
 - [Deployment Guide](docs/deployment.md) — Production deployment for all platforms
 - [Kubernetes Cloud Guides](docs/deployment/README.md) — AKS, EKS, and GKE deployment guides
+- [Air-Gap Installation](docs/air-gap-install.md) — Offline/disconnected installation
+- [Upgrade Guide](docs/upgrade-guide.md) — Version upgrade procedures and preflight checks
 - [Capacity Planning](docs/capacity-planning.md) — Sizing guidance for production deployments
 - [Disaster Recovery](docs/disaster-recovery.md) — DR runbook and backup/restore procedures
 - [Observability Reference](docs/observability.md) — Prometheus metrics catalogue
@@ -308,9 +312,24 @@ go build -o terraform-registry cmd/server/main.go
 - [OIDC Configuration](docs/OIDC_CONFIGURATION.md) — SSO provider setup
 - [Module Security Scanning](docs/module-scanning.md) — Scanner setup (Trivy, Checkov, Terrascan, Snyk, custom)
 - [Module Documentation Extraction](docs/module-documentation.md) — Automatic extraction of inputs, outputs, and provider requirements
+- [Version Approval](docs/version-approval.md) — Version-level approval gate for mirrored providers
 - [Terraform CLI Configuration](docs/terraform-cli-configuration.md) — Configure the Terraform CLI to use this registry
-- [Releasing](RELEASING.md) — Release process and supply-chain verification
+
+### Suite / Coupling
+
+- [Shared Identity Schema](docs/identity-schema.md) — Sharing one identity store across the Terraform suite
+- [Suite Audit Federation](docs/suite-audit-federation.md) — Forwarding audit events to the suite ingest side
+
+### Security & Compliance
+
 - [Security](SECURITY.md) — Reporting vulnerabilities and supported versions
+- [Threat Model](docs/threat-model.md) — STRIDE threat model and mitigations
+- [Secrets Rotation](docs/secrets-rotation.md) — Rotating JWT/encryption/OAuth secrets
+- [Data Residency](docs/data-residency.md) — Regional data-residency and GDPR guidance
+
+### Project
+
+- [Releasing](RELEASING.md) — Release process and supply-chain verification
 - [Contributing](CONTRIBUTING.md) — How to contribute to this project
 - [Code of Conduct](CODE_OF_CONDUCT.md) — Community standards
 - [Changelog](CHANGELOG.md) — Version history and changes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ Releases are fully automated via `release-please.yml` and `release.yml`.
 2. **release-please maintains an open release PR** titled `chore(main): release X.Y.Z`.
    - It accumulates `CHANGELOG.md` entries from merged PR titles.
    - It bumps the version in `deployments/helm/Chart.yaml` (`appVersion` + `version`).
-   - `feat:` → minor bump, `fix:` / `perf:` / `security:` → patch bump, `feat!:` or `BREAKING CHANGE:` → major bump.
+   - `feat:` → minor bump, `fix:` / `perf:` → patch bump, `feat!:` or `BREAKING CHANGE:` → major bump.
    - The PR auto-updates as more commits land on `main`. Review it at any time to preview what will ship.
 
 3. **When ready to release**, review and squash-merge the release-please PR. That is the only required human action.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -109,9 +109,45 @@ func run() error {
 	case "version":
 		fmt.Printf("Terraform Registry v%s (built %s)\n", Version, BuildDate)
 		return nil
+	case "upgrade":
+		return runUpgrade(configPath)
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version", command)
+		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade", command)
 	}
+}
+
+// runUpgrade dispatches the `upgrade` command's subcommands. Currently only
+// `upgrade preflight` is supported, which runs pre-upgrade validation via
+// RunUpgradePreflight (see upgrade.go). Flags are parsed from os.Args without a
+// cobra dependency to match the rest of the CLI surface.
+func runUpgrade(configPath string) error {
+	if len(os.Args) < 3 || os.Args[2] != "preflight" {
+		return fmt.Errorf("usage: %s upgrade preflight [--config <path>] [--verbose]", os.Args[0])
+	}
+
+	// Parse the documented flags. --config overrides the CONFIG_PATH env var;
+	// --verbose enables detailed output.
+	verbose := false
+	args := os.Args[3:]
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--verbose":
+			verbose = true
+		case "--config":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--config requires a path argument")
+			}
+			configPath = args[i+1]
+			i++
+		default:
+			return fmt.Errorf("unknown flag for 'upgrade preflight': %s", args[i])
+		}
+	}
+
+	if code := RunUpgradePreflight(configPath, verbose); code != 0 {
+		os.Exit(code)
+	}
+	return nil
 }
 
 func serve(cfg *config.Config) error {

--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -33,7 +33,20 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000024 | `module_deprecation`                   | ✅ Yes         | Drops deprecation columns; existing deprecation data lost |
 | 000025 | `org_idp_binding`                      | ✅ Yes         | Drops IdP binding columns; IdP associations lost          |
 | 000026 | `org_quotas`                           | ✅ Yes         | Drops quota tables; quota config and usage data lost      |
+| 000027 | `setup_ldap`                           | ✅ Yes         | Drops LDAP setup columns from `system_settings`           |
+| 000028 | `module_version_replacement_source`    | ✅ Yes         | Drops replacement-source column                           |
+| 000029 | `webhook_approval_tokens`              | ✅ Yes         | Drops the approval-tokens table                           |
+| 000030 | `scan_execution_log`                   | ✅ Yes         | Drops scan execution-log column                           |
+| 000031 | `backfill_scanner_name`                | ⚠️ No-op down  | Data backfill; the down migration cannot meaningfully revert it |
+| 000032 | `cve_advisories`                       | ✅ Yes         | Drops the CVE advisory tables                             |
+| 000033 | `ui_theme_config`                      | ✅ Yes         | Drops the UI theme config table                           |
+| 000034 | `terraform_version_signature_storage`  | ✅ Yes         | Drops Terraform-version signature storage-key columns     |
+| 000035 | `provider_version_signature_storage`   | ✅ Yes         | Drops provider-version signature storage-key columns      |
 | 000036 | `releases_gpg_keys`                    | ✅ Yes         | Drops the cached upstream-key table; cache is rebuilt on next refresh tick |
+| 000037 | `version_approval`                      | ✅ Yes         | Drops approval columns/indexes and the `version_approval_events` table; approval state lost |
+| 000038 | `feature_fk_to_identity`               | ✅ Yes         | Reverts feature-table FKs to `public.{users,organizations}`; no-op when the `identity` schema is absent |
+| 000039 | `add_packer_sentinel_opa_tools`        | ⚠️ Conditional | Restores the original tool CHECK constraint; the down fails if rows use `packer`/`sentinel`/`opa` |
+| 000040 | `terraform_mirror_default_stable_approval` | ✅ Yes     | Reverts column defaults; existing rows are not modified   |
 
 ## How to Run Migrations
 
@@ -83,11 +96,31 @@ migrate -path backend/internal/db/migrations \
   -database "postgres://user:pass@host:5432/terraform_registry?sslmode=disable" \
   force 23
 
-# Or use the fix-migration helper
-go run ./cmd/fix-migration --version 23
+# Or use the fix-migration helper, which clears the dirty flag automatically
+# (pass --dry-run to only report the current migration state)
+go run ./cmd/fix-migration
 ```
 
 ## Rollback Procedures by Version Upgrade
+
+### Rolling back 1.0.0 → 0.10.x
+
+The 1.0.0 line adds migrations 027–040 on top of the 0.10.0 schema (which ended at
+migration 026). To return to 0.10.x, roll back to migration 026:
+
+```bash
+# 1. Stop the 1.0.0 backend
+# 2. Roll back migrations 027–040 (one version at a time)
+migrate ... goto 26
+# 3. Deploy 0.10.x
+# 4. Verify: curl /health
+```
+
+**Data loss:** LDAP setup config, CVE advisories, UI theme config, scan execution
+logs, signature storage keys, and all version-approval state (including the
+`version_approval_events` table) are dropped. Migration 039's down also fails if any
+`terraform_mirror_configs` rows use the `packer`/`sentinel`/`opa` tools — update or
+remove those rows before rolling back past 039.
 
 ### Rolling back 0.10.0 → 0.9.x
 

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -220,7 +220,7 @@ var APIKeyExpiryNotificationsSentTotal = promauto.NewCounter(
 
 // RateLimitRejectionsTotal is a CounterVec with labels {tier, key_type} incremented
 // each time a request is rejected (HTTP 429) by the rate limiting middleware.
-// tier is "individual" or "organization"; key_type is "user", "apikey", "ip", or "org".
+// tier is "individual", "organization", or "principal"; key_type is "user", "apikey", "ip", or "org".
 //
 // Example PromQL queries:
 //   - Rejection rate by tier:     sum by (tier) (rate(rate_limit_rejections_total[5m]))

--- a/deployments/helm/values-eks.yaml
+++ b/deployments/helm/values-eks.yaml
@@ -80,7 +80,9 @@ storage:
     bucket: "<S3_BUCKET_NAME>"
     # Use IRSA (IAM Roles for Service Accounts) — no static credentials needed.
     # The pod's ServiceAccount role must have s3:GetObject, s3:PutObject, etc.
-    authMethod: "irsa"
+    # "default" uses the AWS default credential chain, which automatically
+    # consumes the IRSA web-identity token — no explicit IRSA auth method exists.
+    authMethod: "default"
     accessKeyId: ""
     secretAccessKey: ""
   persistence:

--- a/deployments/helm/values-gke.yaml
+++ b/deployments/helm/values-gke.yaml
@@ -80,7 +80,7 @@ storage:
     bucket: "<GCS_BUCKET_NAME>"
     projectId: "<PROJECT_ID>"
     # Workload Identity provides credentials — no key file needed.
-    authMethod: "workload-identity"
+    authMethod: "workload_identity"
     credentialsFile: ""
   persistence:
     enabled: false

--- a/docs/OIDC_CONFIGURATION.md
+++ b/docs/OIDC_CONFIGURATION.md
@@ -155,6 +155,38 @@ dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64
 python3 -c "import secrets; print(secrets.token_hex(32))"
 ```
 
+### Group-to-Role Mapping
+
+When the IdP emits a groups claim (see each provider's section below for how to
+add one), the registry can map those groups to organization membership and role
+templates on every login. Three config keys under `auth.oidc` control this:
+
+- **`group_claim_name`** (`TFR_AUTH_OIDC_GROUP_CLAIM_NAME`) — the ID-token claim
+  that carries the user's groups (commonly `groups`).
+- **`group_mappings`** — a list of `{group, organization, role}` entries. Each
+  matched group assigns (or updates) the user's membership in that organization
+  with that role template.
+- **`default_role`** (`TFR_AUTH_OIDC_DEFAULT_ROLE`) — role template assigned when
+  no group matches. Leave empty to make unmatched users members with no role
+  template.
+
+```yaml
+auth:
+  oidc:
+    group_claim_name: "groups"
+    default_role: "viewer"
+    group_mappings:
+      - group: "registry-admins"
+        organization: "default"
+        role: "admin"
+      - group: "platform-team"
+        organization: "default"
+        role: "editor"
+```
+
+As with all OIDC settings, database-stored configuration (from the setup wizard)
+takes precedence over env/file values.
+
 ### Finding Your Issuer URL
 
 The OIDC issuer URL is the base endpoint for your identity provider. It should resolve to a `.well-known/openid-configuration` endpoint. Common formats:
@@ -170,6 +202,11 @@ To verify, append `/.well-known/openid-configuration` to the URL - it should ret
 ---
 
 ## Supported Providers
+
+The registry uses generic OIDC discovery (`coreos/go-oidc`), so **any
+OIDC-compliant provider is supported**. The providers below have step-by-step
+guides. In every case, request `openid`, `email`, and `profile` (plus `groups`
+when using group-based RBAC).
 
 ### Azure AD / Microsoft Entra ID
 
@@ -187,7 +224,7 @@ To verify, append `/.well-known/openid-configuration` to the URL - it should ret
 
 - **Maturity:** Production-ready
 - **Features:** Social login, multi-factor authentication, extensive integrations
-- **Scopes:** `openid`, `email`, `profile`, `identities`
+- **Scopes:** `openid`, `email`, `profile` (plus `groups` for RBAC)
 - **Protocol:** OAuth 2.0 + OIDC v1.0
 
 ### Okta
@@ -218,22 +255,13 @@ To verify, append `/.well-known/openid-configuration` to the URL - it should ret
 - **Scopes:** `openid`, `email`, `profile`
 - **Protocol:** OAuth 2.0 + OIDC v1.0
 
-### Okta Workforce Identity Cloud
-
-**Best for:** Customer identity and access management (CIAM)
-
-- **Maturity:** Production-ready
-- **Features:** Consumer identity, API access management, passwordless auth
-- **Scopes:** Customizable per application
-- **Protocol:** OAuth 2.0 + OIDC v1.0
-
 ### PingIdentity / Ping One
 
 **Best for:** Hybrid identity environments, legacy system integration
 
 - **Maturity:** Production-ready, enterprise-grade
 - **Features:** Multi-protocol support, risk assessment, device management
-- **Scopes:** `openid`, `email`, `profile`, `identities`
+- **Scopes:** `openid`, `email`, `profile` (plus `groups` for RBAC)
 - **Protocol:** OAuth 2.0 + OIDC v1.0
 
 ---
@@ -664,8 +692,8 @@ openssl rand -hex 32
 
 ### 6. Token Expiration
 
-- Browser session JWTs (and their cookies) live for 4 hours; the frontend
-  silently refreshes before expiry
+- Browser session JWTs (and their cookies) live for 24 hours (86400 seconds);
+  the frontend silently refreshes before expiry
 - API keys should have optional expiration dates
 - Implement token refresh mechanism for long-lived sessions
 - Monitor for and invalidate compromised tokens

--- a/docs/SWAGGER_ANNOTATION_CHECKLIST.md
+++ b/docs/SWAGGER_ANNOTATION_CHECKLIST.md
@@ -7,7 +7,14 @@ This checklist tracks Swagger/OpenAPI annotation progress for all API endpoints 
 
 **Target**: 100% API coverage with Swagger annotations
 
-**Current Status**: ✅ 127/127 annotated (100%) — All Gin-router endpoints complete
+**Current Status**: ⚠️ Partial — this checklist is a manually-maintained subset and has
+drifted from the generated spec. The current `backend/docs/swagger.json` contains **211
+operations across 160 paths**. Numerous live routes are not listed here (e.g. `/v2/*` OCI,
+`/api/v1/admin/quotas`, `/api/v1/admin/advisories`, `/api/v1/admin/policy/*`,
+`/api/v1/ui/theme` & `/api/v1/ui/config`, `/api/v1/suite/*`, module reanalyze and
+module-level deprecate/undeprecate, version-approval bulk endpoints, GDPR export/erase,
+`/api/v1/dev/*`, and `/openapi3.json`). Treat the generated spec — not this file — as the
+source of truth, and regenerate this checklist before relying on it as an endpoint map.
 
 See the **Out-of-Band Endpoints** section at the bottom for observability endpoints that live
 on dedicated ports and are deliberately excluded from the OpenAPI spec.
@@ -23,7 +30,7 @@ on dedicated ports and are deliberately excluded from the OpenAPI spec.
 - [x] `POST /api/v1/auth/refresh` - Refresh JWT token
 - [x] `GET /api/v1/auth/me` - Get current user
 - [x] `GET /api/v1/auth/logout` - OIDC logout
-- [x] `POST /api/v1/auth/token/exchange` - Exchange token
+- [x] `GET /api/v1/auth/exchange-token` - Exchange token
 - [x] `GET /api/v1/auth/saml/metadata` - SAML SP metadata
 - [x] `POST /api/v1/auth/saml/acs` - SAML Assertion Consumer Service
 - [x] `GET /api/v1/auth/providers` - List authentication providers
@@ -312,10 +319,9 @@ complete operational coverage.
 ---
 
 ```txt
-Total Gin-router Endpoints: 127
-Annotated: 127
-Remaining: 0
-Completion: 100% ✅
+Generated spec (backend/docs/swagger.json): 211 operations / 160 paths
+This checklist (manually maintained subset, drifted): 127 entries
+NOTE: not 100% — regenerate from the router/swagger.json before using as an endpoint map.
 
 Out-of-Band Endpoints (not in OpenAPI spec):
   GET /metrics           (port 9090, Prometheus)
@@ -349,9 +355,9 @@ cd backend
 swag init -g cmd/server/main.go --outputTypes json
 ```
 
-Then visit `https://localhost/api-docs` to verify in the Swagger UI.
+Then visit `https://localhost/api-docs/` to verify in the Swagger UI.
 
 ---
 
-**Last Updated**: 2026-04-22
-**Status**: ✅ All 127 Gin-router endpoints annotated — 100% complete; out-of-band observability endpoints documented in-checklist
+**Last Updated**: 2026-04-22 (stale — predates spec growth to 211 operations)
+**Status**: ⚠️ Partial / drifted — this checklist lists 127 entries but the generated spec has 211 operations / 160 paths; regenerate before relying on it. Out-of-band observability endpoints are documented in-checklist.

--- a/docs/adr/001-scope-based-rbac.md
+++ b/docs/adr/001-scope-based-rbac.md
@@ -12,7 +12,7 @@ The registry needs an authorization model that controls access to modules, provi
 
 Terraform registries serve diverse organizational structures. Some teams need a user who can publish modules but not manage mirrors. Others need CI/CD API keys with write access to a single namespace. Coarse roles like "Editor" cannot express these distinctions without either creating an explosion of specialized roles or granting overly broad permissions.
 
-The codebase defines permissions in `internal/auth/scopes.go` with 16 distinct scopes covering modules, providers, mirrors, users, organizations, SCM, API keys, audit, scanning, and an `admin` wildcard. Scopes are stored as string arrays on API keys and in JWT claims.
+The codebase defines permissions in `internal/auth/scopes.go` with 17 distinct scopes covering modules, providers, mirrors, users, organizations, SCM, API keys, audit, scanning, SCIM provisioning, and an `admin` wildcard. Scopes are stored as string arrays on API keys and in JWT claims.
 
 ## Decision
 

--- a/docs/adr/0011-password-hashing.md
+++ b/docs/adr/0011-password-hashing.md
@@ -49,4 +49,4 @@ When increasing the cost factor in the future:
 - API key hashing uses `bcrypt.GenerateFromPassword([]byte(key), 12)`.
 - The `BcryptCost` constant is defined in `internal/auth/apikey.go` and must be used consistently (no hardcoded literals elsewhere).
 - Cost can be increased in a future ADR without a database migration — the upgrade-on-verify pattern handles it transparently.
-- If FIPS-140-3 compliance requires NIST-approved algorithms only, bcrypt is **not** FIPS-approved. The FIPS build variant (see ADR-0012) would need to switch to PBKDF2-SHA256 or Argon2 when a FIPS-validated implementation becomes available.
+- If FIPS-140-3 compliance requires NIST-approved algorithms only, bcrypt is **not** FIPS-approved. A future FIPS build variant would need to switch to PBKDF2-SHA256 or Argon2 when a FIPS-validated implementation becomes available.

--- a/docs/adr/004-jwt-plus-apikey-dual-auth.md
+++ b/docs/adr/004-jwt-plus-apikey-dual-auth.md
@@ -22,7 +22,7 @@ The codebase implements both in `internal/auth/jwt.go` (JWT creation/validation 
 Support dual authentication: JWT tokens for human users and API keys for machine clients.
 
 - **JWT tokens** are issued after OIDC/Azure AD authentication. They carry `user_id`, `email`, `scopes`, and a `jti` (JWT ID) for revocation. Signed with `TFR_JWT_SECRET` using HMAC-SHA256.
-- **API keys** are prefixed strings (`tfr_*`) whose SHA-256 hash is stored in the `api_keys` table. They carry explicit scopes, optional expiration dates, and are tied to a creating user.
+- **API keys** are prefixed strings (`tfr_*`) whose bcrypt hash is stored in the `api_keys` table (see [ADR-0011](0011-password-hashing.md) for the hashing rationale). They carry explicit scopes, optional expiration dates, and are tied to a creating user.
 - **`Authorization` header** accepts both: `Bearer <jwt_token>` and `Bearer <api_key>`.
 - The `AuthMiddleware` attempts JWT validation first; if that fails, it looks up the key hash in the database. This ordering is intentional: JWT validation is a pure crypto operation (fast, no DB hit), while API key lookup requires a database query.
 - Both paths produce the same Gin context shape: `user_id`, `email`, `scopes` -- downstream handlers are authentication-scheme-agnostic.

--- a/docs/adr/006-in-memory-rate-limiting.md
+++ b/docs/adr/006-in-memory-rate-limiting.md
@@ -7,7 +7,7 @@
 
 The registry needs rate limiting to protect against abuse, brute-force attacks on authentication endpoints, and resource exhaustion from misbehaving clients. Three tiers exist:
 
-1. **Auth endpoints** (10 req/min): Login, token exchange -- protects against credential stuffing.
+1. **Auth endpoints** (20 req/min): Login, token exchange -- protects against credential stuffing.
 2. **Upload endpoints** (30 req/min): Module/provider publishing -- protects storage backend.
 3. **General API** (200 req/min): All other endpoints -- protects database and compute.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,11 +22,13 @@ An Architecture Decision Record captures an important architectural decision mad
 | [003](003-storage-backend-abstraction.md)   | Storage Backend Abstraction       | Accepted   |
 | [004](004-jwt-plus-apikey-dual-auth.md)     | JWT + API Key Dual Authentication | Accepted   |
 | [005](005-fire-and-forget-webhooks.md)      | Fire-and-Forget Webhooks          | Accepted   |
-| [006](006-in-memory-rate-limiting.md)       | In-Memory Rate Limiting           | Superseded |
+| [006](006-in-memory-rate-limiting.md)       | In-Memory Rate Limiting           | Superseded by Redis-backed rate limiting (Phase 1.1) |
 | [007](007-setup-wizard-one-time-token.md)   | Setup Wizard One-Time Token       | Accepted   |
 | [008](008-module-scanning-architecture.md)  | Module Scanning Architecture      | Accepted   |
 | [009](009-network-mirror-protocol.md)       | Network Mirror Protocol           | Accepted   |
 | [010](010-binary-mirror-custom-protocol.md) | Binary Mirror Custom Protocol     | Accepted   |
+| [011](011-version-approval-gate.md)         | Version Approval Gate for Mirrors | Accepted   |
+| [0011](0011-password-hashing.md)            | Password and API Key Hashing      | Accepted   |
 
 ## Creating a New ADR
 

--- a/docs/air-gap-install.md
+++ b/docs/air-gap-install.md
@@ -89,7 +89,7 @@ Key settings for air-gapped deployments:
 ```yaml
 server:
   host: "0.0.0.0"
-  port: 5000
+  port: 8080
   tls:
     enabled: true
     cert_file: "/certs/server.crt"
@@ -101,9 +101,9 @@ database:
   name: "terraform_registry"
 
 storage:
-  type: "filesystem"          # or s3 with internal MinIO/Ceph
-  filesystem:
-    path: "/data/modules"
+  default_backend: "local"    # or s3 with internal MinIO/Ceph
+  local:
+    base_path: "/data/modules"
 
 auth:
   oidc:
@@ -248,14 +248,22 @@ volumeMounts:
 
 To mirror modules from an **internal** upstream registry (e.g., another Terraform Registry instance or Artifactory):
 
-```yaml
-# config.yaml
-pull_through:
-  enabled: true
-  upstream_url: "https://registry.internal.example.com"
-  # If the upstream requires authentication:
-  upstream_token: "${UPSTREAM_REGISTRY_TOKEN}"
+Pull-through / mirror caching is **database-backed mirror configuration**, not a static
+`config.yaml` block — there is no `pull_through` config key. Create a mirror via the admin
+API (`POST /api/v1/admin/mirrors`) or the admin UI, supplying the upstream registry URL and
+an optional credential:
+
+```bash
+curl -k -X POST https://localhost:8080/api/v1/admin/mirrors \
+  -H "Authorization: Bearer <ADMIN_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "internal-upstream",
+        "upstream_registry_url": "https://registry.internal.example.com"
+      }'
 ```
+
+See the admin mirror API in [API Reference](api-reference.md) for the full request schema.
 
 ## Verification
 
@@ -263,7 +271,7 @@ After deployment, verify the air-gapped installation:
 
 ```bash
 # 1. Health check
-curl -k https://localhost:5000/health
+curl -k https://localhost:8080/health
 
 # 2. Verify no outbound connections (from the host)
 # Watch network traffic — there should be zero external DNS lookups or connections
@@ -275,7 +283,12 @@ cd examples/module-consumer/
 terraform init
 
 # 4. Verify scanner works offline (if enabled)
-curl -k https://localhost:5000/api/v1/admin/scanning/status
+# The /api/v1/admin/scanning/status endpoint is auth-gated; for an unauthenticated
+# smoke test, confirm the bundled Trivy binary runs offline instead:
+trivy --version
+# (or, with an admin credential:)
+# curl -k -H "Authorization: Bearer <ADMIN_API_KEY>" \
+#   https://localhost:8080/api/v1/admin/scanning/status
 ```
 
 ## Updating an Air-Gapped Deployment
@@ -286,7 +299,7 @@ curl -k https://localhost:5000/api/v1/admin/scanning/status
 4. Load new images: `./load-images.sh`
 5. Run database migrations: the backend auto-migrates on startup.
 6. Restart services with the new image tags.
-7. Verify health: `curl -k https://localhost:5000/health`
+7. Verify health: `curl -k https://localhost:8080/health`
 
 See also: [Upgrade Guide](upgrade-guide.md) for version-specific migration notes.
 

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -31,13 +31,14 @@ table:
 | Column | Type | Default | Description |
 | --- | --- | --- | --- |
 | `retry_count` | `INTEGER` | `0` | Number of retry attempts so far |
-| `max_retries` | `INTEGER` | `0` | Maximum retries allowed for this event |
+| `max_retries` | `INTEGER` | `3` | Maximum retries allowed for this event |
 | `next_retry_at` | `TIMESTAMP WITH TIME ZONE` | `NULL` | When the next retry should be attempted |
+| `last_error` | `TEXT` | `NULL` | Error message from the most recent failed attempt |
 
 **Impact on API consumers:**
 
 - Webhook event responses from `GET /api/v1/admin/webhooks/events` now include
-  `retry_count`, `max_retries`, and `next_retry_at` fields.
+  `retry_count`, `max_retries`, `next_retry_at`, and `last_error` fields.
 - Existing integrations that consume webhook event responses will see new fields but
   are not required to handle them. JSON consumers that ignore unknown fields are
   unaffected.
@@ -47,7 +48,8 @@ table:
 
 **Migration steps:** None required. Run database migrations (`migrate up`) and the new
 columns are added with safe defaults. Existing webhook events will have `retry_count=0`
-and `max_retries=0` (no retries for historical events).
+and `max_retries=3` (the column default), so historical/backfilled rows **are** eligible
+for retries.
 
 ---
 
@@ -132,7 +134,7 @@ New endpoints for marking module versions as deprecated:
 - Deprecated modules still appear in search results and version listings; clients
   should check the `deprecated` field to warn users.
 
-**Required scope:** `modules:publish`
+**Required scope:** `modules:write`
 
 **Migration steps:** None required. The new fields appear automatically after migration.
 
@@ -168,7 +170,7 @@ New endpoints for marking provider versions as deprecated:
 **Impact on API consumers:** Same as module deprecation -- new fields in responses,
 no breaking changes. Clients that ignore unknown fields are unaffected.
 
-**Required scope:** `providers:publish`
+**Required scope:** `providers:write`
 
 **Migration steps:** None required.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,27 +7,15 @@ tools, and gives a conceptual overview of the API surface.
 
 ## Interactive API Documentation
 
-Two interactive viewers are available, both backed by the same OpenAPI 2.0 (Swagger) spec:
-
-### ReDoc — Browsing and Reading
-
-```url
-http(s)://your-registry/api-docs
-```
-
-ReDoc renders the full API spec as a clean, three-panel reference:
-
-- Left panel: endpoint index with search
-- Center panel: full endpoint documentation with parameters, request/response schemas
-- Right panel: request/response examples
-
-Supports dark and light mode. This is the best tool for reading and understanding the API.
+The backend serves Swagger UI, backed by the embedded OpenAPI 2.0 (Swagger) spec.
 
 ### Swagger UI — Interactive Testing
 
 ```url
 http(s)://your-registry/api-docs/
 ```
+
+(`/api-docs` without the trailing slash 301-redirects to `/api-docs/`.)
 
 Swagger UI allows you to make live API calls directly from the browser. To authenticate:
 
@@ -42,18 +30,21 @@ Swagger UI is served by the Go backend and reflects the exact version of the run
 
 ```url
 GET http(s)://your-registry/swagger.json
+GET http(s)://your-registry/openapi3.json
 ```
 
-Machine-readable OpenAPI 2.0 JSON. Use this to generate client SDKs, import into Postman,
-or integrate with API gateways. The spec includes runtime metadata (contact, license)
-configured via `TFR_API_DOCS_*` environment variables.
+`/swagger.json` is machine-readable OpenAPI 2.0 JSON. `/openapi3.json` is the OpenAPI 3
+conversion of the same spec, which downstream consumers (frontend typegen, provider
+`oapi-codegen`) use. Use either to generate client SDKs, import into Postman, or integrate
+with API gateways. The spec includes runtime metadata (contact, license) configured via
+`TFR_API_DOCS_*` environment variables.
 
 ---
 
 ## Authentication
 
 All admin and upload endpoints require a `Bearer` token. Terraform protocol endpoints
-(`/v1/modules/`, `/v1/providers/`, `/v1/mirror/`) are intentionally unauthenticated
+(`/v1/modules/`, `/v1/providers/`, `/terraform/providers/`) are intentionally unauthenticated
 to match the HashiCorp protocol specification — Terraform does not send credentials
 when fetching module/provider metadata.
 
@@ -66,13 +57,20 @@ curl -H "Authorization: Bearer tfr_your_api_key" \
 
 ### JWT (browser session)
 
-```bash
-# Login to obtain a JWT
-curl -X POST https://registry.example.com/auth/login \
-     -H "Content-Type: application/json" \
-     -d '{"email": "user@example.com", "password": "..."}'
+There is no local-password login. Browser sessions are established through your
+configured identity provider:
 
-# Use the returned token
+```bash
+# OIDC/Azure AD/SAML: GET redirects the browser to the IdP; the callback issues
+# an HttpOnly session cookie.
+#   GET /api/v1/auth/login?provider=oidc
+
+# LDAP: POST credentials to obtain a session
+curl -X POST https://registry.example.com/api/v1/auth/ldap/login \
+     -H "Content-Type: application/json" \
+     -d '{"username": "user", "password": "..."}'
+
+# Use the returned token (or session cookie) on subsequent calls
 curl -H "Authorization: Bearer eyJ..." \
      https://registry.example.com/api/v1/modules
 ```
@@ -81,7 +79,7 @@ curl -H "Authorization: Bearer eyJ..." \
 
 ## API Groups Overview
 
-The full endpoint list (104 endpoints) is in the interactive docs above. Here is a
+The full endpoint list is in the interactive docs above. Here is a
 conceptual map of the major groups:
 
 ### Terraform Protocol Endpoints (unauthenticated)
@@ -93,7 +91,7 @@ These endpoints implement the HashiCorp protocols that `terraform init` and `ter
 | Service Discovery | `/.well-known/terraform.json` | Declares module and provider endpoint bases |
 | Module Registry | `/v1/modules/` | List versions, download redirects |
 | Provider Registry | `/v1/providers/` | List versions, platform download info |
-| Network Mirror | `/v1/mirror/` | Provider index and version JSON for `terraform providers mirror` |
+| Network Mirror | `/terraform/providers/` | Provider index and version JSON for `terraform providers mirror` |
 | Binary Mirror Downloads | `/terraform/binaries/:name/` | List and download mirrored Terraform/OpenTofu binaries by config name |
 
 ### Admin API (authentication required)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,8 @@ The registry implements three HashiCorp Terraform protocols, plus a binary mirro
 - **Provider Network Mirror Protocol** — caching provider binaries from upstream registries
 - **Terraform Binary Mirror** — multi-config mirror for Terraform and OpenTofu release binaries, served at `/terraform/binaries/:name/`
 
+Beyond the Terraform protocols, the API package also exposes additional surfaces that have their own detailed docs: an **OCI** distribution endpoint group, **SCIM 2.0** user/group provisioning (gated by the dedicated `scim:provision` scope), and **security advisories** (CVE) endpoints. A security review scoping the full attack surface should account for these in addition to the protocol routes.
+
 Design goals: protocol correctness first, then security, then operational simplicity. The system is stateless at the application layer (all state lives in PostgreSQL and the configured storage backend), which makes horizontal scaling straightforward.
 
 ---
@@ -104,7 +106,9 @@ Handlers follow the **repository pattern**: they call repository methods (in `in
 
 ## Authentication Flow
 
-The system supports three credential types: **JWT** (for browser sessions), **API keys** (for automation), and **OIDC/Azure AD** (for SSO login flows).
+The system supports several credential types: **JWT** (for browser sessions), **API keys** (for automation), and SSO login flows via **OIDC/Azure AD**, **SAML**, **LDAP**, and **mTLS** (client-certificate) providers.
+
+Browser sessions do not use a `Bearer` header. After login the JWT is set as an **HttpOnly `tfr_auth_token` cookie** (inaccessible to page JavaScript), and the middleware tags such requests with `auth_method = jwt_cookie` so the **CSRF middleware** can require a `tfr_csrf` double-submit token on cookie-authenticated mutations. Programmatic clients send `Authorization: Bearer <token>` (JWT or API key) and bypass CSRF. The token-resolution order is: (1) `Authorization: Bearer` header — tried as JWT first, then API key; (2) `tfr_auth_token` cookie — tried as JWT only.
 
 ### Why JWT Is Tried First
 
@@ -167,22 +171,33 @@ Key scopes and their write-implies-read relationship:
 | `mirrors:manage` | Create/update/delete mirrors and trigger syncs (implies `mirrors:read`) |
 | `admin:*` | Full administrative access (implies all scopes) |
 
+### Shared identity module
+
+The core identity primitives — JWT issuance/validation (the `TokenManager`), API
+key generation/validation, and the generic scope-evaluation logic (wildcard
+`admin` + write-implies-read) — are owned by the shared
+`github.com/sethbacon/terraform-suite-identity` module. The files under
+`internal/auth` (`jwt.go`, `apikey.go`, `scopes.go`) are thin shims that delegate
+to that module, with the registry injecting its own registry-specific scope set
+and read/write pairs. So when looking for the implementation of these primitives,
+expect to find it in the shared suite-identity module rather than in this repo.
+
 ---
 
 ## Storage Abstraction
 
 ### Interface Design
 
-All storage backends implement the `storage.Backend` interface:
+All storage backends implement the `storage.Storage` interface:
 
 ```go
-type Backend interface {
-    Upload(ctx, path, reader, size, checksum) (UploadResult, error)
+type Storage interface {
+    Upload(ctx, path, reader, size) (*UploadResult, error)  // computes and returns the checksum
     Download(ctx, path) (io.ReadCloser, error)
     Delete(ctx, path) error
     GetURL(ctx, path, ttl) (string, error)  // returns a signed/presigned URL
     Exists(ctx, path) (bool, error)
-    GetMetadata(ctx, path) (FileMetadata, error)
+    GetMetadata(ctx, path) (*FileMetadata, error)
 }
 ```
 
@@ -195,13 +210,13 @@ Backends register themselves via Go's `init()` mechanism:
 ```go
 // In storage/s3/s3.go
 func init() {
-    factory.Register("s3", func(cfg *config.Config) (Backend, error) {
+    factory.Register("s3", func(cfg *config.Config) (Storage, error) {
         return NewS3Backend(cfg)
     })
 }
 ```
 
-The main package imports each backend with a blank import (`_ "github.com/.../storage/s3"`), which triggers `init()`. Adding a new backend requires only implementing the interface and registering in `init()` — no changes to the factory or main package are needed.
+The router package (`internal/api/router.go`) imports each backend with a blank import (`_ "github.com/.../storage/s3"`), which triggers `init()`. Adding a new backend requires only implementing the interface and registering in `init()` — no changes to the factory or main package are needed.
 
 ---
 
@@ -255,12 +270,20 @@ versions at sync time. See [version-approval.md](version-approval.md) and
 
 ## Background Jobs
 
-| Job | Interval | Purpose |
+| Job | Trigger | Purpose |
 | --- | --- | --- |
-| Mirror Sync | 10 minutes | Poll upstream registries and download new provider versions |
-| Tag Verifier | On webhook | Verify that SCM tags haven't moved since the version was published |
+| Mirror Sync (`mirror_sync.go`) | Periodic (configurable) | Poll upstream registries and download new provider versions |
+| Terraform Binary Mirror Sync (`terraform_mirror_sync.go`) | Periodic (configurable) | Keep enabled Terraform/OpenTofu binary mirrors current from their upstreams |
+| Tag Verifier (`tag_verifier.go`) | On webhook / periodic | Verify that SCM tags haven't moved since the version was published |
+| Module Scanner (`module_scanner_job.go`) | Periodic (`scan_interval_mins`) | Process pending module security scans (see [ADR 008](adr/008-module-scanning-architecture.md)) |
+| Webhook Retry (`webhook_retry_job.go`) | Periodic | Retry failed webhook deliveries with exponential backoff (see [ADR 005](adr/005-fire-and-forget-webhooks.md)) |
+| API Key Expiry Notifier (`api_key_expiry_notifier.go`) | Periodic | Email owners of API keys approaching expiry (once per key) |
+| CVE Poll (`cve_poll.go`) | Periodic | Query OSV.dev for advisories affecting binaries, providers, and the scanner |
+| Audit Cleanup (`audit_cleanup_job.go`) | Periodic | Delete audit-log entries older than the configured retention period |
+| Backup (`backup_job.go`) | Scheduled | Store encrypted `pg_dump` output in the configured object storage backend |
+| Releases Key Refresh (`releases_key_refresh_job.go`) | Periodic | Re-fetch tool release-signing GPG keys with fingerprint pinning |
 
-Jobs run in goroutines started at server startup. They use the same database connection pool as request handlers. Job panics are recovered and logged but do not crash the server.
+The list above is the full set of registered jobs (`internal/jobs/`). Jobs run in goroutines started at server startup. They use the same database connection pool as request handlers. Job panics are recovered and logged but do not crash the server.
 
 ---
 
@@ -300,13 +323,14 @@ Defense-in-depth layers, from outer to inner:
 1. **TLS** (at ingress) — encrypts all traffic
 2. **Rate limiting** — prevents brute-force and enumeration attacks
 3. **Input validation** — semver format, archive structure, path traversal prevention
-4. **Authentication** — JWT or API key required for all non-protocol endpoints
-5. **RBAC** — scope checking before any state mutation
-6. **Audit logging** — immutable record of all mutating actions
-7. **Bcrypt for API keys** — keys stored as bcrypt hashes; compromise of the database does not expose working keys
-8. **GPG verification** — all provider binaries are verified against the publisher's GPG public key
-9. **SHA256 checksums** — file integrity checked on upload and download
-10. **Commit SHA pinning** — SCM-linked versions are immutable by design
+4. **Authentication** — JWT (header or HttpOnly cookie), API key, or an SSO provider (OIDC/Azure AD/SAML/LDAP/mTLS) required for all non-protocol endpoints
+5. **CSRF protection** — cookie-authenticated (browser) mutations require a `tfr_csrf` double-submit token
+6. **RBAC** — scope checking before any state mutation
+7. **Audit logging** — immutable record of all mutating actions
+8. **Bcrypt for API keys** — keys stored as bcrypt hashes; compromise of the database does not expose working keys
+9. **GPG verification** — all provider binaries are verified against the publisher's GPG public key
+10. **SHA256 checksums** — file integrity checked on upload and download
+11. **Commit SHA pinning** — SCM-linked versions are immutable by design
 
 ### Swagger UI and Content Security Policy
 
@@ -325,7 +349,7 @@ The backend starts two additional `http.ServeMux` listeners beside the main Gin 
 | Port (default) | Surface | Config key |
 | --- | --- | --- |
 | `9090` | Prometheus `/metrics` (promhttp handler) | `TFR_TELEMETRY_METRICS_PROMETHEUS_PORT` |
-| `6060` | pprof `/debug/pprof/` | `TFR_TELEMETRY_PPROF_PORT` |
+| `6060` | pprof `/debug/pprof/` | `TFR_TELEMETRY_PROFILING_PORT` |
 
 Neither port is exposed through the public Nginx/load-balancer ingress. They are internal-only and should be firewalled to the monitoring network (Prometheus scraper, ops bastion).
 

--- a/docs/compliance/iso27001-mapping.md
+++ b/docs/compliance/iso27001-mapping.md
@@ -5,8 +5,8 @@ This document maps ISO 27001:2022 Annex A controls to Terraform Registry
 features, configurations, and evidence sources. It supports organizations
 seeking ISO 27001 certification that include the registry in their ISMS scope.
 
-**Last updated:** 2026-04-20
-**Applicable version:** 0.10.0+
+**Last updated:** 2026-06-17
+**Applicable version:** 1.0.0+
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,12 @@ For example, `database.host` in YAML becomes `TFR_DATABASE_HOST` as an env var.
 | `TFR_WEBHOOKS_RETRY_INTERVAL_MINS`                   | int      | `2`                     | No         | Minutes between webhook retries                                     |
 | `TFR_NOTIFICATIONS_ENABLED`                          | bool     | `false`                 | No         | Enable outbound email notifications                                 |
 
+> **Secrets are environment-only.** `TFR_JWT_SECRET`, `TFR_JWT_SECRET_FILE`,
+> `ENCRYPTION_KEY`, and `ENCRYPTION_KEY_PREVIOUS` are **not** part of the Viper config —
+> they have no YAML/struct field and are read directly via `os.Getenv` at startup. The
+> `TFR_<SECTION>_<FIELD>` ↔ YAML-key mapping rule above does **not** apply to them, and they
+> cannot be set in `config.yaml`. (`ENCRYPTION_KEY` intentionally has no `TFR_` prefix.)
+
 ---
 
 ## Redis (Optional)
@@ -146,6 +152,8 @@ database:
 
 `max_connections` controls the size of the connection pool. Set it to roughly `PostgreSQL max_connections / number_of_backend_instances`, leaving headroom for migrations and admin connections. A value of 25 per instance is a safe starting point.
 
+`min_idle_connections` (env `TFR_DATABASE_MIN_IDLE_CONNECTIONS`, default `5`) sets the minimum number of idle connections kept warm in the pool, so the first requests after an idle period do not pay the connection-establishment cost.
+
 ---
 
 ## Server
@@ -155,6 +163,8 @@ server:
   host: 0.0.0.0         # bind to all interfaces; use 127.0.0.1 to restrict to localhost
   port: 8080
   base_url: https://registry.example.com   # IMPORTANT: must be the public URL
+  public_url: ""        # optional; OAuth-facing URL when it differs from base_url
+  default_language: en  # default UI locale (see allowed list below)
   read_timeout: 30s
   write_timeout: 30s
   trusted_proxies: []   # CIDRs/IPs of reverse proxies allowed to set X-Forwarded-For
@@ -166,6 +176,21 @@ server:
 module download redirect targets and provider download URLs. If this is set incorrectly,
 `terraform init` will follow broken redirects and fail. Always set this to the public
 hostname that Terraform clients will reach (e.g., the load balancer or ingress URL).
+
+### `public_url` vs `base_url` (OAuth Redirects)
+
+**`TFR_SERVER_PUBLIC_URL`** is the externally-reachable URL used for OAuth
+callbacks/redirects (via `GetPublicURL()`). It is **optional**: when unset, it falls back
+to `base_url`. It only matters in reverse-proxied deployments where the internal listen
+address (`base_url`) differs from the URL registered with the OAuth provider as the
+redirect URI. If you hit an OIDC redirect-URI-mismatch and `base_url` alone is not the URL
+the IdP redirects back to, set `public_url` to the OAuth-registered URL.
+
+### `default_language`
+
+**`TFR_SERVER_DEFAULT_LANGUAGE`** (default `en`) sets the default UI locale. It is
+validated at startup against a fixed list of 10 locales — **`en`, `es`, `fr`, `de`, `ja`,
+`pt`, `nl`, `nb`, `zh`, `it`** — and an invalid value causes startup to fail.
 
 ### `trusted_proxies` and Client IP
 
@@ -319,27 +344,32 @@ auth:
     client_id: ${AZURE_CLIENT_ID}
     client_secret: ${AZURE_CLIENT_SECRET}
     redirect_url: https://registry.example.com/auth/azure/callback
-    require_verified_email: true   # see note below — Entra ID often omits this claim
 ```
 
+> **Note:** Email-verification enforcement (`require_verified_email`) is currently
+> implemented for the **generic OIDC provider only**. The dedicated `azure_ad`
+> provider has no `require_verified_email` field — see [Email Verification and
+> Account Linking](#email-verification-and-account-linking) below.
+
 For detailed OIDC provider setup (Azure AD, Okta, Keycloak, Auth0, Google Workspace),
-see [OIDC Configuration](oidc_configuration.md).
+see [OIDC Configuration](OIDC_CONFIGURATION.md).
 
 ### Email Verification and Account Linking
 
 The email address asserted by an identity provider is the anchor used to match and link
 accounts, so the registry hardens it in two ways:
 
-- **`TFR_AUTH_OIDC_REQUIRE_VERIFIED_EMAIL`** / **`TFR_AUTH_AZURE_AD_REQUIRE_VERIFIED_EMAIL`**
-  (both default `true`) — a login is rejected unless the ID token asserts
-  `email_verified=true`. An ID token that explicitly sets `email_verified=false` is always
-  rejected regardless of this flag. When the flag is `true` and the claim is **absent**, the
-  login is also rejected.
+- **`TFR_AUTH_OIDC_REQUIRE_VERIFIED_EMAIL`** (default `true`) — for the generic OIDC
+  provider, a login is rejected unless the ID token asserts `email_verified=true`. An ID
+  token that explicitly sets `email_verified=false` is always rejected regardless of this
+  flag. When the flag is `true` and the claim is **absent**, the login is also rejected.
 
-  > **Entra ID / Azure AD note:** v2.0 tokens frequently omit `email_verified`. If your tenant
-  > does not emit it, add it as an optional claim or set
-  > `TFR_AUTH_AZURE_AD_REQUIRE_VERIFIED_EMAIL=false` (only do this if your tenant's emails are
-  > verified out-of-band).
+  > **Scope note:** This enforcement applies to the **generic `oidc` provider only**. The
+  > dedicated `azure_ad` provider does **not** have a `require_verified_email` field, so there
+  > is no equivalent `TFR_AUTH_AZURE_AD_REQUIRE_VERIFIED_EMAIL` variable. If you need
+  > email-verification enforcement for Entra ID, configure it through the generic `oidc`
+  > provider (Entra ID is OIDC-compliant), and note that Entra v2.0 tokens frequently omit
+  > `email_verified` — add it as an optional claim if your tenant does not emit it.
 
 - **Cross-provider account-link guard (always on)** — the registry will not rebind an existing
   account to a different provider identity by email match. Email-based linking is allowed only
@@ -348,6 +378,63 @@ accounts, so the registry hardens it in two ways:
   prevents an attacker who can assert a victim's email through a second provider from taking
   over the victim's account. A genuine subject change (e.g. an IdP re-import) requires an admin
   to clear the stored subject first.
+
+### SAML 2.0
+
+The registry also acts as a SAML 2.0 Service Provider. SAML config is a list of
+structs (one or more IdPs), so it is set in `config.yaml`. The SP metadata and ACS
+endpoints are registered under `/api/v1/auth/saml/`.
+
+```yaml
+auth:
+  saml:
+    enabled: false
+    entity_id: https://registry.example.com/saml/metadata   # this SP's entity ID
+    acs_url: https://registry.example.com/api/v1/auth/saml/acs
+    cert_file: /etc/registry/saml-sp.crt   # SP signing cert
+    key_file: /etc/registry/saml-sp.key    # SP signing key
+    idps:
+      - name: corp-idp
+        metadata_url: https://idp.example.com/metadata   # or metadata_xml: "<inline XML>"
+    # Group-to-role mapping (same model as OIDC)
+    group_attribute_name: groups
+    default_role: viewer
+    group_mappings:
+      - group: registry-admins
+        organization: default
+        role: admin
+```
+
+### LDAP / Active Directory
+
+LDAP authentication exposes a direct login endpoint at **`POST /api/v1/auth/ldap/login`**.
+A service account (`bind_dn`/`bind_password`) is used to search for users.
+
+```yaml
+auth:
+  ldap:
+    enabled: false
+    host: ldap.example.com
+    port: 636
+    use_tls: true            # LDAPS on connect
+    start_tls: false         # or StartTLS on a plain port
+    insecure_skip_verify: false   # NOT recommended in production
+    bind_dn: "CN=svc-registry,OU=Service Accounts,DC=example,DC=com"
+    bind_password: ${LDAP_BIND_PASSWORD}
+    base_dn: "OU=Users,DC=example,DC=com"
+    user_filter: "(sAMAccountName=%s)"
+    user_attr_email: mail
+    user_attr_name: displayName
+    # Group lookup + role mapping
+    group_base_dn: "OU=Groups,DC=example,DC=com"
+    group_filter: "(member=%s)"
+    group_member_attr: member
+    default_role: viewer
+    group_mappings:
+      - group_dn: "CN=Registry Admins,OU=Groups,DC=example,DC=com"
+        organization: default
+        role: admin
+```
 
 ---
 
@@ -361,7 +448,7 @@ export TFR_JWT_SECRET=$(openssl rand -hex 32)
 
 The JWT secret signs authentication tokens. In production:
 
-- Minimum 32 characters. The server refuses to start without a sufficient secret when `TFR_DEV_MODE` is not set.
+- Minimum 32 characters. The server refuses to start without a sufficient secret when `DEV_MODE` is not set.
 - Store in a secrets manager (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault), not in environment files checked into source control.
 
 #### File-Based Hot-Reload (Zero-Downtime Rotation)
@@ -417,8 +504,10 @@ security:
     allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
 ```
 
-Restrict `allowed_origins` to your actual frontend URL(s) in production. The default
-configuration includes `localhost` origins for development only.
+Restrict `allowed_origins` to your actual frontend URL(s) in production. The built-in
+default is `["*"]` (all origins) — this is permissive and **must be restricted in
+production**. (If `config.example.yaml` ships narrower example origins, those are example
+values, not the built-in default.)
 
 ### Rate Limiting
 
@@ -578,16 +667,20 @@ These fields are injected at runtime into the spec served by the backend.
 ## Dev Mode
 
 ```bash
-export TFR_DEV_MODE=true
+export DEV_MODE=true
 ```
+
+Dev mode is gated by the bare `DEV_MODE` env var (`true` or `1`); `NODE_ENV=development`
+also triggers it. Note `DEV_MODE` is intentionally **un-prefixed** (no `TFR_` prefix), the
+same as `ENCRYPTION_KEY`.
 
 Dev mode enables:
 
-- A bypass login endpoint (`POST /auth/dev/login`) that creates a session without OIDC
+- A bypass login endpoint (`POST /api/v1/dev/login`) that creates a session without OIDC
 - Relaxed JWT secret validation (allows short secrets)
 - Additional debug logging
 
-**Never set `TFR_DEV_MODE=true` in production.** The dev login endpoint allows anyone
+**Never set `DEV_MODE=true` in production.** The dev login endpoint allows anyone
 to authenticate as any user without credentials.
 
 ---
@@ -614,10 +707,10 @@ scanning:
 | Variable                          | Type     | Default         | Description                                                                                                                           |
 | --------------------------------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `TFR_SCANNING_ENABLED`            | bool     | `false`         | Master toggle for the scanning feature.                                                                                               |
-| `TFR_SCANNING_TOOL`               | string   | —               | Scanner backend: `trivy`, `checkov`, `terrascan`, `snyk`, or `custom`.                                                                |
+| `TFR_SCANNING_TOOL`               | string   | `trivy`         | Scanner backend: `trivy`, `checkov`, `terrascan`, `snyk`, or `custom`.                                                                |
 | `TFR_SCANNING_BINARY_PATH`        | string   | —               | Absolute path to the scanner binary on the server.                                                                                    |
 | `TFR_SCANNING_EXPECTED_VERSION`   | string   | —               | Exact version string the binary must report. The job refuses to start if it doesn't match. Leave blank to disable pinning.            |
-| `TFR_SCANNING_SEVERITY_THRESHOLD` | string   | (all)           | Comma-separated severities to record: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Blank records all.                                         |
+| `TFR_SCANNING_SEVERITY_THRESHOLD` | string   | `CRITICAL,HIGH,MEDIUM,LOW` | Comma-separated severities to record: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. The default lists all severities (record all); blank also records all. |
 | `TFR_SCANNING_TIMEOUT`            | duration | `5m`            | Maximum time a single scan may run.                                                                                                   |
 | `TFR_SCANNING_WORKER_COUNT`       | int      | `2`             | Concurrent scan workers.                                                                                                              |
 | `TFR_SCANNING_SCAN_INTERVAL_MINS` | int      | `5`             | How often the job polls for pending scans.                                                                                            |
@@ -795,3 +888,128 @@ artifacts:
 
 During migration, reads transparently fall back to the old backend for artifacts that
 have not yet been copied. No downtime is required.
+
+---
+
+## Binary Mirror Access Control
+
+Access control for the `/terraform/binaries` endpoint group (the binary-mirror
+IP allowlist referenced by `trusted_proxies` above).
+
+```yaml
+binary_mirror:
+  auth: none                # none | allowlist | mtls
+  allowlist:                # CIDR ranges allowed when auth=allowlist
+    - 10.0.0.0/8
+```
+
+| Mode        | Behaviour                                                                              |
+| ----------- | -------------------------------------------------------------------------------------- |
+| `none`      | No access control (default). Suitable for internal networks.                           |
+| `allowlist` | Allow only clients whose IP falls within one of the configured CIDR blocks.            |
+| `mtls`      | Require a verified TLS client certificate; the subject CN is logged (no scope check).  |
+
+When `auth=allowlist`, the client IP is resolved using the same `trusted_proxies` rules
+described in the Server section.
+
+---
+
+## Policy Engine (OPA / Rego)
+
+An optional OPA/Rego policy engine that can warn on or block actions. Disabled by
+default (no-op; all actions allowed).
+
+```yaml
+policy:
+  enabled: false
+  mode: warn                          # warn (log and continue) | block (reject)
+  bundle_url: ""                      # HTTP/HTTPS URL of the .tar.gz Rego bundle
+  bundle_refresh_interval: 0          # seconds between background bundle re-fetches; 0 = no refresh
+```
+
+---
+
+## CVE Polling (OSV.dev)
+
+Scheduled vulnerability polling against OSV.dev for advisories affecting Terraform/OpenTofu
+binaries, registered providers, and the configured scanner binary. Opt-in (disabled by
+default).
+
+```yaml
+cve:
+  enabled: false
+  interval_hours: 24                  # how often the poll job runs
+  osv_endpoint: https://api.osv.dev   # OSV.dev base URL
+  email_recipients: []                # addresses notified on new advisories (requires notifications.enabled)
+  poll_binaries: true
+  poll_providers: true
+  poll_scanner: true
+```
+
+---
+
+## mTLS (Client-Certificate Auth)
+
+Mutual TLS client authentication that maps a client certificate subject (CN or full DN)
+to scopes. Configured under `security.mtls`. Subject mappings are a list of structs and so
+must be set in `config.yaml` (env vars cannot express the list).
+
+```yaml
+security:
+  mtls:
+    enabled: false
+    client_ca_file: /etc/registry/client-ca.pem
+    mappings:
+      - subject: "CN=ci-runner"
+        scopes: ["modules:read", "providers:read"]
+```
+
+---
+
+## Per-Principal Rate-Limit Overrides
+
+Custom rate limits for a specific user or API key, under
+`security.rate_limiting.principal_overrides`. Keys are `user:<id>` or `apikey:<id>`. This
+is a map of structs and so must be set in `config.yaml`.
+
+```yaml
+security:
+  rate_limiting:
+    principal_overrides:
+      "user:00000000-0000-0000-0000-000000000001":
+        requests_per_minute: 1000
+        burst: 200
+```
+
+---
+
+## Identity Database
+
+Optionally points the identity schema at a separate or shared database. Any unset field
+falls back to the main `database` config, so a fully unset `identity_database` uses the app
+database (the standalone default). Set `TFR_IDENTITY_DATABASE_*` (same field names as
+`TFR_DATABASE_*`) to share one identity store across the suite.
+
+```yaml
+identity_database:
+  host: identity-db.example.com
+  port: 5432
+  name: identity
+  user: registry
+  password: ${IDENTITY_DB_PASSWORD}
+```
+
+---
+
+## Suite Coupling
+
+Optional runtime coupling to a sibling Suite app (Terraform State Manager). With
+`sibling_url` empty (the default) the registry is fully standalone and nothing is polled.
+
+| Variable                          | Type     | Default | Description                                                                                  |
+| --------------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------- |
+| `TFR_SUITE_SIBLING_URL`           | string   | —       | Sibling app URL (e.g. `https://tfstate.example.com`). Empty = standalone.                    |
+| `TFR_SUITE_POLL_INTERVAL`         | duration | `60s`   | How often the sibling manifest is polled.                                                    |
+| `TFR_SUITE_ROLE_SEED_OWNER`       | string   | `self`  | Which app seeds shared identity role templates: `self`, `registry`, or `tsm`. With a shared identity DB, exactly one app must own the seed. |
+| `TFR_SUITE_IDENTITY_SHARED_STORE` | bool     | `false` | Operator assertion that this app uses the shared identity store + single IdP (advertised in the manifest). |
+| `TFR_SUITE_SIBLING_TOKEN`         | string   | —       | Shared secret (`X-Suite-Service-Token`) for cross-app reads (the "Consumed by" panel). Set to the same value as the sibling's service token. |

--- a/docs/data-residency.md
+++ b/docs/data-residency.md
@@ -273,7 +273,7 @@ operational complexity.
 | Encryption key residency     | Use a regional KMS key (e.g., AWS KMS in the target region)                                                |
 | Audit log retention          | Configure `audit_retention.retention_days` per regulation; use legal holds for investigation periods       |
 | Cross-border transfer        | Ensure replication targets are in permitted regions; document legal basis (e.g., SCCs, adequacy decisions) |
-| Data subject rights          | GDPR export/erasure endpoints available at `/admin/users/:id/export` and `/admin/users/:id/erase`          |
+| Data subject rights          | GDPR export/erasure endpoints available at `/api/v1/admin/users/:id/export` and `/api/v1/admin/users/:id/erase` |
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,21 +177,45 @@ helm install terraform-registry deployments/helm/ \
 
 Key values in `values.yaml` to override:
 
-| Value                     | Description                                     |
-| ------------------------- | ----------------------------------------------- |
-| `config.baseUrl`          | Public URL returned to Terraform CLI (required) |
-| `config.jwtSecret`        | JWT signing secret (required, min 32 chars)     |
-| `config.databasePassword` | PostgreSQL password                             |
-| `config.encryptionKey`    | SCM OAuth token encryption key                  |
-| `storage.backend`         | `local` \| `azure` \| `s3` \| `gcs`             |
-| `ingress.enabled`         | Enable ingress resource                         |
-| `ingress.hostname`        | Ingress hostname                                |
-| `ingress.tls.enabled`     | Enable TLS on ingress                           |
-| `backend.replicas`        | Number of backend replicas                      |
-| `autoscaling.enabled`     | Enable HPA                                      |
-| `frontend.enabled`        | Deploy frontend container                       |
+| Value                       | Description                                     |
+| --------------------------- | ----------------------------------------------- |
+| `server.baseUrl`            | Public URL returned to Terraform CLI (required) |
+| `security.jwtSecret`        | JWT signing secret (required, min 32 chars)     |
+| `externalDatabase.password` | PostgreSQL password                             |
+| `security.encryptionKey`    | SCM OAuth token encryption key                  |
+| `storage.backend`           | `local` \| `azure` \| `s3` \| `gcs`             |
+| `ingress.enabled`           | Enable ingress resource                         |
+| `ingress.hostname`          | Ingress hostname                                |
+| `ingress.tls.enabled`       | Enable TLS on ingress                           |
+| `backend.replicaCount`      | Number of backend replicas                      |
+| `autoscaling.enabled`       | Enable HPA                                      |
+| `frontend.enabled`          | Deploy frontend container                       |
 
 See `deployments/helm/values.yaml` for the full annotated values file.
+
+### Redis (HA / multi-replica)
+
+Redis is **required for any multi-pod deployment** that uses OIDC and/or rate
+limiting. When `redis.host` is set, rate limiting uses distributed GCRA in Redis
+and OIDC session state is stored in Redis. When `redis.host` is empty, the backend
+falls back to **in-memory** rate-limit and session stores — which is incorrect behind
+a load balancer with multiple pods: rate limits are enforced per-pod and OIDC logins
+fail intermittently when the callback lands on a different pod than the one that started
+the flow.
+
+Any guide that enables autoscaling or sets `autoscaling.minReplicas > 1` (the AKS/EKS/GKE
+overlays do) must also configure Redis:
+
+```yaml
+# values.yaml
+redis:
+  host: "redis.example.internal"
+  port: 6379
+  tls: true            # required for Azure Cache for Redis
+  existingSecret: ""   # secret containing REDIS_PASSWORD
+```
+
+See `deployments/helm/values.yaml` (the `redis:` block) for all available keys.
 
 ### Helm: Prometheus ServiceMonitor
 
@@ -404,12 +428,13 @@ Two URL configuration variables serve different purposes:
 | Variable                | Value                          | Purpose                                                                                                                |
 | ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
 | `TFR_SERVER_BASE_URL`   | `https://registry.example.com` | Terraform protocol — embedded in discovery responses and module/provider download URLs that `terraform` CLI will fetch |
-| `TFR_SERVER_PUBLIC_URL` | `https://registry.example.com` | OAuth redirect URL — where the browser is sent after OIDC login completes                                              |
+| `TFR_SERVER_PUBLIC_URL` | `https://registry.example.com` | OAuth redirect URL — where the browser is sent after OIDC login completes. **Optional**; only needed when the public OAuth URL differs from `base_url` |
 
-In an ECS deployment behind an ALB both should be set to your public domain. If
-`TFR_SERVER_PUBLIC_URL` is omitted it falls back to `TFR_SERVER_BASE_URL`, which works
-as long as the backend's `base_url` is already the public URL. If you ever need to split
-them (e.g. different internal vs. external address) set both explicitly.
+In an ECS deployment behind an ALB, `TFR_SERVER_BASE_URL` should be set to your public
+domain. `TFR_SERVER_PUBLIC_URL` is optional: when omitted it falls back to
+`TFR_SERVER_BASE_URL` (via `GetPublicURL()`), which works as long as the backend's
+`base_url` is already the public URL. Only set it explicitly when you need to split the
+two (e.g. a different internal listen URL vs. the external OAuth-registered URL).
 
 ### ACM Certificate and Terraform Plan-Time Errors
 
@@ -440,12 +465,12 @@ The `local-exec` provisioner that triggers the seed task uses **PowerShell** (`i
 does not inherit the system `PATH` and cannot find `aws.exe`. If you are running Terraform
 from Linux or macOS, switch the interpreter back to `/bin/bash`.
 
-Log in with the dev admin at `POST /auth/dev/login`:
+Log in with the dev admin at `POST /api/v1/dev/login`. This endpoint requires
+`DEV_MODE=true` and the pre-seeded `admin@dev.local` user; it ignores any request
+body and always returns a JWT for that fixed user:
 
 ```bash
-curl -X POST https://registry.example.com/auth/dev/login \
-  -H "Content-Type: application/json" \
-  -d '{"email": "admin@dev.local", "password": "dev"}'
+curl -X POST https://registry.example.com/api/v1/dev/login
 ```
 
 ### Resources Created
@@ -600,19 +625,21 @@ See `variables.tf` in each directory for the full list of tunable parameters.
 
 ## Health Checks
 
-The backend exposes a health endpoint:
+The backend exposes two health endpoints:
 
 ```bash
 GET /health
-# Returns 200 OK with JSON:
-# {"status": "ok", "database": "ok", "storage": "ok"}
+# Liveness — pings the database. Returns 200 OK with JSON:
+# {"status": "healthy", "time": "...", "version": "...", "build_date": "..."}
+# On failure returns 503: {"status": "unhealthy", "error": "database connection failed"}
 
-# Or for just liveness (no dependency checks):
-GET /healthz
-# Returns 200 OK: {"status": "ok"}
+GET /ready
+# Readiness — checks DB + storage connectivity. Returns 200 OK with JSON:
+# {"ready": true, "checks": {"database": "healthy", "storage": "healthy"}, "time": "..."}
+# On failure returns 503: {"ready": false, "checks": {...}, "error": "..."}
 ```
 
-Use `/healthz` for Kubernetes liveness probes (lightweight process-alive check) and `/health` for readiness probes (checks DB + storage connectivity). A startup probe on `/healthz` with a higher failure threshold allows slow-starting pods to initialize without being killed.
+Use `/health` for Kubernetes liveness and startup probes (DB-ping process-alive check) and `/ready` for readiness probes (checks DB + storage connectivity). A startup probe on `/health` with a higher failure threshold allows slow-starting pods to initialize without being killed. The bundled Helm chart uses `/health` for startup and liveness probes and `/ready` for the readiness probe.
 
 ---
 
@@ -630,14 +657,14 @@ After deploying, initialize the registry:
    docker-compose exec backend terraform-registry migrate up
    ```
 
-2. **Create the first admin user** via the admin API or the admin setup endpoint:
+2. **Provision the first admin user.** Log in via your configured IdP (OIDC/SAML/LDAP);
+   admin assignment is handled by the setup wizard / group-mapping configuration — see
+   [Initial Setup](initial-setup.md). For local testing only, the dev-login endpoint
+   returns a JWT for the pre-seeded `admin@dev.local` user (requires `DEV_MODE=true` and
+   the seed script). It ignores any request body and always logs in that fixed user:
 
    ```bash
-   # The first user created via OIDC login is automatically an admin
-   # For API key-only setups, use the dev endpoint (requires DEV_MODE=true):
-   curl -X POST http://localhost:8080/auth/dev/login \
-     -H "Content-Type: application/json" \
-     -d '{"email": "admin@example.com", "name": "Admin"}'
+   curl -X POST http://localhost:8080/api/v1/dev/login
    ```
 
 3. **Configure storage** via Admin → Storage in the web UI (or via environment variables)
@@ -889,19 +916,19 @@ docker compose -f deployments/docker-compose.prod.yml logs --tail=50 backend
 #    image.tag: v<version>
 
 # 2. Dry-run first
-helm upgrade terraform-registry deployments/helm/terraform-registry \
+helm upgrade terraform-registry ./deployments/helm \
   --namespace registry \
   -f my-values.yaml \
   --dry-run
 
 # 3. Apply
-helm upgrade terraform-registry deployments/helm/terraform-registry \
+helm upgrade terraform-registry ./deployments/helm \
   --namespace registry \
   -f my-values.yaml \
   --wait --timeout=5m
 
 # 4. Verify rollout
-kubectl rollout status deployment/terraform-registry -n registry
+kubectl rollout status deployment/terraform-registry-backend -n registry
 kubectl get pods -n registry
 ```
 
@@ -949,11 +976,11 @@ curl -sf "http://localhost:9090/metrics" | grep '^http_requests_total'
 # API — list providers (unauthenticated, should return 401 or empty list)
 curl -s "${BASE}/v1/providers" | jq .
 
-# API — login endpoint
-curl -s "${BASE}/v1/auth/login"
+# API — login endpoint (GET; redirects to the configured IdP)
+curl -s "${BASE}/api/v1/auth/login"
 ```
 
-- [ ] `/health` returns `{"status":"ok"}` (HTTP 200)
+- [ ] `/health` returns `{"status":"healthy"}` (HTTP 200)
 - [ ] `/metrics` returns Prometheus text (HTTP 200)
 - [ ] API endpoints respond (correct HTTP codes even if auth-gated)
 - [ ] No 500 errors in application logs for the first 5 minutes post-deploy
@@ -982,7 +1009,7 @@ docker compose -f deployments/docker-compose.prod.yml \
 
 ```bash
 helm rollback terraform-registry -n registry
-kubectl rollout status deployment/terraform-registry -n registry
+kubectl rollout status deployment/terraform-registry-backend -n registry
 ```
 
 #### Rollback Standalone Binary
@@ -999,11 +1026,12 @@ sudo systemctl start terraform-registry
 > Rolling back a schema migration after writes have occurred can cause data loss.
 
 ```bash
-# Review migration state first
-terraform-registry migrate status
+# Inspect the current schema version (the migrate command has no `status`
+# subcommand; query the migrations table directly):
+psql "$DATABASE_URL" -c "SELECT version, dirty FROM schema_migrations;"
 
-# Roll back the last migration
-terraform-registry migrate down 1
+# Roll back the last migration (the `migrate down` command takes no count argument)
+terraform-registry migrate down
 ```
 
 - [ ] Rollback decision logged in the incident channel

--- a/docs/deployment/aks-new-cluster.md
+++ b/docs/deployment/aks-new-cluster.md
@@ -48,7 +48,7 @@ ALB_IDENTITY_NAME="alb-controller-identity"
 # Application
 HOSTNAME="registry.company.com"          # Replace with your domain
 OPS_EMAIL="ops@company.com"
-IMAGE_TAG="v0.8.2"
+IMAGE_TAG="v1.0.0"   # current GA tag — see deployments/COMPATIBILITY.md
 ```
 
 ---

--- a/docs/deployment/eks-deployment.md
+++ b/docs/deployment/eks-deployment.md
@@ -18,7 +18,7 @@ Collect the values you captured during prerequisites:
 | `<IRSA_ROLE_NAME>` | `terraform-registry-irsa`                                                                                                              |
 | `<HOSTNAME>`       | Your public DNS name                                                                                                                   |
 | `<EMAIL>`          | Your ops email                                                                                                                         |
-| `<IMAGE_TAG>`      | `v0.8.2`                                                                                                                               |
+| `<IMAGE_TAG>`      | `v1.0.0` (current GA tag — see [`deployments/COMPATIBILITY.md`](../../deployments/COMPATIBILITY.md))                                    |
 
 ---
 
@@ -30,14 +30,18 @@ Collect the values you captured during prerequisites:
 cp deployments/helm/values-eks.yaml deployments/helm/values-eks-prod.yaml
 # Edit values-eks-prod.yaml — replace every <PLACEHOLDER>
 
+# Apply the SecretProviderClass FIRST (not in the Helm chart for EKS).
+# values-eks.yaml mounts the CSI secrets-store volume referencing this object;
+# if it does not exist yet, pods stay stuck in ContainerCreating (the volume
+# cannot mount) and `helm upgrade --wait` will time out.
+# Edit deployments/kubernetes/overlays/eks/secretproviderclass.yaml, then:
+kubectl create namespace terraform-registry --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f deployments/kubernetes/overlays/eks/secretproviderclass.yaml -n terraform-registry
+
 helm upgrade --install terraform-registry ./deployments/helm \
   --namespace terraform-registry --create-namespace \
   -f deployments/helm/values-eks-prod.yaml \
   --wait --timeout 5m
-
-# Apply the SecretProviderClass separately (not in the Helm chart for EKS)
-# Edit deployments/kubernetes/overlays/eks/secretproviderclass.yaml, then:
-kubectl apply -f deployments/kubernetes/overlays/eks/secretproviderclass.yaml
 ```
 
 ### Option B: Kustomize

--- a/docs/deployment/eks-prerequisites.md
+++ b/docs/deployment/eks-prerequisites.md
@@ -39,13 +39,14 @@ aws ecr get-login-password --region <AWS_REGION> | \
   docker login --username AWS \
   --password-stdin <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
 
+# Use the current GA tag (v1.0.0) — see deployments/COMPATIBILITY.md
 docker tag terraform-registry-backend:latest \
-  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v0.8.2
-docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v0.8.2
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-backend:v1.0.0
 
 docker tag terraform-registry-frontend:latest \
-  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v0.8.2
-docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v0.8.2
+  <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
+docker push <ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/terraform-registry-frontend:v1.0.0
 ```
 
 ### 2b. Amazon RDS for PostgreSQL
@@ -58,7 +59,10 @@ aws rds create-db-instance \
   --db-instance-identifier terraform-registry-db \
   --db-instance-class db.t3.medium \
   --engine postgres \
-  --engine-version 16.2 \
+  # Omit --engine-version to use the latest available 16.x, or run
+  # `aws rds describe-db-engine-versions --engine postgres` and pick an
+  # offered 16.x minor (AWS retires specific minors over time).
+  --engine-version 16 \
   --master-username registry \
   --master-user-password <STRONG_PASSWORD> \
   --db-name terraform_registry \

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@ This document describes how to set up a local development environment, generate 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.26+
 - Docker & Docker Compose (for test environment)
 - Make (optional)
 
@@ -45,7 +45,7 @@ For frontend development and E2E setup, see [terraform-registry-frontend](https:
 
 ## Test Coverage
 
-CI enforces a minimum threshold on `go test ./... -coverprofile=coverage.out`. The build fails if total statement coverage drops below **65%**. The aspirational goal is **70%** ("good for production" per Graphite / Google's "commendable" benchmark).
+CI enforces a minimum threshold on filtered coverage from `go test ./internal/... ./pkg/... -race -coverprofile=coverage.out`. The build fails if total statement coverage drops below the hard floor of **80%**. The aspirational goal is **85%** (target by the Phase 5 / H5.2 milestone, per Graphite / Google's "commendable" benchmark).
 
 Component targets follow a risk-based approach:
 
@@ -61,15 +61,21 @@ Component targets follow a risk-based approach:
 
 ### Measure Coverage Locally
 
+To match CI exactly, run the same package set with `-race`, then apply the
+`coverfilter` step that excludes integration-only functions (those whose doc
+comment carries a `coverage:skip:` marker) from the denominator:
+
 ```bash
 cd backend
-go test ./internal/... -coverprofile=coverage.out -covermode=atomic
-# Total
-go tool cover -func=coverage.out | grep "^total:"
+go test ./internal/... ./pkg/... -race -coverprofile=coverage.out -covermode=atomic
+# Filter integration-only functions, mirroring CI
+go run ./scripts/coverfilter -in coverage.out -out coverage.filtered.out -root .
+# Total (this is the number CI compares against the 80% floor)
+go tool cover -func=coverage.filtered.out | grep "^total:"
 # HTML report (opens in browser)
-go tool cover -html=coverage.out
+go tool cover -html=coverage.filtered.out
 # Per-package sorted by coverage ascending (spot lowest-covered packages)
-go tool cover -func=coverage.out | grep -v "^total:" | awk '{print $NF, $0}' | sort -V
+go tool cover -func=coverage.filtered.out | grep -v "^total:" | awk '{print $NF, $0}' | sort -V
 ```
 
 ## Troubleshooting

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -272,7 +272,7 @@ Perform a DR drill quarterly to validate recovery procedures. Use a non-producti
 
 - [ ] Confirm backup retention has recent backups available
 - [ ] Prepare a separate namespace or cluster for the drill
-- [ ] Document the current database schema version (`SELECT version FROM schema_migrations`)
+- [ ] Document the current database schema version (`SELECT version FROM schema_migrations`). This is the highest applied migration number (currently `40`, not `1`); see the [migrations README](../backend/internal/db/migrations/README.md) for the authoritative current value.
 - [ ] Record the current module/provider count for post-recovery validation
 
 ### Drill Execution

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,9 @@ Expected output:
 ```json
 {
   "status": "healthy",
-  "database": "connected"
+  "time": "2026-01-01T00:00:00Z",
+  "version": "1.0.0",
+  "build_date": "2026-01-01T00:00:00Z"
 }
 ```
 
@@ -111,11 +113,9 @@ curl -s -X POST http://localhost:8080/api/v1/setup/storage \
   -H "Authorization: SetupToken ${SETUP_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
-    "backend": "local",
-    "local": {
-      "base_path": "/app/storage",
-      "serve_directly": true
-    }
+    "backend_type": "local",
+    "local_base_path": "/app/storage",
+    "local_serve_directly": true
   }' | jq .
 ```
 
@@ -126,12 +126,14 @@ curl -s -X POST http://localhost:8080/api/v1/setup/admin \
   -H "Authorization: SetupToken ${SETUP_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
-    "email": "admin@example.com",
-    "username": "admin"
+    "email": "admin@example.com"
   }' | jq .
 ```
 
-The response includes a JWT token for the new admin user.
+The response confirms the admin assignment (`message`, `email`, `organization`,
+`role`); it does **not** issue a JWT. The registry has no local-password login —
+the admin signs in through your configured IdP (OIDC/SAML/LDAP) to obtain a
+browser session.
 
 #### Step 4: Complete Setup
 
@@ -142,12 +144,18 @@ curl -s -X POST http://localhost:8080/api/v1/setup/complete \
 
 ### Create an API Key
 
-Using the admin JWT token from step 3:
+First obtain an admin session token. In production, log in through your IdP
+(OIDC/SAML/LDAP). For local development with `DEV_MODE=true`, the dev-login
+endpoint returns a JWT for the pre-seeded `admin@dev.local` user:
 
 ```bash
-export TOKEN="<jwt-token-from-step-3>"
+export TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/dev/login | jq -r .token)
+```
 
-curl -s -X POST http://localhost:8080/api/v1/admin/api-keys \
+Then create the API key at `POST /api/v1/apikeys`:
+
+```bash
+curl -s -X POST http://localhost:8080/api/v1/apikeys \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -192,20 +200,23 @@ cd /tmp && tar czf my-module.tar.gz -C my-module .
 Upload to the registry:
 
 ```bash
-curl -s -X POST "http://localhost:8080/api/v1/modules/myorg/my-module/generic/1.0.0/upload" \
+curl -s -X POST "http://localhost:8080/api/v1/modules" \
   -H "Authorization: Bearer ${API_KEY}" \
-  -F "module=@/tmp/my-module.tar.gz" | jq .
+  -F "namespace=myorg" \
+  -F "name=my-module" \
+  -F "system=generic" \
+  -F "version=1.0.0" \
+  -F "file=@/tmp/my-module.tar.gz" | jq .
 ```
 
-Expected output:
+Expected output (HTTP 201):
 
 ```json
 {
   "namespace": "myorg",
   "name": "my-module",
   "system": "generic",
-  "version": "1.0.0",
-  "status": "ok"
+  "version": "1.0.0"
 }
 ```
 
@@ -289,10 +300,17 @@ Provider publishing requires platform-specific binary archives and SHA256SUMS fi
 
 ```bash
 # Upload a provider binary for linux/amd64
-curl -s -X POST "http://localhost:8080/api/v1/providers/myorg/myprovider/1.0.0/linux/amd64/upload" \
+curl -s -X POST "http://localhost:8080/api/v1/providers" \
   -H "Authorization: Bearer ${API_KEY}" \
-  -F "binary=@terraform-provider-myprovider_1.0.0_linux_amd64.zip" \
-  -F "shasum=abc123def456..." | jq .
+  -F "namespace=myorg" \
+  -F "type=myprovider" \
+  -F "version=1.0.0" \
+  -F "os=linux" \
+  -F "arch=amd64" \
+  -F "file=@terraform-provider-myprovider_1.0.0_linux_amd64.zip" \
+  -F "shasums_file=@terraform-provider-myprovider_1.0.0_SHA256SUMS" \
+  -F "shasums_signature_file=@terraform-provider-myprovider_1.0.0_SHA256SUMS.sig" \
+  -F "gpg_public_key=@public-key.asc" | jq .
 ```
 
 ### Verify Provider Availability
@@ -330,15 +348,16 @@ curl -s -X POST "http://localhost:8080/api/v1/admin/mirrors" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
-    "hostname": "registry.terraform.io",
-    "namespace": "hashicorp",
-    "type": "aws",
-    "sync_enabled": true,
-    "sync_interval_mins": 60
+    "name": "public-hashicorp",
+    "upstream_registry_url": "https://registry.terraform.io",
+    "namespace_filter": ["hashicorp"],
+    "provider_filter": ["aws"],
+    "enabled": true,
+    "sync_interval_hours": 1
   }' | jq .
 ```
 
-This creates a mirror that syncs the `hashicorp/aws` provider from the public Terraform Registry every 60 minutes.
+This creates a mirror that syncs the `hashicorp/aws` provider from the public Terraform Registry every hour.
 
 ### Trigger an Initial Sync
 

--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -116,7 +116,7 @@ export SETUP_TOKEN_FILE=/tmp/setup-token.txt
 
 1. Navigate to `https://your-registry/setup`
 2. Enter the setup token from the server logs
-3. Follow the 5-step wizard:
+3. Follow the 6-step wizard:
    - **Step 1: Authenticate** — Paste the setup token
    - **Step 2: OIDC Provider** — Configure your identity provider
    - **Step 3: Storage Backend** — Configure module/provider storage
@@ -148,10 +148,15 @@ Response:
   "setup_completed": false,
   "storage_configured": false,
   "oidc_configured": false,
+  "ldap_configured": false,
+  "auth_method": "",
   "admin_configured": false,
   "setup_required": true
 }
 ```
+
+`auth_method` reports the configured authentication method (`oidc` or `ldap`)
+once one is saved; `ldap_configured` mirrors `oidc_configured` for the LDAP path.
 
 ### 3. Test OIDC Configuration
 
@@ -184,6 +189,51 @@ curl -X POST https://your-registry/api/v1/setup/oidc \
     "scopes": ["openid", "email", "profile"]
   }'
 ```
+
+### 4b. Configure LDAP (alternative to OIDC)
+
+LDAP is a first-class authentication option equal to OIDC — configure **either**
+OIDC (steps 3–4) **or** LDAP, not both. Test the connection first, then save:
+
+```bash
+# Test the LDAP connection / bind
+curl -X POST https://your-registry/api/v1/setup/ldap/test \
+  -H "Authorization: SetupToken tfr_setup_YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "host": "ldap.example.com",
+    "port": 636,
+    "use_tls": true,
+    "bind_dn": "cn=registry,ou=svc,dc=example,dc=com",
+    "bind_password": "YOUR_BIND_PASSWORD",
+    "base_dn": "ou=users,dc=example,dc=com",
+    "user_filter": "(uid=%s)",
+    "user_attr_email": "mail",
+    "user_attr_name": "cn",
+    "group_base_dn": "ou=groups,dc=example,dc=com",
+    "group_filter": "(member=%s)",
+    "group_member_attr": "member"
+  }'
+
+# Save the LDAP configuration
+curl -X POST https://your-registry/api/v1/setup/ldap \
+  -H "Authorization: SetupToken tfr_setup_YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "host": "ldap.example.com",
+    "port": 636,
+    "use_tls": true,
+    "bind_dn": "cn=registry,ou=svc,dc=example,dc=com",
+    "bind_password": "YOUR_BIND_PASSWORD",
+    "base_dn": "ou=users,dc=example,dc=com",
+    "user_filter": "(uid=%s)"
+  }'
+```
+
+Required fields: `host`, `bind_dn`, `bind_password`, `base_dn`, `user_filter`.
+Use `use_tls: true` for LDAPS (port 636) or `start_tls: true` for StartTLS on the
+plain port. The group fields enable group-to-role mapping. After saving, the
+setup-status response reports `auth_method: "ldap"` and `ldap_configured: true`.
 
 ### 5. Test Storage Configuration
 

--- a/docs/module-scanning.md
+++ b/docs/module-scanning.md
@@ -15,7 +15,7 @@ Scanning is **disabled by default**. The scanner binary must be installed on the
 4. For each pending record the job downloads the module archive from storage, extracts it to a temporary directory, and invokes the scanner binary.
 5. Results (severity counts and raw JSON output) are stored in the `module_scans` table.
 6. The temporary directory is deleted immediately after the scan completes.
-7. Results are visible in the UI (Security Scan panel on the module detail page) and via `GET /api/v1/admin/modules/{namespace}/{name}/{system}/versions/{version}/scan`.
+7. Results are visible in the UI (Security Scan panel on the module detail page) and via `GET /api/v1/modules/{namespace}/{name}/{system}/versions/{version}/scan`.
 
 ---
 
@@ -161,7 +161,7 @@ All options live under the `scanning:` key in `config.yaml` or use the `TFR_SCAN
 | `tool`               | `TFR_SCANNING_TOOL`               | string   | —       | Scanner backend: `trivy`, `checkov`, `terrascan`, `snyk`, or `custom`.                                                    |
 | `binary_path`        | `TFR_SCANNING_BINARY_PATH`        | string   | —       | Absolute path to the scanner executable on the server.                                                                    |
 | `expected_version`   | `TFR_SCANNING_EXPECTED_VERSION`   | string   | —       | If set, the job refuses to run if the installed binary reports a different version. Supply-chain protection.              |
-| `severity_threshold` | `TFR_SCANNING_SEVERITY_THRESHOLD` | string   | (all)   | Comma-separated list of severities to record, e.g. `CRITICAL,HIGH`. Findings below the threshold are omitted from counts. |
+| `severity_threshold` | `TFR_SCANNING_SEVERITY_THRESHOLD` | string   | `CRITICAL,HIGH,MEDIUM,LOW` | Comma-separated list of severities to record, e.g. `CRITICAL,HIGH`. The default lists all severities (record all). Findings below the threshold are omitted from counts. |
 | `timeout`            | `TFR_SCANNING_TIMEOUT`            | duration | `5m`    | Maximum time a single scan may run before it is killed.                                                                   |
 | `worker_count`       | `TFR_SCANNING_WORKER_COUNT`       | int      | `2`     | Number of scans to run concurrently.                                                                                      |
 | `scan_interval_mins` | `TFR_SCANNING_SCAN_INTERVAL_MINS` | int      | `5`     | How often (in minutes) the job polls for pending scans.                                                                   |
@@ -178,8 +178,13 @@ All options live under the `scanning:` key in `config.yaml` or use the `TFR_SCAN
 Trivy requires no authentication. The registry invokes:
 
 ```text
-trivy fs --format json --scanners vuln,secret,misconfig --exit-code 0 --quiet <dir>
+trivy fs --format json --scanners vuln,secret,misconfig --exit-code 0 --cache-dir <cache-dir> --quiet <dir>
 ```
+
+The `--cache-dir` is passed on both the scan and the version probe so Trivy never
+attempts to write to `~/.cache` on a read-only root filesystem (e.g. Kubernetes
+pods with `readOnlyRootFilesystem: true`). It honours `TRIVY_CACHE_DIR` if set,
+otherwise defaults to `<tmpdir>/trivy-cache`.
 
 **Air-gapped environments:** Trivy downloads its vulnerability database on first use. In air-gapped deployments, pre-populate the database:
 
@@ -435,7 +440,7 @@ Results are available in two places:
 
 ```bash
 curl -H "Authorization: Bearer $TOKEN" \
-  https://registry.example.com/api/v1/admin/modules/myorg/vpc/aws/versions/1.0.0/scan
+  https://registry.example.com/api/v1/modules/myorg/vpc/aws/versions/1.0.0/scan
 ```
 
 Response:
@@ -464,6 +469,19 @@ Response:
 | `clean`    | Scan completed with zero findings.              |
 | `findings` | Scan completed with one or more findings.       |
 | `error`    | Scan failed. Check `error_message` for details. |
+
+### Other scanning endpoints
+
+For scripting installs and monitoring, the following endpoints are also available:
+
+| Method | Path                                                                  | Scope           | Purpose                                  |
+| ------ | --------------------------------------------------------------------- | --------------- | ---------------------------------------- |
+| GET    | `/api/v1/modules/{namespace}/{name}/{system}/versions/{version}/scan` | `scanning:read` | Fetch the scan result for a version      |
+| GET    | `/api/v1/admin/scanning/config`                                       | `admin`         | Current scanning configuration           |
+| GET    | `/api/v1/admin/scanning/stats`                                        | `scanning:read` | Aggregate scan statistics                |
+| GET    | `/api/v1/admin/scanning/scans/{id}`                                   | `scanning:read` | Fetch a single scan record by ID         |
+| POST   | `/api/v1/admin/scanning/install`                                      | `admin`         | Trigger scanner auto-install             |
+| POST   | `/api/v1/setup/scanning/install`                                      | setup phase     | Install the scanner during initial setup |
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -271,12 +271,13 @@ increase being zero during the expected notification window.
 | Property | Value                                                                                  |
 | -------- | -------------------------------------------------------------------------------------- |
 | Type     | Counter (CounterVec)                                                                   |
-| Labels   | `tier` (`individual` or `organization`), `key_type` (`user`, `apikey`, `ip`, or `org`) |
+| Labels   | `tier` (`individual`, `organization`, or `principal`), `key_type` (`user`, `apikey`, `ip`, or `org`) |
 | Source   | `internal/middleware/ratelimit.go`                                                     |
 | Updated  | Each time a request is rejected with HTTP 429                                          |
 
 Tracks every request rejected by the rate limiting middleware. The `tier` label
-distinguishes individual (per-user/IP) rejections from organization-level rejections.
+distinguishes individual (per-user/IP) rejections from organization-level rejections;
+the `principal` value is emitted when a per-user/per-key principal override is hit.
 Use `key_type` to identify whether rejections are hitting anonymous IP-based clients
 or authenticated users/API keys.
 
@@ -444,6 +445,57 @@ investigate slow queries holding connections open.
 
 ---
 
+### Publishing, Policy & Releases-Key Metrics
+
+#### `registry_module_publishes_total` / `registry_provider_publishes_total`
+
+| Property | Value                                                                        |
+| -------- | ---------------------------------------------------------------------------- |
+| Type     | Counter (CounterVec)                                                          |
+| Labels   | Modules: `namespace`, `system`. Providers: `namespace`, `type`               |
+| Source   | `internal/telemetry/metrics.go`                                              |
+| Updated  | Each time a module/provider version is published                             |
+
+Count published module and provider versions. Example: `increase(registry_provider_publishes_total[24h])`.
+
+#### `registry_policy_evaluations_total`
+
+| Property | Value                                                          |
+| -------- | -------------------------------------------------------------- |
+| Type     | Counter (CounterVec)                                           |
+| Labels   | `result` (`allowed`, `warn`, `blocked`)                        |
+| Source   | `internal/telemetry/metrics.go` (policy engine)               |
+| Updated  | After each policy evaluation                                   |
+
+Tracks OPA/Sentinel policy evaluations by outcome. Example: `rate(registry_policy_evaluations_total{result="blocked"}[5m])`.
+
+#### `terraform_registry_releases_key_refresh_total`
+
+| Property | Value                                                                                                    |
+| -------- | -------------------------------------------------------------------------------------------------------- |
+| Type     | Counter (CounterVec)                                                                                      |
+| Labels   | `tool`, `outcome` (`success`, `fingerprint_mismatch`, `fetch_failed`, `parse_failed`, `db_failed`, `skipped_unchanged`) |
+| Source   | Releases-key refresh job                                                                                  |
+| Updated  | On each refresh attempt                                                                                   |
+
+Counts release-signing GPG key refresh attempts. The `fingerprint_mismatch` outcome is a
+security-relevant alert signal — a refreshed key fingerprint no longer matches the
+expected value. Example: `increase(terraform_registry_releases_key_refresh_total{outcome="fingerprint_mismatch"}[1h])`.
+
+#### `terraform_registry_releases_key_expires_seconds`
+
+| Property | Value                                                       |
+| -------- | ----------------------------------------------------------- |
+| Type     | Gauge (GaugeVec)                                            |
+| Labels   | `tool`, `source` (`cache` or `embedded`)                    |
+| Source   | Releases-key refresh job                                    |
+| Updated  | On each refresh                                             |
+
+Seconds until the earliest signing-key expiry. Alert when within 30 days of expiry:
+`min by (tool) (terraform_registry_releases_key_expires_seconds) < 86400 * 30`.
+
+---
+
 ## PromQL Examples
 
 All examples assume the Prometheus job label is `job="terraform-registry"`.
@@ -578,7 +630,8 @@ increase(terraform_registry_audit_logs_cleaned_total{job="terraform-registry"}[2
 ## Recommended Alert Rules
 
 The Helm chart ships a ready-to-use PrometheusRule resource at
-`deployments/helm/templates/prometheusrule.yaml`. Enable it with:
+`deployments/helm/templates/prometheusrule.yaml`. It is **disabled by default**
+(`prometheusRule.enabled: false` in `values.yaml`); enable it with:
 
 ```yaml
 # values.yaml
@@ -752,17 +805,18 @@ cd deployments
 docker-compose --profile monitoring up -d
 
 # Grafana UI
-open http://localhost:3001   # admin / admin
+open http://localhost:3000   # admin / admin
 ```
 
 Prometheus is automatically added as a data source (URL: `http://prometheus:9090`).
 
 ### Importing a Dashboard
 
-1. Log into Grafana at `http://localhost:3001`
+1. Log into Grafana at `http://localhost:3000`
 2. Go to **Dashboards → Import**
-3. Paste the JSON from `deployments/grafana/terraform-registry.json` (if present) or
-   create a new dashboard with the queries below
+3. Paste the JSON from `deployments/observability/grafana-dashboard.json` (the same
+   dashboard the Helm chart ships via `deployments/helm/templates/grafana-dashboard.yaml`)
+   or create a new dashboard with the queries below
 
 ### Suggested Dashboard Panels
 

--- a/docs/plans/scm-shared-app-credentials-migration.md
+++ b/docs/plans/scm-shared-app-credentials-migration.md
@@ -1,0 +1,257 @@
+# Plan: Migrate Registry SCM Auth from Per-User OAuth to Shared App Credentials
+
+> **Status:** Proposed
+> **Repo:** `terraform-registry-backend` (+ `terraform-registry-frontend`)
+> **Scope:** Replace the **per-user OAuth token** model for SCM module linking with
+> a single **admin-created, org-shared app credential** per SCM provider — the same
+> kind of app/service auth the TSM drift plans adopt (Entra app registration for
+> Azure DevOps, GitHub App for GitHub). Removes the "every user must Connect"
+> friction.
+
+## 1. Motivation
+
+Today the registry stores **one OAuth token per (user, provider)** in
+`scm_oauth_tokens` and resolves the token for a repo sync from the **module
+creator**:
+
+```go
+// internal/services/scm_publisher.go (verified)
+if module.CreatedBy != nil {
+    tokenRecord, _ := p.scmRepo.GetUserToken(ctx, createdByUUID, repo.SCMProviderID)
+    accessToken, _ := p.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+    oauthToken = &scm.OAuthToken{ AccessToken: accessToken, ... }
+}
+```
+
+Consequences we want to remove:
+
+- Each user must run the OAuth **authorize → callback** dance before they can link.
+- A module's syncs **depend on the creator's** personal token; if that user's token
+  expires/revokes or they leave, publishing breaks.
+- GitHub OAuth tokens **don't refresh** at all here
+  (`RenewToken` returns `ErrTokenRefreshFailed`).
+
+**Target:** an admin registers one app credential per provider; **all users** linking
+modules and **all** background syncs use that shared, app-owned credential.
+
+## 2. Goals / Non-goals
+
+### Goals
+
+- One **admin-managed** credential per SCM provider, shared across users for module
+  linking + webhook-driven publish.
+- App/service auth matching TSM: **Entra app registration** (Azure DevOps),
+  **GitHub App** (GitHub). GitLab/Bitbucket: see §8.
+- Sync no longer keyed on `module.CreatedBy`.
+- Keep the existing `scm.Connector` package and `TokenCipher`; minimize churn.
+
+### Non-goals
+
+- Per-user authorization for *write-on-behalf-of-user* features (none rely on it for
+  publishing today). Audit any UI that shows "connected as a specific user".
+- Removing the OAuth code paths immediately — keep them during a deprecation window
+  (§9), then delete.
+
+## 3. Current-state anchors (verified)
+
+- Schema [`000001_initial_schema.up.sql`](../backend/internal/db/migrations/000001_initial_schema.up.sql):
+  - `scm_providers(client_id, client_secret_encrypted, tenant_id, base_url, ...)`
+  - `scm_oauth_tokens(user_id, scm_provider_id, access_token_encrypted,
+    refresh_token_encrypted, token_type, expires_at, UNIQUE(user_id, scm_provider_id))`
+  - `module_scm_repos(module_id, scm_provider_id, repository_owner, repository_name, ...)`
+- OAuth endpoints + token storage:
+  [`internal/api/admin/scm_oauth.go`](../backend/internal/api/admin/scm_oauth.go)
+  (`InitiateOAuth`, `HandleOAuthCallback`, `RefreshToken`, token status, revoke,
+  `SavePATToken`).
+- Connector interface + Entra `.default`/`offline_access`:
+  [`internal/scm/connector.go`](../backend/internal/scm/connector.go),
+  [`internal/scm/azuredevops/connector.go`](../backend/internal/scm/azuredevops/connector.go).
+- Token consumption: `GetUserToken(...)` in
+  [`internal/services/scm_publisher.go`](../backend/internal/services/scm_publisher.go).
+- Crypto: `TokenCipher.Seal/Open` (AES-256-GCM, key rotation) in
+  [`internal/crypto/tokencipher.go`](../backend/internal/crypto/tokencipher.go).
+- Next migration number: **`000041`**.
+
+## 4. Design
+
+### 4.1 New credential model — provider-level, not per-user
+
+Add a single shared credential per provider, minted on demand (no user binding):
+
+```sql
+-- migration 000041_scm_shared_app_credentials
+
+-- How a provider authenticates for shared, headless access.
+ALTER TABLE scm_providers ADD COLUMN auth_mode TEXT NOT NULL DEFAULT 'oauth_user'
+    CHECK (auth_mode IN ('oauth_user', 'entra_app', 'github_app'));
+
+-- GitHub App fields (auth_mode = 'github_app').
+ALTER TABLE scm_providers ADD COLUMN github_app_id TEXT;
+ALTER TABLE scm_providers ADD COLUMN github_installation_id TEXT;
+ALTER TABLE scm_providers ADD COLUMN encrypted_app_private_key TEXT; -- base64 GCM
+
+-- Entra app-registration uses existing client_id + tenant_id +
+-- client_secret_encrypted (already on scm_providers) with a client-credentials
+-- grant. No new columns needed for Entra beyond auth_mode.
+
+-- Cached shared token (optional persistence so restarts don't re-mint immediately).
+CREATE TABLE scm_provider_tokens (
+    scm_provider_id        UUID PRIMARY KEY REFERENCES scm_providers(id) ON DELETE CASCADE,
+    access_token_encrypted TEXT NOT NULL,
+    token_type             VARCHAR(50) NOT NULL DEFAULT 'Bearer',
+    expires_at             TIMESTAMP,
+    updated_at             TIMESTAMP NOT NULL DEFAULT NOW()
+);
+```
+
+`auth_mode='oauth_user'` preserves today's behaviour during migration.
+`entra_app` / `github_app` are the shared app modes.
+
+### 4.2 Shared token minter
+
+Add a provider-level minter alongside the connector:
+
+```go
+// internal/scm/appcreds/minter.go (new)
+type SharedMinter interface {
+    // MintProviderToken returns a usable token for a provider, refreshing if needed.
+    MintProviderToken(ctx context.Context, p *scm.SCMProvider) (*scm.OAuthToken, error)
+}
+```
+
+- `entra_app`: client-credentials POST to
+  `login.microsoftonline.com/{tenant}/oauth2/v2.0/token`,
+  `scope=499b84ac-.../.default` (reuse the constant already in the ADO connector).
+- `github_app`: app-JWT (RS256 from `encrypted_app_private_key`) →
+  `POST /app/installations/{id}/access_tokens`.
+- Cache in `scm_provider_tokens` (encrypted via `TokenCipher`) with a refresh margin;
+  re-mint on expiry. Re-mintable from stored secrets, so cache loss is non-fatal.
+
+> The minter mirrors the two TSM minters (Entra client-credentials, GitHub App). The
+> registry and TSM implementations stay independent (no shared module), but the
+> request shaping should be kept identical for review parity.
+
+### 4.3 Token resolution change (the core migration)
+
+`scm_publisher.go` stops using `module.CreatedBy`/`GetUserToken`:
+
+```go
+// before: per-user, keyed on module creator
+// tokenRecord, _ := p.scmRepo.GetUserToken(ctx, createdByUUID, repo.SCMProviderID)
+
+// after: one shared credential per provider
+provider, _ := p.scmRepo.GetProvider(ctx, repo.SCMProviderID)
+switch provider.AuthMode {
+case "entra_app", "github_app":
+    oauthToken, _ = p.sharedMinter.MintProviderToken(ctx, provider)
+case "oauth_user":
+    // legacy fallback during deprecation window (existing code path)
+}
+```
+
+Every other consumer of `GetUserToken` for **linking/sync** is repointed the same
+way. Interactive repo-browsing endpoints (list repos/branches/tags in the link
+wizard) also switch to the shared token, which is the whole point — users no longer
+need a personal token to browse.
+
+### 4.4 Admin API + endpoints
+
+- Extend the provider create/update admin handlers
+  ([`internal/api/admin/`](../backend/internal/api/admin/)) to accept
+  `auth_mode` and the app fields (Entra: existing client/tenant/secret;
+  GitHub App: app id, installation id, private key PEM). Encrypt secrets via
+  `TokenCipher`.
+- Add `POST /api/v1/scm-providers/{id}/verify` — mint a shared token and hit a cheap
+  API (`GET /_apis/projects` for ADO, `GET /installation/repositories` for GitHub) →
+  `{ ok, expires_at }`. Admin-gated.
+- **Deprecate** the per-user endpoints (`/oauth/authorize`, `/oauth/callback`,
+  `/oauth/refresh`, `/oauth/token`) — keep functioning while `auth_mode='oauth_user'`
+  exists, mark deprecated in swagger, remove in the cleanup phase (§9).
+- RBAC: shared-credential management stays **admin-only** (same gating as provider
+  CRUD today).
+
+### 4.5 Frontend (`terraform-registry-frontend`)
+
+- `SCMProvidersPage.tsx`: provider form gains an **Auth mode** selector
+  (App credential | Per-user OAuth [deprecated]). For app modes, render the relevant
+  fields + "Test connection". Remove the per-user **Connect/Refresh/Disconnect**
+  affordances for app-mode providers (they become a single org-level status row).
+- `api.ts`/`types/scm.ts`: add `auth_mode` + app fields; add `verifySCMProvider`.
+- Link-module wizard: drop any "you must connect your account first" gate when the
+  provider is in app mode — browsing/listing uses the shared credential.
+
+## 5. Data migration & backfill
+
+- The migration is **additive**; existing providers default to `auth_mode='oauth_user'`
+  and keep working unchanged.
+- No automatic conversion of existing OAuth tokens (they're user-delegated and can't
+  become app creds). An admin **opts a provider into** app mode by entering app
+  credentials; on save, the provider flips to `entra_app`/`github_app` and subsequent
+  syncs use the shared token.
+- Existing `scm_oauth_tokens` rows are left in place until the cleanup phase, then
+  dropped with the table.
+
+## 6. Security
+
+- Shared secrets (Entra client secret, GitHub App private key) encrypted at rest via
+  `TokenCipher` (existing key-rotation supported); never returned in JSON (expose
+  only `has_*` booleans).
+- The shared token is **powerful** (acts for the whole org). Document least-privilege
+  app permissions (ADO: Code Read; GitHub App: Contents R, Metadata R, plus webhook
+  perms only if the registry manages webhooks).
+- Audit-log credential create/update/verify and every sync that uses the shared token
+  (record `provider_id`, not a user).
+- Threat note: moving from per-user to shared widens blast radius of one credential —
+  mitigate with least privilege + rotation + admin-only management.
+
+## 7. Testing
+
+- **Unit:** shared minter (Entra client-credentials + GitHub App JWT), cache
+  hit/miss/expiry, error mapping. `httptest` + throwaway RSA key.
+- **Unit:** `scm_publisher` resolves the shared token by `auth_mode` and **no longer**
+  calls `GetUserToken` in app mode; `oauth_user` legacy path still works.
+- **Unit:** admin create/update validates app fields; secrets never echoed; `/verify`.
+- **Migration:** up adds columns/table + default `oauth_user`; existing providers
+  unaffected; down is safe only with no app-mode rows (fail loudly otherwise).
+- **Frontend:** auth-mode form gating; removal of per-user Connect in app mode; verify
+  call; link wizard no longer blocks on personal connection.
+- `make test` (Go) + `npx vitest run` for touched FE; ensure `gosec` baseline updated
+  if JWT signing trips a rule.
+
+## 8. GitLab / Bitbucket
+
+- **GitLab:** supports OAuth refresh and also **group/project access tokens** and
+  **CI job tokens**; the closest "shared app" analog is a bot/group access token
+  stored as a shared provider credential (`auth_mode` could gain `shared_token`).
+  Out of scope for the first cut — keep GitLab on `oauth_user` until a follow-up.
+- **Bitbucket DC:** already PAT-based (`SavePATToken`). A shared PAT stored at the
+  provider level is a trivial extension (`auth_mode='shared_token'`); fold into the
+  follow-up.
+- First delivery targets **Azure DevOps (Entra app)** and **GitHub (GitHub App)** —
+  matching the TSM plans — and leaves GitLab/Bitbucket on the existing path.
+
+## 9. Rollout & deprecation
+
+1. Ship migration `000041` + shared minter + admin API (additive; default
+   `oauth_user`). Per-user OAuth still fully works.
+2. Ship FE auth-mode selector + verify.
+3. Pilot: flip one provider to app mode; confirm linking + webhook publish use the
+   shared credential and no per-user Connect is required.
+4. Announce deprecation of per-user OAuth for publishing.
+5. **Cleanup phase (separate PR, after a validation window):** repoint any remaining
+   consumers, drop per-user OAuth endpoints + `scm_oauth_tokens` table + the
+   `oauth_user` branch.
+
+## 10. Effort / sequencing
+
+1. Migration `000041` (columns + `scm_provider_tokens`).
+2. Shared minter (Entra + GitHub App) + cache (unit-tested standalone).
+3. Repoint `scm_publisher` + interactive browse endpoints off `GetUserToken`.
+4. Admin create/update/verify + JSON exposure.
+5. Frontend auth-mode UI + wizard de-gate.
+6. Deprecate per-user endpoints (swagger + UI).
+7. Tests + runbook.
+8. **Later:** cleanup PR removing OAuth-user code + table.
+
+Steps 1–4 are backend-only and independently reviewable; the user-facing behaviour
+change lands with step 5.

--- a/docs/roadmap-version-approval.md
+++ b/docs/roadmap-version-approval.md
@@ -1,5 +1,11 @@
 # Roadmap: Version Approval for Mirrors
 
+> **Status: Implemented / Shipped.** This feature is fully implemented; see
+> [docs/version-approval.md](version-approval.md) for the user-facing guide. This
+> document is retained as the original planning record. The schema and endpoint
+> details below have been reconciled against the shipped migration
+> (`000037_version_approval.up.sql`).
+
 ## Summary
 
 Add a version-level approval gate to provider mirrors and terraform binary mirrors. When enabled, newly synced versions enter `pending_approval` state and are hidden from Terraform clients until an administrator approves them. This makes "latest" = "latest approved version."
@@ -21,6 +27,14 @@ Organizations need to vet mirrored provider versions before exposing them to dev
 Migration `000037_version_approval.up.sql`:
 
 ```sql
+-- Gate flag + optional auto-approve rules on each mirror-config table.
+ALTER TABLE mirror_configurations
+  ADD COLUMN requires_approval  BOOLEAN DEFAULT FALSE NOT NULL,
+  ADD COLUMN auto_approve_rules JSONB   DEFAULT NULL;
+ALTER TABLE terraform_mirror_configs
+  ADD COLUMN requires_approval  BOOLEAN DEFAULT FALSE NOT NULL,
+  ADD COLUMN auto_approve_rules JSONB   DEFAULT NULL;
+
 ALTER TABLE mirrored_provider_versions
   ADD COLUMN approval_status VARCHAR(20) DEFAULT NULL
     CHECK (approval_status IN ('pending_approval', 'approved', 'rejected'));
@@ -29,10 +43,12 @@ ALTER TABLE terraform_versions
   ADD COLUMN approval_status VARCHAR(20) DEFAULT NULL
     CHECK (approval_status IN ('pending_approval', 'approved', 'rejected'));
 
-ALTER TABLE mirror_configurations
-  ADD COLUMN auto_approve_rules JSONB DEFAULT NULL;
-ALTER TABLE terraform_mirror_configs
-  ADD COLUMN auto_approve_rules JSONB DEFAULT NULL;
+-- Partial indexes keep "pending count" and protocol filtering fast without
+-- penalising the common case (approval_status IS NULL).
+CREATE INDEX idx_mpv_approval_status
+  ON mirrored_provider_versions (approval_status) WHERE approval_status IS NOT NULL;
+CREATE INDEX idx_tfv_approval_status
+  ON terraform_versions (approval_status) WHERE approval_status IS NOT NULL;
 
 CREATE TABLE version_approval_events (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -135,10 +135,10 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
    - Trigger a tag push or verify the webhook integration is functional.
    - Check logs for decryption errors (there should be none).
 
-6. **(Optional) Re-encrypt all tokens** with the new key. This eliminates the dependency on the previous key. You can do this by:
+6. **(Optional) Re-encrypt all tokens** with the new key. This eliminates the dependency on the previous key. **Not yet available as a built-in command — a manual SQL/script step is required today.** Do this by:
    - Iterating all `scm_providers` rows with encrypted tokens.
    - Decrypting with the dual-key cipher and re-encrypting with only the current key.
-   - A future version of the registry will include a built-in admin command for this.
+   - A built-in admin command for this is not yet available; the dual-key fallback (above) is the supported zero-downtime path, and this re-encryption is optional cleanup.
 
 7. **Remove the previous key** once all tokens have been re-encrypted (or after a sufficient grace period):
 
@@ -179,7 +179,7 @@ OIDC client secrets are configured via `TFR_AUTH_OIDC_CLIENT_SECRET` (or `TFR_AU
 
    ```bash
    kubectl create secret generic registry-oidc-secrets \
-     --from-literal=OIDC_CLIENT_SECRET="new-secret-value" \
+     --from-literal=TFR_AUTH_OIDC_CLIENT_SECRET="new-secret-value" \
      --dry-run=client -o yaml | kubectl apply -f -
    ```
 

--- a/docs/suite-audit-federation.md
+++ b/docs/suite-audit-federation.md
@@ -24,8 +24,10 @@ original `source_timestamp`, `auth_method`, and `status_code` in metadata).
 ## Preconditions
 
 Federation is only **coherent under a shared identity store**, and TSM enforces
-this — it accepts entries only when `sharedStore` is asserted (advertised as the
-`audit.ingest.v1` manifest capability) and rejects them otherwise:
+this — it accepts entries only when `sharedStore` is asserted (advertised by TSM,
+the ingest side, as the `audit.ingest.v1` manifest capability; the registry's own
+manifest advertises only `modules.v1`/`providers.v1`/`mirror.v1`/`oci.v1`) and
+rejects them otherwise:
 
 1. **Shared identity store.** Both apps point at one physical identity database
    (one host + one database name). Only then do the registry's `user_id` /

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -92,7 +92,7 @@ Terraform modules and providers. It comprises:
 | S-1 | Attacker impersonates a legitimate user via stolen API key | Backend auth           | API keys are bcrypt-hashed (cost ≥12); keys have expiry dates; rate limiting on auth endpoints; audit logging of all auth events | ✅ Implemented |
 | S-2 | Attacker forges OIDC/SAML tokens                           | Backend auth           | Token signature verification against IdP JWKS/metadata; issuer + audience validation; nonce/replay protection                    | ✅ Implemented |
 | S-3 | Attacker performs LDAP injection to bypass auth            | Backend LDAP connector | Parameterized LDAP queries with input escaping; bind DN validation                                                               | ✅ Implemented |
-| S-4 | Attacker hijacks session via XSS                           | Frontend               | httpOnly + Secure + SameSite=Strict cookies; CSP with nonces; no inline scripts                                                  | ✅ Implemented |
+| S-4 | Attacker hijacks session via XSS                           | Frontend               | httpOnly + Secure + SameSite=Lax cookies (Lax, not Strict, is required so the cookie survives the OIDC top-level redirect); CSP with nonces; no inline scripts | ✅ Implemented |
 | S-5 | DNS spoofing redirects IdP callbacks                       | Backend OIDC           | Strict redirect_uri validation; state parameter CSRF protection                                                                  | ✅ Implemented |
 
 ### 5.2 Tampering (T)
@@ -142,9 +142,14 @@ Terraform modules and providers. It comprises:
 | --- | ---------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | E-1 | User escalates from read-only to admin               | Backend RBAC | Scope-based authorization on every endpoint; role templates are immutable after creation (admin audit); middleware enforces scope checks | ✅ Implemented |
 | E-2 | SCIM token used beyond provisioning scope            | Backend SCIM | SCIM tokens have dedicated `scim:provision` scope; cannot access module/provider endpoints                                               | ✅ Implemented |
-| E-3 | Container escape leads to host compromise            | Deployment   | Non-root container user; read-only root filesystem; dropped capabilities; seccomp/AppArmor profiles recommended in deployment docs       | ✅ Implemented |
+| E-3 | Container escape leads to host compromise            | Deployment   | Non-root container user; read-only root filesystem; dropped capabilities; seccomp/AppArmor profiles recommended in deployment docs       | ⚙️ Operator-configured |
 | E-4 | SQL injection leads to privilege escalation          | Backend      | Parameterized queries; DB user has minimum required grants (no SUPERUSER); separate migration user for DDL                               | ✅ Implemented |
 | E-5 | Path traversal in module/provider archive extraction | Backend      | Archive extraction validates paths; rejects entries with `..` components; temp directory isolation                                       | ✅ Implemented |
+
+> **Status legend:** ✅ Implemented = enforced by the application; ⚠️ Partial =
+> partially enforced; ⚙️ Operator-configured = the application ships safe defaults
+> and guidance, but full enforcement depends on deployment configuration (e.g.
+> seccomp/AppArmor profiles applied by the operator).
 
 ## 6. Assumptions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,7 +50,7 @@ Connected to localhost:5432/terraform_registry as registry
   schema_migrations               1
 
 === MIGRATION STATE ===
-  version=1  dirty=false
+  version=40  dirty=false
 
 === MODULES ===
   myorg/vpc/aws  (id: 3f2a…)
@@ -59,6 +59,10 @@ Connected to localhost:5432/terraform_registry as registry
 === PROVIDERS ===
   myorg/myprovider  (id: 7d4e…)
 ```
+
+> The reported migration `version` equals the highest applied migration number (currently
+> `40`), not `1`. See the
+> [migrations README](../backend/internal/db/migrations/README.md) for the per-version index.
 
 ### cmd/fix-migration — repair dirty migration state
 
@@ -135,7 +139,7 @@ go build -o api-test.exe ./cmd/api-test
 **Example output:**
 
 ```txt
-[PASS] #1   GET     /terraform.json                                          200  (1ms)
+[PASS] #1   GET     /.well-known/terraform.json                              200  (1ms)
 [PASS] #2   GET     /api/v1/admin/organizations                              200  (2ms)
 ...
 [SKIP] #47  GET     /api/v1/admin/tf-mirrors/:id/versions/:version → no synced version data available
@@ -214,20 +218,11 @@ go run cmd/server/main.go migrate up
 no migration files found
 ```
 
-The server looks for migrations in `backend/internal/db/migrations/`. Ensure the binary
-is run from the `backend/` directory or set the migration path explicitly.
-
-#### Version Mismatch After Consolidation
-
-If you ran the registry before Session 26 (when migrations were consolidated into a single
-file), reset the migration state:
-
-```sql
-TRUNCATE schema_migrations;
-INSERT INTO schema_migrations (version, dirty) VALUES (1, false);
-```
-
-Then restart the server — it will recognize the schema as current and skip re-applying.
+Migrations are **embedded into the binary** at build time via `go:embed` (see
+`backend/internal/db/db.go`) and loaded with `iofs` — there is no runtime filesystem
+lookup and no migration-path flag, so the working directory is irrelevant. This error
+indicates a corrupt or incorrectly-built binary (the embedded `migrations/*.sql` files are
+missing); rebuild from a clean checkout rather than adjusting paths.
 
 ### Slow Queries
 
@@ -268,8 +263,11 @@ export TFR_JWT_SECRET=$(openssl rand -hex 32)
 If you're in development and want to bypass this check:
 
 ```bash
-export TFR_DEV_MODE=true
+export DEV_MODE=true   # DEV_MODE=1 also works
 ```
+
+> Note: `DEV_MODE` is intentionally **not** `TFR_`-prefixed (same as `ENCRYPTION_KEY`).
+> Setting `TFR_DEV_MODE` has no effect.
 
 ### Invalid API Key
 
@@ -345,9 +343,11 @@ Or use the `EnsureContainer()` helper described in the admin storage configurati
 
 **Invalid SAS token:**
 
-SAS tokens have a configurable TTL. If downloads fail with `AuthenticationFailed`,
-increase `TFR_STORAGE_AZURE_SAS_TOKEN_EXPIRY` (default: `15m`). Large provider binaries
-on slow connections may need `1h` or more.
+The SAS-token TTL is **not** operator-configurable via an environment variable — it is
+passed programmatically by the download handler into `GetURL(ctx, path, ttl)`. There is no
+`TFR_STORAGE_AZURE_SAS_TOKEN_EXPIRY` setting. If large provider binaries fail with
+`AuthenticationFailed` on slow connections, the cause is usually clock skew between the
+host and Azure or an incorrect `account_key` rather than the TTL; verify those first.
 
 **Account key error:**
 
@@ -707,14 +707,14 @@ If this is zero when you expect notifications, check:
 
 - `TFR_NOTIFICATIONS_ENABLED=true` is set
 - `TFR_NOTIFICATIONS_SMTP_HOST` is reachable from the server (`telnet <host> 587`)
-- `TFR_NOTIFICATIONS_WARNING_DAYS` covers the keys approaching expiry
+- `TFR_NOTIFICATIONS_API_KEY_EXPIRY_WARNING_DAYS` covers the keys approaching expiry
 - Backend logs for `"failed to send expiry email"` lines (visible at `info` level)
 
 ### Metrics Endpoint Not Reachable
 
 If `curl http://localhost:9090/metrics` times out or returns connection refused:
 
-- `TFR_TELEMETRY_ENABLED` must be `true` (default)
+- `TFR_TELEMETRY_METRICS_ENABLED` must be `true` — this is the gate that actually starts the metrics listener (`TFR_TELEMETRY_ENABLED` is a separate global toggle and does **not** control whether the listener binds)
 - `TFR_TELEMETRY_METRICS_PROMETHEUS_PORT` defaults to `9090` — verify it matches your scrape config
 - The metrics listener binds to `0.0.0.0` but is intentionally **not** routed through the public Nginx ingress; access it directly on the internal network or via SSH tunnel
 - Check backend startup logs for `"metrics server started"` to confirm the listener came up

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -54,7 +54,7 @@ The preflight check validates:
 
    ```bash
    curl -s https://registry.example.com/health | jq
-   curl -s https://registry.example.com/api/v1/version | jq
+   curl -s https://registry.example.com/version | jq
    ```
 
 8. **Verify key functionality:**
@@ -102,7 +102,7 @@ If issues are found after upgrade:
 **Pre-flight:**
 
 ```bash
-./terraform-registry upgrade preflight --from 0.6 --to 0.7
+./terraform-registry upgrade preflight --config config.yaml
 ```
 
 **Rollback:** Migrations 000020–000023 are all reversible. Run `migrate down` to version 19 before deploying 0.6.x.
@@ -129,7 +129,7 @@ If issues are found after upgrade:
 **Pre-flight:**
 
 ```bash
-./terraform-registry upgrade preflight --from 0.7 --to 0.8
+./terraform-registry upgrade preflight --config config.yaml
 ```
 
 **Rollback:** Migrations 000024–000025 are reversible. Note: SAML/LDAP user records created during 0.8.0 operation will be orphaned on rollback.
@@ -142,13 +142,15 @@ If issues are found after upgrade:
 
 **Migrations:**
 
-- Per-org quota tables
-- Legal hold table for audit logs
+- `000026_org_quotas` — adds per-org quota tables
+
+> Note: Legal hold for audit logs is implemented in application code
+> (`backend/internal/audit/legal_hold.go`), not via a dedicated migration.
 
 **Pre-flight:**
 
 ```bash
-./terraform-registry upgrade preflight --from 0.8 --to 0.9
+./terraform-registry upgrade preflight --config config.yaml
 ```
 
 ### 0.9.x → 0.10.0
@@ -166,7 +168,7 @@ If issues are found after upgrade:
 **Pre-flight:**
 
 ```bash
-./terraform-registry upgrade preflight --from 0.9 --to 0.10
+./terraform-registry upgrade preflight --config config.yaml
 ```
 
 ---
@@ -177,40 +179,37 @@ If issues are found after upgrade:
 Usage: terraform-registry upgrade preflight [flags]
 
 Flags:
-  --config string     Path to config.yaml (default "config.yaml")
-  --from string       Current version (auto-detected from DB if omitted)
-  --to string         Target version (auto-detected from binary if omitted)
-  --verbose           Show detailed migration plan
-  --dry-run           Validate only, do not apply any changes
+  --config string     Path to config.yaml (overrides CONFIG_PATH; falls back to environment variables)
+  --verbose           Show the detail message for every check, not just warnings/failures
 
 Examples:
   terraform-registry upgrade preflight
-  terraform-registry upgrade preflight --from 0.7 --to 0.8 --verbose
+  terraform-registry upgrade preflight --config config.yaml --verbose
 ```
+
+The current/target versions and the pending-migration set are derived
+automatically: the current schema version is read from `schema_migrations`, and
+the target version is the binary's own build version. The command validates
+state and reports readiness; it never applies migrations (those run on the next
+`serve` startup), so there is no separate dry-run mode.
 
 ### Preflight Check Output
 
 ```text
 Terraform Registry — Upgrade Preflight
 =======================================
-Current version:  0.7.2
-Target version:   0.8.0
-Database:         connected (PostgreSQL 16.2)
-Schema version:   23
-Target schema:    25
+Binary version:   1.0.0
+Build date:       2026-04-29T00:00:00Z
 
-Pending migrations:
-  000024_module_deprecation.up.sql  [reversible]
-  000025_org_idp_binding.up.sql     [reversible]
+  ✓ Configuration
+  ✓ Database: Connected (PostgreSQL 16.2 ...)
+  ✓ PostgreSQL version: Version 16.x
+  ✓ Schema: Current schema version: 40
+  ✓ Encryption key: Present
+  ✓ Storage backend: Type: s3
+  ⚠ Redis: Not configured — required for multi-pod deployments
 
-Configuration checks:
-  ✓ Database connectivity
-  ✓ Storage backend accessible
-  ✓ Encryption key present
-  ⚠ Deprecated config: auth.oidc_issuer_url → use auth.oidc.issuer_url
-  ✓ Redis connectivity (required for multi-pod)
-
-Result: READY TO UPGRADE (1 warning)
+Result: READY TO UPGRADE (with warnings)
 ```
 
 ---

--- a/docs/version-approval.md
+++ b/docs/version-approval.md
@@ -47,6 +47,16 @@ infrastructure code.
   versions.
 - Mirrors without the flag behave exactly as before, with zero filtering cost.
 
+## Enabling the gate
+
+The **Require approval** toggle maps to the `requires_approval` boolean on the
+mirror configuration (both provider mirrors and Terraform binary mirrors). The
+optional auto-approve rules described below live in the `auto_approve_rules`
+JSONB field on the same configuration. Both fields are set through the admin
+mirror API/UI rather than static config; see
+[configuration.md](configuration.md) for the mirror-configuration fields and the
+[API reference](api-reference.md) for the admin mirror endpoints.
+
 ## Auto-approve rules
 
 To avoid manual review of low-risk versions, a gated mirror can carry an


### PR DESCRIPTION
## Summary
Documentation accuracy pass against the code, plus two shipped bugs the review surfaced.

### Code / config fixes
- **deployments/helm/values-eks.yaml** / **values-gke.yaml** — `storage.*.authMethod` was set to values the backend **rejects at runtime** (`irsa`, `workload-identity`); corrected to the accepted enums (`default`, `workload_identity`), verified against the s3/gcs storage backends.
- **cmd/server/main.go** — wired up the orphaned `upgrade preflight` command (`RunUpgradePreflight` existed but was never dispatched → "unknown command"); `upgrade-guide.md` rewritten to the real flag surface (`--config`/`--verbose`).
- `go build ./...` and `go vet ./...` pass.

### Documentation corrections (high-impact)
- Wrong env vars / paths: `TFR_DEV_MODE`→`DEV_MODE`, `/auth/dev/login`→`/api/v1/dev/login`, session lifetime 4h→24h, removed the non-existent `TFR_AUTH_AZURE_AD_REQUIRE_VERIFIED_EMAIL`.
- `getting-started.md` upload/provider/mirror/health/admin examples rewritten against the real router.
- `architecture.md` — added the cookie+CSRF browser auth flow, SAML/LDAP/mTLS providers, full Background Jobs table, shared identity-module note; ADR-004 corrected (bcrypt, not SHA-256).
- `configuration.md` — added SAML/LDAP, binary-mirror, policy, CVE, mTLS, principal-overrides, identity-database, and suite-coupling reference sections.
- Refreshed stale tables (migration index, CI coverage 80%, Go 1.26, SECURITY contexts) and many smaller accuracy items.

This is Phase 1 (correcting existing docs) of a multi-repo documentation review; the missing net-new docs follow in Phase 2.

Note: `backend/gosec-report.md` was left in place — it is referenced by `ci.yml`, so it is not the deletable orphan the review suspected.