### PR TITLE
fix(suite): build the module-consumers proxy URL with net/url

### DIFF
--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -129,30 +129,28 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 		}
 
 		moduleAddr := c.Param("namespace") + "/" + c.Param("name") + "/" + c.Param("system")
-		// Emit every acceptable host as a repeated &host= param; the sibling
+
+		// Build the outbound URL structurally from the trusted sibling origin
+		// (siblingURL, parsed from the discovery-advertised PublicURL). The
+		// user-provided module address and the registry's own host set are
+		// attached only as escaped query parameters via net/url, so they cannot
+		// influence the request scheme/host/path — the request authority is
+		// fixed to the sibling by construction. (Resolves CodeQL
+		// go/request-forgery: structured net/url construction confines the
+		// untrusted input to the query component instead of concatenating it
+		// into the URL string, which the taint analysis cannot localize.)
+		target := *siblingURL
+		target.Path = strings.TrimRight(siblingURL.Path, "/") + "/api/v1/consumers"
+		// Emit every acceptable host as a repeated host= param; the sibling
 		// matches a state if its captured host is any of them.
-		var sb strings.Builder
-		sb.WriteString(strings.TrimRight(m.PublicURL, "/"))
-		sb.WriteString("/api/v1/consumers?module=")
-		sb.WriteString(url.QueryEscape(moduleAddr))
+		q := url.Values{}
+		q.Set("module", moduleAddr)
 		for _, h := range hosts {
-			sb.WriteString("&host=")
-			sb.WriteString(url.QueryEscape(h))
+			q.Add("host", h)
 		}
-		target := sb.String()
+		target.RawQuery = q.Encode()
 
-		// Defense-in-depth against request forgery (CodeQL go/request-forgery):
-		// the user-provided path params are QueryEscape'd into the query string
-		// above and cannot influence the request authority, but assert explicitly
-		// that the resolved target stays on the trusted sibling origin before
-		// dialing it.
-		parsed, err := url.Parse(target)
-		if err != nil || parsed.Scheme != siblingURL.Scheme || parsed.Host != siblingURL.Host {
-			c.JSON(http.StatusOK, empty)
-			return
-		}
-
-		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, parsed.String(), nil)
+		req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, target.String(), nil)
 		if err != nil {
 			c.JSON(http.StatusOK, empty)
 			return


### PR DESCRIPTION
## What

Resolves CodeQL **alert #36** (`go/request-forgery`, **critical**, `backend/internal/api/suite.go`).

PR #522 pinned the outbound module-consumers proxy request to the trusted sibling host with a re-parse/host-equality guard. That fixed the SSRF, but CodeQL **still flagged the call** after #522 merged — because the URL was assembled by **string concatenation** (`strings.Builder` of base + `?module=` + escaped params). The taint analysis can't localize the user input to the query component when it's concatenated into the URL string, so it conservatively treats the whole URL (host included) as user-influenced.

## Fix

Build the URL **structurally** with `net/url`:
- Copy the already-parsed, trusted `siblingURL` (from the discovery-advertised `PublicURL`) for scheme/host/path.
- Attach the module address and the registry's host set as escaped query parameters via `url.Values`.

The request **authority is now fixed to the sibling by construction** — user input can only ever reach the query string, never the scheme/host/path. This also removes the now-redundant re-parse/host-equality guard #522 added (the invariant it asserted holds by construction).

## Behavior

Unchanged. The sibling still receives the same `module=` and repeated `host=` params (query-param order differs cosmetically — `url.Values.Encode()` sorts keys — but the sibling reads them order-independently). Covered by the existing `TestModuleConsumers_*` suite, including `ProxiesActiveSibling` (which only passes if the request actually reaches the sibling origin) and `EmitsHostAliasSet`.

## Verification

`gofmt`/`go vet` clean · full `internal/api` suite green · gosec **0 new findings** vs baseline. CodeQL re-validated on this branch before merge (the whole point — see linked scan).