### PR TITLE
fix: resolve module subpath against archive root before unwrapping

### DIFF
--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -204,33 +204,43 @@ func (p *SCMPublisher) downloadAndPackage(ctx context.Context, connector scm.Con
 		return "", "", fmt.Errorf("extraction failed: %w", err)
 	}
 
-	// Unwrap the single root directory that GitHub/GitLab inject into their
-	// archive downloads (e.g. "terraform-azurerm-vm-91b78b65.../"). This must
-	// happen unconditionally before applying subpath. The previous approach only
-	// triggered when os.Stat returned IsNotExist, but when subpath is "/" (the
-	// default), filepath.Join(tempDir, "/") resolves to tempDir itself (which
-	// always exists), so the wrapper-detection fallback never fired.
-	baseDir := tempDir
-	if entries, err := os.ReadDir(tempDir); err == nil && len(entries) == 1 && entries[0].IsDir() {
-		baseDir = filepath.Join(tempDir, entries[0].Name())
-	}
-
-	// Resolve the configured module subpath within the repo root.
-	// filepath.Clean("/") == "/" and filepath.Join(base, ".") == base, so
-	// normalise "/" → "." to get the repo root when no subpath is configured.
+	// Resolve the module within the extracted archive. GitHub/GitLab wrap the repo in a
+	// single "<repo>-<sha>/" directory and the subpath must be resolved inside that wrapper.
+	// Azure DevOps does NOT wrap, and a legacy module whose repository root is a single
+	// "<module>/" folder also presents as one top-level directory but must NOT be unwrapped
+	// (descending into it then loses the subpath). So resolve the subpath against the
+	// extracted root first and only fall back to a lone top-level directory if the module is
+	// not valid at the root. Each candidate is validated, so we pick the one that actually
+	// holds a module regardless of whether the provider wrapped the archive.
 	cleanSubpath := filepath.Clean(subpath)
 	if cleanSubpath == "/" {
 		cleanSubpath = "."
 	}
-	modulePath := filepath.Join(baseDir, cleanSubpath)
 
-	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
-		return "", "", fmt.Errorf("module path %q not found in repository", subpath)
+	candidates := []string{tempDir}
+	if entries, err := os.ReadDir(tempDir); err == nil && len(entries) == 1 && entries[0].IsDir() {
+		candidates = append(candidates, filepath.Join(tempDir, entries[0].Name()))
 	}
 
-	// Validate module structure
-	if err := p.validateModuleStructure(modulePath); err != nil {
-		return "", "", fmt.Errorf("invalid module structure: %w", err)
+	var modulePath string
+	var validateErr error
+	for _, base := range candidates {
+		cand := filepath.Join(base, cleanSubpath)
+		if st, err := os.Stat(cand); err != nil || !st.IsDir() {
+			continue
+		}
+		if err := p.validateModuleStructure(cand); err != nil {
+			validateErr = err
+			continue
+		}
+		modulePath = cand
+		break
+	}
+	if modulePath == "" {
+		if validateErr != nil {
+			return "", "", fmt.Errorf("invalid module structure: %w", validateErr)
+		}
+		return "", "", fmt.Errorf("module path %q not found in repository", subpath)
 	}
 
 	// Create new tarball with commit SHA manifest

--- a/backend/internal/services/scm_publisher_test.go
+++ b/backend/internal/services/scm_publisher_test.go
@@ -499,6 +499,29 @@ func TestDownloadAndPackage_GitHubWrapperWithExplicitSubpath(t *testing.T) {
 	}
 }
 
+// TestDownloadAndPackage_NoWrapperSingleModuleDir verifies that an archive with no
+// wrapper directory whose repository root IS a single module folder (e.g. Azure DevOps
+// downloads, and legacy modules whose early commits are just "terraform_<x>_module/" at
+// the root) resolves the configured subpath correctly. The previous unwrap heuristic
+// descended into that single top-level folder and then failed to find the subpath, which
+// silently dropped every such version on sync.
+func TestDownloadAndPackage_NoWrapperSingleModuleDir(t *testing.T) {
+	archiveData := makeTarGz(t, map[string]string{
+		"terraform_diagnostic_settings_module/main.tf":      `resource "azurerm_monitor_diagnostic_setting" "x" {}`,
+		"terraform_diagnostic_settings_module/variables.tf": `variable "name" {}`,
+	})
+
+	p := newTestPublisher(t)
+	connector := &mockConnector{archiveData: archiveData}
+
+	_, _, err := p.downloadAndPackage(context.Background(), connector, nil,
+		"Terraform", "terraform-azurerm-diagnostic-settings", "abc123",
+		"terraform_diagnostic_settings_module")
+	if err != nil {
+		t.Fatalf("single-folder repo (no wrapper) should resolve, got: %v", err)
+	}
+}
+
 // TestDownloadAndPackage_SubpathNotFound verifies that a configured module_path
 // that does not exist inside the archive returns a clear error.
 func TestDownloadAndPackage_SubpathNotFound(t *testing.T) {


### PR DESCRIPTION
## Problem
SCM module sync silently imported only a subset of a repo's tagged versions (often just the newest). Root cause: `downloadAndPackage` unconditionally descends into a single top-level directory in the extracted archive, assuming a GitHub/GitLab `<repo>-<sha>/` wrapper.

Azure DevOps archives have **no wrapper**, and a module whose repository root is a single `<module>/` folder (the normal shape of legacy modules' early commits) also presents as one top-level directory. The heuristic descended into that folder and then couldn't find the configured `module_path` subpath, so every such version was skipped. A version only imported if its commit happened to have ≥2 root entries (e.g. a root `.gitignore` added later) — which is why only the latest tag synced for affected repos.

## Fix
Resolve the configured subpath against the extracted root **first**, and only fall back to a lone top-level directory if the module isn't valid there — validating each candidate with `validateModuleStructure`. This correctly handles:
- Azure DevOps (no wrapper)
- GitHub/GitLab (single `<repo>-<sha>/` wrapper)
- repos whose root is a single `<module>/` folder

## Test
Adds `TestDownloadAndPackage_NoWrapperSingleModuleDir`; existing wrapper/subpath/error tests still pass.