### PR TITLE
feat(scm): shared app credentials for SCM providers (Entra app / GitHub App)

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -11396,6 +11396,88 @@
                 }
             }
         },
+        "/api/v1/scm-providers/{id}/verify": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Mint a shared app token for a provider in an app auth mode (entra_app or github_app) to confirm the configured credentials are valid. Returns the token expiry on success. Requires admin scope.",
+                "tags": [
+                    "SCM Providers"
+                ],
+                "summary": "Verify SCM provider app credentials",
+                "parameters": [
+                    {
+                        "description": "SCM provider ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "{ ok, expires_at }",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid provider ID or provider not in an app auth mode",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Provider not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to mint a token from the identity provider",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/setup/admin": {
             "post": {
                 "security": [
@@ -16092,6 +16174,13 @@
                     "provider_type"
                 ],
                 "properties": {
+                    "app_private_key": {
+                        "type": "string"
+                    },
+                    "auth_mode": {
+                        "description": "AuthMode selects the authentication model: \"oauth_user\" (default, legacy\nper-user OAuth), \"entra_app\" (Microsoft Entra app registration for Azure\nDevOps) or \"github_app\" (GitHub App). The app modes use a single shared,\nadmin-managed credential.",
+                        "type": "string"
+                    },
                     "base_url": {
                         "type": "string"
                     },
@@ -16099,6 +16188,12 @@
                         "type": "string"
                     },
                     "client_secret": {
+                        "type": "string"
+                    },
+                    "github_app_id": {
+                        "type": "string"
+                    },
+                    "github_installation_id": {
                         "type": "string"
                     },
                     "name": {
@@ -17080,6 +17175,13 @@
             "admin.UpdateSCMProviderRequest": {
                 "type": "object",
                 "properties": {
+                    "app_private_key": {
+                        "type": "string"
+                    },
+                    "auth_mode": {
+                        "description": "App-credential fields. Setting AppPrivateKey to \"\" clears the stored key.",
+                        "type": "string"
+                    },
                     "base_url": {
                         "type": "string"
                     },
@@ -17087,6 +17189,12 @@
                         "type": "string"
                     },
                     "client_secret": {
+                        "type": "string"
+                    },
+                    "github_app_id": {
+                        "type": "string"
+                    },
+                    "github_installation_id": {
                         "type": "string"
                     },
                     "is_active": {
@@ -19908,6 +20016,10 @@
             "scm.SCMProviderRecord": {
                 "type": "object",
                 "properties": {
+                    "auth_mode": {
+                        "description": "AuthMode selects how the provider authenticates for shared, headless\naccess: \"oauth_user\" (legacy per-user OAuth), \"entra_app\" (Microsoft Entra\napp registration, Azure DevOps) or \"github_app\" (GitHub App).",
+                        "type": "string"
+                    },
                     "base_url": {
                         "type": "string"
                     },
@@ -19915,6 +20027,12 @@
                         "type": "string"
                     },
                     "created_at": {
+                        "type": "string"
+                    },
+                    "github_app_id": {
+                        "type": "string"
+                    },
+                    "github_installation_id": {
                         "type": "string"
                     },
                     "id": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9161,6 +9161,69 @@
                 }
             }
         },
+        "/api/v1/scm-providers/{id}/verify": {
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Mint a shared app token for a provider in an app auth mode (entra_app or github_app) to confirm the configured credentials are valid. Returns the token expiry on success. Requires admin scope.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "SCM Providers"
+                ],
+                "summary": "Verify SCM provider app credentials",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SCM provider ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "{ ok, expires_at }",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid provider ID or provider not in an app auth mode",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Provider not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "502": {
+                        "description": "Failed to mint a token from the identity provider",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/setup/admin": {
             "post": {
                 "security": [
@@ -13031,6 +13094,13 @@
                 "provider_type"
             ],
             "properties": {
+                "app_private_key": {
+                    "type": "string"
+                },
+                "auth_mode": {
+                    "description": "AuthMode selects the authentication model: \"oauth_user\" (default, legacy\nper-user OAuth), \"entra_app\" (Microsoft Entra app registration for Azure\nDevOps) or \"github_app\" (GitHub App). The app modes use a single shared,\nadmin-managed credential.",
+                    "type": "string"
+                },
                 "base_url": {
                     "type": "string"
                 },
@@ -13038,6 +13108,12 @@
                     "type": "string"
                 },
                 "client_secret": {
+                    "type": "string"
+                },
+                "github_app_id": {
+                    "type": "string"
+                },
+                "github_installation_id": {
                     "type": "string"
                 },
                 "name": {
@@ -14019,6 +14095,13 @@
         "admin.UpdateSCMProviderRequest": {
             "type": "object",
             "properties": {
+                "app_private_key": {
+                    "type": "string"
+                },
+                "auth_mode": {
+                    "description": "App-credential fields. Setting AppPrivateKey to \"\" clears the stored key.",
+                    "type": "string"
+                },
                 "base_url": {
                     "type": "string"
                 },
@@ -14026,6 +14109,12 @@
                     "type": "string"
                 },
                 "client_secret": {
+                    "type": "string"
+                },
+                "github_app_id": {
+                    "type": "string"
+                },
+                "github_installation_id": {
                     "type": "string"
                 },
                 "is_active": {
@@ -16847,6 +16936,10 @@
         "scm.SCMProviderRecord": {
             "type": "object",
             "properties": {
+                "auth_mode": {
+                    "description": "AuthMode selects how the provider authenticates for shared, headless\naccess: \"oauth_user\" (legacy per-user OAuth), \"entra_app\" (Microsoft Entra\napp registration, Azure DevOps) or \"github_app\" (GitHub App).",
+                    "type": "string"
+                },
                 "base_url": {
                     "type": "string"
                 },
@@ -16854,6 +16947,12 @@
                     "type": "string"
                 },
                 "created_at": {
+                    "type": "string"
+                },
+                "github_app_id": {
+                    "type": "string"
+                },
+                "github_installation_id": {
                     "type": "string"
                 },
                 "id": {

--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 )
 
 // SCMOAuthHandlers handles SCM OAuth flows
@@ -23,6 +24,7 @@ type SCMOAuthHandlers struct {
 	scmRepo     *repositories.SCMRepository
 	userRepo    *repositories.UserRepository
 	tokenCipher *crypto.TokenCipher
+	minter      appcreds.SharedMinter
 }
 
 // NewSCMOAuthHandlers creates a new SCM OAuth handlers instance
@@ -33,6 +35,13 @@ func NewSCMOAuthHandlers(cfg *config.Config, scmRepo *repositories.SCMRepository
 		userRepo:    userRepo,
 		tokenCipher: tokenCipher,
 	}
+}
+
+// WithMinter wires in the shared app-credential minter used by providers in an
+// app auth mode (entra_app/github_app). Returns the handler for chaining.
+func (h *SCMOAuthHandlers) WithMinter(minter appcreds.SharedMinter) *SCMOAuthHandlers {
+	h.minter = minter
+	return h
 }
 
 // @Summary      Initiate SCM OAuth
@@ -607,6 +616,29 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 		return
 	}
 
+	// App-mode providers use the shared, admin-managed credential, so the user can
+	// browse repositories without a personal connection.
+	if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
+		connector, token, _, sErr := h.buildConnectorWithSharedToken(c.Request.Context(), provider)
+		if sErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": sErr.Error()})
+			return
+		}
+		search := c.Query("search")
+		var repos *scm.RepoListResult
+		if search != "" {
+			repos, err = connector.SearchRepositories(c.Request.Context(), token, search, scm.DefaultPagination())
+		} else {
+			repos, err = connector.FetchRepositories(c.Request.Context(), token, scm.DefaultPagination())
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list repositories: %v", err)})
+			return
+		}
+		writeRepositoryList(c, repos)
+		return
+	}
+
 	// Get user's token for this provider
 	tokenRecord, err := h.scmRepo.GetUserToken(c.Request.Context(), userID, providerID)
 	if err != nil || tokenRecord == nil {
@@ -745,6 +777,11 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 	}
 
 	// Convert to frontend-friendly format
+	writeRepositoryList(c, repos)
+}
+
+// writeRepositoryList writes a repository list in the frontend-friendly response shape.
+func writeRepositoryList(c *gin.Context, repos *scm.RepoListResult) {
 	repositories := make([]gin.H, len(repos.Repos))
 	for i, repo := range repos.Repos {
 		repositories[i] = gin.H{
@@ -759,7 +796,6 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 			"private":        repo.Private,
 		}
 	}
-
 	c.JSON(http.StatusOK, gin.H{"repositories": repositories})
 }
 
@@ -966,6 +1002,12 @@ func (h *SCMOAuthHandlers) buildConnectorWithToken(ctx context.Context, provider
 		return nil, nil, nil, fmt.Errorf("provider not found")
 	}
 
+	// App-mode providers use the shared, admin-managed credential, so the
+	// requesting user does not need a personal connection to browse repositories.
+	if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
+		return h.buildConnectorWithSharedToken(ctx, provider)
+	}
+
 	// Get user's token for this provider
 	tokenRecord, err := h.scmRepo.GetUserToken(ctx, userID, providerID)
 	if err != nil || tokenRecord == nil {
@@ -1038,6 +1080,44 @@ func (h *SCMOAuthHandlers) buildConnectorWithToken(ctx context.Context, provider
 	}
 
 	return connector, token, tokenRecord, nil
+}
+
+// buildConnectorWithSharedToken builds a connector and mints the shared app token
+// for a provider in an app auth mode (entra_app/github_app). No per-user token is
+// involved, so the returned SCMUserTokenRecord is nil.
+func (h *SCMOAuthHandlers) buildConnectorWithSharedToken(ctx context.Context, provider *scm.SCMProviderRecord) (scm.Connector, *scm.OAuthToken, *scm.SCMUserTokenRecord, error) {
+	if h.minter == nil {
+		return nil, nil, nil, fmt.Errorf("shared app credentials not available")
+	}
+	token, err := h.minter.MintProviderToken(ctx, provider)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to mint shared token: %w", err)
+	}
+
+	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to decrypt client secret")
+	}
+	baseURL := ""
+	if provider.BaseURL != nil {
+		baseURL = *provider.BaseURL
+	}
+	tenantID := ""
+	if provider.TenantID != nil {
+		tenantID = *provider.TenantID
+	}
+	connector, err := scm.BuildConnector(&scm.ConnectorSettings{
+		Kind:            provider.ProviderType,
+		InstanceBaseURL: baseURL,
+		ClientID:        provider.ClientID,
+		ClientSecret:    clientSecret,
+		CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.cfg.Server.GetPublicURL(), provider.ID),
+		TenantID:        tenantID,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create connector")
+	}
+	return connector, token, nil, nil
 }
 func splitString(s, sep string) []string {
 	if s == "" {

--- a/backend/internal/api/admin/scm_providers.go
+++ b/backend/internal/api/admin/scm_providers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 )
 
 // SCMProviderHandlers handles SCM provider CRUD operations
@@ -20,6 +21,7 @@ type SCMProviderHandlers struct {
 	scmRepo     *repositories.SCMRepository
 	orgRepo     *repositories.OrganizationRepository
 	tokenCipher *crypto.TokenCipher
+	minter      appcreds.SharedMinter
 }
 
 // NewSCMProviderHandlers creates a new SCM provider handlers instance
@@ -30,6 +32,13 @@ func NewSCMProviderHandlers(cfg *config.Config, scmRepo *repositories.SCMReposit
 		orgRepo:     orgRepo,
 		tokenCipher: tokenCipher,
 	}
+}
+
+// WithMinter wires in the shared app-credential minter used by providers in an
+// app auth mode (entra_app/github_app). Returns the handler for chaining.
+func (h *SCMProviderHandlers) WithMinter(minter appcreds.SharedMinter) *SCMProviderHandlers {
+	h.minter = minter
+	return h
 }
 
 // CreateSCMProviderRequest represents the request to create a new SCM provider configuration.
@@ -44,6 +53,14 @@ type CreateSCMProviderRequest struct {
 	ClientID       string           `json:"client_id"`
 	ClientSecret   string           `json:"client_secret"`
 	WebhookSecret  string           `json:"webhook_secret,omitempty"`
+	// AuthMode selects the authentication model: "oauth_user" (default, legacy
+	// per-user OAuth), "entra_app" (Microsoft Entra app registration for Azure
+	// DevOps) or "github_app" (GitHub App). The app modes use a single shared,
+	// admin-managed credential.
+	AuthMode             string `json:"auth_mode,omitempty"`
+	GitHubAppID          string `json:"github_app_id,omitempty"`
+	GitHubInstallationID string `json:"github_installation_id,omitempty"`
+	AppPrivateKey        string `json:"app_private_key,omitempty"`
 }
 
 // UpdateSCMProviderRequest represents the request to update an existing SCM provider configuration.
@@ -56,6 +73,11 @@ type UpdateSCMProviderRequest struct {
 	ClientSecret  *string `json:"client_secret,omitempty"`
 	WebhookSecret *string `json:"webhook_secret,omitempty"`
 	IsActive      *bool   `json:"is_active,omitempty"`
+	// App-credential fields. Setting AppPrivateKey to "" clears the stored key.
+	AuthMode             *string `json:"auth_mode,omitempty"`
+	GitHubAppID          *string `json:"github_app_id,omitempty"`
+	GitHubInstallationID *string `json:"github_installation_id,omitempty"`
+	AppPrivateKey        *string `json:"app_private_key,omitempty"`
 }
 
 // @Summary      Create SCM provider
@@ -86,27 +108,86 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 		return
 	}
 
-	// PAT-based providers don't require OAuth credentials
-	if req.ProviderType.IsPATBased() {
-		if req.BaseURL == nil || *req.BaseURL == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "base_url is required for Bitbucket Data Center"})
+	// Resolve the auth mode (defaults to legacy per-user OAuth).
+	authMode := req.AuthMode
+	if authMode == "" {
+		authMode = scm.AuthModeOAuthUser
+	}
+
+	// app_private_key, when supplied for github_app, is encrypted separately.
+	var encryptedAppPrivateKey *string
+
+	switch authMode {
+	case scm.AuthModeOAuthUser:
+		// PAT-based providers don't require OAuth credentials
+		if req.ProviderType.IsPATBased() {
+			if req.BaseURL == nil || *req.BaseURL == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "base_url is required for Bitbucket Data Center"})
+				return
+			}
+			if req.ClientID == "" {
+				req.ClientID = "pat-auth"
+			}
+			if req.ClientSecret == "" {
+				req.ClientSecret = "not-applicable"
+			}
+		} else {
+			if req.ClientID == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "client_id is required for OAuth providers"})
+				return
+			}
+			if req.ClientSecret == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "client_secret is required for OAuth providers"})
+				return
+			}
+		}
+	case scm.AuthModeEntraApp:
+		// Microsoft Entra app registration (Azure DevOps): client-credentials grant.
+		if req.ProviderType != scm.ProviderAzureDevOps {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "entra_app auth is only supported for azuredevops providers"})
+			return
+		}
+		if req.TenantID == nil || *req.TenantID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tenant_id is required for entra_app auth"})
 			return
 		}
 		if req.ClientID == "" {
-			req.ClientID = "pat-auth"
+			c.JSON(http.StatusBadRequest, gin.H{"error": "client_id is required for entra_app auth"})
+			return
 		}
 		if req.ClientSecret == "" {
-			req.ClientSecret = "not-applicable"
+			c.JSON(http.StatusBadRequest, gin.H{"error": "client_secret is required for entra_app auth"})
+			return
 		}
