### PR TITLE
feat(mirror): add terraform-docs as a first-class binary mirror tool

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -17752,6 +17752,7 @@
                             "packer",
                             "sentinel",
                             "opa",
+                            "terraform-docs",
                             "custom"
                         ]
                     },
@@ -19235,6 +19236,7 @@
                             "packer",
                             "sentinel",
                             "opa",
+                            "terraform-docs",
                             "custom"
                         ]
                     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -14672,6 +14672,7 @@
                         "packer",
                         "sentinel",
                         "opa",
+                        "terraform-docs",
                         "custom"
                     ]
                 },
@@ -16155,6 +16156,7 @@
                         "packer",
                         "sentinel",
                         "opa",
+                        "terraform-docs",
                         "custom"
                     ]
                 },

--- a/backend/internal/cve/matcher.go
+++ b/backend/internal/cve/matcher.go
@@ -34,10 +34,11 @@ var scannerPackage = map[string][2]string{
 
 // binaryRepoURL maps a tool name to the canonical GitHub repo URL used in OSV GIT queries.
 var binaryRepoURL = map[string]string{
-	"terraform": "https://github.com/hashicorp/terraform",
-	"opentofu":  "https://github.com/opentofu/opentofu",
-	"packer":    "https://github.com/hashicorp/packer",
-	"opa":       "https://github.com/open-policy-agent/opa",
+	"terraform":      "https://github.com/hashicorp/terraform",
+	"opentofu":       "https://github.com/opentofu/opentofu",
+	"packer":         "https://github.com/hashicorp/packer",
+	"opa":            "https://github.com/open-policy-agent/opa",
+	"terraform-docs": "https://github.com/terraform-docs/terraform-docs",
 }
 
 // batchSize is the maximum number of queries per OSV /v1/querybatch call.

--- a/backend/internal/db/migrations/000042_add_terraform_docs_tool.down.sql
+++ b/backend/internal/db/migrations/000042_add_terraform_docs_tool.down.sql
@@ -1,0 +1,9 @@
+-- Revert the tool CHECK constraint to exclude terraform-docs
+-- (will fail if rows with tool = 'terraform-docs' exist).
+ALTER TABLE terraform_mirror_configs
+    DROP CONSTRAINT IF EXISTS terraform_mirror_configs_tool_check;
+
+ALTER TABLE terraform_mirror_configs
+    ADD CONSTRAINT terraform_mirror_configs_tool_check CHECK (
+        tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa', 'custom')
+    );

--- a/backend/internal/db/migrations/000042_add_terraform_docs_tool.up.sql
+++ b/backend/internal/db/migrations/000042_add_terraform_docs_tool.up.sql
@@ -1,0 +1,8 @@
+-- Expand the tool CHECK constraint to include terraform-docs.
+ALTER TABLE terraform_mirror_configs
+    DROP CONSTRAINT IF EXISTS terraform_mirror_configs_tool_check;
+
+ALTER TABLE terraform_mirror_configs
+    ADD CONSTRAINT terraform_mirror_configs_tool_check CHECK (
+        tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa', 'terraform-docs', 'custom')
+    );

--- a/backend/internal/db/models/terraform_mirror.go
+++ b/backend/internal/db/models/terraform_mirror.go
@@ -105,7 +105,7 @@ type TerraformSyncHistory struct {
 type CreateTerraformMirrorConfigRequest struct {
 	Name              string   `json:"name" binding:"required,min=1,max=255"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              string   `json:"tool" binding:"required,oneof=terraform opentofu packer sentinel opa custom"`
+	Tool              string   `json:"tool" binding:"required,oneof=terraform opentofu packer sentinel opa terraform-docs custom"`
 	UpstreamURL       string   `json:"upstream_url" binding:"required,url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`
@@ -121,7 +121,7 @@ type CreateTerraformMirrorConfigRequest struct {
 type UpdateTerraformMirrorConfigRequest struct {
 	Name              *string  `json:"name,omitempty" binding:"omitempty,min=1,max=255"`
 	Description       *string  `json:"description,omitempty"`
-	Tool              *string  `json:"tool,omitempty" binding:"omitempty,oneof=terraform opentofu packer sentinel opa custom"`
+	Tool              *string  `json:"tool,omitempty" binding:"omitempty,oneof=terraform opentofu packer sentinel opa terraform-docs custom"`
 	UpstreamURL       *string  `json:"upstream_url,omitempty" binding:"omitempty,url"`
 	PlatformFilter    []string `json:"platform_filter,omitempty"`
 	VersionFilter     *string  `json:"version_filter,omitempty"`

--- a/backend/internal/db/repositories/cve_repository.go
+++ b/backend/internal/db/repositories/cve_repository.go
@@ -284,7 +284,7 @@ func (r *CVERepository) ListAllBinaryCandidates(ctx context.Context) ([]BinaryCa
 		FROM terraform_versions tv
 		JOIN terraform_mirror_configs c ON c.id = tv.config_id
 		WHERE c.enabled = true
-		  AND c.tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa')
+		  AND c.tool IN ('terraform', 'opentofu', 'packer', 'sentinel', 'opa', 'terraform-docs')
 		  AND tv.is_deprecated = false
 		  AND tv.sync_status = 'synced'
 		ORDER BY c.tool, tv.version

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -966,6 +966,8 @@ func productNameForTool(tool string) string {
 		return "sentinel"
 	case "opa":
 		return "opa"
+	case "terraform-docs":
+		return "terraform-docs"
 	default:
 		return "terraform"
 	}

--- a/backend/internal/jobs/terraform_mirror_sync_helpers_test.go
+++ b/backend/internal/jobs/terraform_mirror_sync_helpers_test.go
@@ -40,6 +40,18 @@ func TestProductNameForTool_Unknown(t *testing.T) {
 	}
 }
 
+func TestProductNameForTool_TerraformDocs(t *testing.T) {
+	if got := productNameForTool("terraform-docs"); got != "terraform-docs" {
+		t.Errorf("got %q, want %q", got, "terraform-docs")
+	}
+}
+
+func TestProductNameForTool_TerraformDocsUpperCase(t *testing.T) {
+	if got := productNameForTool("Terraform-Docs"); got != "terraform-docs" {
+		t.Errorf("got %q, want %q", got, "terraform-docs")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // gpgKeyForTool
 // ---------------------------------------------------------------------------
@@ -75,6 +87,15 @@ func TestGPGKeyForTool_Unknown(t *testing.T) {
 	key := gpgKeyForTool("something-else")
 	if key != "" {
 		t.Errorf("expected empty key for unknown tool, got non-empty")
+	}
+}
+
+func TestGPGKeyForTool_TerraformDocs(t *testing.T) {
+	// terraform-docs publishes no GPG signatures (checksum-only upstream), so it
+	// must return an empty key; sync then verifies by SHA-256 checksum only.
+	SetReleasesKeyResolver(nil)
+	if key := gpgKeyForTool("terraform-docs"); key != "" {
+		t.Errorf("expected empty GPG key for terraform-docs, got non-empty")
 	}
 }
 

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -17,6 +17,8 @@
 //   - Binary zips matching the pattern  {product}_{version}_{os}_{arch}.zip
 //   - SHA256SUMS file matching          {product}_{version}_SHA256SUMS
 //   - GPG signature matching            {product}_{version}_SHA256SUMS.sig   (or .72D7468F.sig)
+//   - Hyphenated archives matching      {product}-v{version}-{os}-{arch}.tar.gz|.zip  (terraform-docs)
+//   - Combined checksum file matching   {product}-v{version}.sha256sum                (terraform-docs)
 package mirror
 
 import (
@@ -142,6 +144,23 @@ var sha256sumsRE = regexp.MustCompile(`^(.+?)_([^_]+)_SHA256SUMS$`)
 // sha256sumsSigRE matches: {product}_{version}_SHA256SUMS.sig  (or .*.sig)
 var sha256sumsSigRE = regexp.MustCompile(`^(.+?)_([^_]+)_SHA256SUMS\..*sig$`)
 
+// tfDocsArchiveRE matches hyphen-delimited, version-prefixed release archives:
+//
+//	{product}-v{version}-{os}-{arch}.tar.gz   e.g. terraform-docs-v0.24.0-linux-amd64.tar.gz
+//	{product}-v{version}-{os}-{arch}.zip      e.g. terraform-docs-v0.24.0-windows-amd64.zip
+//
+// Used by terraform-docs, whose assets are hyphen-delimited (not underscore) and
+// shipped as .tar.gz / .zip archives rather than bare {product}_{os}_{arch} files.
+// The product prefix is still validated against c.ProductName by the caller, so
+// the greedy leading group cannot cross-match another tool's assets.
+var tfDocsArchiveRE = regexp.MustCompile(`^(.+)-v([0-9][^-\s]*)-([a-z0-9]+)-([a-z0-9]+)\.(?:tar\.gz|zip)$`)
+
+// tfDocsSumsRE matches a single combined checksum file that carries the version
+// in its name with a ".sha256sum" suffix: {product}-v{version}.sha256sum
+// e.g. terraform-docs-v0.24.0.sha256sum. Its body is the standard
+// "<sha256>  <filename>" format parsed by ParseSHASums.
+var tfDocsSumsRE = regexp.MustCompile(`^(.+)-v([0-9][^-\s]*)\.sha256sum$`)
+
 // ----- ListVersions ---------------------------------------------------------
 
 // ListVersions fetches all (non-draft) releases from GitHub and returns them
@@ -247,6 +266,23 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 			continue
 		}
 
+		// Hyphenated, version-prefixed archive? (e.g. terraform-docs-v0.24.0-linux-amd64.tar.gz)
+		if m := tfDocsArchiveRE.FindStringSubmatch(name); m != nil {
+			product, osName, arch := m[1], m[3], m[4]
+			if !strings.EqualFold(product, c.ProductName) {
+				continue
+			}
+			builds = append(builds, TerraformReleaseBuild{
+				Name:     product,
+				Version:  version,
+				OS:       osName,
+				Arch:     arch,
+				Filename: name,
+				URL:      url,
+			})
+			continue
+		}
+
 		// Per-file .sha256 sidecar? (e.g. opa_linux_amd64.sha256)
 		if m := perFileSHA256RE.FindStringSubmatch(name); m != nil {
 			perFileSHAs[m[1]] = url
@@ -255,6 +291,14 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 
 		// SHA256SUMS file?
 		if m := sha256sumsRE.FindStringSubmatch(name); m != nil {
+			if strings.EqualFold(m[1], c.ProductName) {
+				sha256sumsURL = url
+			}
+			continue
+		}
+
+		// Combined ".sha256sum" checksum file? (e.g. terraform-docs-v0.24.0.sha256sum)
+		if m := tfDocsSumsRE.FindStringSubmatch(name); m != nil {
 			if strings.EqualFold(m[1], c.ProductName) {
 				sha256sumsURL = url
 			}
@@ -411,7 +455,7 @@ func (c *GitHubReleasesClient) DownloadBinaryStream(ctx context.Context, downloa
 // ----- helpers --------------------------------------------------------------
 
 func (c *GitHubReleasesClient) findSHA256SumsURL(ctx context.Context, version string) (string, error) {
-	return c.findAssetURL(ctx, version, sha256sumsRE)
+	return c.findAssetURL(ctx, version, sha256sumsRE, tfDocsSumsRE)
 }
 
 func (c *GitHubReleasesClient) findSHA256SumsSigURL(ctx context.Context, version string) (string, error) {
@@ -420,8 +464,9 @@ func (c *GitHubReleasesClient) findSHA256SumsSigURL(ctx context.Context, version
 
 // findAssetURL fetches the specific release by tag (tries with and without
 // leading "v") and returns the browser_download_url of the first asset whose
-// name matches re and whose product prefix matches c.ProductName.
-func (c *GitHubReleasesClient) findAssetURL(ctx context.Context, version string, re *regexp.Regexp) (string, error) {
+// name matches any of the supplied regexes and whose product prefix (capture
+// group 1) matches c.ProductName.
+func (c *GitHubReleasesClient) findAssetURL(ctx context.Context, version string, res ...*regexp.Regexp) (string, error) {
 	// GitHub tags may use "v1.9.0" or "1.9.0" — try both.
 	for _, tag := range []string{"v" + version, version} {
 		rel, err := c.fetchReleaseByTag(ctx, tag)
@@ -429,9 +474,11 @@ func (c *GitHubReleasesClient) findAssetURL(ctx context.Context, version string,
 			continue
 		}
 		for _, asset := range rel.Assets {
-			if m := re.FindStringSubmatch(asset.Name); m != nil {
-				if strings.EqualFold(m[1], c.ProductName) {
-					return asset.BrowserDownloadURL, nil
+			for _, re := range res {
+				if m := re.FindStringSubmatch(asset.Name); m != nil {
+					if strings.EqualFold(m[1], c.ProductName) {
+						return asset.BrowserDownloadURL, nil
+					}
 				}
 			}
 		}

--- a/backend/internal/mirror/github_releases_test.go
+++ b/backend/internal/mirror/github_releases_test.go
@@ -309,6 +309,157 @@ func TestSHA256SumsSigRE(t *testing.T) {
 	}
 }
 
+func TestTfDocsArchiveRE(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		product string
+		version string
+		os      string
+		arch    string
+		match   bool
+	}{
+		{"linux amd64 tar.gz", "terraform-docs-v0.24.0-linux-amd64.tar.gz", "terraform-docs", "0.24.0", "linux", "amd64", true},
+		{"darwin arm64 tar.gz", "terraform-docs-v0.24.0-darwin-arm64.tar.gz", "terraform-docs", "0.24.0", "darwin", "arm64", true},
+		{"freebsd arm tar.gz", "terraform-docs-v0.19.0-freebsd-arm.tar.gz", "terraform-docs", "0.19.0", "freebsd", "arm", true},
+		{"windows amd64 zip", "terraform-docs-v0.24.0-windows-amd64.zip", "terraform-docs", "0.24.0", "windows", "amd64", true},
+		// Must NOT match underscore-delimited, bare, or non-archive assets.
+		{"opentofu underscore zip", "opentofu_1.9.0_linux_amd64.zip", "", "", "", "", false},
+		{"opa bare binary", "opa_linux_amd64", "", "", "", "", false},
+		{"combined sha256sum", "terraform-docs-v0.24.0.sha256sum", "", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tfDocsArchiveRE.FindStringSubmatch(tt.input)
+			if tt.match {
+				if m == nil {
+					t.Fatalf("tfDocsArchiveRE did not match %q", tt.input)
+				}
+				if m[1] != tt.product || m[2] != tt.version || m[3] != tt.os || m[4] != tt.arch {
+					t.Errorf("groups = [%q %q %q %q], want [%q %q %q %q]",
+						m[1], m[2], m[3], m[4], tt.product, tt.version, tt.os, tt.arch)
+				}
+			} else if m != nil {
+				t.Errorf("tfDocsArchiveRE unexpectedly matched %q", tt.input)
+			}
+		})
+	}
+}
+
+func TestTfDocsSumsRE(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		product string
+		match   bool
+	}{
+		{"combined sha256sum", "terraform-docs-v0.24.0.sha256sum", "terraform-docs", true},
+		{"archive tar.gz", "terraform-docs-v0.24.0-linux-amd64.tar.gz", "", false},
+		{"per-file sha256", "opa_linux_amd64.sha256", "", false},
+		{"underscore SHA256SUMS", "opentofu_1.9.0_SHA256SUMS", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tfDocsSumsRE.FindStringSubmatch(tt.input)
+			if tt.match {
+				if m == nil {
+					t.Fatalf("tfDocsSumsRE did not match %q", tt.input)
+				}
+				if m[1] != tt.product {
+					t.Errorf("product = %q, want %q", m[1], tt.product)
+				}
+			} else if m != nil {
+				t.Errorf("tfDocsSumsRE unexpectedly matched %q", tt.input)
+			}
+		})
+	}
+}
+
+// TestTerraformDocsAssets_NoCrossMatch guards against the terraform-docs asset
+// names being accidentally consumed by the underscore-oriented regexes (which
+// would mis-parse them). The two naming schemes must stay mutually exclusive.
+func TestTerraformDocsAssets_NoCrossMatch(t *testing.T) {
+	if binaryZipRE.MatchString("terraform-docs-v0.24.0-windows-amd64.zip") {
+		t.Error("binaryZipRE must not match the hyphenated terraform-docs zip")
+	}
+	if bareBinaryRE.MatchString("terraform-docs-v0.24.0-linux-amd64.tar.gz") {
+		t.Error("bareBinaryRE must not match a terraform-docs archive")
+	}
+	if perFileSHA256RE.MatchString("terraform-docs-v0.24.0.sha256sum") {
+		t.Error("perFileSHA256RE must not match the combined .sha256sum file")
+	}
+	if sha256sumsRE.MatchString("terraform-docs-v0.24.0.sha256sum") {
+		t.Error("sha256sumsRE must not match the .sha256sum file")
+	}
+}
+
+// TestParseRelease_TerraformDocs verifies the terraform-docs release layout
+// (hyphenated .tar.gz/.zip archives + a single combined .sha256sum file) parses
+// into builds with the combined checksum file recorded as SHASumsURL and no
+// signature (terraform-docs is unsigned upstream).
+func TestParseRelease_TerraformDocs(t *testing.T) {
+	c := &GitHubReleasesClient{
+		Owner:       "terraform-docs",
+		Repo:        "terraform-docs",
+		ProductName: "terraform-docs",
+	}
+
+	rel := gitHubRelease{
+		TagName: "v0.24.0",
+		Assets: []gitHubAsset{
+			{Name: "terraform-docs-v0.24.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0-linux-amd64.tar.gz"},
+			{Name: "terraform-docs-v0.24.0-darwin-arm64.tar.gz", BrowserDownloadURL: "https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0-darwin-arm64.tar.gz"},
+			{Name: "terraform-docs-v0.24.0-windows-amd64.zip", BrowserDownloadURL: "https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0-windows-amd64.zip"},
+			{Name: "terraform-docs-v0.24.0.sha256sum", BrowserDownloadURL: "https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/terraform-docs-v0.24.0.sha256sum"},
+		},
+	}
+
+	vi, ok := c.parseRelease(rel)
+	if !ok {
+		t.Fatal("parseRelease returned ok=false, expected true")
+	}
+	if vi.Version != "0.24.0" {
+		t.Errorf("Version = %q, want 0.24.0", vi.Version)
+	}
+	if len(vi.Builds) != 3 {
+		t.Fatalf("Builds count = %d, want 3", len(vi.Builds))
+	}
+	if vi.SHASumsURL == "" {
+		t.Error("SHASumsURL should be set from the .sha256sum asset")
+	}
+	if vi.SHASumsSignature != "" {
+		t.Error("SHASumsSignature should be empty (terraform-docs is unsigned)")
+	}
+
+	var foundLinux bool
+	for _, b := range vi.Builds {
+		if b.OS == "linux" && b.Arch == "amd64" {
+			foundLinux = true
+			if b.Filename != "terraform-docs-v0.24.0-linux-amd64.tar.gz" {
+				t.Errorf("linux/amd64 filename = %q", b.Filename)
+			}
+		}
+	}
+	if !foundLinux {
+		t.Error("expected a linux/amd64 build")
+	}
+}
+
+// TestParseRelease_TerraformDocsWrongProductSkipped ensures archives whose
+// product prefix does not match the configured product are ignored.
+func TestParseRelease_TerraformDocsWrongProductSkipped(t *testing.T) {
+	c := &GitHubReleasesClient{ProductName: "terraform-docs"}
+	rel := gitHubRelease{
+		TagName: "v0.24.0",
+		Assets: []gitHubAsset{
+			{Name: "some-other-tool-v0.24.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/x.tar.gz"},
+		},
+	}
+	if _, ok := c.parseRelease(rel); ok {
+		t.Error("parseRelease should return ok=false when no assets match the product")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Redirect transport: rewrites any host → test server
 // ---------------------------------------------------------------------------

--- a/backend/internal/mirror/signing.go
+++ b/backend/internal/mirror/signing.go
@@ -11,9 +11,25 @@ import "strings"
 //
 // OPA (open-policy-agent/opa) is the canonical case: its GitHub releases ship
 // opa_<os>_<arch> binaries each with a sibling opa_<os>_<arch>.sha256, and no
-// .sig / SHA256SUMS / cosign artifacts.
+// .sig / SHA256SUMS / cosign signature artifacts attached to the release.
+//
+// Nuance (verified 2026-06-28): recent OPA releases (v1.18.0+) do carry an
+// out-of-band GitHub Artifact Attestation — a Sigstore-signed in-toto statement
+// (predicate https://in-toto.io/attestation/release/v0.2) served from GitHub's
+// attestation API, not as a release asset. It is NOT GPG and NOT SLSA build
+// provenance (the default `gh attestation verify` provenance lookup 404s), so it
+// does not change the checksum-only handling here; attestation-based authenticity
+// would be a separate future enhancement, not a GPG key to embed.
+//
+// terraform-docs (terraform-docs/terraform-docs) is a second case (verified
+// 2026-06-30): its GitHub releases ship terraform-docs-v<ver>-<os>-<arch>.tar.gz
+// (and .zip for windows) archives plus a single combined
+// terraform-docs-v<ver>.sha256sum checksum file, with no .sig / cosign / SLSA
+// provenance artifacts. Integrity is verified against that checksum file;
+// authenticity cannot be, exactly as with OPA.
 var unsignedUpstreamTools = map[string]bool{
-	"opa": true,
+	"opa":            true,
+	"terraform-docs": true,
 }
 
 // IsUnsignedUpstreamTool reports whether the given tool's upstream publishes no

--- a/backend/internal/mirror/signing_test.go
+++ b/backend/internal/mirror/signing_test.go
@@ -3,8 +3,9 @@ package mirror
 import "testing"
 
 func TestIsUnsignedUpstreamTool(t *testing.T) {
-	// OPA is unsigned upstream; matching is case-insensitive and trims space.
-	for _, tool := range []string{"opa", "OPA", "Opa", " opa "} {
+	// OPA and terraform-docs are unsigned upstream; matching is case-insensitive
+	// and trims space.
+	for _, tool := range []string{"opa", "OPA", "Opa", " opa ", "terraform-docs", "Terraform-Docs", " terraform-docs "} {
 		if !IsUnsignedUpstreamTool(tool) {
 			t.Errorf("IsUnsignedUpstreamTool(%q) = false, want true", tool)
 		}


### PR DESCRIPTION
## Summary
Adds `terraform-docs` (terraform-docs/terraform-docs) as a first-class supported tool in the Terraform binary mirror, with the same security posture as the existing tools.

## Changes
- **Asset parsing**: the GitHub releases client now recognises terraform-docs' hyphenated, version-prefixed archives (`terraform-docs-v0.24.0-linux-amd64.tar.gz` / `.zip`) and its single combined `terraform-docs-v0.24.0.sha256sum` checksum file. These matched none of the existing regexes, so versions would previously be skipped silently.
- **Verification**: terraform-docs publishes no GPG/cosign/SLSA signatures — only SHA-256 checksums. It is treated as an unsigned-upstream tool (like OPA): each binary is checksum-verified and the tool is honestly surfaced as "unsigned upstream" in the signing-keys view. Sync fails on checksum mismatch.
- **CVE scanning + banners**: terraform-docs is added to the CVE `binaryRepoURL` map (OSV GIT queries) and the binary-candidate SQL allowlist, so OSV scanning and the OSS advisory banner apply automatically.
- **Config surface**: added to mirror-config validation (`oneof`) and a new migration `000042` extending the `tool` CHECK constraint.

## Tests
- New/updated unit tests for asset + checksum parsing, unsigned-upstream classification, and tool-name mapping.
- `go build ./...` clean; affected package tests pass (mirror, jobs, cve, repositories, advisories).

## Notes
- No server-side extraction change — archives are stored as-is and verified at the archive level, consistent with all other tools.
- Frontend UI support is in a companion PR on `terraform-registry-frontend`.
