### PR TITLE
fix(terraform-mirror): delete stored binaries when removing versions or configs

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -4927,7 +4927,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Deletes a Terraform binary mirror config and all its associated versions/history. Requires mirrors:manage scope.",
+                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -5394,7 +5394,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Removes a version and its platform records. Stored binaries are not deleted from storage. Requires mirrors:manage scope.",
+                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.",
                 "tags": [
                     "Terraform Mirror"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3929,7 +3929,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Deletes a Terraform binary mirror config and all its associated versions/history. Requires mirrors:manage scope.",
+                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.",
                 "produces": [
                     "application/json"
                 ],
@@ -4294,7 +4294,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Removes a version and its platform records. Stored binaries are not deleted from storage. Requires mirrors:manage scope.",
+                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.",
                 "produces": [
                     "application/json"
                 ],

--- a/backend/internal/api/admin/providers_test.go
+++ b/backend/internal/api/admin/providers_test.go
@@ -21,6 +21,7 @@ import (
 
 type mockStorage struct {
 	deleteErr error
+	deleted   []string
 }
 
 func (m *mockStorage) Upload(_ context.Context, _ string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
@@ -29,7 +30,10 @@ func (m *mockStorage) Upload(_ context.Context, _ string, _ io.Reader, _ int64) 
 func (m *mockStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
 	return nil, nil
 }
-func (m *mockStorage) Delete(_ context.Context, _ string) error { return m.deleteErr }
+func (m *mockStorage) Delete(_ context.Context, path string) error {
+	m.deleted = append(m.deleted, path)
+	return m.deleteErr
+}
 func (m *mockStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
 	return "", nil
 }

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -26,8 +27,9 @@ type TerraformMirrorSyncJobInterface interface {
 
 // TerraformMirrorHandler handles admin endpoints for the Terraform binary mirror.
 type TerraformMirrorHandler struct {
-	repo    *repositories.TerraformMirrorRepository
-	syncJob TerraformMirrorSyncJobInterface
+	repo           *repositories.TerraformMirrorRepository
+	syncJob        TerraformMirrorSyncJobInterface
+	storageBackend storage.Storage
 }
 
 // NewTerraformMirrorHandler creates a new TerraformMirrorHandler.
@@ -38,6 +40,36 @@ func NewTerraformMirrorHandler(repo *repositories.TerraformMirrorRepository) *Te
 // SetSyncJob attaches the live sync job so handlers can trigger manual syncs.
 func (h *TerraformMirrorHandler) SetSyncJob(syncJob TerraformMirrorSyncJobInterface) {
 	h.syncJob = syncJob
+}
+
+// SetStorageBackend attaches the object-storage backend so deleting a version
+// also removes its stored binaries. When unset, deletes only touch the database.
+func (h *TerraformMirrorHandler) SetStorageBackend(s storage.Storage) {
+	h.storageBackend = s
+}
+
+// deleteVersionArtifacts best-effort removes a version's stored binaries from
+// object storage: every platform package plus the version's SHA256SUMS and
+// detached signature. Storage errors are intentionally swallowed — a dangling
+// metadata row is worse than an orphaned blob (which can be swept later), so a
+// storage failure must never block the database delete. No-op when no storage
+// backend is configured.
+func (h *TerraformMirrorHandler) deleteVersionArtifacts(ctx context.Context, v *models.TerraformVersion) {
+	if h.storageBackend == nil || v == nil {
+		return
+	}
+	if platforms, listErr := h.repo.ListPlatformsForVersion(ctx, v.ID); listErr == nil {
+		for _, p := range platforms {
+			if p.StorageKey != nil && *p.StorageKey != "" {
+				_ = h.storageBackend.Delete(ctx, *p.StorageKey)
+			}
+		}
+	}
+	for _, key := range []*string{v.SumsStorageKey, v.SigStorageKey} {
+		if key != nil && *key != "" {
+			_ = h.storageBackend.Delete(ctx, *key)
+		}
+	}
 }
 
 // ---- POST /api/v1/admin/terraform-mirrors ----------------------------------
@@ -335,7 +367,7 @@ func (h *TerraformMirrorHandler) UpdateConfig(c *gin.Context) {
 // ---- DELETE /api/v1/admin/terraform-mirrors/:id -----------------------------
 
 // @Summary      Delete Terraform mirror configuration
-// @Description  Deletes a Terraform binary mirror config and all its associated versions/history. Requires mirrors:manage scope.
+// @Description  Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -359,6 +391,18 @@ func (h *TerraformMirrorHandler) DeleteConfig(c *gin.Context) {
 	if cfg == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Mirror config not found"})
 		return
+	}
+
+	// Remove every version's stored binaries before deleting the config. The DB
+	// delete cascades the version/platform rows, but object-storage blobs are not
+	// FK-managed, so without this they would be orphaned. Best-effort.
+	if h.storageBackend != nil {
+		ctx := c.Request.Context()
+		if versions, listErr := h.repo.ListVersions(ctx, id, false); listErr == nil {
+			for i := range versions {
+				h.deleteVersionArtifacts(ctx, &versions[i])
+			}
+		}
 	}
 
 	if delErr := h.repo.Delete(c.Request.Context(), id); delErr != nil {
@@ -528,7 +572,7 @@ func (h *TerraformMirrorHandler) GetVersion(c *gin.Context) {
 // ---- DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version ----------
 
 // @Summary      Delete a mirrored Terraform version
-// @Description  Removes a version and its platform records. Stored binaries are not deleted from storage. Requires mirrors:manage scope.
+// @Description  Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -556,6 +600,9 @@ func (h *TerraformMirrorHandler) DeleteVersion(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Version not found"})
 		return
 	}
+
+	// Remove the stored artifacts before the database rows (best-effort).
+	h.deleteVersionArtifacts(c.Request.Context(), v)
 
 	if delErr := h.repo.DeleteVersion(c.Request.Context(), v.ID); delErr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete version: " + delErr.Error()})

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -431,6 +431,81 @@ func TestTMDeleteConfig_Success(t *testing.T) {
 	}
 }
 
+// When a storage backend is attached, deleting a config removes the stored
+// binaries for every version it owns (each platform package plus per-version
+// SHA256SUMS and detached signature) before the cascading database delete.
+func TestTMDeleteConfig_DeletesBinaries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	store := &mockStorage{}
+	h := NewTerraformMirrorHandler(repo)
+	h.SetStorageBackend(store)
+	r := gin.New()
+	r.DELETE("/terraform-mirrors/:id", h.DeleteConfig)
+
+	// GetByID -> the config being deleted.
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE id").
+		WillReturnRows(sampleTMCRow())
+	// ListVersions -> two synced versions, each with stored SHA256SUMS + signature.
+	versionCols := []string{
+		"id", "config_id", "version", "is_latest", "is_deprecated", "release_date",
+		"sync_status", "sync_error", "synced_at", "created_at", "updated_at",
+		"sums_storage_key", "sig_storage_key", "approval_status",
+	}
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id").
+		WillReturnRows(sqlmock.NewRows(versionCols).
+			AddRow(knownUUID, knownUUID, "1.7.0", true, false, nil,
+				"synced", nil, nil, time.Now(), time.Now(),
+				"tf/1.7.0/SHA256SUMS", "tf/1.7.0/SHA256SUMS.sig", "approved").
+			AddRow(knownUUID, knownUUID, "1.6.0", false, false, nil,
+				"synced", nil, nil, time.Now(), time.Now(),
+				"tf/1.6.0/SHA256SUMS", "tf/1.6.0/SHA256SUMS.sig", "approved"))
+	// ListPlatformsForVersion -> one stored binary per version (queried in list order).
+	mock.ExpectQuery("SELECT.*FROM terraform_version_platforms WHERE version_id").
+		WillReturnRows(sqlmock.NewRows(tmPlatformCols).
+			AddRow(knownUUID, knownUUID, "linux", "amd64", "u", "f1", "h1",
+				"tf/1.7.0/linux/amd64/terraform_1.7.0_linux_amd64.zip", "s3", true, true,
+				"synced", nil, nil, time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM terraform_version_platforms WHERE version_id").
+		WillReturnRows(sqlmock.NewRows(tmPlatformCols).
+			AddRow(knownUUID, knownUUID, "linux", "amd64", "u", "f2", "h2",
+				"tf/1.6.0/linux/amd64/terraform_1.6.0_linux_amd64.zip", "s3", true, true,
+				"synced", nil, nil, time.Now(), time.Now()))
+	mock.ExpectExec("DELETE FROM terraform_mirror_configs WHERE id").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/terraform-mirrors/"+knownUUID, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	want := []string{
+		"tf/1.7.0/linux/amd64/terraform_1.7.0_linux_amd64.zip",
+		"tf/1.7.0/SHA256SUMS",
+		"tf/1.7.0/SHA256SUMS.sig",
+		"tf/1.6.0/linux/amd64/terraform_1.6.0_linux_amd64.zip",
+		"tf/1.6.0/SHA256SUMS",
+		"tf/1.6.0/SHA256SUMS.sig",
+	}
+	for _, key := range want {
+		found := false
+		for _, d := range store.deleted {
+			if d == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected storage Delete(%q); got %v", key, store.deleted)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TriggerSync tests
 // ---------------------------------------------------------------------------
@@ -804,6 +879,70 @@ func TestTMMirrorDeleteVersion_Success(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// When a storage backend is attached, deleting a version also removes the stored
+// platform packages plus the version's SHA256SUMS and detached signature.
+func TestTMMirrorDeleteVersion_DeletesBinaries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	store := &mockStorage{}
+	h := NewTerraformMirrorHandler(repo)
+	h.SetStorageBackend(store)
+	r := gin.New()
+	r.DELETE("/terraform-mirrors/:id/versions/:version", h.DeleteVersion)
+
+	// GetVersionByString -> a synced version that has stored SHA256SUMS + signature.
+	mock.ExpectQuery("SELECT.*FROM terraform_versions WHERE config_id.*AND version").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "config_id", "version", "is_latest", "is_deprecated", "release_date",
+			"sync_status", "sync_error", "synced_at", "created_at", "updated_at",
+			"sums_storage_key", "sig_storage_key", "approval_status",
+		}).AddRow(
+			knownUUID, knownUUID, "1.7.0", true, false, nil,
+			"synced", nil, nil, time.Now(), time.Now(),
+			"terraform-binaries/1.7.0/SHA256SUMS", "terraform-binaries/1.7.0/SHA256SUMS.sig", "approved",
+		))
+	// ListPlatformsForVersion -> two stored platform binaries.
+	mock.ExpectQuery("SELECT.*FROM terraform_version_platforms WHERE version_id").
+		WillReturnRows(sqlmock.NewRows(tmPlatformCols).
+			AddRow(knownUUID, knownUUID, "linux", "amd64", "u", "f1", "h1",
+				"terraform-binaries/1.7.0/linux/amd64/terraform_1.7.0_linux_amd64.zip", "s3", true, true,
+				"synced", nil, nil, time.Now(), time.Now()).
+			AddRow(knownUUID, knownUUID, "windows", "amd64", "u", "f2", "h2",
+				"terraform-binaries/1.7.0/windows/amd64/terraform_1.7.0_windows_amd64.zip", "s3", true, true,
+				"synced", nil, nil, time.Now(), time.Now()))
+	mock.ExpectExec("DELETE FROM terraform_versions WHERE id").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/terraform-mirrors/"+knownUUID+"/versions/1.7.0", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	want := []string{
+		"terraform-binaries/1.7.0/linux/amd64/terraform_1.7.0_linux_amd64.zip",
+		"terraform-binaries/1.7.0/windows/amd64/terraform_1.7.0_windows_amd64.zip",
+		"terraform-binaries/1.7.0/SHA256SUMS",
+		"terraform-binaries/1.7.0/SHA256SUMS.sig",
+	}
+	for _, key := range want {
+		found := false
+		for _, d := range store.deleted {
+			if d == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected storage Delete(%q); got %v", key, store.deleted)
+		}
 	}
 }
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -603,6 +603,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize Terraform binary mirror admin handler
 	tfMirrorAdminHandler := admin.NewTerraformMirrorHandler(tfMirrorRepo)
 	tfMirrorAdminHandler.SetSyncJob(tfMirrorSyncJob)
+	tfMirrorAdminHandler.SetStorageBackend(storageBackend) // delete stored binaries when a version is removed
 	releasesGPGKeysAdminHandler := admin.NewReleasesGPGKeysHandler(releasesKeyRepo, tfMirrorRepo, cfg.ReleasesGPGKeys)
 	versionApprovalHandler := admin.NewVersionApprovalHandler(repositories.NewVersionApprovalRepository(sqlxDB))
 	providerAdminHandlers := admin.NewProviderAdminHandlers(db, storageBackend, cfg)


### PR DESCRIPTION
## Problem

The Terraform mirror admin handlers orphaned stored binaries on delete:

- **`DeleteVersion`** removed only the database rows. The console tooltip advertised "Delete version and its binaries", but the packages, `SHA256SUMS`, and detached signature were left behind in object storage.
- **`DeleteConfig`** had the same gap at a larger blast radius: deleting a mirror config cascaded the version/platform rows in the database but left every version's binaries orphaned in storage.

## Fix

Both handlers now remove stored artifacts before the database delete, mirroring the existing provider-mirror cleanup:

- A shared `deleteVersionArtifacts` helper deletes each platform package plus the version's `SHA256SUMS` and detached signature.
- `DeleteVersion` calls it for the single version; `DeleteConfig` iterates every version the config owns.
- Cleanup is **best-effort** (a storage error never blocks the metadata delete) and **nil-guarded** (no-op when no storage backend is configured), so existing behavior and tests are unchanged when storage isn't wired in.

Swagger descriptions for both endpoints were updated to reflect the real behavior.

## Testing

- `go build ./...`
- `go test ./internal/api/admin/` — full package passes, including new `TestTMMirrorDeleteVersion_DeletesBinaries` and `TestTMDeleteConfig_DeletesBinaries`, which assert the platform packages, `SHA256SUMS`, and signatures are deleted from storage.