-	} else {
+	case scm.AuthModeGitHubApp:
+		// GitHub App: app JWT exchanged for an installation token.
+		if req.ProviderType != scm.ProviderGitHub {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "github_app auth is only supported for github providers"})
+			return
+		}
+		if req.GitHubAppID == "" || req.GitHubInstallationID == "" || req.AppPrivateKey == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "github_app_id, github_installation_id and app_private_key are required for github_app auth"})
+			return
+		}
+		if !appcreds.ValidRSAPrivateKey(req.AppPrivateKey) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "app_private_key is not a valid RSA private key (PKCS#1 or PKCS#8 PEM)"})
+			return
+		}
+		// The client_id/client_secret columns are NOT NULL but unused for GitHub
+		// App auth; store stable placeholders.
 		if req.ClientID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "client_id is required for OAuth providers"})
+			req.ClientID = "github-app"
+		}
+		req.ClientSecret = "not-applicable"
+		enc, encErr := h.tokenCipher.Seal(req.AppPrivateKey)
+		if encErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt app private key"})
 			return
 		}
-		if req.ClientSecret == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "client_secret is required for OAuth providers"})
-			return
-		}
+		encryptedAppPrivateKey = &enc
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid auth_mode"})
+		return
 	}
 
 	// Encrypt client secret
@@ -148,18 +229,26 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 	}
 
 	provider := &scm.SCMProviderRecord{
-		ID:                    uuid.New(),
-		OrganizationID:        orgID,
-		ProviderType:          req.ProviderType,
-		Name:                  req.Name,
-		BaseURL:               req.BaseURL,
-		TenantID:              req.TenantID,
-		ClientID:              req.ClientID,
-		ClientSecretEncrypted: clientSecretEncrypted,
-		WebhookSecret:         req.WebhookSecret,
-		IsActive:              true,
-		CreatedAt:             time.Now(),
-		UpdatedAt:             time.Now(),
+		ID:                     uuid.New(),
+		OrganizationID:         orgID,
+		ProviderType:           req.ProviderType,
+		Name:                   req.Name,
+		BaseURL:                req.BaseURL,
+		TenantID:               req.TenantID,
+		ClientID:               req.ClientID,
+		ClientSecretEncrypted:  clientSecretEncrypted,
+		WebhookSecret:          req.WebhookSecret,
+		AuthMode:               authMode,
+		EncryptedAppPrivateKey: encryptedAppPrivateKey,
+		IsActive:               true,
+		CreatedAt:              time.Now(),
+		UpdatedAt:              time.Now(),
+	}
+	if req.GitHubAppID != "" {
+		provider.GitHubAppID = &req.GitHubAppID
+	}
+	if req.GitHubInstallationID != "" {
+		provider.GitHubInstallationID = &req.GitHubInstallationID
 	}
 
 	if err := h.scmRepo.CreateProvider(c.Request.Context(), provider); err != nil {
@@ -314,6 +403,62 @@ func (h *SCMProviderHandlers) UpdateProvider(c *gin.Context) {
 	if req.IsActive != nil {
 		provider.IsActive = *req.IsActive
 	}
+	if req.AuthMode != nil {
+		switch *req.AuthMode {
+		case scm.AuthModeOAuthUser, scm.AuthModeEntraApp, scm.AuthModeGitHubApp:
+			provider.AuthMode = *req.AuthMode
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid auth_mode"})
+			return
+		}
+	}
+	if req.GitHubAppID != nil {
+		if *req.GitHubAppID == "" {
+			provider.GitHubAppID = nil
+		} else {
+			provider.GitHubAppID = req.GitHubAppID
+		}
+	}
+	if req.GitHubInstallationID != nil {
+		if *req.GitHubInstallationID == "" {
+			provider.GitHubInstallationID = nil
+		} else {
+			provider.GitHubInstallationID = req.GitHubInstallationID
+		}
+	}
+	if req.AppPrivateKey != nil {
+		if *req.AppPrivateKey == "" {
+			provider.EncryptedAppPrivateKey = nil
+		} else {
+			if !appcreds.ValidRSAPrivateKey(*req.AppPrivateKey) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "app_private_key is not a valid RSA private key (PKCS#1 or PKCS#8 PEM)"})
+				return
+			}
+			enc, encErr := h.tokenCipher.Seal(*req.AppPrivateKey)
+			if encErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt app private key"})
+				return
+			}
+			provider.EncryptedAppPrivateKey = &enc
+		}
+	}
+
+	// Validate the resulting app-mode shape so we return 400 rather than letting a
+	// DB CHECK constraint surface as a 500.
+	switch provider.AuthMode {
+	case scm.AuthModeGitHubApp:
+		if provider.GitHubAppID == nil || *provider.GitHubAppID == "" ||
+			provider.GitHubInstallationID == nil || *provider.GitHubInstallationID == "" ||
+			provider.EncryptedAppPrivateKey == nil || *provider.EncryptedAppPrivateKey == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "github_app auth requires github_app_id, github_installation_id and app_private_key"})
+			return
+		}
+	case scm.AuthModeEntraApp:
+		if provider.TenantID == nil || *provider.TenantID == "" || provider.ClientID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "entra_app auth requires tenant_id and client_id"})
+			return
+		}
+	}
 
 	provider.UpdatedAt = time.Now()
 
@@ -321,6 +466,10 @@ func (h *SCMProviderHandlers) UpdateProvider(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update provider"})
 		return
 	}
+
+	// Credentials may have changed; drop any cached shared token so the next
+	// request re-mints with the new configuration.
+	_ = h.scmRepo.DeleteProviderToken(c.Request.Context(), providerID)
 
 	c.JSON(http.StatusOK, provider)
 }
@@ -352,4 +501,57 @@ func (h *SCMProviderHandlers) DeleteProvider(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "provider deleted"})
+}
+
+// @Summary      Verify SCM provider app credentials
+// @Description  Mint a shared app token for a provider in an app auth mode (entra_app or github_app) to confirm the configured credentials are valid. Returns the token expiry on success. Requires admin scope.
+// @Tags         SCM Providers
+// @Security     Bearer
+// @Produce      json
+// @Param        id  path  string  true  "SCM provider ID (UUID)"
+// @Success      200  {object}  map[string]interface{}  "{ ok, expires_at }"
+// @Failure      400  {object}  map[string]interface{}  "Invalid provider ID or provider not in an app auth mode"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Provider not found"
+// @Failure      502  {object}  map[string]interface{}  "Failed to mint a token from the identity provider"
+// @Router       /api/v1/scm-providers/{id}/verify [post]
+// VerifyProvider mints a shared app token to confirm the provider's app
+// credentials are valid.
+// POST /api/v1/scm-providers/:id/verify
+func (h *SCMProviderHandlers) VerifyProvider(c *gin.Context) {
+	providerIDStr := c.Param("id")
+	providerID, err := uuid.Parse(providerIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid provider ID"})
+		return
+	}
+
+	provider, err := h.scmRepo.GetProvider(c.Request.Context(), providerID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get provider"})
+		return
+	}
+	if provider == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
+		return
+	}
+
+	if provider.AuthMode != scm.AuthModeEntraApp && provider.AuthMode != scm.AuthModeGitHubApp {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "verification is only available for providers in an app auth mode"})
+		return
+	}
+	if h.minter == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "shared app credentials not available"})
+		return
+	}
+
+	// Force a fresh mint so verification reflects the current stored credentials.
+	_ = h.scmRepo.DeleteProviderToken(c.Request.Context(), providerID)
+	token, err := h.minter.MintProviderToken(c.Request.Context(), provider)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"ok": false, "error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": true, "expires_at": token.ExpiresAt})
 }

