### PR TITLE
docs: add shared-identity ADR (012) and canonical-host guide

### DIFF
--- a/docs/adr/012-shared-identity-component.md
+++ b/docs/adr/012-shared-identity-component.md
@@ -1,0 +1,170 @@
+<!-- markdownlint-disable MD013 -->
+# 12. Shared Identity Component
+
+**Status**: Accepted
+
+## Context
+
+The registry began life as a standalone application: it owns its users,
+organizations, API keys, role templates, OIDC config, audit logs, and JWT
+revocation list, all in its own `public` schema, and it ships the auth
+primitives (JWT signing/validation, API-key generation/validation, scope
+checking) inline in `internal/auth/`.
+
+A second application in the same product family — the Terraform State Manager
+(TSM) — needs the *same* identity primitives and, for some operators, the *same*
+identity store. If each app reimplements JWT claims, bcrypt API-key hashing,
+scope semantics, and host normalization, the two implementations drift: a token
+minted by one app fails to validate in the other, scope wildcards diverge, and
+the "is this the same user?" question has no defensible answer. Two forces are
+in tension:
+
+1. **Standalone must stay standalone.** The overwhelmingly common deployment is
+   a single registry with no sibling. None of this can add a service to deploy,
+   change default behavior, or require a shared database. The registry must run
+   exactly as before when no sibling is configured.
+
+2. **Coupled deployments must share one identity, not two synced copies.** When
+   an operator deliberately runs the registry and TSM together, a user,
+   organization, or API key should be *one* row that both apps read — not a
+   replication pipeline between two stores that can fall out of sync.
+
+We also already had a concrete cross-app feature that surfaces the coupling: the
+"Consumed by" panel (which managed states reference a given registry module).
+That join only works if both apps agree on the JWT issuer, the scope model, and
+the canonical host identity of the registry.
+
+## Decision
+
+Extract the identity and suite-coupling primitives into a single shared Go
+**library** — [`terraform-suite-identity`](https://github.com/sethbacon/terraform-suite-identity)
+(`github.com/sethbacon/terraform-suite-identity`, pinned at `v0.16.0` in
+`backend/go.mod`) — and link it into the registry binary. It is a library, not a
+service: there is nothing extra to deploy.
+
+### What the shared module owns
+
+- **JWT** — `identity/auth.TokenManager` performs signing, validation, JTI
+  stamping, and the previous-key overlap during rotation. The registry's
+  `internal/auth/jwt.go` keeps only `TFR_JWT_SECRET` resolution and the
+  `fsnotify` file watch (`TFR_JWT_SECRET_FILE`) that drives rotation; it
+  delegates `Generate`/`Validate` to the `TokenManager`. The `iss` claim is the
+  app-stable id `"terraform-registry"`. `auth.Claims` is a re-export of
+  `identityauth.Claims`.
+- **API keys** — `internal/auth/apikey.go` delegates generation, validation, and
+  header extraction to `identity/auth`. Length, display-prefix length, and the
+  bcrypt cost (see [ADR-0011](0011-password-hashing.md)) are the module's
+  constants; the registry only fixes the `tfr_` key prefix.
+- **Scopes** — the generic checker (admin wildcard, write-implies-read) and the
+  identity-core scope strings (`users:*`, `organizations:*`, `apikeys:manage`,
+  `audit:read`, `admin`) live in `identity/auth`. The registry's
+  `internal/auth/scopes.go` *injects* its own domain scopes (`modules:*`,
+  `providers:*`, `mirrors:*`, `scm:*`, `scanning:read`, `scim:provision`) and the
+  read/write pairs, then calls `identityauth.HasScope` et al.
+- **Canonical host** — `identity/suite.CanonicalHost` normalizes a host so the
+  cross-app join compares like-for-like (lowercase, strip scheme/trailing dot,
+  fold IDN to punycode, drop default ports). See [Canonical host
+  resolution](../canonical-host.md).
+- **Suite manifest, version negotiation, and discovery** — `identity/suite`
+  defines the capability `Manifest`, MAJOR-token compatibility
+  (`NegotiateCompat`), and the polling `DiscoveryClient`. The package has *no*
+  application or web-framework dependencies, so both apps import it identically
+  and the contract cannot drift.
+- **Shared identity schema + migrations** — the module carries the `identity`
+  schema migrations and `identity.RunMigrations`, so the table shapes are owned
+  in one place rather than copied into each app's migration set.
+
+### Detect-and-attach ownership model
+
+The shared store is **opt-in and additive**, gated by environment flags that all
+default to off so production behavior is unchanged until explicitly enabled
+(`cmd/server/main.go`):
+
+- `TFR_IDENTITY_MIGRATIONS_ENABLED=true` runs `identity.RunMigrations` at startup,
+  creating/updating the `identity` schema alongside `public`. Safe and reversible;
+  it does not change runtime routing on its own.
+- `TFR_IDENTITY_SCHEMA_ENABLED=true` opens a dedicated pool whose `search_path`
+  is `<schema>,public` (`TFR_IDENTITY_SCHEMA_NAME`, default `identity`) and routes
+  identity reads/writes there. Feature tables (modules, providers, mirrors) keep
+  using the primary `public` pool.
+
+The phrase "detect-and-attach" describes how the app *behaves toward whatever it
+finds* rather than provisioning it:
+
+- The feature-table FK repoint (migration `000038_feature_fk_to_identity`) is
+  guarded by `IF EXISTS (… schema_name = 'identity')`: it repoints
+  `public.{modules,providers,…}` FKs from `public.{users,organizations}` to
+  `identity.{users,organizations}` **only when the identity schema is present**,
+  and is a no-op otherwise. The same binary therefore does the right thing
+  whether or not a shared store has been attached.
+- Under a shared identity *database*, exactly one app must own seeding of the
+  system role templates, or the apps overwrite each other's role → scope mapping
+  on every restart. `TFR_SUITE_ROLE_SEED_OWNER` (`self` | `registry` | `tsm`,
+  default `self`) selects the owner via `SuiteConfig.ShouldSeedRoles`. The
+  shared schema seeds identity-core scopes; the registry layers its own domain
+  scopes onto the system roles at startup, idempotently.
+
+### Standalone vs coupled suite design
+
+Runtime coupling is discovered, never assumed. `TFR_SUITE_SIBLING_URL` empty
+(the default) means fully standalone — nothing is polled and the registry
+behaves exactly as it always has. When a sibling URL is set, the registry:
+
+- Publishes its own manifest at `GET /api/v1/suite/manifest`
+  (`internal/api/suite.go`, `buildSuiteManifest`) advertising its app id, public
+  URL, identity issuer/`sharedStore`/schema, and capabilities (`modules.v1`,
+  `providers.v1`, `mirror.v1`, `oci.v1`).
+- Runs a background `suite.DiscoveryClient` that polls the sibling's manifest,
+  negotiates schema-MAJOR compatibility, and exposes the last-good result as
+  `active` / `degraded` / `unreachable`. Degraded/unreachable windows never leak
+  a stale identity assertion to the SPA.
+- Server-proxies the "Consumed by" lookup to the sibling
+  (`moduleConsumersHandler`), authenticated with the shared
+  `X-Suite-Service-Token` (`TFR_SUITE_SIBLING_TOKEN`). Whenever the sibling is
+  absent, unreachable, or the token is unset, the proxy returns an empty list and
+  the panel simply hides — the registry stays fully standalone.
+
+Single sign-on is asserted to the UI only when **both** apps set their shared-store
+flag (`TFR_SUITE_IDENTITY_SHARED_STORE` here and its sibling), so the SPA never
+claims seamless SSO that the deployment cannot deliver.
+
+## Consequences
+
+**Easier**:
+
+- One canonical implementation of JWT, API keys, scope checking, and host
+  normalization, so a token, key, or scope means the same thing in every suite
+  app and cannot silently drift.
+- The registry stays a single self-contained binary: the shared component is a
+  linked library, with nothing extra to deploy and no behavioral change by
+  default.
+- Coupled operators get one identity store (one user, one org, one key across the
+  suite) rather than a replication pipeline.
+- Cross-app features (the "Consumed by" join) have a defensible contract: agreed
+  issuer, agreed scope model, agreed canonical host.
+
+**Harder**:
+
+- A shared library version must be kept compatible across two repos; the manifest
+  schema is therefore strictly additive (never remove or repurpose a field) and
+  compatibility is gated on the MAJOR token only.
+- The shared-store path adds operational surface — migration enablement, the
+  schema cutover, the cross-schema FK repoint (migration 000038, see
+  [identity-schema.md](../identity-schema.md)), and single-owner role seeding —
+  that standalone deployments never touch but that coupled operators must
+  understand.
+- Identity behavior is split between the shared module and the registry's
+  injection points (`internal/auth/scopes.go`, the secret resolution in
+  `jwt.go`), so a contributor changing auth must look in two places.
+
+## Related
+
+- [ADR-001](001-scope-based-rbac.md) — Scope-Based RBAC (the scope model now
+  provided by the shared module's checker).
+- [ADR-004](004-jwt-plus-apikey-dual-auth.md) — JWT + API Key Dual Authentication
+  (both schemes now delegate to the shared `identity/auth` package).
+- [ADR-0011](0011-password-hashing.md) — Password and API Key Hashing.
+- [docs/identity-schema.md](../identity-schema.md) — operating the shared
+  identity schema and the cutover.
+- [docs/canonical-host.md](../canonical-host.md) — canonical-host resolution for
+  the suite "Consumed by" join.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,6 +27,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [008](008-module-scanning-architecture.md)  | Module Scanning Architecture      | Accepted   |
 | [009](009-network-mirror-protocol.md)       | Network Mirror Protocol           | Accepted   |
 | [010](010-binary-mirror-custom-protocol.md) | Binary Mirror Custom Protocol     | Accepted   |
+| [012](012-shared-identity-component.md)     | Shared Identity Component         | Accepted   |
 
 ## Creating a New ADR
 

--- a/docs/canonical-host.md
+++ b/docs/canonical-host.md
@@ -1,0 +1,150 @@
+# Canonical Host Resolution (Suite "Consumed by")
+
+This note is for operators running the registry **coupled** with the Terraform
+State Manager (TSM) sibling and wondering why a module's **"Consumed by"** panel
+is empty when you expect it to list states. It explains the host-identity join
+that powers that panel and the knobs that fix a host mismatch.
+
+> You do not need any of this for a standalone registry. With
+> `TFR_SUITE_SIBLING_URL` unset, nothing is polled and the panel never appears.
+> See [ADR-012](adr/012-shared-identity-component.md) for the standalone-vs-coupled
+> design.
+
+---
+
+## The mismatch this solves
+
+When a Terraform state uses a registry module, TSM records the **host** from the
+module's source address (e.g. `registry.example.com/team/vpc/aws`). The "Consumed
+by" panel asks the sibling, in effect: *which states reference a module on **my**
+host?* The registry answers by sending TSM the set of hosts it considers itself
+reachable under. The join only works if those two host strings match exactly.
+
+But the registry knows itself by two different values, and they often differ:
+
+- **Discovery / base URL** (`server.base_url`) — the address the registry listens
+  on and advertises for service discovery. Behind a reverse proxy this is often an
+  internal address (e.g. `http://registry.internal:8080`).
+- **Public / join-key URL** (`server.public_url`, via
+  `ServerConfig.GetPublicURL()`) — the externally registered URL used for OAuth
+  callbacks and the URL authors actually type into module sources.
+
+If TSM captured the public host but the registry only offered its base host (or
+vice versa), the exact-string join silently fails and the panel shows nothing.
+
+---
+
+## How resolution works
+
+Two pieces, both from the shared `terraform-suite-identity` library so the registry
+and TSM normalize identically.
+
+### 1. CanonicalHost normalization
+
+`suite.CanonicalHost` (in the shared module's `identity/suite/host.go`) folds away
+the differences that should not matter for an identity match. For a raw host it:
+
+- strips any accidental scheme prefix (keeps only the authority),
+- lowercases the host and removes a trailing FQDN dot,
+- folds an internationalized (Unicode/IDN) host to its **punycode** ASCII form,
+  so a Unicode source address matches a punycode-stored one (best-effort: a host
+  the IDNA lookup profile rejects, e.g. one with underscores, is left as the
+  lowercased value rather than dropped), and
+- drops a **default port** (`:80`/`:443`) while preserving any non-default port.
+
+So `HTTPS://Registry.Example.com.:443/` and `registry.example.com` both canonicalize
+to `registry.example.com`, and `café.example.com` matches `xn--caf-dma.example.com`.
+
+### 2. The alias set (join key)
+
+`canonicalHostSet` (in `internal/api/host.go`) builds the de-duplicated set of
+canonical hosts the registry presents to TSM, in this order:
+
+1. the **public** host (`GetPublicURL()`),
+2. the **base / discovery** host (`base_url`), and
+3. any operator-configured **aliases** (`TFR_SERVER_HOST_ALIASES`).
+
+Empty/unparseable entries are dropped and duplicates are removed. Including both
+the public and base hosts heals the common reverse-proxy case where authors still
+address the base host even though `public_url` is set.
+
+`moduleConsumersHandler` (`internal/api/suite.go`) emits every host in that set as
+a repeated `&host=` query parameter on its server-to-server call to the sibling's
+`/api/v1/consumers` endpoint; TSM matches a state if its captured host equals **any**
+of them. The call carries the shared `X-Suite-Service-Token`
+(`TFR_SUITE_SIBLING_TOKEN`), has a 2-second timeout, and returns an empty list on
+any failure — so the panel hides and the page never blocks.
+
+---
+
+## When to set `TFR_SERVER_HOST_ALIASES`
+
+Set it (comma-separated) when states reference the registry under a hostname that
+is **neither** your `public_url` **nor** your `base_url`. Common cases:
+
+- **Vanity CNAME** — modules are sourced from `tf.example.com` but the registry's
+  `public_url` is `registry.example.com`.
+- **Split-horizon / migrated DNS** — an old hostname still appears in committed
+  state sources after a rename.
+- **Port asymmetry** — `public_url` carries a non-default port (e.g.
+  `registry.example.com:8443`) but authors reference the portless name.
+
+```bash
+# Registry public_url is https://registry.example.com, but states reference
+# tf.example.com and an internal name. Widen the join key:
+TFR_SERVER_HOST_ALIASES=tf.example.com,registry.internal
+```
+
+Aliases only **widen the join key** for the "Consumed by" lookup. They do not change
+OAuth callbacks, CORS, TLS, or what the registry serves.
+
+---
+
+## Worked example
+
+Configuration:
+
+```yaml
+server:
+  base_url:   http://registry.internal:8080
+  public_url: https://registry.example.com
+  host_aliases: [tf.example.com]
+```
+
+The set the registry sends to TSM (canonicalized, de-duped, in order):
+
+```text
+registry.example.com        # from public_url (:443 dropped)
+registry.internal:8080      # from base_url (non-default port kept)
+tf.example.com              # from host_aliases
+```
+
+A state whose module source is `tf.example.com/team/vpc/aws` matches on the third
+host and appears in the panel; one sourced from `REGISTRY.Example.com/...` matches
+the first after canonicalization.
+
+---
+
+## Troubleshooting an empty panel
+
+1. **Confirm coupling is live.** `GET /api/v1/ui/config` should report the sibling
+   `state` as `active`. `degraded`/`unreachable` means discovery cannot reach TSM —
+   fix `TFR_SUITE_SIBLING_URL` / network first.
+2. **Confirm the service token is set on both sides.** `TFR_SUITE_SIBLING_TOKEN`
+   here must equal TSM's `TSM_SUITE_SERVICE_TOKEN`. If it is unset, the proxy is
+   inert and always returns empty.
+3. **Compare hosts.** Look at the module source address recorded in TSM and at the
+   registry's `public_url`/`base_url`. If the host is none of public, base, or an
+   existing alias, add it to `TFR_SERVER_HOST_ALIASES`.
+4. **Watch for case/port/IDN only.** Those are folded automatically; if a host
+   differs only by case, a default port, a trailing dot, or Unicode vs punycode,
+   it already matches and the problem is elsewhere.
+
+---
+
+## See also
+
+- [ADR-012](adr/012-shared-identity-component.md) — Shared Identity Component
+  (standalone vs coupled suite design).
+- [docs/identity-schema.md](identity-schema.md) — the shared identity store.
+- `docs/configuration.md` — full environment-variable reference.

--- a/docs/identity-schema.md
+++ b/docs/identity-schema.md
@@ -8,8 +8,8 @@ Terraform tooling suite (e.g. the state manager) share **one** identity store, s
 organization, or API key is the same across the suite.
 
 The identity layer lives in the [`terraform-suite-identity`](https://github.com/sethbacon/terraform-suite-identity)
-Go module (ADR 002). That module is a **library** linked into the registry binary — not a
-separate service. There is nothing extra to deploy.
+Go module ([ADR 012](adr/012-shared-identity-component.md)). That module is a **library**
+linked into the registry binary — not a separate service. There is nothing extra to deploy.
 
 ---
 
@@ -127,4 +127,4 @@ to `public` to remain visible.
 ## See also
 
 - `docs/configuration.md` — the full environment-variable reference.
-- ADR 002 (shared identity component) in the registry and state-manager repositories.
+- [ADR 012](adr/012-shared-identity-component.md) (shared identity component) in the registry and state-manager repositories.


### PR DESCRIPTION
## Summary
Adds the missing shared-identity ADR and canonical-host operator note, and fixes the dangling "ADR 002" cross-references across the suite (Phase 2 of the suite documentation review).

- **docs/adr/012-shared-identity-component.md** — the decision to extract auth/JWT/API-key/scope/CanonicalHost/manifest into the shared `terraform-suite-identity` module, the detect-and-attach ownership model, and the standalone-vs-coupled design.
- **docs/canonical-host.md** — canonical-host resolution for the suite "Consumed by" join (discovery=BaseURL vs join-key=PublicURL, normalization/punycode, alias set).
- Indexes ADR 012 in `docs/adr/README.md` and repoints `docs/identity-schema.md`'s "ADR 002" reference (the suite-identity and state-manager repos' references were corrected in their own PRs).

Note: this edits `docs/adr/README.md`, which is also touched by the Phase-1 PR #517 — if both are open, the later merge may need a trivial one-row table merge.