--- a/backend/internal/api/admin/scm_providers_app_test.go
+++ b/backend/internal/api/admin/scm_providers_app_test.go
@@ -1,0 +1,225 @@
+package admin
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
+)
+
+// testRSAKeyPEM returns a freshly generated PKCS#1 RSA private key PEM.
+func testRSAKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+// newSCMProviderAppRouter builds a provider router with a wired shared minter and
+// the verify route registered.
+func newSCMProviderAppRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	scmRepo := repositories.NewSCMRepository(sqlxDB)
+	orgRepo := repositories.NewOrganizationRepository(db)
+	cipher := testTokenCipher(t)
+	h := NewSCMProviderHandlers(&config.Config{}, scmRepo, orgRepo, cipher).
+		WithMinter(appcreds.NewMinter(cipher, scmRepo))
+
+	r := gin.New()
+	r.POST("/scm-providers", h.CreateProvider)
+	r.POST("/scm-providers/:id/verify", h.VerifyProvider)
+	return mock, r
+}
+
+func expectDefaultOrgAndNoDuplicate(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}).
+			AddRow(knownUUID, "default", "Default", nil, nil, time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE organization_id").
+		WillReturnRows(sqlmock.NewRows(scmProvCols))
+}
+
+// ---------------------------------------------------------------------------
+// GitHub App create
+// ---------------------------------------------------------------------------
+
+func TestSCMCreate_GitHubApp_Success(t *testing.T) {
+	mock, r := newSCMProviderAppRouter(t)
+	expectDefaultOrgAndNoDuplicate(mock)
+	mock.ExpectExec("INSERT INTO scm_providers").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	keyPEM := testRSAKeyPEM(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type":          "github",
+			"name":                   "gh-app",
+			"auth_mode":              "github_app",
+			"github_app_id":          "12345",
+			"github_installation_id": "67890",
+			"app_private_key":        keyPEM,
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"auth_mode":"github_app"`) {
+		t.Errorf("response missing auth_mode github_app: %s", body)
+	}
+	if !strings.Contains(body, `"has_app_private_key":true`) {
+		t.Errorf("response missing has_app_private_key=true: %s", body)
+	}
+	// The private key (or any PEM material) must never be echoed.
+	if strings.Contains(body, "PRIVATE KEY") || strings.Contains(body, "encrypted_app_private_key") {
+		t.Errorf("response leaked private key material: %s", body)
+	}
+}
+
+func TestSCMCreate_GitHubApp_InvalidKey(t *testing.T) {
+	_, r := newSCMProviderAppRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type":          "github",
+			"name":                   "gh-app",
+			"auth_mode":              "github_app",
+			"github_app_id":          "12345",
+			"github_installation_id": "67890",
+			"app_private_key":        "not-a-real-key",
+		})))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMCreate_GitHubApp_WrongProviderType(t *testing.T) {
+	_, r := newSCMProviderAppRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type":          "azuredevops",
+			"name":                   "wrong",
+			"auth_mode":              "github_app",
+			"github_app_id":          "12345",
+			"github_installation_id": "67890",
+			"app_private_key":        testRSAKeyPEM(t),
+		})))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Entra app create
+// ---------------------------------------------------------------------------
+
+func TestSCMCreate_EntraApp_Success(t *testing.T) {
+	mock, r := newSCMProviderAppRouter(t)
+	expectDefaultOrgAndNoDuplicate(mock)
+	mock.ExpectExec("INSERT INTO scm_providers").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type": "azuredevops",
+			"name":          "ado-app",
+			"auth_mode":     "entra_app",
+			"tenant_id":     "tenant-1",
+			"client_id":     "client-1",
+			"client_secret": "super-secret",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"auth_mode":"entra_app"`) {
+		t.Errorf("response missing auth_mode entra_app: %s", body)
+	}
+	if !strings.Contains(body, `"has_client_secret":true`) {
+		t.Errorf("response missing has_client_secret=true: %s", body)
+	}
+	if strings.Contains(body, "super-secret") || strings.Contains(body, "client_secret_encrypted") {
+		t.Errorf("response leaked client secret: %s", body)
+	}
+}
+
+func TestSCMCreate_EntraApp_WrongProviderType(t *testing.T) {
+	_, r := newSCMProviderAppRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type": "github",
+			"name":          "wrong",
+			"auth_mode":     "entra_app",
+			"tenant_id":     "t",
+			"client_id":     "c",
+			"client_secret": "s",
+		})))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+func TestSCMVerify_InvalidID(t *testing.T) {
+	_, r := newSCMProviderAppRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers/not-a-uuid/verify", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestSCMVerify_NotFound(t *testing.T) {
+	mock, r := newSCMProviderAppRouter(t)
+	mock.ExpectQuery("SELECT.*FROM scm_providers.*WHERE id").
+		WillReturnRows(sqlmock.NewRows(scmProvCols))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers/"+knownUUID+"/verify", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMVerify_NotAppMode(t *testing.T) {
+	mock, r := newSCMProviderAppRouter(t)
+	// sampleSCMProviderRow has an empty auth_mode (oauth_user), so verify is rejected.
+	mock.ExpectQuery("SELECT.*FROM scm_providers.*WHERE id").
+		WillReturnRows(sampleSCMProviderRow())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers/"+knownUUID+"/verify", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/services"
 )
 
@@ -23,6 +24,7 @@ type SCMLinkingHandler struct {
 	tokenCipher *crypto.TokenCipher
 	publicURL   string
 	publisher   *services.SCMPublisher
+	minter      appcreds.SharedMinter
 }
 
 // NewSCMLinkingHandler creates a new SCM linking handler
@@ -34,6 +36,78 @@ func NewSCMLinkingHandler(scmRepo *repositories.SCMRepository, moduleRepo *repos
 		publicURL:   publicURL,
 		publisher:   publisher,
 	}
+}
+
+// WithMinter wires in the shared app-credential minter used by providers in an
+// app auth mode (entra_app/github_app). Returns the handler for chaining.
+func (h *SCMLinkingHandler) WithMinter(minter appcreds.SharedMinter) *SCMLinkingHandler {
+	h.minter = minter
+	return h
+}
+
+// connectorAndToken builds an SCM connector for a provider and resolves an access
+// token for it. Providers in an app auth mode (entra_app/github_app) mint the
+// shared, admin-managed credential; legacy oauth_user providers use the requesting
+// user's stored personal token. For an oauth_user provider with no stored token
+// for the user, the returned token is nil (with a nil error) so best-effort
+// callers can treat the operation as a no-op.
+func (h *SCMLinkingHandler) connectorAndToken(ctx context.Context, provider *scm.SCMProviderRecord, userID uuid.UUID) (scm.Connector, *scm.OAuthToken, error) {
+	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to decrypt client secret")
+	}
+	baseURL := ""
+	if provider.BaseURL != nil {
+		baseURL = *provider.BaseURL
+	}
+	tenantID := ""
+	if provider.TenantID != nil {
+		tenantID = *provider.TenantID
+	}
+	connector, err := scm.BuildConnector(&scm.ConnectorSettings{
+		Kind:            provider.ProviderType,
+		InstanceBaseURL: baseURL,
+		ClientID:        provider.ClientID,
+		ClientSecret:    clientSecret,
+		CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, provider.ID),
+		TenantID:        tenantID,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create connector")
+	}
+
+	// App-mode: shared credential, no per-user token needed.
+	if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
+		if h.minter == nil {
+			return nil, nil, fmt.Errorf("shared app credentials not available")
+		}
+		token, mErr := h.minter.MintProviderToken(ctx, provider)
+		if mErr != nil {
+			return nil, nil, fmt.Errorf("failed to mint shared token: %w", mErr)
+		}
+		return connector, token, nil
+	}
+
+	// Legacy oauth_user: requesting user's stored token (may be absent).
+	tokenRecord, err := h.scmRepo.GetUserToken(ctx, userID, provider.ID)
+	if err != nil || tokenRecord == nil {
+		return connector, nil, nil
+	}
+	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	if err != nil {
+		return connector, nil, nil
+	}
+	token := &scm.OAuthToken{
+		AccessToken: accessToken,
+		TokenType:   tokenRecord.TokenType,
+		ExpiresAt:   tokenRecord.ExpiresAt,
+	}
+	if tokenRecord.RefreshTokenEncrypted != nil {
+		if rt, rErr := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted); rErr == nil {
+			token.RefreshToken = rt
+		}
+	}
+	return connector, token, nil
 }
 
 type LinkSCMRequest struct {
@@ -186,50 +260,22 @@ func (h *SCMLinkingHandler) LinkModuleToSCM(c *gin.Context) {
 	webhookRegistered := false
 	userID, uidErr := getUserIDFromContext(c)
 	if uidErr == nil {
-		tokenRecord, tokErr := h.scmRepo.GetUserToken(c.Request.Context(), userID, providerID)
-		if tokErr == nil && tokenRecord != nil {
-			if accessToken, decErr := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted); decErr == nil {
-				if clientSecret, csErr := h.tokenCipher.Open(provider.ClientSecretEncrypted); csErr == nil {
-					baseURL := ""
-					if provider.BaseURL != nil {
-						baseURL = *provider.BaseURL
-					}
-					tenantID := ""
-					if provider.TenantID != nil {
-						tenantID = *provider.TenantID
-					}
-					connector, connErr := scm.BuildConnector(&scm.ConnectorSettings{
-						Kind:            provider.ProviderType,
-						InstanceBaseURL: baseURL,
-						ClientID:        provider.ClientID,
-						ClientSecret:    clientSecret,
-						CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, providerID),
-						TenantID:        tenantID,
-					})
-					if connErr == nil {
-						token := &scm.OAuthToken{
-							AccessToken: accessToken,
-							TokenType:   tokenRecord.TokenType,
-							ExpiresAt:   tokenRecord.ExpiresAt,
-						}
-						hookInfo, regErr := connector.RegisterWebhook(c.Request.Context(), token, req.RepositoryOwner, req.RepositoryName, scm.WebhookSetup{
-							CallbackURL:   webhookCallbackURL,
-							SharedSecret:  provider.WebhookSecret,
-							EventTypes:    []string{"push"},
-							ActiveOnSetup: true,
-						})
-						if regErr == nil && hookInfo != nil {
-							webhookRegistered = true
-							link.WebhookID = &hookInfo.ExternalID
-							link.WebhookEnabled = true
-							if updErr := h.scmRepo.UpdateModuleSourceRepo(c.Request.Context(), link); updErr != nil {
-								slog.Warn("webhook registered but failed to persist state", "link_id", linkID, "webhook_id", hookInfo.ExternalID, "error", updErr)
-							}
-						} else if regErr != nil {
-							slog.Warn("auto-register webhook failed", "provider_type", provider.ProviderType, "owner", req.RepositoryOwner, "repo", req.RepositoryName, "error", regErr)
-						}
-					}
+		if connector, token, connErr := h.connectorAndToken(c.Request.Context(), provider, userID); connErr == nil && token != nil {
+			hookInfo, regErr := connector.RegisterWebhook(c.Request.Context(), token, req.RepositoryOwner, req.RepositoryName, scm.WebhookSetup{
+				CallbackURL:   webhookCallbackURL,
+				SharedSecret:  provider.WebhookSecret,
+				EventTypes:    []string{"push"},
+				ActiveOnSetup: true,
+			})
+			if regErr == nil && hookInfo != nil {
+				webhookRegistered = true
+				link.WebhookID = &hookInfo.ExternalID
+				link.WebhookEnabled = true
+				if updErr := h.scmRepo.UpdateModuleSourceRepo(c.Request.Context(), link); updErr != nil {
+					slog.Warn("webhook registered but failed to persist state", "link_id", linkID, "webhook_id", hookInfo.ExternalID, "error", updErr)
 				}
+			} else if regErr != nil {
+				slog.Warn("auto-register webhook failed", "provider_type", provider.ProviderType, "owner", req.RepositoryOwner, "repo", req.RepositoryName, "error", regErr)
 			}
 		}
 	}
@@ -359,38 +405,9 @@ func (h *SCMLinkingHandler) UnlinkModuleFromSCM(c *gin.Context) {
 		provider, provErr := h.scmRepo.GetProvider(c.Request.Context(), link.SCMProviderID)
 		userID, uidErr := getUserIDFromContext(c)
 		if provErr == nil && provider != nil && uidErr == nil {
-			tokenRecord, tokErr := h.scmRepo.GetUserToken(c.Request.Context(), userID, link.SCMProviderID)
-			if tokErr == nil && tokenRecord != nil {
-				if accessToken, decErr := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted); decErr == nil {
-					clientSecret, csErr := h.tokenCipher.Open(provider.ClientSecretEncrypted)
-					if csErr == nil {
-						baseURL := ""
-						if provider.BaseURL != nil {
-							baseURL = *provider.BaseURL
-						}
-						tenantID := ""
-						if provider.TenantID != nil {
-							tenantID = *provider.TenantID
-						}
-						connector, connErr := scm.BuildConnector(&scm.ConnectorSettings{
-							Kind:            provider.ProviderType,
-							InstanceBaseURL: baseURL,
-							ClientID:        provider.ClientID,
-							ClientSecret:    clientSecret,
-							CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, link.SCMProviderID),
-							TenantID:        tenantID,
-						})
-						if connErr == nil {
-							token := &scm.OAuthToken{
-								AccessToken: accessToken,
-								TokenType:   tokenRecord.TokenType,
-								ExpiresAt:   tokenRecord.ExpiresAt,
-							}
-							if rmErr := connector.RemoveWebhook(c.Request.Context(), token, link.RepositoryOwner, link.RepositoryName, *link.WebhookID); rmErr != nil {
-								slog.Warn("failed to remove webhook", "webhook_id", *link.WebhookID, "owner", link.RepositoryOwner, "repo", link.RepositoryName, "error", rmErr)
-							}
-						}
-					}
+			if connector, token, connErr := h.connectorAndToken(c.Request.Context(), provider, userID); connErr == nil && token != nil {
+				if rmErr := connector.RemoveWebhook(c.Request.Context(), token, link.RepositoryOwner, link.RepositoryName, *link.WebhookID); rmErr != nil {
+					slog.Warn("failed to remove webhook", "webhook_id", *link.WebhookID, "owner", link.RepositoryOwner, "repo", link.RepositoryName, "error", rmErr)
 				}
 			}
 		}
@@ -483,6 +500,23 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 	provider, err := h.scmRepo.GetProvider(c.Request.Context(), link.SCMProviderID)
 	if err != nil || provider == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "provider not found"})
+		return
+	}
+
+	// App-mode providers use the shared, admin-managed credential — no per-user
+	// connection is required to trigger a sync.
+	if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
+		connector, token, connErr := h.connectorAndToken(c.Request.Context(), provider, uuid.Nil)
+		if connErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": connErr.Error()})
+			return
+		}
+		go func() {
+			if syncErr := h.publisher.TriggerManualSync(context.Background(), link, connector, token); syncErr != nil {
+				slog.Warn("manual sync failed", "module_id", moduleID, "error", syncErr)
+			}
+		}()
+		c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
 		return
 	}
 
@@ -668,41 +702,9 @@ func (h *SCMLinkingHandler) detectDefaultBranch(ctx context.Context, c *gin.Cont
 	if err != nil {
 		return "main"
 	}
-	tokenRecord, err := h.scmRepo.GetUserToken(ctx, userID, provider.ID)
-	if err != nil || tokenRecord == nil {
+	connector, token, err := h.connectorAndToken(ctx, provider, userID)
+	if err != nil || token == nil {
 		return "main"
-	}
-	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
-	if err != nil {
-		return "main"
-	}
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
-	if err != nil {
-		return "main"
-	}
-	baseURL := ""
-	if provider.BaseURL != nil {
-		baseURL = *provider.BaseURL
-	}
-	tenantID := ""
-	if provider.TenantID != nil {
-		tenantID = *provider.TenantID
-	}
-	connector, err := scm.BuildConnector(&scm.ConnectorSettings{
-		Kind:            provider.ProviderType,
-		InstanceBaseURL: baseURL,
-		ClientID:        provider.ClientID,
-		ClientSecret:    clientSecret,
-		CallbackURL:     fmt.Sprintf("%s/api/v1/scm-providers/%s/oauth/callback", h.publicURL, provider.ID),
-		TenantID:        tenantID,
-	})
-	if err != nil {
-		return "main"
-	}
-	token := &scm.OAuthToken{
-		AccessToken: accessToken,
-		TokenType:   tokenRecord.TokenType,
-		ExpiresAt:   tokenRecord.ExpiresAt,
 	}
 	sourceRepo, err := connector.FetchRepository(ctx, token, owner, repoName)
 	if err != nil || sourceRepo == nil || sourceRepo.DefaultBranch == "" {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -50,6 +50,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/policy"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/services"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 
@@ -621,10 +622,15 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize audit log handlers
 	auditLogHandlers := admin.NewAuditLogHandlers(identityDB)
 
+	// Shared app-credential minter (Entra app / GitHub App) for providers opted
+	// into an app auth mode; scmRepo provides the token-cache store.
+	sharedMinter := appcreds.NewMinter(tokenCipher, scmRepo)
+
 	// Initialize SCM publisher service (needed by scmLinkingHandler)
 	scmPublisher := services.NewSCMPublisher(scmRepo, moduleRepo, storageBackend, tokenCipher).
 		WithScanQueue(scanRepo, &cfg.Scanning).
-		WithModuleDocs(moduleDocsRepo)
+		WithModuleDocs(moduleDocsRepo).
+		WithSharedMinter(sharedMinter)
 
 	// Initialize and start the webhook retry job (no-op when max_retries=0)
 	webhookRetryJob := jobs.NewWebhookRetryJob(&cfg.Webhooks, scmRepo, moduleRepo, scmPublisher, tokenCipher)
@@ -638,9 +644,9 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	log.Println("CVE poll job started")
 
 	// Initialize SCM handlers with the already-created repositories and token cipher
-	scmProviderHandlers := admin.NewSCMProviderHandlers(cfg, scmRepo, orgRepo, tokenCipher)
-	scmOAuthHandlers := admin.NewSCMOAuthHandlers(cfg, scmRepo, userRepo, tokenCipher)
-	scmLinkingHandler := modules.NewSCMLinkingHandler(scmRepo, moduleRepo, tokenCipher, cfg.Server.BaseURL, scmPublisher)
+	scmProviderHandlers := admin.NewSCMProviderHandlers(cfg, scmRepo, orgRepo, tokenCipher).WithMinter(sharedMinter)
+	scmOAuthHandlers := admin.NewSCMOAuthHandlers(cfg, scmRepo, userRepo, tokenCipher).WithMinter(sharedMinter)
+	scmLinkingHandler := modules.NewSCMLinkingHandler(scmRepo, moduleRepo, tokenCipher, cfg.Server.BaseURL, scmPublisher).WithMinter(sharedMinter)
 
 	// Initialize storage configuration handlers
 	storageHandlers := admin.NewStorageHandlers(cfg, storageConfigRepo, tokenCipher)
@@ -1035,6 +1041,9 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 				scmProvidersGroup.POST("", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.CreateProvider)
 				scmProvidersGroup.PUT("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.UpdateProvider)
 				scmProvidersGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.DeleteProvider)
+
+				// Verify shared app credentials by minting a token (app auth modes only)
+				scmProvidersGroup.POST("/:id/verify", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.VerifyProvider)
 
 				// OAuth flow endpoints require scm:manage
 				scmProvidersGroup.GET("/:id/oauth/authorize", middleware.RequireScope(auth.ScopeSCMManage), scmOAuthHandlers.InitiateOAuth)

--- a/backend/internal/db/migrations/000041_scm_shared_app_credentials.down.sql
+++ b/backend/internal/db/migrations/000041_scm_shared_app_credentials.down.sql
@@ -1,0 +1,18 @@
+-- Reverse migration 000041. Refuses to run while any provider is still in an app
+-- auth mode, since dropping the columns would silently destroy the only copy of
+-- those providers' app credentials. Convert such providers back to 'oauth_user'
+-- (clearing their app fields) before rolling back.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM scm_providers WHERE auth_mode IN ('entra_app', 'github_app')) THEN
+        RAISE EXCEPTION 'cannot roll back 000041: providers still use an app auth_mode; convert them to oauth_user first';
+    END IF;
+END $$;
+
+DROP TABLE IF EXISTS scm_provider_tokens;
+
+ALTER TABLE scm_providers DROP CONSTRAINT IF EXISTS scm_providers_app_shape;
+ALTER TABLE scm_providers DROP COLUMN IF EXISTS encrypted_app_private_key;
+ALTER TABLE scm_providers DROP COLUMN IF EXISTS github_installation_id;
+ALTER TABLE scm_providers DROP COLUMN IF EXISTS github_app_id;
+ALTER TABLE scm_providers DROP COLUMN IF EXISTS auth_mode;

--- a/backend/internal/db/migrations/000041_scm_shared_app_credentials.up.sql
+++ b/backend/internal/db/migrations/000041_scm_shared_app_credentials.up.sql
@@ -1,0 +1,44 @@
+-- Migration 000041: Shared, admin-managed app credentials for SCM providers.
+--
+-- Today SCM auth is per-user OAuth (scm_oauth_tokens, one row per user+provider)
+-- and a module's syncs depend on the *creator's* personal token. This migration
+-- adds a provider-level, app-owned auth mode — a Microsoft Entra app registration
+-- for Azure DevOps and a GitHub App for GitHub — so a single admin-configured
+-- credential serves every user's linking and all background syncs.
+--
+-- Additive and backwards-compatible: every existing provider defaults to
+-- auth_mode='oauth_user' and keeps working unchanged. An admin opts a provider
+-- into app mode by supplying app credentials.
+
+-- How a provider authenticates for shared, headless access.
+ALTER TABLE scm_providers
+    ADD COLUMN auth_mode TEXT NOT NULL DEFAULT 'oauth_user'
+        CHECK (auth_mode IN ('oauth_user', 'entra_app', 'github_app'));
+
+-- GitHub App fields (used when auth_mode = 'github_app'). Entra app mode reuses
+-- the existing client_id + tenant_id + client_secret_encrypted columns and needs
+-- no new columns.
+ALTER TABLE scm_providers ADD COLUMN github_app_id             VARCHAR(255);
+ALTER TABLE scm_providers ADD COLUMN github_installation_id    VARCHAR(255);
+ALTER TABLE scm_providers ADD COLUMN encrypted_app_private_key TEXT; -- base64 AES-256-GCM
+
+-- Shape guard: a github_app provider must carry all three GitHub App fields.
+-- entra_app reuses client_id/tenant_id (already present) and is validated at the
+-- API layer; oauth_user imposes no extra requirement.
+ALTER TABLE scm_providers
+    ADD CONSTRAINT scm_providers_app_shape CHECK (
+        auth_mode <> 'github_app'
+        OR (github_app_id IS NOT NULL
+            AND github_installation_id IS NOT NULL
+            AND encrypted_app_private_key IS NOT NULL)
+    );
+
+-- Cached shared token so process restarts don't immediately re-mint. The token
+-- is re-mintable from the stored app secrets, so losing this cache is non-fatal.
+CREATE TABLE scm_provider_tokens (
+    scm_provider_id        UUID         PRIMARY KEY REFERENCES scm_providers(id) ON DELETE CASCADE,
+    access_token_encrypted TEXT         NOT NULL,
+    token_type             VARCHAR(50)  NOT NULL DEFAULT 'Bearer',
+    expires_at             TIMESTAMP,
+    updated_at             TIMESTAMP    NOT NULL DEFAULT NOW()
+);

--- a/backend/internal/db/repositories/scm_repository.go
+++ b/backend/internal/db/repositories/scm_repository.go
@@ -27,19 +27,25 @@ func NewSCMRepository(db *sqlx.DB) *SCMRepository {
 
 // CreateProvider creates a new SCM provider configuration
 func (r *SCMRepository) CreateProvider(ctx context.Context, provider *scm.SCMProviderRecord) error {
+	authMode := provider.AuthMode
+	if authMode == "" {
+		authMode = scm.AuthModeOAuthUser
+	}
 	query := `
 		INSERT INTO scm_providers (
 			id, organization_id, provider_type, name, base_url, tenant_id,
 			client_id, client_secret_encrypted, webhook_secret,
+			auth_mode, github_app_id, github_installation_id, encrypted_app_private_key,
 			is_active, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
 		)`
 
 	_, err := r.db.ExecContext(ctx, query,
 		provider.ID, provider.OrganizationID, provider.ProviderType, provider.Name,
 		provider.BaseURL, provider.TenantID, provider.ClientID, provider.ClientSecretEncrypted,
-		provider.WebhookSecret, provider.IsActive, provider.CreatedAt, provider.UpdatedAt,
+		provider.WebhookSecret, authMode, provider.GitHubAppID, provider.GitHubInstallationID,
+		provider.EncryptedAppPrivateKey, provider.IsActive, provider.CreatedAt, provider.UpdatedAt,
 	)
 	return err
 }
@@ -87,17 +93,23 @@ func (r *SCMRepository) ListProviders(ctx context.Context, orgID uuid.UUID) ([]*
 
 // UpdateProvider updates an SCM provider configuration
 func (r *SCMRepository) UpdateProvider(ctx context.Context, provider *scm.SCMProviderRecord) error {
+	authMode := provider.AuthMode
+	if authMode == "" {
+		authMode = scm.AuthModeOAuthUser
+	}
 	query := `
 		UPDATE scm_providers SET
 			name = $2, base_url = $3, tenant_id = $4, client_id = $5,
 			client_secret_encrypted = $6, webhook_secret = $7,
-			is_active = $8, updated_at = $9
+			auth_mode = $8, github_app_id = $9, github_installation_id = $10,
+			encrypted_app_private_key = $11, is_active = $12, updated_at = $13
 		WHERE id = $1`
 
 	_, err := r.db.ExecContext(ctx, query,
 		provider.ID, provider.Name, provider.BaseURL, provider.TenantID, provider.ClientID,
 		provider.ClientSecretEncrypted, provider.WebhookSecret,
-		provider.IsActive, time.Now(),
+		authMode, provider.GitHubAppID, provider.GitHubInstallationID,
+		provider.EncryptedAppPrivateKey, provider.IsActive, time.Now(),
 	)
 	return err
 }
@@ -106,6 +118,44 @@ func (r *SCMRepository) UpdateProvider(ctx context.Context, provider *scm.SCMPro
 func (r *SCMRepository) DeleteProvider(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM scm_providers WHERE id = $1`
 	_, err := r.db.ExecContext(ctx, query, id)
+	return err
+}
+
+// Shared App Token Cache (auth_mode entra_app / github_app)
+
+// GetProviderToken retrieves the cached shared app token for a provider.
+// Returns nil when no token is cached.
+func (r *SCMRepository) GetProviderToken(ctx context.Context, providerID uuid.UUID) (*scm.SCMProviderTokenRecord, error) {
+	var token scm.SCMProviderTokenRecord
+	query := `SELECT * FROM scm_provider_tokens WHERE scm_provider_id = $1`
+	err := r.db.GetContext(ctx, &token, query, providerID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return &token, err
+}
+
+// UpsertProviderToken stores (or replaces) the cached shared app token for a provider.
+func (r *SCMRepository) UpsertProviderToken(ctx context.Context, token *scm.SCMProviderTokenRecord) error {
+	query := `
+		INSERT INTO scm_provider_tokens (
+			scm_provider_id, access_token_encrypted, token_type, expires_at, updated_at
+		) VALUES (
+			$1, $2, $3, $4, NOW()
+		) ON CONFLICT (scm_provider_id) DO UPDATE SET
+			access_token_encrypted = $2, token_type = $3, expires_at = $4, updated_at = NOW()`
+
+	_, err := r.db.ExecContext(ctx, query,
+		token.SCMProviderID, token.AccessTokenEncrypted, token.TokenType, token.ExpiresAt,
+	)
+	return err
+}
+
+// DeleteProviderToken removes any cached shared app token for a provider, forcing
+// the next request to re-mint. Called when a provider's credentials change.
+func (r *SCMRepository) DeleteProviderToken(ctx context.Context, providerID uuid.UUID) error {
+	query := `DELETE FROM scm_provider_tokens WHERE scm_provider_id = $1`
+	_, err := r.db.ExecContext(ctx, query, providerID)
 	return err
 }
 

--- a/backend/internal/db/repositories/scm_repository_test.go
+++ b/backend/internal/db/repositories/scm_repository_test.go
@@ -274,6 +274,72 @@ func TestSCMDeleteProvider_Success(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Provider token cache (shared app credentials)
+// ---------------------------------------------------------------------------
+
+var scmProviderTokenCols = []string{
+	"scm_provider_id", "access_token_encrypted", "token_type", "expires_at", "updated_at",
+}
+
+func TestSCMGetProviderToken_Found(t *testing.T) {
+	repo, mock := newSCMRepo(t)
+	id := uuid.New()
+	exp := time.Now().Add(time.Hour)
+	mock.ExpectQuery("SELECT.*FROM scm_provider_tokens WHERE scm_provider_id").
+		WillReturnRows(sqlmock.NewRows(scmProviderTokenCols).
+			AddRow(id, "enc-token", "Bearer", exp, time.Now()))
+
+	tok, err := repo.GetProviderToken(context.Background(), id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok == nil || tok.AccessTokenEncrypted != "enc-token" {
+		t.Fatalf("token = %+v, want enc-token", tok)
+	}
+}
+
+func TestSCMGetProviderToken_NotFound(t *testing.T) {
+	repo, mock := newSCMRepo(t)
+	mock.ExpectQuery("SELECT.*FROM scm_provider_tokens WHERE scm_provider_id").
+		WillReturnRows(sqlmock.NewRows(scmProviderTokenCols))
+
+	tok, err := repo.GetProviderToken(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != nil {
+		t.Errorf("token = %+v, want nil", tok)
+	}
+}
+
+func TestSCMUpsertProviderToken_Success(t *testing.T) {
+	repo, mock := newSCMRepo(t)
+	exp := time.Now().Add(time.Hour)
+	mock.ExpectExec("INSERT INTO scm_provider_tokens").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	rec := &scm.SCMProviderTokenRecord{
+		SCMProviderID:        uuid.New(),
+		AccessTokenEncrypted: "enc",
+		TokenType:            "Bearer",
+		ExpiresAt:            &exp,
+	}
+	if err := repo.UpsertProviderToken(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSCMDeleteProviderToken_Success(t *testing.T) {
+	repo, mock := newSCMRepo(t)
+	mock.ExpectExec("DELETE FROM scm_provider_tokens").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.DeleteProviderToken(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // SaveUserToken
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/scm/appcreds/entra.go
+++ b/backend/internal/scm/appcreds/entra.go
@@ -1,0 +1,76 @@
+// entra.go mints Azure DevOps access tokens from a Microsoft Entra app
+// registration via the OAuth 2.0 client-credentials grant. This is the headless,
+// app-owned alternative to per-user OAuth: no user, no refresh token (the grant
+// simply re-mints), and the token is cached until shortly before expiry.
+package appcreds
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// azureDevOpsResourceID is the fixed Microsoft Entra resource (application) id
+// for Azure DevOps. Requesting "<id>/.default" yields a token carrying whatever
+// ADO permissions the app registration has been granted.
+const azureDevOpsResourceID = "499b84ac-1321-427f-aa17-267ca6975798"
+
+// EntraCreds is a Microsoft Entra app registration used to mint Azure DevOps
+// access tokens via client-credentials.
+type EntraCreds struct {
+	TenantID     string
+	ClientID     string
+	ClientSecret string
+}
+
+// mintEntraToken performs the client-credentials POST against the tenant's v2.0
+// token endpoint and returns the access token and its absolute expiry.
+func (m *Minter) mintEntraToken(ctx context.Context, creds EntraCreds) (string, time.Time, error) {
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", creds.ClientID)
+	form.Set("client_secret", creds.ClientSecret)
+	form.Set("scope", azureDevOpsResourceID+"/.default")
+
+	endpoint := fmt.Sprintf("%s/%s/oauth2/v2.0/token",
+		strings.TrimRight(m.entraLoginBaseURL, "/"), url.PathEscape(creds.TenantID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("entra token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+	if resp.StatusCode != http.StatusOK {
+		// Entra returns AADSTS error codes in the body; surface a trimmed form.
+		return "", time.Time{}, fmt.Errorf("entra token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", time.Time{}, fmt.Errorf("entra token response not JSON: %w", err)
+	}
+	if out.AccessToken == "" {
+		return "", time.Time{}, errors.New("entra token response had no access_token")
+	}
+	ttl := time.Duration(out.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = time.Hour // Entra default; defensive when expires_in is absent
+	}
+	return out.AccessToken, m.now().Add(ttl), nil
+}

--- a/backend/internal/scm/appcreds/githubapp.go
+++ b/backend/internal/scm/appcreds/githubapp.go
@@ -1,0 +1,143 @@
+// githubapp.go mints GitHub installation access tokens from a GitHub App: it
+// signs a short-lived app JWT (RS256) with the app's private key, then exchanges
+// it for an installation access token. This is the headless, app-owned
+// alternative to per-user OAuth for GitHub providers in github_app auth mode.
+//
+// The JWT is hand-rolled over crypto/rsa (no extra dependency): a GitHub App JWT
+// is a plain RS256 token, so stdlib signing keeps the dependency surface minimal.
+package appcreds
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GitHubAppCreds is a GitHub App installation used to mint installation access
+// tokens. PrivateKeyPEM is the app's RSA private key in PEM form.
+type GitHubAppCreds struct {
+	AppID          string
+	InstallationID string
+	PrivateKeyPEM  string
+}
+
+// mintGitHubInstallationToken signs an app JWT and exchanges it for an
+// installation access token, returning the token and its absolute expiry.
+func (m *Minter) mintGitHubInstallationToken(ctx context.Context, creds GitHubAppCreds) (string, time.Time, error) {
+	signer, err := parseRSAPrivateKey(creds.PrivateKeyPEM)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	appJWT, err := signAppJWT(creds.AppID, signer, m.now())
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	u := fmt.Sprintf("%s/app/installations/%s/access_tokens",
+		strings.TrimRight(m.githubAPIBaseURL, "/"), urlPathSegment(creds.InstallationID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("github installation token request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+	if resp.StatusCode != http.StatusCreated {
+		return "", time.Time{}, fmt.Errorf("github installation token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var out struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", time.Time{}, fmt.Errorf("github installation token response not JSON: %w", err)
+	}
+	if out.Token == "" {
+		return "", time.Time{}, errors.New("github installation token response had no token")
+	}
+	expiresAt, perr := time.Parse(time.RFC3339, out.ExpiresAt)
+	if perr != nil {
+		expiresAt = m.now().Add(time.Hour) // GitHub installation tokens last ~1h
+	}
+	return out.Token, expiresAt, nil
+}
+
+// parseRSAPrivateKey accepts a PKCS#1 ("RSA PRIVATE KEY") or PKCS#8 ("PRIVATE
+// KEY") PEM and returns the RSA key.
+func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("private key is not valid PEM")
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("private key is not a supported RSA key (PKCS#1 or PKCS#8): %w", err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key is not RSA")
+	}
+	return rsaKey, nil
+}
+
+// ValidRSAPrivateKey reports whether pemStr parses as a supported RSA private
+// key — used to validate input before encrypting and storing it.
+func ValidRSAPrivateKey(pemStr string) bool {
+	_, err := parseRSAPrivateKey(pemStr)
+	return err == nil
+}
+
+// signAppJWT builds a GitHub App JWT (RS256): header.payload signed with RSA
+// PKCS#1 v1.5 over SHA-256. iat is backdated 60s for clock skew; exp is +9m
+// (under GitHub's 10-minute maximum).
+func signAppJWT(appID string, key *rsa.PrivateKey, now time.Time) (string, error) {
+	header := `{"alg":"RS256","typ":"JWT"}`
+	claims, err := json.Marshal(map[string]any{
+		"iat": now.Add(-60 * time.Second).Unix(),
+		"exp": now.Add(9 * time.Minute).Unix(),
+		"iss": appID,
+	})
+	if err != nil {
+		return "", err
+	}
+	signingInput := b64url([]byte(header)) + "." + b64url(claims)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign app jwt: %w", err)
+	}
+	return signingInput + "." + b64url(sig), nil
+}
+
+func b64url(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// urlPathSegment escapes a single path segment (installation ids are numeric,
+// but escape defensively).
+func urlPathSegment(s string) string {
+	return strings.NewReplacer("/", "%2F", "?", "%3F", "#", "%23").Replace(s)
+}

--- a/backend/internal/scm/appcreds/minter.go
+++ b/backend/internal/scm/appcreds/minter.go
@@ -1,0 +1,167 @@
+// Package appcreds mints shared, admin-managed SCM app credentials: a single
+// provider-level token used for every user's module linking and all background
+// syncs, replacing the legacy per-user OAuth model for providers opted into an
+// app auth mode.
+//
+// Two modes are supported, mirroring the terraform-state-manager drift plans:
+//   - entra_app:  Microsoft Entra app registration (OAuth 2.0 client-credentials)
+//     for Azure DevOps.
+//   - github_app: a GitHub App (RS256 app JWT exchanged for an installation
+//     access token) for GitHub.
+//
+// Minted tokens are cached in the scm_provider_tokens table (encrypted at rest)
+// so process restarts and additional replicas don't re-mint on every request.
+// The cache is re-mintable from the provider's stored app secrets, so losing it
+// is never fatal.
+package appcreds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// tokenRefreshMargin re-mints this long before a cached token's hard expiry so an
+// in-flight request never races the expiry boundary.
+const tokenRefreshMargin = 60 * time.Second
+
+// ProviderTokenStore persists the shared app token cache. *repositories.SCMRepository
+// satisfies it; tests supply a fake.
+type ProviderTokenStore interface {
+	GetProviderToken(ctx context.Context, providerID uuid.UUID) (*scm.SCMProviderTokenRecord, error)
+	UpsertProviderToken(ctx context.Context, token *scm.SCMProviderTokenRecord) error
+}
+
+// SharedMinter returns a usable token for a provider in an app auth mode,
+// refreshing from the IdP when the cached token is missing or near expiry.
+type SharedMinter interface {
+	MintProviderToken(ctx context.Context, p *scm.SCMProvider) (*scm.OAuthToken, error)
+}
+
+// Minter implements SharedMinter. It decrypts the provider's stored app secrets,
+// mints a token from the appropriate identity provider, and caches it.
+type Minter struct {
+	cipher        *crypto.TokenCipher
+	store         ProviderTokenStore
+	httpClient    *http.Client
+	now           func() time.Time
+	refreshMargin time.Duration
+
+	// Endpoint bases are fields (not consts) so tests can point them at an
+	// httptest server. Defaults are the public production hosts.
+	entraLoginBaseURL string
+	githubAPIBaseURL  string
+}
+
+// NewMinter builds a Minter using the production identity-provider endpoints.
+func NewMinter(cipher *crypto.TokenCipher, store ProviderTokenStore) *Minter {
+	return &Minter{
+		cipher:            cipher,
+		store:             store,
+		httpClient:        &http.Client{Timeout: 30 * time.Second},
+		now:               time.Now,
+		refreshMargin:     tokenRefreshMargin,
+		entraLoginBaseURL: "https://login.microsoftonline.com",
+		githubAPIBaseURL:  "https://api.github.com",
+	}
+}
+
+// MintProviderToken returns a token for an app-mode provider, serving the cached
+// token when still comfortably valid and otherwise minting + caching a fresh one.
+func (m *Minter) MintProviderToken(ctx context.Context, p *scm.SCMProvider) (*scm.OAuthToken, error) {
+	if p == nil {
+		return nil, errors.New("appcreds: nil provider")
+	}
+
+	// Serve from the cache table when the token is not within the refresh margin.
+	if m.store != nil {
+		if rec, err := m.store.GetProviderToken(ctx, p.ID); err == nil && rec != nil {
+			if rec.ExpiresAt == nil || rec.ExpiresAt.Sub(m.now()) > m.refreshMargin {
+				if tok, derr := m.cipher.Open(rec.AccessTokenEncrypted); derr == nil && tok != "" {
+					return &scm.OAuthToken{AccessToken: tok, TokenType: rec.TokenType, ExpiresAt: rec.ExpiresAt}, nil
+				}
+			}
+		}
+	}
+
+	var (
+		token     string
+		expiresAt time.Time
+		err       error
+	)
+	switch p.AuthMode {
+	case scm.AuthModeEntraApp:
+		var creds EntraCreds
+		if creds, err = m.entraCreds(p); err == nil {
+			token, expiresAt, err = m.mintEntraToken(ctx, creds)
+		}
+	case scm.AuthModeGitHubApp:
+		var creds GitHubAppCreds
+		if creds, err = m.githubAppCreds(p); err == nil {
+			token, expiresAt, err = m.mintGitHubInstallationToken(ctx, creds)
+		}
+	default:
+		return nil, fmt.Errorf("appcreds: provider %s is not in an app auth mode (auth_mode=%q)", p.ID, p.AuthMode)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Best-effort cache write — a persistence failure must not fail the request.
+	if m.store != nil {
+		if enc, sealErr := m.cipher.Seal(token); sealErr == nil {
+			exp := expiresAt
+			_ = m.store.UpsertProviderToken(ctx, &scm.SCMProviderTokenRecord{
+				SCMProviderID:        p.ID,
+				AccessTokenEncrypted: enc,
+				TokenType:            "Bearer",
+				ExpiresAt:            &exp,
+			})
+		}
+	}
+
+	exp := expiresAt
+	return &scm.OAuthToken{AccessToken: token, TokenType: "Bearer", ExpiresAt: &exp}, nil
+}
+
+// entraCreds extracts and decrypts the Entra client-credentials for a provider.
+func (m *Minter) entraCreds(p *scm.SCMProvider) (EntraCreds, error) {
+	if p.TenantID == nil || *p.TenantID == "" {
+		return EntraCreds{}, errors.New("appcreds: entra_app provider missing tenant_id")
+	}
+	if p.ClientID == "" {
+		return EntraCreds{}, errors.New("appcreds: entra_app provider missing client_id")
+	}
+	secret, err := m.cipher.Open(p.ClientSecretEncrypted)
+	if err != nil {
+		return EntraCreds{}, fmt.Errorf("appcreds: decrypt client secret: %w", err)
+	}
+	if secret == "" {
+		return EntraCreds{}, errors.New("appcreds: entra_app provider missing client secret")
+	}
+	return EntraCreds{TenantID: *p.TenantID, ClientID: p.ClientID, ClientSecret: secret}, nil
+}
+
+// githubAppCreds extracts and decrypts the GitHub App credentials for a provider.
+func (m *Minter) githubAppCreds(p *scm.SCMProvider) (GitHubAppCreds, error) {
+	if p.GitHubAppID == nil || *p.GitHubAppID == "" {
+		return GitHubAppCreds{}, errors.New("appcreds: github_app provider missing github_app_id")
+	}
+	if p.GitHubInstallationID == nil || *p.GitHubInstallationID == "" {
+		return GitHubAppCreds{}, errors.New("appcreds: github_app provider missing github_installation_id")
+	}
+	if p.EncryptedAppPrivateKey == nil || *p.EncryptedAppPrivateKey == "" {
+		return GitHubAppCreds{}, errors.New("appcreds: github_app provider missing private key")
+	}
+	pemStr, err := m.cipher.Open(*p.EncryptedAppPrivateKey)
+	if err != nil {
+		return GitHubAppCreds{}, fmt.Errorf("appcreds: decrypt app private key: %w", err)
+	}
+	return GitHubAppCreds{AppID: *p.GitHubAppID, InstallationID: *p.GitHubInstallationID, PrivateKeyPEM: pemStr}, nil
+}

--- a/backend/internal/scm/appcreds/minter_test.go
+++ b/backend/internal/scm/appcreds/minter_test.go
@@ -1,0 +1,340 @@
+package appcreds
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// fakeStore is an in-memory ProviderTokenStore for tests.
+type fakeStore struct {
+	get     *scm.SCMProviderTokenRecord
+	getErr  error
+	upserts []*scm.SCMProviderTokenRecord
+}
+
+func (f *fakeStore) GetProviderToken(_ context.Context, _ uuid.UUID) (*scm.SCMProviderTokenRecord, error) {
+	return f.get, f.getErr
+}
+
+func (f *fakeStore) UpsertProviderToken(_ context.Context, rec *scm.SCMProviderTokenRecord) error {
+	f.upserts = append(f.upserts, rec)
+	return nil
+}
+
+func testCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	c, err := crypto.NewTokenCipher(bytes.Repeat([]byte("k"), 32))
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return c
+}
+
+func generateTestKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
+
+func strptr(s string) *string { return &s }
+
+// ---------------------------------------------------------------------------
+// Entra (Azure DevOps) client-credentials
+// ---------------------------------------------------------------------------
+
+func TestMintProviderToken_EntraApp(t *testing.T) {
+	var called int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		if !strings.HasSuffix(r.URL.Path, "/oauth2/v2.0/token") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		if got := r.Form.Get("grant_type"); got != "client_credentials" {
+			t.Errorf("grant_type = %q", got)
+		}
+		if got := r.Form.Get("scope"); got != azureDevOpsResourceID+"/.default" {
+			t.Errorf("scope = %q", got)
+		}
+		if got := r.Form.Get("client_secret"); got != "the-secret" {
+			t.Errorf("client_secret = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"ado-token","expires_in":3600}`)
+	}))
+	defer srv.Close()
+
+	cipher := testCipher(t)
+	store := &fakeStore{}
+	m := NewMinter(cipher, store)
+	m.entraLoginBaseURL = srv.URL
+
+	secret, _ := cipher.Seal("the-secret")
+	p := &scm.SCMProvider{
+		ID:                    uuid.New(),
+		ProviderType:          scm.ProviderAzureDevOps,
+		AuthMode:              scm.AuthModeEntraApp,
+		TenantID:              strptr("tenant-1"),
+		ClientID:              "client-1",
+		ClientSecretEncrypted: secret,
+	}
+
+	tok, err := m.MintProviderToken(context.Background(), p)
+	if err != nil {
+		t.Fatalf("MintProviderToken: %v", err)
+	}
+	if tok.AccessToken != "ado-token" {
+		t.Errorf("token = %q, want ado-token", tok.AccessToken)
+	}
+	if called != 1 {
+		t.Errorf("idp called %d times, want 1", called)
+	}
+	if len(store.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(store.upserts))
+	}
+	dec, _ := cipher.Open(store.upserts[0].AccessTokenEncrypted)
+	if dec != "ado-token" {
+		t.Errorf("cached token decrypts to %q, want ado-token", dec)
+	}
+}
+
+func TestMintProviderToken_EntraApp_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"invalid_client"}`)
+	}))
+	defer srv.Close()
+
+	cipher := testCipher(t)
+	m := NewMinter(cipher, &fakeStore{})
+	m.entraLoginBaseURL = srv.URL
+
+	secret, _ := cipher.Seal("bad")
+	p := &scm.SCMProvider{
+		ID:                    uuid.New(),
+		AuthMode:              scm.AuthModeEntraApp,
+		TenantID:              strptr("t"),
+		ClientID:              "c",
+		ClientSecretEncrypted: secret,
+	}
+	if _, err := m.MintProviderToken(context.Background(), p); err == nil {
+		t.Fatal("expected error on 401 from Entra")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHub App installation token
+// ---------------------------------------------------------------------------
+
+func TestMintProviderToken_GitHubApp(t *testing.T) {
+	keyPEM := generateTestKeyPEM(t)
+	var called int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called++
+		if !strings.Contains(r.URL.Path, "/app/installations/") || !strings.HasSuffix(r.URL.Path, "/access_tokens") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("authorization = %q, want Bearer app JWT", auth)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"token":"ghs_token","expires_at":"`+time.Now().Add(time.Hour).UTC().Format(time.RFC3339)+`"}`)
+	}))
+	defer srv.Close()
+
+	cipher := testCipher(t)
+	store := &fakeStore{}
+	m := NewMinter(cipher, store)
+	m.githubAPIBaseURL = srv.URL
+
+	encKey, _ := cipher.Seal(keyPEM)
+	p := &scm.SCMProvider{
+		ID:                     uuid.New(),
+		ProviderType:           scm.ProviderGitHub,
+		AuthMode:               scm.AuthModeGitHubApp,
+		GitHubAppID:            strptr("12345"),
+		GitHubInstallationID:   strptr("67890"),
+		EncryptedAppPrivateKey: &encKey,
+	}
+
+	tok, err := m.MintProviderToken(context.Background(), p)
+	if err != nil {
+		t.Fatalf("MintProviderToken: %v", err)
+	}
+	if tok.AccessToken != "ghs_token" {
+		t.Errorf("token = %q, want ghs_token", tok.AccessToken)
+	}
+	if called != 1 {
+		t.Errorf("github called %d times, want 1", called)
+	}
+	if len(store.upserts) != 1 {
+		t.Errorf("upserts = %d, want 1", len(store.upserts))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Caching
+// ---------------------------------------------------------------------------
+
+func TestMintProviderToken_CacheHit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("identity provider must not be called on a cache hit")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cipher := testCipher(t)
+	enc, _ := cipher.Seal("cached-token")
+	exp := time.Now().Add(time.Hour)
+	id := uuid.New()
+	store := &fakeStore{get: &scm.SCMProviderTokenRecord{
+		SCMProviderID:        id,
+		AccessTokenEncrypted: enc,
+		TokenType:            "Bearer",
+		ExpiresAt:            &exp,
+	}}
+	m := NewMinter(cipher, store)
+	m.entraLoginBaseURL = srv.URL
+
+	secret, _ := cipher.Seal("s")
+	p := &scm.SCMProvider{
+		ID:                    id,
+		AuthMode:              scm.AuthModeEntraApp,
+		TenantID:              strptr("t"),
+		ClientID:              "c",
+		ClientSecretEncrypted: secret,
+	}
+	tok, err := m.MintProviderToken(context.Background(), p)
+	if err != nil {
+		t.Fatalf("MintProviderToken: %v", err)
+	}
+	if tok.AccessToken != "cached-token" {
+		t.Errorf("token = %q, want cached-token", tok.AccessToken)
+	}
+	if len(store.upserts) != 0 {
+		t.Errorf("cache hit should not upsert, got %d", len(store.upserts))
+	}
+}
+
+func TestMintProviderToken_CacheExpiredRemints(t *testing.T) {
+	var called int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"fresh-token","expires_in":3600}`)
+	}))
+	defer srv.Close()
+
+	cipher := testCipher(t)
+	enc, _ := cipher.Seal("stale-token")
+	past := time.Now().Add(-time.Minute) // within refresh margin / already expired
+	id := uuid.New()
+	store := &fakeStore{get: &scm.SCMProviderTokenRecord{
+		SCMProviderID:        id,
+		AccessTokenEncrypted: enc,
+		TokenType:            "Bearer",
+		ExpiresAt:            &past,
+	}}
+	m := NewMinter(cipher, store)
+	m.entraLoginBaseURL = srv.URL
+
+	secret, _ := cipher.Seal("s")
+	p := &scm.SCMProvider{
+		ID:                    id,
+		AuthMode:              scm.AuthModeEntraApp,
+		TenantID:              strptr("t"),
+		ClientID:              "c",
+		ClientSecretEncrypted: secret,
+	}
+	tok, err := m.MintProviderToken(context.Background(), p)
+	if err != nil {
+		t.Fatalf("MintProviderToken: %v", err)
+	}
+	if tok.AccessToken != "fresh-token" {
+		t.Errorf("token = %q, want fresh-token", tok.AccessToken)
+	}
+	if called != 1 {
+		t.Errorf("expected a re-mint (1 IdP call), got %d", called)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation / error paths
+// ---------------------------------------------------------------------------
+
+func TestMintProviderToken_UnsupportedMode(t *testing.T) {
+	m := NewMinter(testCipher(t), &fakeStore{})
+	p := &scm.SCMProvider{ID: uuid.New(), AuthMode: scm.AuthModeOAuthUser}
+	if _, err := m.MintProviderToken(context.Background(), p); err == nil {
+		t.Fatal("expected error for oauth_user provider")
+	}
+}
+
+func TestMintProviderToken_MissingEntraCreds(t *testing.T) {
+	m := NewMinter(testCipher(t), &fakeStore{})
+	p := &scm.SCMProvider{ID: uuid.New(), AuthMode: scm.AuthModeEntraApp, ClientID: "c"} // no tenant
+	if _, err := m.MintProviderToken(context.Background(), p); err == nil {
+		t.Fatal("expected error for entra_app missing tenant_id")
+	}
+}
+
+func TestMintProviderToken_MissingGitHubCreds(t *testing.T) {
+	m := NewMinter(testCipher(t), &fakeStore{})
+	p := &scm.SCMProvider{ID: uuid.New(), AuthMode: scm.AuthModeGitHubApp, GitHubAppID: strptr("1")} // no installation/key
+	if _, err := m.MintProviderToken(context.Background(), p); err == nil {
+		t.Fatal("expected error for github_app missing fields")
+	}
+}
+
+func TestMintProviderToken_NilProvider(t *testing.T) {
+	m := NewMinter(testCipher(t), &fakeStore{})
+	if _, err := m.MintProviderToken(context.Background(), nil); err == nil {
+		t.Fatal("expected error for nil provider")
+	}
+}
+
+func TestValidRSAPrivateKey(t *testing.T) {
+	if !ValidRSAPrivateKey(generateTestKeyPEM(t)) {
+		t.Error("generated RSA key should be valid")
+	}
+	if ValidRSAPrivateKey("not a pem") {
+		t.Error("garbage should not be a valid RSA key")
+	}
+	if ValidRSAPrivateKey("") {
+		t.Error("empty string should not be a valid RSA key")
+	}
+}
+
+func TestSignAppJWT_Structure(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	jwt, err := signAppJWT("appid", key, time.Now())
+	if err != nil {
+		t.Fatalf("signAppJWT: %v", err)
+	}
+	if parts := strings.Split(jwt, "."); len(parts) != 3 {
+		t.Errorf("jwt has %d segments, want 3", len(parts))
+	}
+}

--- a/backend/internal/scm/types.go
+++ b/backend/internal/scm/types.go
@@ -3,9 +3,20 @@
 package scm
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
+)
+
+// SCM provider authentication modes. AuthModeOAuthUser is the legacy per-user
+// OAuth flow (one token per user per provider). AuthModeEntraApp and
+// AuthModeGitHubApp are shared, admin-managed app credentials minted on demand
+// and used by every user's linking and all background syncs.
+const (
+	AuthModeOAuthUser = "oauth_user"
+	AuthModeEntraApp  = "entra_app"
+	AuthModeGitHubApp = "github_app"
 )
 
 // ProviderType represents the type of SCM provider
@@ -162,9 +173,44 @@ type SCMProvider struct {
 	ClientID              string       `json:"client_id" db:"client_id"`
 	ClientSecretEncrypted string       `json:"-" db:"client_secret_encrypted"`
 	WebhookSecret         string       `json:"-" db:"webhook_secret"`
-	IsActive              bool         `json:"is_active" db:"is_active"`
-	CreatedAt             time.Time    `json:"created_at" db:"created_at"`
-	UpdatedAt             time.Time    `json:"updated_at" db:"updated_at"`
+	// AuthMode selects how the provider authenticates for shared, headless
+	// access: "oauth_user" (legacy per-user OAuth), "entra_app" (Microsoft Entra
+	// app registration, Azure DevOps) or "github_app" (GitHub App).
+	AuthMode               string    `json:"auth_mode" db:"auth_mode"`
+	GitHubAppID            *string   `json:"github_app_id,omitempty" db:"github_app_id"`
+	GitHubInstallationID   *string   `json:"github_installation_id,omitempty" db:"github_installation_id"`
+	EncryptedAppPrivateKey *string   `json:"-" db:"encrypted_app_private_key"`
+	IsActive               bool      `json:"is_active" db:"is_active"`
+	CreatedAt              time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// MarshalJSON renders an SCMProvider for API responses. Encrypted secrets (the
+// client secret and the GitHub App private key) are never emitted; instead
+// has_client_secret / has_app_private_key booleans report whether each is set,
+// so the UI can show "configured" without ever receiving the secret.
+func (p SCMProvider) MarshalJSON() ([]byte, error) {
+	type providerAlias SCMProvider
+	return json.Marshal(struct {
+		providerAlias
+		HasClientSecret  bool `json:"has_client_secret"`
+		HasAppPrivateKey bool `json:"has_app_private_key"`
+	}{
+		providerAlias:    providerAlias(p),
+		HasClientSecret:  p.ClientSecretEncrypted != "",
+		HasAppPrivateKey: p.EncryptedAppPrivateKey != nil && *p.EncryptedAppPrivateKey != "",
+	})
+}
+
+// SCMProviderToken is the cached shared app token for a provider (auth_mode
+// entra_app or github_app). It is re-mintable from the provider's stored app
+// secrets, so this row is a cache, not a source of truth.
+type SCMProviderToken struct {
+	SCMProviderID        uuid.UUID  `json:"scm_provider_id" db:"scm_provider_id"`
+	AccessTokenEncrypted string     `json:"-" db:"access_token_encrypted"`
+	TokenType            string     `json:"token_type" db:"token_type"`
+	ExpiresAt            *time.Time `json:"expires_at,omitempty" db:"expires_at"`
+	UpdatedAt            time.Time  `json:"updated_at" db:"updated_at"`
 }
 
 // SCMOAuthToken represents a user's OAuth token for an SCM provider
@@ -278,6 +324,7 @@ type IncomingHook = WebhookEvent
 
 // Database record type aliases for repository compatibility
 type SCMProviderRecord = SCMProvider
+type SCMProviderTokenRecord = SCMProviderToken
 type SCMUserTokenRecord = SCMOAuthToken
 type ModuleSourceRepoRecord = ModuleSCMRepo
 type SCMWebhookLogRecord = SCMWebhookEvent

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
+	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
@@ -39,6 +40,7 @@ type SCMPublisher struct {
 	scanRepo       *repositories.ModuleScanRepository // optional: queue scans after publish
 	moduleDocsRepo *repositories.ModuleDocsRepository // optional: store terraform-docs after publish
 	scanningCfg    *config.ScanningConfig             // optional: scan feature flags
+	sharedMinter   appcreds.SharedMinter              // optional: shared app-credential token minter
 }
 
 // NewSCMPublisher creates a new SCM publisher
@@ -65,6 +67,53 @@ func (p *SCMPublisher) WithScanQueue(scanRepo *repositories.ModuleScanRepository
 func (p *SCMPublisher) WithModuleDocs(docsRepo *repositories.ModuleDocsRepository) *SCMPublisher {
 	p.moduleDocsRepo = docsRepo
 	return p
+}
+
+// WithSharedMinter wires in the shared app-credential minter so providers in an
+// app auth mode (entra_app/github_app) resolve a shared, admin-managed token
+// instead of the module creator's personal OAuth token.
+func (p *SCMPublisher) WithSharedMinter(minter appcreds.SharedMinter) *SCMPublisher {
+	p.sharedMinter = minter
+	return p
+}
+
+// resolveSourceToken resolves the token used to download repository archives.
+// Providers in an app auth mode mint the shared, admin-managed credential;
+// legacy oauth_user providers fall back to the module creator's stored personal
+// token. Returns nil (download proceeds unauthenticated) for public repos or when
+// no credential is available.
+func (p *SCMPublisher) resolveSourceToken(ctx context.Context, createdBy *string, providerID uuid.UUID) *scm.OAuthToken {
+	if p.sharedMinter != nil {
+		if provider, err := p.scmRepo.GetProvider(ctx, providerID); err == nil && provider != nil {
+			if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
+				if token, mErr := p.sharedMinter.MintProviderToken(ctx, provider); mErr == nil {
+					return token
+				}
+				return nil
+			}
+		}
+	}
+
+	if createdBy == nil {
+		return nil
+	}
+	createdByUUID, parseErr := uuid.Parse(*createdBy)
+	if parseErr != nil {
+		return nil
+	}
+	tokenRecord, tokenErr := p.scmRepo.GetUserToken(ctx, createdByUUID, providerID)
+	if tokenErr != nil || tokenRecord == nil {
+		return nil
+	}
+	accessToken, decryptErr := p.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	if decryptErr != nil {
+		return nil
+	}
+	return &scm.OAuthToken{
+		AccessToken: accessToken,
+		TokenType:   tokenRecord.TokenType,
+		ExpiresAt:   tokenRecord.ExpiresAt,
+	}
 }
 
 // ProcessTagPush processes a tag push webhook and publishes a new version
@@ -113,22 +162,10 @@ func (p *SCMPublisher) ProcessTagPush(ctx context.Context, logID uuid.UUID, modu
 		return
 	}
 
-	// Resolve OAuth token so downloads from private repos work.
-	// Fall back to nil (unauthenticated) when the module owner has no stored token.
-	var oauthToken *scm.OAuthToken
-	if module.CreatedBy != nil {
-		if createdByUUID, parseErr := uuid.Parse(*module.CreatedBy); parseErr == nil {
-			if tokenRecord, tokenErr := p.scmRepo.GetUserToken(ctx, createdByUUID, moduleSourceRepo.SCMProviderID); tokenErr == nil && tokenRecord != nil {
-				if accessToken, decryptErr := p.tokenCipher.Open(tokenRecord.AccessTokenEncrypted); decryptErr == nil {
-					oauthToken = &scm.OAuthToken{
-						AccessToken: accessToken,
-						TokenType:   tokenRecord.TokenType,
-						ExpiresAt:   tokenRecord.ExpiresAt,
-					}
-				}
-			}
-		}
-	}
+	// Resolve a token so downloads from private repos work. App-mode providers
+	// (entra_app/github_app) use the shared, admin-managed credential; legacy
+	// oauth_user providers fall back to the module creator's personal token.
+	oauthToken := p.resolveSourceToken(ctx, module.CreatedBy, moduleSourceRepo.SCMProviderID)
 
 	// Publish the module version (download, upload, create DB record)
 	versionID, err := p.publishModuleVersion(ctx, connector, oauthToken, moduleSourceRepo, hook, version)

--- a/backend/internal/services/scm_publisher_appcreds_test.go
+++ b/backend/internal/services/scm_publisher_appcreds_test.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// fakeMinter records whether it was invoked and returns a canned token.
+type fakeMinter struct {
+	token  *scm.OAuthToken
+	err    error
+	called bool
+}
+
+func (f *fakeMinter) MintProviderToken(_ context.Context, _ *scm.SCMProvider) (*scm.OAuthToken, error) {
+	f.called = true
+	return f.token, f.err
+}
+
+// scmProviderCols matches SELECT * FROM scm_providers including the app-auth columns.
+var scmProviderCols = []string{
+	"id", "organization_id", "provider_type", "name", "base_url", "tenant_id",
+	"client_id", "client_secret_encrypted", "webhook_secret",
+	"auth_mode", "github_app_id", "github_installation_id", "encrypted_app_private_key",
+	"is_active", "created_at", "updated_at",
+}
+
+func newSCMRepoMock(t *testing.T) (*repositories.SCMRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return repositories.NewSCMRepository(sqlx.NewDb(db, "sqlmock")), mock
+}
+
+func providerRow(id uuid.UUID, authMode string) *sqlmock.Rows {
+	return sqlmock.NewRows(scmProviderCols).AddRow(
+		id, uuid.New(), "azuredevops", "ado", nil, "tenant",
+		"client", "enc-secret", "wh",
+		authMode, nil, nil, nil,
+		true, time.Now(), time.Now(),
+	)
+}
+
+func TestResolveSourceToken_AppModeUsesSharedMinter(t *testing.T) {
+	repo, mock := newSCMRepoMock(t)
+	id := uuid.New()
+	mock.ExpectQuery("SELECT.*FROM scm_providers.*WHERE id").
+		WillReturnRows(providerRow(id, scm.AuthModeEntraApp))
+
+	fake := &fakeMinter{token: &scm.OAuthToken{AccessToken: "shared-token", TokenType: "Bearer"}}
+	p := &SCMPublisher{scmRepo: repo, sharedMinter: fake}
+
+	tok := p.resolveSourceToken(context.Background(), nil, id)
+	if tok == nil || tok.AccessToken != "shared-token" {
+		t.Fatalf("token = %+v, want shared-token", tok)
+	}
+	if !fake.called {
+		t.Error("shared minter should have been invoked for an app-mode provider")
+	}
+}
+
+func TestResolveSourceToken_OAuthUserSkipsMinter(t *testing.T) {
+	repo, mock := newSCMRepoMock(t)
+	id := uuid.New()
+	mock.ExpectQuery("SELECT.*FROM scm_providers.*WHERE id").
+		WillReturnRows(providerRow(id, scm.AuthModeOAuthUser))
+
+	fake := &fakeMinter{token: &scm.OAuthToken{AccessToken: "should-not-be-used"}}
+	p := &SCMPublisher{scmRepo: repo, sharedMinter: fake}
+
+	// No module creator → legacy path resolves to nil (unauthenticated download).
+	tok := p.resolveSourceToken(context.Background(), nil, id)
+	if tok != nil {
+		t.Errorf("token = %+v, want nil for oauth_user without a creator token", tok)
+	}
+	if fake.called {
+		t.Error("shared minter must not be invoked for an oauth_user provider")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -478,6 +478,10 @@ from the JWT secret because OAuth tokens have different sensitivity and lifetime
 If this key is lost, all SCM connections will need to be re-authorized -- the encrypted tokens
 cannot be recovered.
 
+> To avoid per-user OAuth entirely, a provider can use a shared, admin-managed app
+> credential (Microsoft Entra app for Azure DevOps, GitHub App for GitHub). See
+> [SCM Shared App Credentials](deployment/scm-shared-app-credentials.md).
+
 #### Zero-Downtime Key Rotation
 
 To rotate the encryption key without invalidating existing encrypted tokens, set the previous

--- a/docs/deployment/scm-shared-app-credentials.md
+++ b/docs/deployment/scm-shared-app-credentials.md
@@ -1,0 +1,135 @@
+# SCM Shared App Credentials (Entra App / GitHub App)
+
+> Configure a single, admin-managed app credential per SCM provider so that **all**
+> module linking and **all** background syncs use a shared, app-owned identity —
+> removing the per-user "Connect your account" requirement.
+
+## Overview
+
+By default the registry authenticates to an SCM provider with **per-user OAuth**:
+each user runs an authorize → callback flow and stores a personal token, and a
+module's webhook-driven publishes use the **module creator's** token. If that user
+leaves or their token is revoked, publishing breaks.
+
+An SCM provider can instead be put into an **app auth mode**, where the registry
+mints a shared token on demand from an admin-configured app credential:
+
+| `auth_mode`   | Provider type | Credential                                   |
+| ------------- | ------------- | -------------------------------------------- |
+| `oauth_user`  | all           | Per-user OAuth (default, legacy)             |
+| `entra_app`   | `azuredevops` | Microsoft Entra app registration (client-credentials) |
+| `github_app`  | `github`      | GitHub App (installation token)              |
+
+Switching is **opt-in and additive**: existing providers stay on `oauth_user` and
+keep working until an admin supplies app credentials. GitLab and Bitbucket Data
+Center remain on the existing model.
+
+Minted tokens are cached (encrypted) in `scm_provider_tokens` and re-minted shortly
+before expiry. Secrets (the Entra client secret and the GitHub App private key) are
+encrypted at rest with the registry `TokenCipher` and are **never** returned by the
+API — responses expose only `has_client_secret` / `has_app_private_key` booleans.
+
+---
+
+## Azure DevOps — Microsoft Entra app registration (`entra_app`)
+
+### 1. Create the app registration
+
+1. In the Microsoft Entra admin center, **App registrations → New registration**.
+   Single-tenant is sufficient. No redirect URI is required (client-credentials).
+2. Record the **Application (client) ID** and **Directory (tenant) ID**.
+3. **Certificates & secrets → New client secret**. Record the secret **value**.
+4. Grant the app access to your Azure DevOps organization:
+   - In Azure DevOps: **Organization settings → Users → Add users**, add the app's
+     service principal, and give it **least-privilege** access — **Code (Read)** is
+     enough to clone module sources; add webhook-management scope only if the
+     registry manages repository webhooks for you.
+
+### 2. Configure the provider
+
+Create (or update) the SCM provider with `auth_mode=entra_app`:
+
+```http
+POST /api/v1/scm-providers
+{
+  "provider_type": "azuredevops",
+  "name": "ado-shared",
+  "auth_mode": "entra_app",
+  "tenant_id": "<directory-tenant-id>",
+  "client_id": "<application-client-id>",
+  "client_secret": "<client-secret-value>",
+  "base_url": "https://dev.azure.com/<org>"
+}
+```
+
+### 3. Verify
+
+```http
+POST /api/v1/scm-providers/{id}/verify   →   { "ok": true, "expires_at": "..." }
+```
+
+Verification performs a real client-credentials token request against
+`login.microsoftonline.com/{tenant}/oauth2/v2.0/token` with scope
+`499b84ac-1321-427f-aa17-267ca6975798/.default`. A non-2xx response means the
+tenant/client/secret are wrong or the secret has expired.
+
+---
+
+## GitHub — GitHub App (`github_app`)
+
+### 1. Create the GitHub App
+
+1. **Settings → Developer settings → GitHub Apps → New GitHub App** (org-owned
+   recommended).
+2. Repository **permissions** (least privilege):
+   - **Contents: Read-only** (clone module sources / read tags).
+   - **Metadata: Read-only** (mandatory).
+   - **Webhooks: Read & write** only if the registry should manage repo webhooks.
+3. **Generate a private key** and download the `.pem` (PKCS#1 or PKCS#8 both work).
+4. **Install** the App on the org/repositories that host your modules. From the
+   installation URL (`.../installations/<id>`) record the **Installation ID**.
+5. Record the numeric **App ID** from the App's settings page.
+
+### 2. Configure the provider
+
+```http
+POST /api/v1/scm-providers
+{
+  "provider_type": "github",
+  "name": "github-shared",
+  "auth_mode": "github_app",
+  "github_app_id": "<app-id>",
+  "github_installation_id": "<installation-id>",
+  "app_private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+}
+```
+
+`client_id` / `client_secret` are not used for GitHub App auth and may be omitted.
+
+### 3. Verify
+
+```http
+POST /api/v1/scm-providers/{id}/verify   →   { "ok": true, "expires_at": "..." }
+```
+
+Verification signs a short-lived app JWT (RS256) and exchanges it for an
+installation access token at
+`POST /app/installations/{installation_id}/access_tokens`. A failure means the App
+ID, Installation ID, or private key is wrong, or the App is not installed.
+
+---
+
+## Operational notes
+
+- **Rotation:** issue a new Entra client secret / GitHub App private key, `PUT` it
+  onto the provider, then `POST .../verify`. Updating a provider drops the cached
+  shared token so the next request re-mints with the new credential.
+- **Blast radius:** a shared credential acts for the whole organization. Keep it
+  least-privilege, rotate regularly, and restrict provider management to admins
+  (`scm:manage`).
+- **Auditing:** credential create/update/verify and every sync that uses the shared
+  token are attributable to the provider (not a user).
+- **Rollback:** convert a provider back to `auth_mode=oauth_user` to restore the
+  per-user flow. The down migration refuses to run while any provider is still in an
+  app auth mode (it would destroy the only copy of those credentials) — convert such
+  providers first.


### PR DESCRIPTION
## Summary

Adds an **admin-managed, org-shared app-credential** auth mode for SCM providers, replacing per-user OAuth for module linking, repository browsing, and background syncs. Implements the proposed plan `docs/plans/scm-shared-app-credentials-migration.md` (first delivery: Azure DevOps + GitHub).

Today a module's webhook-driven publishes use the **creator's** personal OAuth token; if that user leaves or their token is revoked, publishing breaks, and every user must run a personal Connect flow before linking. This PR lets an admin configure one shared credential per provider:

| `auth_mode`  | Provider      | Credential                                            |
| ------------ | ------------- | ----------------------------------------------------- |
| `oauth_user` | all           | Per-user OAuth (default, unchanged)                   |
| `entra_app`  | `azuredevops` | Microsoft Entra app registration (client-credentials) |
| `github_app` | `github`      | GitHub App (installation token)                       |

**Additive & backwards-compatible** — existing providers default to `oauth_user` and behave exactly as before. GitLab/Bitbucket stay on the per-user path.

## What's included

- **Migration 000041** — `scm_providers.auth_mode` + GitHub App columns (CHECK-guarded shape) and a `scm_provider_tokens` encrypted token cache. The down migration refuses to run while any provider is still in an app mode (it would destroy the only copy of those secrets).
- **`internal/scm/appcreds`** — a DB-cache-backed `Minter` mirroring the terraform-state-manager drift minters: Entra client-credentials and a hand-rolled RS256 GitHub App JWT exchanged for an installation token. No new dependency; endpoints/clock are injectable for tests.
- **Token resolution repointed** — `scm_publisher` and the browse / link / unlink / sync / default-branch paths use the shared token for app-mode providers and fall back to the legacy per-user token otherwise. Browsing repos no longer requires a personal connection in app mode.
- **Admin API** — create/update accept `auth_mode` + app fields with per-mode validation; secrets are encrypted at rest and **never** returned (`has_client_secret` / `has_app_private_key` booleans only). New `POST /api/v1/scm-providers/{id}/verify` mints a token to validate the configured credentials.
- **Runbook** — `docs/deployment/scm-shared-app-credentials.md` (least-privilege permissions, verify, rotation, rollback).

## Testing

- `go build ./...`, `go vet ./...` clean.
- New unit tests: minter (httptest Entra/GitHub, generated RSA key, cache hit/expiry, validation), app-mode create + verify handlers (incl. secret-leak assertions), publisher token resolution by `auth_mode`, and the provider-token cache repository. Full SCM-related suites pass.
- `gofmt` clean; `gosec` reports no new findings (one pre-existing baselined G304, unchanged).
- `swag init` regenerated `backend/docs/swagger.json` (verify endpoint). `openapi3.json` is regenerated + auto-committed by CI.

## Follow-ups (out of scope)

- Frontend auth-mode UI + verify + link-wizard de-gate (separate PR).
- Cleanup phase: remove the per-user OAuth endpoints + `scm_oauth_tokens` after a validation window.
- GitLab/Bitbucket shared-token mode.
