### PR TITLE
feat: admin-managed security scanner updates (backend)

### DIFF
--- a/backend/internal/api/admin/notifications.go
+++ b/backend/internal/api/admin/notifications.go
@@ -1,0 +1,361 @@
+// notifications.go implements admin endpoints for viewing and updating the
+// outbound notification (SMTP) configuration shared by the CVE poll job, the
+// API key expiry notifier, and the scanner update job, plus a send-test-email
+// probe. The SMTP password is write-only: it is encrypted at rest (via the
+// shared token cipher) and never returned by the API.
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/mail"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/notify"
+)
+
+// NotificationsConfigDB is the persistence shape stored in
+// system_settings.notifications_config. It is exported so router.go can reuse
+// it when reloading the persisted configuration into cfg.Notifications at
+// startup.
+type NotificationsConfigDB struct {
+	Enabled                        bool `json:"enabled"`
+	APIKeyExpiryWarningDays        int  `json:"api_key_expiry_warning_days,omitempty"`
+	APIKeyExpiryCheckIntervalHours int  `json:"api_key_expiry_check_interval_hours,omitempty"`
+	SMTP                           struct {
+		Host              string `json:"host"`
+		Port              int    `json:"port"`
+		Username          string `json:"username"`
+		From              string `json:"from"`
+		UseTLS            bool   `json:"use_tls"`
+		PasswordEncrypted string `json:"smtp_password_encrypted,omitempty"`
+	} `json:"smtp"`
+}
+
+// NotificationsConfigResponse is the redacted public view of the notifications
+// config. The SMTP password/ciphertext is never included.
+type NotificationsConfigResponse struct {
+	Enabled                        bool                      `json:"enabled"`
+	SMTP                           NotificationsSMTPResponse `json:"smtp"`
+	APIKeyExpiryWarningDays        int                       `json:"api_key_expiry_warning_days"`
+	APIKeyExpiryCheckIntervalHours int                       `json:"api_key_expiry_check_interval_hours"`
+	PasswordConfigured             bool                      `json:"password_configured"`
+}
+
+// NotificationsSMTPResponse is the redacted SMTP portion of NotificationsConfigResponse.
+type NotificationsSMTPResponse struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username"`
+	From     string `json:"from"`
+	UseTLS   bool   `json:"use_tls"`
+}
+
+// notificationsConfigInput is the PUT request body.
+type notificationsConfigInput struct {
+	Enabled bool `json:"enabled"`
+	SMTP    struct {
+		Host     string `json:"host"`
+		Port     int    `json:"port"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+		From     string `json:"from"`
+		UseTLS   bool   `json:"use_tls"`
+	} `json:"smtp"`
+	APIKeyExpiryWarningDays        int `json:"api_key_expiry_warning_days"`
+	APIKeyExpiryCheckIntervalHours int `json:"api_key_expiry_check_interval_hours"`
+}
+
+// notificationsTestEmailInput is the POST /admin/notifications/test request body.
+// All fields are optional: recipients default to cve.email_recipients, and any
+// omitted smtp override field falls back to the live notifications config.
+type notificationsTestEmailInput struct {
+	Recipients []string `json:"recipients"`
+	Subject    string   `json:"subject"`
+	SMTP       *struct {
+		Host     string `json:"host"`
+		Port     int    `json:"port"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+		From     string `json:"from"`
+		UseTLS   *bool  `json:"use_tls"`
+	} `json:"smtp"`
+}
+
+// NotificationsHandler handles the admin notifications-config endpoints.
+type NotificationsHandler struct {
+	cfg         *config.NotificationsConfig
+	repo        *repositories.OIDCConfigRepository
+	tokenCipher *crypto.TokenCipher
+	cveCfg      *config.CVEConfig
+}
+
+// NewNotificationsHandler constructs a NotificationsHandler. cfg must be a
+// pointer to the live config.Notifications struct so updates take effect
+// in-place for background jobs holding the same pointer.
+func NewNotificationsHandler(
+	cfg *config.NotificationsConfig,
+	repo *repositories.OIDCConfigRepository,
+	tokenCipher *crypto.TokenCipher,
+	cveCfg *config.CVEConfig,
+) *NotificationsHandler {
+	return &NotificationsHandler{
+		cfg:         cfg,
+		repo:        repo,
+		tokenCipher: tokenCipher,
+		cveCfg:      cveCfg,
+	}
+}
+
+// toResponse builds the redacted response shape shared by GetConfig and PutConfig.
+func (h *NotificationsHandler) toResponse(passwordConfigured bool) NotificationsConfigResponse {
+	return NotificationsConfigResponse{
+		Enabled: h.cfg.Enabled,
+		SMTP: NotificationsSMTPResponse{
+			Host:     h.cfg.SMTP.Host,
+			Port:     h.cfg.SMTP.Port,
+			Username: h.cfg.SMTP.Username,
+			From:     h.cfg.SMTP.From,
+			UseTLS:   h.cfg.SMTP.UseTLS,
+		},
+		APIKeyExpiryWarningDays:        h.cfg.APIKeyExpiryWarningDays,
+		APIKeyExpiryCheckIntervalHours: h.cfg.APIKeyExpiryCheckIntervalHours,
+		PasswordConfigured:             passwordConfigured,
+	}
+}
+
+// @Summary      Get notifications configuration
+// @Description  Returns the current outbound-notification (SMTP) configuration. The SMTP password is never returned; password_configured indicates whether one is set. Requires admin scope.
+// @Tags         Notifications
+// @Security     Bearer
+// @Produce      json
+// @Success      200  {object}  NotificationsConfigResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Router       /api/v1/admin/notifications/config [get]
+// GetConfig returns the current notifications configuration (password redacted).
+func (h *NotificationsHandler) GetConfig(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	passwordConfigured := h.cfg.SMTP.Password != ""
+	if raw, err := h.repo.GetNotificationsConfig(ctx); err == nil && raw != nil {
+		var dbc NotificationsConfigDB
+		if json.Unmarshal(raw, &dbc) == nil && dbc.SMTP.PasswordEncrypted != "" {
+			passwordConfigured = true
+		}
+	}
+
+	c.JSON(http.StatusOK, h.toResponse(passwordConfigured))
+}
+
+// @Summary      Update notifications configuration
+// @Description  Updates the outbound-notification (SMTP) configuration. The SMTP password is write-only: send a non-empty value to change it, or omit/blank it to preserve the currently stored password. Requires admin scope.
+// @Tags         Notifications
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        body  body  notificationsConfigInput  true  "Notifications configuration"
+// @Success      200  {object}  NotificationsConfigResponse
+// @Failure      400  {object}  map[string]interface{}  "Invalid configuration input"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/notifications/config [put]
+// PutConfig validates and persists the notifications configuration, then updates
+// the in-memory config in place so background jobs observe the change immediately.
+func (h *NotificationsHandler) PutConfig(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var input notificationsConfigInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if input.SMTP.Port == 0 {
+		input.SMTP.Port = 587
+	}
+	if err := validateNotificationsInput(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var existingEncrypted string
+	if raw, err := h.repo.GetNotificationsConfig(ctx); err == nil && raw != nil {
+		var existing NotificationsConfigDB
+		if json.Unmarshal(raw, &existing) == nil {
+			existingEncrypted = existing.SMTP.PasswordEncrypted
+		}
+	}
+
+	dbc, err := buildNotificationsConfigDB(input, h.tokenCipher, existingEncrypted)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt smtp password"})
+		return
+	}
+
+	configJSON, err := json.Marshal(dbc)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal notifications configuration"})
+		return
+	}
+	if err := h.repo.SetNotificationsConfig(ctx, configJSON); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save notifications configuration"})
+		return
+	}
+
+	// Update the in-memory config in place (never reassign h.cfg) so the CVE
+	// poll job, API key expiry notifier, and scanner update job all observe
+	// the new settings on their next run.
+	h.cfg.Enabled = input.Enabled
+	h.cfg.SMTP.Host = input.SMTP.Host
+	h.cfg.SMTP.Port = input.SMTP.Port
+	h.cfg.SMTP.Username = input.SMTP.Username
+	h.cfg.SMTP.From = input.SMTP.From
+	h.cfg.SMTP.UseTLS = input.SMTP.UseTLS
+	h.cfg.APIKeyExpiryWarningDays = input.APIKeyExpiryWarningDays
+	h.cfg.APIKeyExpiryCheckIntervalHours = input.APIKeyExpiryCheckIntervalHours
+	if input.SMTP.Password != "" {
+		h.cfg.SMTP.Password = input.SMTP.Password
+	}
+
+	passwordConfigured := dbc.SMTP.PasswordEncrypted != "" || h.cfg.SMTP.Password != ""
+	c.JSON(http.StatusOK, h.toResponse(passwordConfigured))
+}
+
+// validateNotificationsInput checks the basic field constraints for a PUT
+// request: when enabled, host and from are required; the port (after the
+// caller applies the 0->587 default) must be a valid TCP port; and from, when
+// present, must be a syntactically valid email address.
+func validateNotificationsInput(input *notificationsConfigInput) error {
+	if input.SMTP.Port < 1 || input.SMTP.Port > 65535 {
+		return &ValidationError{Field: "smtp.port", Message: "must be between 1 and 65535"}
+	}
+	if input.Enabled {
+		if input.SMTP.Host == "" {
+			return &ValidationError{Field: "smtp.host", Message: "required when notifications are enabled"}
+		}
+		if input.SMTP.From == "" {
+			return &ValidationError{Field: "smtp.from", Message: "required when notifications are enabled"}
+		}
+	}
+	if input.SMTP.From != "" {
+		if _, err := mail.ParseAddress(input.SMTP.From); err != nil {
+			return &ValidationError{Field: "smtp.from", Message: "must be a valid email address"}
+		}
+	}
+	return nil
+}
+
+// buildNotificationsConfigDB maps a validated PUT input to the DB persistence
+// shape, applying the seal/empty-password rule: a non-empty input password is
+// sealed into SMTP.PasswordEncrypted; an empty password preserves
+// existingEncrypted (the previously persisted ciphertext, if any).
+func buildNotificationsConfigDB(input notificationsConfigInput, tokenCipher *crypto.TokenCipher, existingEncrypted string) (NotificationsConfigDB, error) {
+	var dbc NotificationsConfigDB
+	dbc.Enabled = input.Enabled
+	dbc.APIKeyExpiryWarningDays = input.APIKeyExpiryWarningDays
+	dbc.APIKeyExpiryCheckIntervalHours = input.APIKeyExpiryCheckIntervalHours
+	dbc.SMTP.Host = input.SMTP.Host
+	dbc.SMTP.Port = input.SMTP.Port
+	dbc.SMTP.Username = input.SMTP.Username
+	dbc.SMTP.From = input.SMTP.From
+	dbc.SMTP.UseTLS = input.SMTP.UseTLS
+
+	if input.SMTP.Password != "" {
+		encrypted, err := tokenCipher.Seal(input.SMTP.Password)
+		if err != nil {
+			return dbc, err
+		}
+		dbc.SMTP.PasswordEncrypted = encrypted
+	} else {
+		dbc.SMTP.PasswordEncrypted = existingEncrypted
+	}
+	return dbc, nil
+}
+
+// @Summary      Send a test notification email
+// @Description  Sends a test email using the current (or request-overridden) SMTP configuration, without saving anything. Recipients default to cve.email_recipients when omitted. Always returns 200 with {success,message}, even when the send fails. Requires admin scope.
+// @Tags         Notifications
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        body  body  notificationsTestEmailInput  true  "Test email parameters"
+// @Success      200  {object}  map[string]interface{}
+// @Failure      400  {object}  map[string]interface{}  "Missing recipients or SMTP host"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Router       /api/v1/admin/notifications/test [post]
+// TestEmail sends a test notification email without persisting any configuration.
+func (h *NotificationsHandler) TestEmail(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	var input notificationsTestEmailInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	tempSMTP := h.cfg.SMTP
+	if input.SMTP != nil {
+		if input.SMTP.Host != "" {
+			tempSMTP.Host = input.SMTP.Host
+		}
+		if input.SMTP.Port != 0 {
+			tempSMTP.Port = input.SMTP.Port
+		}
+		if input.SMTP.Username != "" {
+			tempSMTP.Username = input.SMTP.Username
+		}
+		if input.SMTP.From != "" {
+			tempSMTP.From = input.SMTP.From
+		}
+		if input.SMTP.UseTLS != nil {
+			tempSMTP.UseTLS = *input.SMTP.UseTLS
+		}
+		if input.SMTP.Password != "" {
+			tempSMTP.Password = input.SMTP.Password
+		}
+	}
+
+	// When the request omits the password, fall back to the decrypted stored
+	// password rather than whatever happens to be in the in-memory config
+	// (which may be empty if the process hasn't reloaded since a PUT).
+	if input.SMTP == nil || input.SMTP.Password == "" {
+		if raw, err := h.repo.GetNotificationsConfig(ctx); err == nil && raw != nil {
+			var dbc NotificationsConfigDB
+			if json.Unmarshal(raw, &dbc) == nil && dbc.SMTP.PasswordEncrypted != "" {
+				if pw, derr := h.tokenCipher.Open(dbc.SMTP.PasswordEncrypted); derr == nil {
+					tempSMTP.Password = pw
+				}
+			}
+		}
+	}
+
+	recipients := input.Recipients
+	if len(recipients) == 0 {
+		recipients = h.cveCfg.EmailRecipients
+	}
+	if len(recipients) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one recipient is required"})
+		return
+	}
+	if tempSMTP.Host == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "smtp host is not configured"})
+		return
+	}
+
+	subject := input.Subject
+	if subject == "" {
+		subject = "Terraform Registry: test notification"
+	}
+	body := "This is a test notification email sent from the Terraform Registry admin notifications settings."
+
+	mailer := notify.New(&tempSMTP)
+	if err := mailer.Send(recipients, subject, body); err != nil {
+		c.JSON(http.StatusOK, gin.H{"success": false, "message": "failed to send test email: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "test email sent"})
+}

--- a/backend/internal/api/admin/notifications_test.go
+++ b/backend/internal/api/admin/notifications_test.go
@@ -1,0 +1,315 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// testTokenCipher is defined in scm_providers_test.go (shared helper).
+
+// newNotificationsHandler builds a NotificationsHandler backed by sqlmock, mirroring
+// the newOIDCConfigAdminRouter pattern used elsewhere in this package.
+func newNotificationsHandler(t *testing.T) (*NotificationsHandler, *config.NotificationsConfig, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	repo := repositories.NewOIDCConfigRepository(sqlx.NewDb(db, "sqlmock"))
+	cfg := &config.NotificationsConfig{}
+	cveCfg := &config.CVEConfig{}
+	return NewNotificationsHandler(cfg, repo, testTokenCipher(t), cveCfg), cfg, mock
+}
+
+// ---------------------------------------------------------------------------
+// validateNotificationsInput (pure)
+// ---------------------------------------------------------------------------
+
+func TestValidateNotificationsInput_DisabledNoFieldsRequired(t *testing.T) {
+	input := &notificationsConfigInput{Enabled: false}
+	input.SMTP.Port = 587
+
+	if err := validateNotificationsInput(input); err != nil {
+		t.Errorf("expected no error when disabled, got %v", err)
+	}
+}
+
+func TestValidateNotificationsInput_EnabledRequiresHostAndFrom(t *testing.T) {
+	input := &notificationsConfigInput{Enabled: true}
+	input.SMTP.Port = 587
+	if err := validateNotificationsInput(input); err == nil {
+		t.Fatal("expected error when enabled without host/from")
+	}
+
+	input.SMTP.Host = "smtp.example.com"
+	if err := validateNotificationsInput(input); err == nil {
+		t.Fatal("expected error when enabled without from")
+	}
+
+	input.SMTP.From = "not-an-email"
+	if err := validateNotificationsInput(input); err == nil {
+		t.Fatal("expected error for invalid from address")
+	}
+
+	input.SMTP.From = "admin@example.com"
+	if err := validateNotificationsInput(input); err != nil {
+		t.Errorf("expected no error with valid host/from, got %v", err)
+	}
+}
+
+func TestValidateNotificationsInput_PortRange(t *testing.T) {
+	input := &notificationsConfigInput{}
+	input.SMTP.Port = 0
+	if err := validateNotificationsInput(input); err == nil {
+		t.Fatal("expected error for port 0 (caller must default before validating)")
+	}
+
+	input.SMTP.Port = 70000
+	if err := validateNotificationsInput(input); err == nil {
+		t.Fatal("expected error for out-of-range port")
+	}
+
+	input.SMTP.Port = 587
+	if err := validateNotificationsInput(input); err != nil {
+		t.Errorf("expected no error for valid port, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildNotificationsConfigDB (pure, seal + empty-password-preserves rule)
+// ---------------------------------------------------------------------------
+
+func TestBuildNotificationsConfigDB_SealsNewPassword(t *testing.T) {
+	tc := testTokenCipher(t)
+	input := notificationsConfigInput{Enabled: true}
+	input.SMTP.Host = "smtp.example.com"
+	input.SMTP.From = "admin@example.com"
+	input.SMTP.Password = "hunter2"
+
+	dbc, err := buildNotificationsConfigDB(input, tc, "existing-ciphertext")
+	if err != nil {
+		t.Fatalf("buildNotificationsConfigDB: %v", err)
+	}
+	if dbc.SMTP.PasswordEncrypted == "" || dbc.SMTP.PasswordEncrypted == "existing-ciphertext" {
+		t.Fatalf("expected a newly sealed ciphertext, got %q", dbc.SMTP.PasswordEncrypted)
+	}
+
+	decrypted, err := tc.Open(dbc.SMTP.PasswordEncrypted)
+	if err != nil {
+		t.Fatalf("tc.Open: %v", err)
+	}
+	if decrypted != "hunter2" {
+		t.Errorf("decrypted password = %q, want %q", decrypted, "hunter2")
+	}
+}
+
+func TestBuildNotificationsConfigDB_EmptyPasswordPreservesExisting(t *testing.T) {
+	tc := testTokenCipher(t)
+	input := notificationsConfigInput{Enabled: true}
+	input.SMTP.Host = "smtp.example.com"
+	input.SMTP.From = "admin@example.com"
+	// Password intentionally left empty.
+
+	dbc, err := buildNotificationsConfigDB(input, tc, "existing-ciphertext")
+	if err != nil {
+		t.Fatalf("buildNotificationsConfigDB: %v", err)
+	}
+	if dbc.SMTP.PasswordEncrypted != "existing-ciphertext" {
+		t.Errorf("PasswordEncrypted = %q, want preserved %q", dbc.SMTP.PasswordEncrypted, "existing-ciphertext")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetConfig (handler, sqlmock-backed)
+// ---------------------------------------------------------------------------
+
+func TestNotificationsHandler_GetConfig_NoPassword(t *testing.T) {
+	h, _, mock := newNotificationsHandler(t)
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow(nil))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.GET("/notifications/config", h.GetConfig)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/notifications/config", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp NotificationsConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.PasswordConfigured {
+		t.Error("expected password_configured=false")
+	}
+	if strings.Contains(w.Body.String(), "password") == false {
+		// password_configured key is expected to be present; the raw password/ciphertext must not be.
+	}
+	if strings.Contains(strings.ToLower(w.Body.String()), "smtp_password_encrypted") {
+		t.Error("response must never include the encrypted password field")
+	}
+}
+
+func TestNotificationsHandler_GetConfig_PasswordConfiguredFromDB(t *testing.T) {
+	h, _, mock := newNotificationsHandler(t)
+	dbRow := `{"enabled":true,"smtp":{"host":"smtp.example.com","port":587,"from":"a@example.com","smtp_password_encrypted":"cipher"}}`
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(dbRow)))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.GET("/notifications/config", h.GetConfig)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/notifications/config", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp NotificationsConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.PasswordConfigured {
+		t.Error("expected password_configured=true when DB row has a stored ciphertext")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PutConfig (handler, sqlmock-backed)
+// ---------------------------------------------------------------------------
+
+func TestNotificationsHandler_PutConfig_ValidationError(t *testing.T) {
+	h, _, _ := newNotificationsHandler(t)
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/notifications/config", h.PutConfig)
+	body := `{"enabled":true,"smtp":{"from":"admin@example.com"}}` // missing host
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/notifications/config", strings.NewReader(body)))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestNotificationsHandler_PutConfig_EmptyPasswordPreservesExisting(t *testing.T) {
+	h, cfg, mock := newNotificationsHandler(t)
+
+	existingRow := `{"enabled":true,"smtp":{"host":"old.example.com","port":587,"from":"old@example.com","smtp_password_encrypted":"existing-cipher"}}`
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(existingRow)))
+	mock.ExpectExec("UPDATE system_settings").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/notifications/config", h.PutConfig)
+	body := `{"enabled":true,"smtp":{"host":"smtp.example.com","from":"admin@example.com","port":587}}` // no password
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/notifications/config", strings.NewReader(body)))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	// The in-memory password must be left untouched (still empty here) since
+	// the request omitted it.
+	if cfg.SMTP.Password != "" {
+		t.Errorf("cfg.SMTP.Password = %q, want unchanged empty string", cfg.SMTP.Password)
+	}
+
+	var resp NotificationsConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.PasswordConfigured {
+		t.Error("expected password_configured=true (preserved from existing DB row)")
+	}
+	if resp.SMTP.Host != "smtp.example.com" {
+		t.Errorf("SMTP.Host = %q, want %q", resp.SMTP.Host, "smtp.example.com")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestNotificationsHandler_PutConfig_SealsNewPassword(t *testing.T) {
+	h, cfg, mock := newNotificationsHandler(t)
+
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow(nil))
+	mock.ExpectExec("UPDATE system_settings").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/notifications/config", h.PutConfig)
+	body := `{"enabled":true,"smtp":{"host":"smtp.example.com","from":"admin@example.com","port":587,"password":"hunter2"}}`
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/notifications/config", strings.NewReader(body)))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+	if cfg.SMTP.Password != "hunter2" {
+		t.Errorf("cfg.SMTP.Password = %q, want %q (updated in place)", cfg.SMTP.Password, "hunter2")
+	}
+
+	var resp NotificationsConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.PasswordConfigured {
+		t.Error("expected password_configured=true after sealing a new password")
+	}
+	if strings.Contains(strings.ToLower(w.Body.String()), "hunter2") {
+		t.Error("response must never include the plaintext password")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestEmail (handler, validation-only — no live SMTP send in unit tests)
+// ---------------------------------------------------------------------------
+
+func TestNotificationsHandler_TestEmail_NoRecipients(t *testing.T) {
+	h, _, _ := newNotificationsHandler(t)
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.POST("/notifications/test", h.TestEmail)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/notifications/test", strings.NewReader(`{}`)))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (no recipients, no cve.email_recipients fallback), body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestNotificationsHandler_TestEmail_NoHost(t *testing.T) {
+	h, _, mock := newNotificationsHandler(t)
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow(nil))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.POST("/notifications/test", h.TestEmail)
+	body := `{"recipients":["a@example.com"]}`
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/notifications/test", strings.NewReader(body)))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (no smtp host configured), body=%s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/api/admin/scanning_check.go
+++ b/backend/internal/api/admin/scanning_check.go
@@ -1,0 +1,31 @@
+// scanning_check.go implements the admin endpoint that triggers an immediate
+// scanner update check, bypassing the scheduled interval.
+package admin
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
+)
+
+// TriggerScannerCheckResponse is returned by POST /api/v1/admin/scanning/check.
+type TriggerScannerCheckResponse struct {
+	Message string `json:"message"`
+} // @name TriggerScannerCheckResponse
+
+// @Summary      Trigger an immediate scanner update check
+// @Description  Signals the scheduled scanner update job to run a check now instead of waiting for its next tick. Requires admin scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Produce      json
+// @Success      202  {object}  TriggerScannerCheckResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Router       /api/v1/admin/scanning/check [post]
+func TriggerScannerCheckHandler(job *jobs.ScannerUpdateJob) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		job.TriggerCheck()
+		c.JSON(http.StatusAccepted, TriggerScannerCheckResponse{Message: "scanner update check triggered"})
+	}
+}

--- a/backend/internal/api/admin/scanning_install.go
+++ b/backend/internal/api/admin/scanning_install.go
@@ -7,14 +7,20 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
 
 // InstallScannerAdminInput is the request body for POST /api/v1/admin/scanning/install.
 type InstallScannerAdminInput struct {
-	Tool    string `json:"tool" binding:"required"`
-	Version string `json:"version"`
+	Tool     string `json:"tool" binding:"required"`
+	Version  string `json:"version"`
+	Activate bool   `json:"activate"`
 } // @name InstallScannerInput
 
 // InstallScannerAdminResponse is returned by POST /api/v1/admin/scanning/install.
@@ -25,11 +31,40 @@ type InstallScannerAdminResponse struct {
 	BinaryPath string `json:"binary_path,omitempty"`
 	Sha256     string `json:"sha256,omitempty"`
 	SourceURL  string `json:"source_url,omitempty"`
+	Activated  bool   `json:"activated,omitempty"`
 	Error      string `json:"error,omitempty"`
 } // @name InstallScannerResponse
 
+// ScanningInstallHandler holds dependencies for POST /api/v1/admin/scanning/install,
+// including the activation reconciler used when the request asks to activate the
+// installed version immediately.
+type ScanningInstallHandler struct {
+	cfg          *config.ScanningConfig
+	install      installer.InstallFunc
+	updateJob    *jobs.ScannerUpdateJob
+	sbvRepo      *repositories.ScannerBinaryVersionRepository
+	approvalRepo *repositories.VersionApprovalRepository
+}
+
+// NewScanningInstallHandler constructs a ScanningInstallHandler.
+func NewScanningInstallHandler(
+	cfg *config.ScanningConfig,
+	install installer.InstallFunc,
+	updateJob *jobs.ScannerUpdateJob,
+	sbvRepo *repositories.ScannerBinaryVersionRepository,
+	approvalRepo *repositories.VersionApprovalRepository,
+) *ScanningInstallHandler {
+	return &ScanningInstallHandler{
+		cfg:          cfg,
+		install:      install,
+		updateJob:    updateJob,
+		sbvRepo:      sbvRepo,
+		approvalRepo: approvalRepo,
+	}
+}
+
 // @Summary      Install or upgrade a scanner binary
-// @Description  Admin-only post-setup action that downloads, verifies, and installs a supported scanner binary. Returns the installed binary path — updating the scanning configuration to use it is a separate admin action. Requires admin scope.
+// @Description  Admin-only post-setup action that downloads, verifies, and installs a supported scanner binary. When activate=true, the installed version is also recorded as approved and activated (scanning configuration updated, scanner job restarted) immediately. Requires admin scope.
 // @Tags         Security Scanning
 // @Security     Bearer
 // @Accept       json
@@ -40,7 +75,7 @@ type InstallScannerAdminResponse struct {
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Install directory not configured"
 // @Router       /api/v1/admin/scanning/install [post]
-func InstallScannerHandler(cfg *config.ScanningConfig, install installer.InstallFunc) gin.HandlerFunc {
+func (h *ScanningInstallHandler) Install() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input InstallScannerAdminInput
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -51,7 +86,7 @@ func InstallScannerHandler(cfg *config.ScanningConfig, install installer.Install
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
 		defer cancel()
 
-		ok, result, errMsg := installer.Handle(ctx, cfg.InstallDir, install, input.Tool, input.Version)
+		ok, result, errMsg := installer.Handle(ctx, h.cfg.InstallDir, h.install, input.Tool, input.Version)
 		if !ok {
 			if errMsg == "scanning.install_dir is not configured on the server" {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": errMsg})
@@ -67,13 +102,50 @@ func InstallScannerHandler(cfg *config.ScanningConfig, install installer.Install
 		}
 
 		slog.Info("admin: scanner installed", "tool", input.Tool, "version", result.Version, "path", result.BinaryPath)
-		c.JSON(http.StatusOK, InstallScannerAdminResponse{
+		resp := InstallScannerAdminResponse{
 			Success:    true,
 			Tool:       input.Tool,
 			Version:    result.Version,
 			BinaryPath: result.BinaryPath,
 			Sha256:     result.Sha256,
 			SourceURL:  result.SourceURL,
-		})
+		}
+
+		if input.Activate {
+			approvedStatus := models.VersionApprovalStatusApproved
+			v := &models.ScannerBinaryVersion{
+				ID:                uuid.New(),
+				Tool:              input.Tool,
+				Version:           result.Version,
+				SourceURL:         &result.SourceURL,
+				Sha256:            &result.Sha256,
+				SignatureVerified: result.SignatureVerified,
+				SignatureType:     result.SignatureType,
+				SyncStatus:        "downloaded",
+				BinaryPath:        &result.BinaryPath,
+				ApprovalStatus:    &approvedStatus,
+			}
+			if err := h.sbvRepo.Upsert(ctx, v); err != nil {
+				slog.Error("admin: failed to record installed scanner version", "tool", input.Tool, "version", result.Version, "error", err)
+			} else if h.approvalRepo != nil {
+				if err := h.approvalRepo.RecordEvent(ctx, &models.VersionApprovalEvent{
+					ScannerBinaryVersionID: &v.ID,
+					Action:                 models.VersionApprovalActionApproved,
+					PerformedBy:            currentUserID(c),
+				}); err != nil {
+					slog.Error("admin: failed to record approval event for installed scanner version", "tool", input.Tool, "version", result.Version, "error", err)
+				}
+			}
+
+			if h.updateJob != nil {
+				if err := h.updateJob.Activate(ctx, v); err != nil {
+					slog.Error("admin: failed to activate installed scanner version", "tool", input.Tool, "version", result.Version, "error", err)
+				} else {
+					resp.Activated = true
+				}
+			}
+		}
+
+		c.JSON(http.StatusOK, resp)
 	}
 }

--- a/backend/internal/api/admin/scanning_install_test.go
+++ b/backend/internal/api/admin/scanning_install_test.go
@@ -21,7 +21,7 @@ func jsonBodyAdmin(v interface{}) *bytes.Buffer {
 func TestInstallScannerHandler_BadJSON(t *testing.T) {
 	cfg := &config.ScanningConfig{InstallDir: "/tmp/test"}
 	r := gin.New()
-	r.POST("/install", InstallScannerHandler(cfg, nil))
+	r.POST("/install", NewScanningInstallHandler(cfg, nil, nil, nil, nil).Install())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin("not json{"))
@@ -36,7 +36,7 @@ func TestInstallScannerHandler_BadJSON(t *testing.T) {
 func TestInstallScannerHandler_UnsupportedTool(t *testing.T) {
 	cfg := &config.ScanningConfig{InstallDir: "/tmp/test"}
 	r := gin.New()
-	r.POST("/install", InstallScannerHandler(cfg, nil))
+	r.POST("/install", NewScanningInstallHandler(cfg, nil, nil, nil, nil).Install())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin(map[string]string{"tool": "snyk"}))
@@ -56,7 +56,7 @@ func TestInstallScannerHandler_UnsupportedTool(t *testing.T) {
 func TestInstallScannerHandler_EmptyInstallDir(t *testing.T) {
 	cfg := &config.ScanningConfig{InstallDir: ""}
 	r := gin.New()
-	r.POST("/install", InstallScannerHandler(cfg, nil))
+	r.POST("/install", NewScanningInstallHandler(cfg, nil, nil, nil, nil).Install())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin(map[string]string{"tool": "trivy"}))
@@ -80,7 +80,7 @@ func TestInstallScannerHandler_InstallerSuccess(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.POST("/install", InstallScannerHandler(cfg, stub))
+	r.POST("/install", NewScanningInstallHandler(cfg, stub, nil, nil, nil).Install())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin(map[string]string{"tool": "trivy"}))
@@ -107,7 +107,7 @@ func TestInstallScannerHandler_InstallerError(t *testing.T) {
 	}
 
 	r := gin.New()
-	r.POST("/install", InstallScannerHandler(cfg, stub))
+	r.POST("/install", NewScanningInstallHandler(cfg, stub, nil, nil, nil).Install())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin(map[string]string{"tool": "trivy"}))

--- a/backend/internal/api/admin/scanning_latest.go
+++ b/backend/internal/api/admin/scanning_latest.go
@@ -1,0 +1,91 @@
+// scanning_latest.go implements the admin endpoint that checks the latest upstream
+// scanner release without downloading or installing anything.
+package admin
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	goversion "github.com/hashicorp/go-version"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/scanner"
+	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
+)
+
+// ScannerLatestResponse is returned by GET /api/v1/admin/scanning/latest.
+type ScannerLatestResponse struct {
+	Tool               string `json:"tool"`
+	CurrentVersion     string `json:"current_version,omitempty"`
+	LatestVersion      string `json:"latest_version"`
+	UpdateAvailable    bool   `json:"update_available"`
+	SignatureSupported bool   `json:"signature_supported"`
+} // @name ScannerLatestResponse
+
+// @Summary      Check the latest available scanner version
+// @Description  Queries the upstream GitHub release for the latest version of the given (or configured) scanner tool and compares it to the currently installed/configured version. Does not download or install anything. Requires scanning:read scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Produce      json
+// @Param        tool  query  string  false  "Scanner tool to check (defaults to the configured tool)"
+// @Success      200  {object}  ScannerLatestResponse
+// @Failure      400  {object}  map[string]interface{}  "Unsupported tool"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      500  {object}  map[string]interface{}  "Failed to resolve upstream release"
+// @Router       /api/v1/admin/scanning/latest [get]
+func GetScannerLatestHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tool := c.Query("tool")
+		if tool == "" {
+			tool = cfg.Tool
+		}
+
+		if !installer.Supports(tool) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported tool", "supported": installer.SupportedTools()})
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+		defer cancel()
+
+		latest, err := installer.CheckLatest(ctx, installer.InstallConfig{InstallDir: cfg.InstallDir}, tool)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		currentVersion := cfg.ExpectedVersion
+		if cfg.Enabled {
+			if _, ok := scanner.ResolveBinaryPath(cfg); ok {
+				if s, err := scanner.New(cfg); err == nil {
+					if v, err := s.Version(ctx); err == nil {
+						currentVersion = v
+					}
+				}
+			}
+		}
+
+		resp := ScannerLatestResponse{
+			Tool:               tool,
+			CurrentVersion:     currentVersion,
+			LatestVersion:      latest.LatestVersion,
+			SignatureSupported: latest.SignatureSupported,
+		}
+
+		if currentVersion == "" {
+			resp.UpdateAvailable = true
+		} else {
+			cur, curErr := goversion.NewVersion(strings.TrimPrefix(currentVersion, "v"))
+			lat, latErr := goversion.NewVersion(strings.TrimPrefix(latest.LatestVersion, "v"))
+			if curErr == nil && latErr == nil {
+				resp.UpdateAvailable = lat.GreaterThan(cur)
+			} else {
+				resp.UpdateAvailable = currentVersion != latest.LatestVersion
+			}
+		}
+
+		c.JSON(http.StatusOK, resp)
+	}
+}

--- a/backend/internal/api/admin/scanning_latest_test.go
+++ b/backend/internal/api/admin/scanning_latest_test.go
@@ -1,0 +1,102 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
+)
+
+func TestGetScannerLatestHandler_UnsupportedTool(t *testing.T) {
+	cfg := &config.ScanningConfig{Tool: "trivy"}
+	r := gin.New()
+	r.GET("/latest", GetScannerLatestHandler(cfg))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/latest?tool=snyk", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestGetScannerLatestHandler_UpdateAvailable(t *testing.T) {
+	archiveName := "trivy_0.60.0_Linux-64bit.tar.gz"
+	checksumsName := "trivy_0.60.0_checksums.txt"
+
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	type ghAssetJSON struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	}
+	release := struct {
+		TagName string        `json:"tag_name"`
+		Assets  []ghAssetJSON `json:"assets"`
+	}{
+		TagName: "v0.60.0",
+		Assets: []ghAssetJSON{
+			{Name: archiveName, BrowserDownloadURL: server.URL + "/assets/" + archiveName},
+			{Name: checksumsName, BrowserDownloadURL: server.URL + "/assets/" + checksumsName},
+		},
+	}
+
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(release)
+	})
+
+	spec := installer.AssetSpec{
+		LatestReleaseAPI: server.URL + "/releases/latest",
+		VersionedAPI:     server.URL + "/releases/tags/v%s",
+		AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_Linux-64bit\.tar\.gz$`),
+		ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+		BinaryInArchive:  "trivy",
+		ArchiveFormat:    "tar.gz",
+	}
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := installer.Catalog["trivy"]
+	installer.Catalog["trivy"] = map[string]installer.AssetSpec{platform: spec}
+	t.Cleanup(func() { installer.Catalog["trivy"] = origCatalog })
+
+	// GetScannerLatestHandler has no HTTPClient injection point, so it uses
+	// http.DefaultTransport internally; point it at the httptest TLS server's
+	// certificate for the duration of this test.
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = origTransport })
+
+	cfg := &config.ScanningConfig{Tool: "trivy", ExpectedVersion: "0.50.0"}
+	r := gin.New()
+	r.GET("/latest", GetScannerLatestHandler(cfg))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/latest", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var resp ScannerLatestResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.LatestVersion != "0.60.0" {
+		t.Errorf("LatestVersion = %q, want 0.60.0", resp.LatestVersion)
+	}
+	if resp.CurrentVersion != "0.50.0" {
+		t.Errorf("CurrentVersion = %q, want 0.50.0", resp.CurrentVersion)
+	}
+	if !resp.UpdateAvailable {
+		t.Error("expected UpdateAvailable = true (0.60.0 > 0.50.0)")
+	}
+}

--- a/backend/internal/api/admin/version_approvals_test.go
+++ b/backend/internal/api/admin/version_approvals_test.go
@@ -174,6 +174,8 @@ func TestVAHandler_Reject_NotFound(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`UPDATE terraform_versions SET approval_status`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE scanner_binary_versions SET approval_status`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectRollback()
 
 	w := httptest.NewRecorder()

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -79,6 +79,7 @@ type BackgroundServices struct {
 	webhookRetryJob       *jobs.WebhookRetryJob
 	cvePollJob            *jobs.CVEPollJob
 	releasesKeyRefreshJob *jobs.ReleasesKeyRefreshJob
+	scannerUpdateJob      *jobs.ScannerUpdateJob
 	rateLimiters          []middleware.RateLimiterBackend
 	principalOverrides    *middleware.PrincipalOverrideLimiters
 }
@@ -111,6 +112,9 @@ func (bg *BackgroundServices) Shutdown() {
 	}
 	if bg.cvePollJob != nil {
 		bg.cvePollJob.Stop()
+	}
+	if bg.scannerUpdateJob != nil {
+		bg.scannerUpdateJob.Stop()
 	}
 	for _, rl := range bg.rateLimiters {
 		if rl != nil {
@@ -279,6 +283,15 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			log.Printf("module scanner job failed to start: %v", err)
 		}
 	}()
+
+	// Initialize and start the scheduled scanner update-check job (no-op when
+	// scanning.auto_update.enabled=false). Discovers newer upstream scanner
+	// releases, files them into the version-approval workflow, and reconciles
+	// approved-but-inactive versions into the running scanner.
+	sbvRepo := repositories.NewScannerBinaryVersionRepository(sqlxDB)
+	scannerApprovalRepo := repositories.NewVersionApprovalRepository(sqlxDB)
+	scannerUpdateJob := jobs.NewScannerUpdateJob(&cfg.Scanning, &cfg.Notifications, &cfg.CVE, sbvRepo, scannerApprovalRepo, oidcConfigRepo, moduleScannerJob, nil, nil)
+	go scannerUpdateJob.Start(context.Background())
 
 	// Initialize and start the audit log cleanup job (no-op when retention_days=0)
 	auditCleanupJob := jobs.NewAuditCleanupJob(&cfg.AuditRetention, auditRepo)
@@ -947,9 +960,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			authenticatedGroup.GET("/admin/scanning/scans/:id",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScanByIDHandler(db))
+			installHandler := admin.NewScanningInstallHandler(&cfg.Scanning, nil, scannerUpdateJob, sbvRepo, scannerApprovalRepo)
 			authenticatedGroup.POST("/admin/scanning/install",
 				middleware.RequireScope(auth.ScopeAdmin),
-				admin.InstallScannerHandler(&cfg.Scanning, nil))
+				installHandler.Install())
+			authenticatedGroup.POST("/admin/scanning/check",
+				middleware.RequireScope(auth.ScopeAdmin),
+				admin.TriggerScannerCheckHandler(scannerUpdateJob))
 			authenticatedGroup.GET("/admin/scanning/latest",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScannerLatestHandler(&cfg.Scanning))
@@ -1291,6 +1308,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		webhookRetryJob:       webhookRetryJob,
 		cvePollJob:            cvePollJob,
 		releasesKeyRefreshJob: releasesKeyRefreshJob,
+		scannerUpdateJob:      scannerUpdateJob,
 		rateLimiters:          collectRateLimiterBackends(authRateLimiter, generalRateLimiter, uploadRateLimiter, orgRateLimiter),
 		principalOverrides:    principalOverrides,
 	}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -950,6 +950,9 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			authenticatedGroup.POST("/admin/scanning/install",
 				middleware.RequireScope(auth.ScopeAdmin),
 				admin.InstallScannerHandler(&cfg.Scanning, nil))
+			authenticatedGroup.GET("/admin/scanning/latest",
+				middleware.RequireScope(auth.ScopeScanningRead),
+				admin.GetScannerLatestHandler(&cfg.Scanning))
 
 			// API Keys management - self-service for own keys
 			// Users can manage their own API keys without api_keys:manage scope

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -326,6 +326,39 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		}
 	}
 
+	// Reload persisted notifications config from the database (if present),
+	// applying it on top of the YAML/env defaults. This mirrors the scanning
+	// config reload above; it must run after tokenCipher is constructed since
+	// the stored SMTP password is encrypted. Fields are set in place on
+	// cfg.Notifications (never reassigned) so jobs holding &cfg.Notifications
+	// observe the reloaded values.
+	if njson, err := oidcConfigRepo.GetNotificationsConfig(context.Background()); err == nil && njson != nil {
+		var dbc admin.NotificationsConfigDB
+		if err := json.Unmarshal(njson, &dbc); err != nil {
+			log.Printf("notifications startup: failed to parse persisted config: %v", err)
+		} else {
+			cfg.Notifications.Enabled = dbc.Enabled
+			cfg.Notifications.SMTP.Host = dbc.SMTP.Host
+			cfg.Notifications.SMTP.Port = dbc.SMTP.Port
+			cfg.Notifications.SMTP.Username = dbc.SMTP.Username
+			cfg.Notifications.SMTP.From = dbc.SMTP.From
+			cfg.Notifications.SMTP.UseTLS = dbc.SMTP.UseTLS
+			if dbc.SMTP.PasswordEncrypted != "" {
+				if pw, derr := tokenCipher.Open(dbc.SMTP.PasswordEncrypted); derr == nil {
+					cfg.Notifications.SMTP.Password = pw
+				} else {
+					log.Printf("notifications startup: failed to decrypt persisted smtp password: %v", derr)
+				}
+			}
+			if dbc.APIKeyExpiryWarningDays > 0 {
+				cfg.Notifications.APIKeyExpiryWarningDays = dbc.APIKeyExpiryWarningDays
+			}
+			if dbc.APIKeyExpiryCheckIntervalHours > 0 {
+				cfg.Notifications.APIKeyExpiryCheckIntervalHours = dbc.APIKeyExpiryCheckIntervalHours
+			}
+		}
+	}
+
 	// Add middleware
 	router.Use(gin.Recovery())
 	router.Use(middleware.RequestIDMiddleware())
@@ -665,6 +698,9 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize storage configuration handlers
 	storageHandlers := admin.NewStorageHandlers(cfg, storageConfigRepo, tokenCipher)
 
+	// Initialize notifications configuration handlers
+	notificationsHandler := admin.NewNotificationsHandler(&cfg.Notifications, oidcConfigRepo, tokenCipher, &cfg.CVE)
+
 	// Initialize OIDC admin configuration handlers
 	oidcAdminHandlers := admin.NewOIDCConfigAdminHandlers(oidcConfigRepo)
 
@@ -970,6 +1006,17 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			authenticatedGroup.GET("/admin/scanning/latest",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScannerLatestHandler(&cfg.Scanning))
+
+			// Notifications (SMTP) admin endpoints
+			authenticatedGroup.GET("/admin/notifications/config",
+				middleware.RequireScope(auth.ScopeAdmin),
+				notificationsHandler.GetConfig)
+			authenticatedGroup.PUT("/admin/notifications/config",
+				middleware.RequireScope(auth.ScopeAdmin),
+				notificationsHandler.PutConfig)
+			authenticatedGroup.POST("/admin/notifications/test",
+				middleware.RequireScope(auth.ScopeAdmin),
+				notificationsHandler.TestEmail)
 
 			// API Keys management - self-service for own keys
 			// Users can manage their own API keys without api_keys:manage scope

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -199,6 +199,24 @@ type ScanningConfig struct {
 	// Empty disables the auto-install endpoint; operators who prefer to pre-install
 	// scanners themselves can leave it unset.
 	InstallDir string `mapstructure:"install_dir"`
+	// AutoUpdate configures the scheduled scanner version-check job (Phase D).
+	AutoUpdate ScannerAutoUpdateConfig `mapstructure:"auto_update"`
+}
+
+// ScannerAutoUpdateConfig controls the scheduled job that checks upstream for newer
+// scanner releases. When enabled, newer versions are discovered, downloaded, verified,
+// and (unless auto-approved) filed as pending version approvals. Never installs
+// unattended unless an auto-approve rule matches.
+type ScannerAutoUpdateConfig struct {
+	// Enabled gates the scheduled scanner update-check job. Default false.
+	Enabled bool `mapstructure:"enabled"`
+	// IntervalHours is how often to check upstream for new versions. Default 24.
+	IntervalHours int `mapstructure:"interval_hours"`
+	// RequiresApproval gates newly discovered versions behind manual approval. Default true.
+	RequiresApproval bool `mapstructure:"requires_approval"`
+	// AutoApproveRules is a JSON document of auto-approve rules (same shape as mirror
+	// auto_approve_rules). Empty means no auto-approval. Default empty.
+	AutoApproveRules string `mapstructure:"auto_approve_rules"`
 }
 
 // ServerConfig holds HTTP server configuration
@@ -807,6 +825,10 @@ func bindEnvVars(v *viper.Viper) error {
 		"scanning.version_args",
 		"scanning.scan_args",
 		"scanning.output_format",
+		"scanning.auto_update.enabled",
+		"scanning.auto_update.interval_hours",
+		"scanning.auto_update.requires_approval",
+		"scanning.auto_update.auto_approve_rules",
 
 		// Audit retention
 		"audit_retention.retention_days",
@@ -1003,6 +1025,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scanning.worker_count", 2)
 	v.SetDefault("scanning.scan_interval_mins", 5)
 	v.SetDefault("scanning.install_dir", "/app/scanners")
+	v.SetDefault("scanning.auto_update.enabled", false)
+	v.SetDefault("scanning.auto_update.interval_hours", 24)
+	v.SetDefault("scanning.auto_update.requires_approval", true)
 
 	// Audit retention defaults
 	v.SetDefault("audit_retention.retention_days", 90)

--- a/backend/internal/db/migrations/000043_setup_notifications.down.sql
+++ b/backend/internal/db/migrations/000043_setup_notifications.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE system_settings
+  DROP COLUMN IF EXISTS notifications_config,
+  DROP COLUMN IF EXISTS notifications_configured_at,
+  DROP COLUMN IF EXISTS notifications_configured;

--- a/backend/internal/db/migrations/000043_setup_notifications.up.sql
+++ b/backend/internal/db/migrations/000043_setup_notifications.up.sql
@@ -1,0 +1,10 @@
+-- 000043_setup_notifications.up.sql
+-- Adds DB-persisted notification/SMTP configuration to system_settings, mirroring
+-- the scanning_config columns added in 000021_setup_scanning. This lets the
+-- notifications configuration be saved/reloaded at runtime instead of only via
+-- YAML/env. The SMTP password inside notifications_config MUST be encrypted by
+-- the caller before it is stored here.
+ALTER TABLE system_settings
+  ADD COLUMN IF NOT EXISTS notifications_configured    BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS notifications_configured_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS notifications_config        JSONB;

--- a/backend/internal/db/migrations/000044_scanner_binary_versions.down.sql
+++ b/backend/internal/db/migrations/000044_scanner_binary_versions.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_vae_sbv;
+
+ALTER TABLE version_approval_events DROP CONSTRAINT IF EXISTS exactly_one_target;
+ALTER TABLE version_approval_events ADD  CONSTRAINT exactly_one_target CHECK (
+    (mirrored_provider_version_id IS NOT NULL)::int +
+    (terraform_version_id         IS NOT NULL)::int = 1
+);
+ALTER TABLE version_approval_events DROP COLUMN IF EXISTS scanner_binary_version_id;
+
+DROP TABLE IF EXISTS scanner_binary_versions;

--- a/backend/internal/db/migrations/000044_scanner_binary_versions.up.sql
+++ b/backend/internal/db/migrations/000044_scanner_binary_versions.up.sql
@@ -1,0 +1,35 @@
+-- Scanner binary versions discovered by the scheduled update-check job. Participates
+-- in the version-approval workflow (type="scanner"): pending rows are gated until an
+-- admin approves, then a reconciler activates the binary. approval_status semantics
+-- match provider/terraform mirror versions.
+CREATE TABLE IF NOT EXISTS scanner_binary_versions (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tool               VARCHAR(50)  NOT NULL,
+    version            VARCHAR(100) NOT NULL,
+    source_url         TEXT,
+    sha256             VARCHAR(128),
+    signature_verified BOOLEAN      NOT NULL DEFAULT false,
+    signature_type     VARCHAR(20)  NOT NULL DEFAULT 'none',
+    sync_status        VARCHAR(20)  NOT NULL DEFAULT 'downloaded',
+    approval_status    VARCHAR(20)  DEFAULT NULL
+        CHECK (approval_status IN ('pending_approval','approved','rejected')),
+    is_active          BOOLEAN      NOT NULL DEFAULT false,
+    binary_path        TEXT,
+    discovered_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (tool, version)
+);
+CREATE INDEX IF NOT EXISTS idx_sbv_approval_status ON scanner_binary_versions (approval_status) WHERE approval_status IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sbv_active ON scanner_binary_versions (tool) WHERE is_active;
+
+-- Extend the approval-events audit table with the scanner FK and widen the
+-- exactly-one-target constraint to three targets.
+ALTER TABLE version_approval_events
+    ADD COLUMN IF NOT EXISTS scanner_binary_version_id UUID REFERENCES scanner_binary_versions(id) ON DELETE CASCADE;
+ALTER TABLE version_approval_events DROP CONSTRAINT IF EXISTS exactly_one_target;
+ALTER TABLE version_approval_events ADD  CONSTRAINT exactly_one_target CHECK (
+    (mirrored_provider_version_id IS NOT NULL)::int +
+    (terraform_version_id         IS NOT NULL)::int +
+    (scanner_binary_version_id    IS NOT NULL)::int = 1
+);
+CREATE INDEX IF NOT EXISTS idx_vae_sbv ON version_approval_events (scanner_binary_version_id) WHERE scanner_binary_version_id IS NOT NULL;

--- a/backend/internal/db/models/scanner_binary_version.go
+++ b/backend/internal/db/models/scanner_binary_version.go
@@ -1,0 +1,32 @@
+// Package models - scanner_binary_version.go defines the ScannerBinaryVersion model
+// backing the module security-scanner (trivy/terrascan/checkov) update workflow. Rows
+// are discovered by a scheduled update-check job and participate in the generic
+// version-approval workflow (type="scanner") alongside provider and terraform
+// mirror versions.
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ScannerBinaryVersion represents a single discovered release of a module
+// security-scanning tool binary. approval_status gates activation the same way
+// it gates provider/terraform mirror versions; is_active marks the currently
+// installed+running binary for its tool (at most one per tool).
+type ScannerBinaryVersion struct {
+	ID                uuid.UUID `json:"id" db:"id"`
+	Tool              string    `json:"tool" db:"tool"`
+	Version           string    `json:"version" db:"version"`
+	SourceURL         *string   `json:"source_url,omitempty" db:"source_url"`
+	Sha256            *string   `json:"sha256,omitempty" db:"sha256"`
+	SignatureVerified bool      `json:"signature_verified" db:"signature_verified"`
+	SignatureType     string    `json:"signature_type" db:"signature_type"`
+	SyncStatus        string    `json:"sync_status" db:"sync_status"`
+	ApprovalStatus    *string   `json:"approval_status,omitempty" db:"approval_status"` // NULL|pending_approval|approved|rejected
+	IsActive          bool      `json:"is_active" db:"is_active"`
+	BinaryPath        *string   `json:"binary_path,omitempty" db:"binary_path"`
+	DiscoveredAt      time.Time `json:"discovered_at" db:"discovered_at"`
+	CreatedAt         time.Time `json:"created_at" db:"created_at"`
+}

--- a/backend/internal/db/models/version_approval.go
+++ b/backend/internal/db/models/version_approval.go
@@ -32,14 +32,16 @@ const (
 const (
 	VersionApprovalTypeProvider  = "provider"
 	VersionApprovalTypeTerraform = "terraform"
+	VersionApprovalTypeScanner   = "scanner"
 )
 
 // VersionApprovalEvent is one row of the version_approval_events audit table.
-// Exactly one of MirroredProviderVersionID / TerraformVersionID is set.
+// Exactly one of MirroredProviderVersionID / TerraformVersionID / ScannerBinaryVersionID is set.
 type VersionApprovalEvent struct {
 	ID                        uuid.UUID  `json:"id" db:"id"`
 	MirroredProviderVersionID *uuid.UUID `json:"-" db:"mirrored_provider_version_id"`
 	TerraformVersionID        *uuid.UUID `json:"-" db:"terraform_version_id"`
+	ScannerBinaryVersionID    *uuid.UUID `json:"-" db:"scanner_binary_version_id"`
 	Action                    string     `json:"action" db:"action"`
 	PerformedBy               *uuid.UUID `json:"-" db:"performed_by"`
 	PerformedByName           *string    `json:"performed_by_name,omitempty" db:"performed_by_name"`

--- a/backend/internal/db/repositories/oidc_config_repository.go
+++ b/backend/internal/db/repositories/oidc_config_repository.go
@@ -261,6 +261,34 @@ func (r *OIDCConfigRepository) GetScanningConfig(ctx context.Context) ([]byte, e
 	return configJSON, nil
 }
 
+// SetNotificationsConfig stores the notifications configuration JSON (SMTP password
+// MUST be encrypted by the caller before it reaches here) and marks notifications configured.
+func (r *OIDCConfigRepository) SetNotificationsConfig(ctx context.Context, configJSON []byte) error {
+	query := `
+		UPDATE system_settings SET
+			notifications_configured = true,
+			notifications_configured_at = NOW(),
+			notifications_config = $1,
+			updated_at = $2
+		WHERE id = 1`
+	_, err := r.db.ExecContext(ctx, query, configJSON, time.Now())
+	return err
+}
+
+// GetNotificationsConfig retrieves the notifications configuration JSON (may be nil).
+func (r *OIDCConfigRepository) GetNotificationsConfig(ctx context.Context) ([]byte, error) {
+	var configJSON []byte
+	query := `SELECT notifications_config FROM system_settings WHERE id = 1`
+	err := r.db.GetContext(ctx, &configJSON, query)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return configJSON, nil
+}
+
 // SetLDAPConfig stores the LDAP configuration JSON and marks LDAP as configured.
 // It also sets auth_method to 'ldap'.
 func (r *OIDCConfigRepository) SetLDAPConfig(ctx context.Context, configJSON []byte) error {

--- a/backend/internal/db/repositories/scanner_binary_version_repository.go
+++ b/backend/internal/db/repositories/scanner_binary_version_repository.go
@@ -1,0 +1,196 @@
+// scanner_binary_version_repository.go provides database operations for module
+// security-scanner (trivy/terrascan/checkov) binary versions discovered by the
+// scheduled update-check job. Rows plug into the generic version-approval
+// workflow (see version_approval_repository.go) as type="scanner".
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// ScannerBinaryVersionRepository handles database operations for scanner binary versions.
+type ScannerBinaryVersionRepository struct {
+	db *sqlx.DB
+}
+
+// NewScannerBinaryVersionRepository creates a new ScannerBinaryVersionRepository.
+func NewScannerBinaryVersionRepository(db *sqlx.DB) *ScannerBinaryVersionRepository {
+	return &ScannerBinaryVersionRepository{db: db}
+}
+
+// Upsert inserts a discovered version row, or does nothing if (tool, version)
+// already exists. Returns the resulting row (including generated fields).
+// approval_status is intentionally NOT touched on conflict: a re-discovery
+// must never reset an already-decided version back to pending.
+func (r *ScannerBinaryVersionRepository) Upsert(ctx context.Context, v *models.ScannerBinaryVersion) error {
+	if v.ID == uuid.Nil {
+		v.ID = uuid.New()
+	}
+
+	query := `
+		INSERT INTO scanner_binary_versions (
+			id, tool, version, source_url, sha256, signature_verified, signature_type,
+			sync_status, approval_status, is_active, binary_path
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+		ON CONFLICT (tool, version) DO NOTHING
+		RETURNING id, tool, version, source_url, sha256, signature_verified, signature_type,
+		          sync_status, approval_status, is_active, binary_path, discovered_at, created_at
+	`
+
+	err := r.db.QueryRowContext(ctx, query,
+		v.ID,
+		v.Tool,
+		v.Version,
+		v.SourceURL,
+		v.Sha256,
+		v.SignatureVerified,
+		v.SignatureType,
+		v.SyncStatus,
+		v.ApprovalStatus,
+		v.IsActive,
+		v.BinaryPath,
+	).Scan(
+		&v.ID,
+		&v.Tool,
+		&v.Version,
+		&v.SourceURL,
+		&v.Sha256,
+		&v.SignatureVerified,
+		&v.SignatureType,
+		&v.SyncStatus,
+		&v.ApprovalStatus,
+		&v.IsActive,
+		&v.BinaryPath,
+		&v.DiscoveredAt,
+		&v.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		// Conflict hit DO NOTHING: row already existed, nothing was returned.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to upsert scanner binary version: %w", err)
+	}
+	return nil
+}
+
+// GetByToolVersion looks up a version row by tool+version, or nil if not found.
+func (r *ScannerBinaryVersionRepository) GetByToolVersion(ctx context.Context, tool, version string) (*models.ScannerBinaryVersion, error) {
+	query := `
+		SELECT id, tool, version, source_url, sha256, signature_verified, signature_type,
+		       sync_status, approval_status, is_active, binary_path, discovered_at, created_at
+		FROM scanner_binary_versions
+		WHERE tool = $1 AND version = $2
+	`
+
+	var v models.ScannerBinaryVersion
+	err := r.db.GetContext(ctx, &v, query, tool, version)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scanner binary version: %w", err)
+	}
+
+	return &v, nil
+}
+
+// ListForTool returns all version rows for a tool, newest discovered first.
+func (r *ScannerBinaryVersionRepository) ListForTool(ctx context.Context, tool string) ([]models.ScannerBinaryVersion, error) {
+	query := `
+		SELECT id, tool, version, source_url, sha256, signature_verified, signature_type,
+		       sync_status, approval_status, is_active, binary_path, discovered_at, created_at
+		FROM scanner_binary_versions
+		WHERE tool = $1
+		ORDER BY discovered_at DESC
+	`
+
+	var versions []models.ScannerBinaryVersion
+	if err := r.db.SelectContext(ctx, &versions, query, tool); err != nil {
+		return nil, fmt.Errorf("failed to list scanner binary versions: %w", err)
+	}
+
+	return versions, nil
+}
+
+// ListApprovedInactive returns approved-but-not-yet-active versions across all
+// tools, for the activation reconciler to pick up.
+func (r *ScannerBinaryVersionRepository) ListApprovedInactive(ctx context.Context) ([]models.ScannerBinaryVersion, error) {
+	query := `
+		SELECT id, tool, version, source_url, sha256, signature_verified, signature_type,
+		       sync_status, approval_status, is_active, binary_path, discovered_at, created_at
+		FROM scanner_binary_versions
+		WHERE approval_status = 'approved' AND NOT is_active
+	`
+
+	var versions []models.ScannerBinaryVersion
+	if err := r.db.SelectContext(ctx, &versions, query); err != nil {
+		return nil, fmt.Errorf("failed to list approved inactive scanner binary versions: %w", err)
+	}
+
+	return versions, nil
+}
+
+// MarkActive marks the given version as the active binary for its tool,
+// demoting any previously active version of the same tool. Only one row per
+// tool can be active at a time.
+func (r *ScannerBinaryVersionRepository) MarkActive(ctx context.Context, id uuid.UUID) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scanner_binary_versions SET is_active = false
+		 WHERE tool = (SELECT tool FROM scanner_binary_versions WHERE id = $1)`,
+		id); err != nil {
+		return fmt.Errorf("failed to demote active scanner binary versions: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE scanner_binary_versions SET is_active = true WHERE id = $1`,
+		id); err != nil {
+		return fmt.Errorf("failed to mark scanner binary version active: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// GetActive returns the currently active binary version for a tool, or nil if none.
+func (r *ScannerBinaryVersionRepository) GetActive(ctx context.Context, tool string) (*models.ScannerBinaryVersion, error) {
+	query := `
+		SELECT id, tool, version, source_url, sha256, signature_verified, signature_type,
+		       sync_status, approval_status, is_active, binary_path, discovered_at, created_at
+		FROM scanner_binary_versions
+		WHERE tool = $1 AND is_active
+	`
+
+	var v models.ScannerBinaryVersion
+	err := r.db.GetContext(ctx, &v, query, tool)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active scanner binary version: %w", err)
+	}
+
+	return &v, nil
+}
+
+// Delete removes a scanner binary version row.
+func (r *ScannerBinaryVersionRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM scanner_binary_versions WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete scanner binary version: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/db/repositories/version_approval_repository.go
+++ b/backend/internal/db/repositories/version_approval_repository.go
@@ -74,6 +74,19 @@ const terraformSelect = `
 	JOIN terraform_mirror_configs tmc ON tmc.id = tv.config_id
 	WHERE tv.approval_status IS NOT NULL`
 
+// scannerSelect is the scanner-binary-version branch. There is no mirror config
+// for a scanner tool, so mirror_config_name/id are fixed placeholder values.
+const scannerSelect = `
+	SELECT sbv.id AS id, 'scanner' AS type, sbv.version AS version,
+	       sbv.approval_status AS approval_status,
+	       NULL::text AS provider_namespace, NULL::text AS provider_name,
+	       'Security Scanner' AS mirror_config_name,
+	       '00000000-0000-0000-0000-000000000000'::uuid AS mirror_config_id,
+	       sbv.signature_verified AS gpg_verified, sbv.signature_verified AS shasum_verified,
+	       sbv.discovered_at AS synced_at
+	FROM scanner_binary_versions sbv
+	WHERE sbv.approval_status IS NOT NULL`
+
 // innerQuery builds the UNION-ALL subquery honouring the type filter.
 func innerQuery(typeFilter string) string {
 	switch typeFilter {
@@ -81,8 +94,10 @@ func innerQuery(typeFilter string) string {
 		return providerSelect
 	case models.VersionApprovalTypeTerraform:
 		return terraformSelect
+	case models.VersionApprovalTypeScanner:
+		return scannerSelect
 	default:
-		return providerSelect + "\nUNION ALL" + terraformSelect
+		return providerSelect + "\nUNION ALL" + terraformSelect + "\nUNION ALL" + scannerSelect
 	}
 }
 
@@ -139,7 +154,8 @@ func (r *VersionApprovalRepository) PendingCount(ctx context.Context) (int, erro
 	const q = `
 		SELECT
 		  (SELECT COUNT(*) FROM mirrored_provider_versions WHERE approval_status = $1) +
-		  (SELECT COUNT(*) FROM terraform_versions WHERE approval_status = $1)`
+		  (SELECT COUNT(*) FROM terraform_versions WHERE approval_status = $1) +
+		  (SELECT COUNT(*) FROM scanner_binary_versions WHERE approval_status = $1)`
 	var count int
 	if err := r.db.QueryRowContext(ctx, q, models.VersionApprovalStatusPending).Scan(&count); err != nil {
 		return 0, fmt.Errorf("failed to count pending approvals: %w", err)
@@ -170,7 +186,7 @@ func (r *VersionApprovalRepository) SetStatus(ctx context.Context, id uuid.UUID,
 		return fmt.Errorf("failed to update provider version status: %w", err)
 	}
 	if n, _ := res.RowsAffected(); n > 0 {
-		if err := insertEvent(ctx, tx, &id, nil, action, performedBy, notes, nil); err != nil {
+		if err := insertEvent(ctx, tx, &id, nil, nil, action, performedBy, notes, nil); err != nil {
 			return err
 		}
 		return tx.Commit()
@@ -183,19 +199,34 @@ func (r *VersionApprovalRepository) SetStatus(ctx context.Context, id uuid.UUID,
 	if err != nil {
 		return fmt.Errorf("failed to update terraform version status: %w", err)
 	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		if err := insertEvent(ctx, tx, nil, &id, nil, action, performedBy, notes, nil); err != nil {
+			return err
+		}
+		// A terraform approve/reject can change which version is "latest".
+		var configID uuid.UUID
+		if err := tx.GetContext(ctx, &configID, `SELECT config_id FROM terraform_versions WHERE id = $1`, id); err != nil {
+			return fmt.Errorf("failed to load config for latest recalc: %w", err)
+		}
+		if err := recalcTerraformLatest(ctx, tx, configID); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+
+	// Fall back to scanner binary versions. No is_latest or activation side
+	// effects here: activation is handled by the scanner update job's reconciler.
+	res, err = tx.ExecContext(ctx,
+		`UPDATE scanner_binary_versions SET approval_status = $2 WHERE id = $1 AND approval_status IS NOT NULL`,
+		id, newStatus)
+	if err != nil {
+		return fmt.Errorf("failed to update scanner binary version status: %w", err)
+	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return sql.ErrNoRows
 	}
-	if err := insertEvent(ctx, tx, nil, &id, action, performedBy, notes, nil); err != nil {
-		return err
-	}
-	// A terraform approve/reject can change which version is "latest".
-	var configID uuid.UUID
-	if err := tx.GetContext(ctx, &configID, `SELECT config_id FROM terraform_versions WHERE id = $1`, id); err != nil {
-		return fmt.Errorf("failed to load config for latest recalc: %w", err)
-	}
-	if err := recalcTerraformLatest(ctx, tx, configID); err != nil {
+	if err := insertEvent(ctx, tx, nil, nil, &id, action, performedBy, notes, nil); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -215,12 +246,12 @@ func (r *VersionApprovalRepository) RecordEvent(ctx context.Context, ev *models.
 // newest first, resolving the performer's display name.
 func (r *VersionApprovalRepository) Events(ctx context.Context, versionID uuid.UUID) ([]models.VersionApprovalEvent, error) {
 	const q = `
-		SELECT e.id, e.mirrored_provider_version_id, e.terraform_version_id,
+		SELECT e.id, e.mirrored_provider_version_id, e.terraform_version_id, e.scanner_binary_version_id,
 		       e.action, e.performed_by, u.name AS performed_by_name,
 		       e.notes, e.auto_approve_rule, e.created_at
 		FROM version_approval_events e
 		LEFT JOIN users u ON u.id = e.performed_by
-		WHERE e.mirrored_provider_version_id = $1 OR e.terraform_version_id = $1
+		WHERE e.mirrored_provider_version_id = $1 OR e.terraform_version_id = $1 OR e.scanner_binary_version_id = $1
 		ORDER BY e.created_at DESC`
 
 	var events []models.VersionApprovalEvent
@@ -259,12 +290,12 @@ func recalcTerraformLatest(ctx context.Context, tx *sqlx.Tx, configID uuid.UUID)
 }
 
 // insertEvent inserts an approval event within a transaction.
-func insertEvent(ctx context.Context, tx *sqlx.Tx, mpvID, tfvID *uuid.UUID, action string, performedBy *uuid.UUID, notes *string, rule *string) error {
+func insertEvent(ctx context.Context, tx *sqlx.Tx, mpvID, tfvID, sbvID *uuid.UUID, action string, performedBy *uuid.UUID, notes *string, rule *string) error {
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO version_approval_events
-		  (mirrored_provider_version_id, terraform_version_id, action, performed_by, notes, auto_approve_rule)
-		VALUES ($1, $2, $3, $4, $5, $6)`,
-		mpvID, tfvID, action, performedBy, notes, rule)
+		  (mirrored_provider_version_id, terraform_version_id, scanner_binary_version_id, action, performed_by, notes, auto_approve_rule)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		mpvID, tfvID, sbvID, action, performedBy, notes, rule)
 	if err != nil {
 		return fmt.Errorf("failed to insert approval event: %w", err)
 	}
@@ -275,9 +306,9 @@ func insertEvent(ctx context.Context, tx *sqlx.Tx, mpvID, tfvID *uuid.UUID, acti
 func insertEventDB(ctx context.Context, db *sqlx.DB, ev *models.VersionApprovalEvent) error {
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO version_approval_events
-		  (mirrored_provider_version_id, terraform_version_id, action, performed_by, notes, auto_approve_rule)
-		VALUES ($1, $2, $3, $4, $5, $6)`,
-		ev.MirroredProviderVersionID, ev.TerraformVersionID, ev.Action, ev.PerformedBy, ev.Notes, ev.AutoApproveRule)
+		  (mirrored_provider_version_id, terraform_version_id, scanner_binary_version_id, action, performed_by, notes, auto_approve_rule)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		ev.MirroredProviderVersionID, ev.TerraformVersionID, ev.ScannerBinaryVersionID, ev.Action, ev.PerformedBy, ev.Notes, ev.AutoApproveRule)
 	if err != nil {
 		return fmt.Errorf("failed to insert approval event: %w", err)
 	}

--- a/backend/internal/db/repositories/version_approval_repository_test.go
+++ b/backend/internal/db/repositories/version_approval_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,7 +67,7 @@ func TestVersionApprovalList_Success(t *testing.T) {
 func TestVersionApprovalList_TypeFilters(t *testing.T) {
 	// Each type filter narrows the inner query to a single branch; exercise both
 	// plus the default UNION to cover innerQuery.
-	for _, typ := range []string{"provider", "terraform", ""} {
+	for _, typ := range []string{"provider", "terraform", "scanner", ""} {
 		t.Run("type="+typ, func(t *testing.T) {
 			repo, mock := newVersionApprovalRepo(t)
 			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM`).
@@ -79,6 +80,22 @@ func TestVersionApprovalList_TypeFilters(t *testing.T) {
 				t.Fatalf("unexpected error for type %q: %v", typ, err)
 			}
 		})
+	}
+}
+
+func TestInnerQuery_Scanner(t *testing.T) {
+	q := innerQuery(models.VersionApprovalTypeScanner)
+	if !strings.Contains(q, "scanner_binary_versions") {
+		t.Fatalf("expected innerQuery(scanner) to reference scanner_binary_versions, got: %s", q)
+	}
+}
+
+func TestInnerQuery_Default_IncludesAllBranches(t *testing.T) {
+	q := innerQuery("")
+	for _, table := range []string{"mirrored_provider_versions", "terraform_versions", "scanner_binary_versions"} {
+		if !strings.Contains(q, table) {
+			t.Fatalf("expected default innerQuery to reference %s, got: %s", table, q)
+		}
 	}
 }
 
@@ -185,6 +202,33 @@ func TestVersionApprovalSetStatus_Terraform(t *testing.T) {
 	}
 }
 
+func TestVersionApprovalSetStatus_Scanner(t *testing.T) {
+	repo, mock := newVersionApprovalRepo(t)
+	id := uuid.New()
+
+	mock.ExpectBegin()
+	// Provider and terraform updates affect no rows -> fall through to scanner.
+	mock.ExpectExec(`UPDATE mirrored_provider_versions SET approval_status`).
+		WithArgs(id, "approved").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE terraform_versions SET approval_status`).
+		WithArgs(id, "approved").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE scanner_binary_versions SET approval_status`).
+		WithArgs(id, "approved").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`INSERT INTO version_approval_events`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := repo.SetStatus(context.Background(), id, "approved", nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
 func TestVersionApprovalSetStatus_NotFound(t *testing.T) {
 	repo, mock := newVersionApprovalRepo(t)
 	id := uuid.New()
@@ -193,6 +237,8 @@ func TestVersionApprovalSetStatus_NotFound(t *testing.T) {
 	mock.ExpectExec(`UPDATE mirrored_provider_versions SET approval_status`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`UPDATE terraform_versions SET approval_status`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE scanner_binary_versions SET approval_status`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectRollback()
 

--- a/backend/internal/jobs/api_key_expiry_notifier.go
+++ b/backend/internal/jobs/api_key_expiry_notifier.go
@@ -9,16 +9,14 @@ package jobs
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log"
-	"net"
-	"net/smtp"
 	"strings"
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/notify"
 )
 
 // APIKeyExpiryNotifier periodically emails users whose API keys are about to expire.
@@ -26,6 +24,7 @@ type APIKeyExpiryNotifier struct {
 	apiKeyRepo *repositories.APIKeyRepository
 	userRepo   *repositories.UserRepository
 	cfg        *config.NotificationsConfig
+	mailer     *notify.Mailer
 	interval   time.Duration
 	stopChan   chan struct{}
 }
@@ -45,6 +44,7 @@ func NewAPIKeyExpiryNotifier(
 		apiKeyRepo: apiKeyRepo,
 		userRepo:   userRepo,
 		cfg:        cfg,
+		mailer:     notify.New(cfg.SMTP),
 		interval:   time.Duration(hours) * time.Hour,
 		stopChan:   make(chan struct{}),
 	}
@@ -161,65 +161,5 @@ func (n *APIKeyExpiryNotifier) sendExpiryEmail(toEmail, userName, keyName, keyPr
 		"— Terraform Registry",
 	}, "\r\n")
 
-	smtpCfg := &n.cfg.SMTP
-	headers := fmt.Sprintf(
-		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n",
-		smtpCfg.From, toEmail, subject,
-	)
-	msg := []byte(headers + body + "\r\n")
-
-	addr := fmt.Sprintf("%s:%d", smtpCfg.Host, smtpCfg.Port)
-	auth := smtp.PlainAuth("", smtpCfg.Username, smtpCfg.Password, smtpCfg.Host)
-
-	if smtpCfg.UseTLS {
-		return sendMailTLS(addr, smtpCfg.Host, auth, smtpCfg.From, []string{toEmail}, msg)
-	}
-	return smtp.SendMail(addr, auth, smtpCfg.From, []string{toEmail}, msg)
-}
-
-// sendMailTLS connects via implicit TLS (port 465 / SMTPS) and sends a message.
-// Use this when UseTLS=true and the port is 465; for port 587 STARTTLS,
-// smtp.SendMail handles the upgrade automatically — but we call this path for
-// both so the config is unambiguous: UseTLS=true always means an encrypted connection.
-func sendMailTLS(addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
-	tlsConfig := &tls.Config{
-		ServerName: host,
-		MinVersion: tls.VersionTLS12,
-	}
-
-	conn, err := tls.Dial("tcp", addr, tlsConfig)
-	if err != nil {
-		// Fall back to STARTTLS via the standard smtp.SendMail path (port 587 pattern)
-		return smtp.SendMail(addr, auth, from, to, msg)
-	}
-	defer conn.Close()
-
-	hostname, _, _ := net.SplitHostPort(addr)
-	c, err := smtp.NewClient(conn, hostname)
-	if err != nil {
-		return fmt.Errorf("smtp new client: %w", err)
-	}
-	defer c.Quit() //nolint:errcheck
-
-	if auth != nil {
-		if err := c.Auth(auth); err != nil {
-			return fmt.Errorf("smtp auth: %w", err)
-		}
-	}
-	if err := c.Mail(from); err != nil {
-		return fmt.Errorf("smtp MAIL FROM: %w", err)
-	}
-	for _, addr := range to {
-		if err := c.Rcpt(addr); err != nil {
-			return fmt.Errorf("smtp RCPT TO %s: %w", addr, err)
-		}
-	}
-	w, err := c.Data()
-	if err != nil {
-		return fmt.Errorf("smtp DATA: %w", err)
-	}
-	if _, err := w.Write(msg); err != nil {
-		return fmt.Errorf("smtp write: %w", err)
-	}
-	return w.Close()
+	return n.mailer.Send([]string{toEmail}, subject, body)
 }

--- a/backend/internal/jobs/api_key_expiry_notifier.go
+++ b/backend/internal/jobs/api_key_expiry_notifier.go
@@ -44,7 +44,7 @@ func NewAPIKeyExpiryNotifier(
 		apiKeyRepo: apiKeyRepo,
 		userRepo:   userRepo,
 		cfg:        cfg,
-		mailer:     notify.New(cfg.SMTP),
+		mailer:     notify.New(&cfg.SMTP),
 		interval:   time.Duration(hours) * time.Hour,
 		stopChan:   make(chan struct{}),
 	}

--- a/backend/internal/jobs/cve_poll.go
+++ b/backend/internal/jobs/cve_poll.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/smtp"
 	"strings"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/cve/osv"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/notify"
 )
 
 // digestThreshold is the minimum number of new advisories that triggers a single
@@ -30,6 +30,7 @@ type CVEPollJob struct {
 	auditRepo *repositories.AuditRepository
 	cveCfg    *config.CVEConfig
 	notifCfg  *config.NotificationsConfig
+	mailer    *notify.Mailer
 	stopChan  chan struct{}
 	manualCh  chan struct{}
 }
@@ -55,6 +56,7 @@ func NewCVEPollJob(
 		auditRepo: auditRepo,
 		cveCfg:    cveCfg,
 		notifCfg:  notifCfg,
+		mailer:    notify.New(notifCfg.SMTP),
 		stopChan:  make(chan struct{}),
 		manualCh:  make(chan struct{}, 1),
 	}
@@ -256,21 +258,8 @@ func (j *CVEPollJob) sendDigestEmail(recipients []string, advisories []models.CV
 	return j.sendEmail(recipients, subject, strings.Join(lines, "\r\n"))
 }
 
-// sendEmail is a thin wrapper that delegates to the shared SMTP helper.
+// sendEmail is a thin wrapper that delegates to the shared mailer.
 // coverage:skip:integration-only — calls smtp.SendMail / TLS dial; requires live SMTP.
 func (j *CVEPollJob) sendEmail(to []string, subject, body string) error {
-	smtpCfg := &j.notifCfg.SMTP
-	headers := fmt.Sprintf(
-		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n",
-		smtpCfg.From, strings.Join(to, ", "), subject,
-	)
-	msg := []byte(headers + body + "\r\n")
-
-	addr := fmt.Sprintf("%s:%d", smtpCfg.Host, smtpCfg.Port)
-	auth := smtp.PlainAuth("", smtpCfg.Username, smtpCfg.Password, smtpCfg.Host)
-
-	if smtpCfg.UseTLS {
-		return sendMailTLS(addr, smtpCfg.Host, auth, smtpCfg.From, to, msg)
-	}
-	return smtp.SendMail(addr, auth, smtpCfg.From, to, msg)
+	return j.mailer.Send(to, subject, body)
 }

--- a/backend/internal/jobs/cve_poll.go
+++ b/backend/internal/jobs/cve_poll.go
@@ -56,7 +56,7 @@ func NewCVEPollJob(
 		auditRepo: auditRepo,
 		cveCfg:    cveCfg,
 		notifCfg:  notifCfg,
-		mailer:    notify.New(notifCfg.SMTP),
+		mailer:    notify.New(&notifCfg.SMTP),
 		stopChan:  make(chan struct{}),
 		manualCh:  make(chan struct{}, 1),
 	}

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -72,7 +72,7 @@ func NewScannerUpdateJob(
 		approvalRepo: approvalRepo,
 		oidcCfgRepo:  oidcCfgRepo,
 		scannerJob:   scannerJob,
-		mailer:       notify.New(notifCfg.SMTP),
+		mailer:       notify.New(&notifCfg.SMTP),
 		check:        check,
 		download:     download,
 		stopChan:     make(chan struct{}),

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -1,0 +1,404 @@
+// scanner_update_job.go implements ScannerUpdateJob, a background job that checks
+// upstream for newer module security-scanner (trivy/terrascan/checkov) releases,
+// downloads and verifies them into a versioned present-but-inactive path, files a
+// version-approval row (auto-approved when a matching rule fires, otherwise
+// pending), and emails admins. Approved-but-inactive versions are picked up by
+// the activation reconciler, which updates the scanning configuration and
+// restarts ModuleScannerJob against the new binary.
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/notify"
+	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
+)
+
+// ScannerUpdateJob periodically checks upstream for newer scanner releases and
+// reconciles approved-but-inactive versions into the running scanner.
+type ScannerUpdateJob struct {
+	scanCfg      *config.ScanningConfig
+	notifCfg     *config.NotificationsConfig
+	cveCfg       *config.CVEConfig
+	sbvRepo      *repositories.ScannerBinaryVersionRepository
+	approvalRepo *repositories.VersionApprovalRepository
+	oidcCfgRepo  *repositories.OIDCConfigRepository
+	scannerJob   *ModuleScannerJob
+	mailer       *notify.Mailer
+	check        installer.CheckFunc
+	download     installer.InstallFunc
+	stopChan     chan struct{}
+	manualCh     chan struct{}
+}
+
+// NewScannerUpdateJob constructs a ScannerUpdateJob. check and download default to
+// installer.CheckLatest and installer.DownloadVerified when nil, allowing tests to
+// inject stubs.
+func NewScannerUpdateJob(
+	scanCfg *config.ScanningConfig,
+	notifCfg *config.NotificationsConfig,
+	cveCfg *config.CVEConfig,
+	sbvRepo *repositories.ScannerBinaryVersionRepository,
+	approvalRepo *repositories.VersionApprovalRepository,
+	oidcCfgRepo *repositories.OIDCConfigRepository,
+	scannerJob *ModuleScannerJob,
+	check installer.CheckFunc,
+	download installer.InstallFunc,
+) *ScannerUpdateJob {
+	if check == nil {
+		check = installer.CheckLatest
+	}
+	if download == nil {
+		download = installer.DownloadVerified
+	}
+	return &ScannerUpdateJob{
+		scanCfg:      scanCfg,
+		notifCfg:     notifCfg,
+		cveCfg:       cveCfg,
+		sbvRepo:      sbvRepo,
+		approvalRepo: approvalRepo,
+		oidcCfgRepo:  oidcCfgRepo,
+		scannerJob:   scannerJob,
+		mailer:       notify.New(notifCfg.SMTP),
+		check:        check,
+		download:     download,
+		stopChan:     make(chan struct{}),
+		manualCh:     make(chan struct{}, 1),
+	}
+}
+
+// Name returns the human-readable job name used in logs.
+func (j *ScannerUpdateJob) Name() string { return "scanner-update" }
+
+// Start begins the background update-check loop. It runs an initial check (plus
+// activation reconciliation) immediately on startup, then repeats on the
+// configured interval. The loop exits when ctx is cancelled or Stop() is called.
+func (j *ScannerUpdateJob) Start(ctx context.Context) {
+	if !j.scanCfg.AutoUpdate.Enabled {
+		log.Println("[scanner-update] disabled (scanning.auto_update.enabled=false)")
+		return
+	}
+
+	intervalHours := j.scanCfg.AutoUpdate.IntervalHours
+	if intervalHours <= 0 {
+		intervalHours = 24
+	}
+	interval := time.Duration(intervalHours) * time.Hour
+
+	log.Printf("[scanner-update] started (interval: %v)", interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Run once immediately at startup.
+	j.runCheck(ctx)
+	j.reconcileActivations(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			j.runCheck(ctx)
+			j.reconcileActivations(ctx)
+		case <-j.manualCh:
+			log.Println("[scanner-update] manual trigger received")
+			j.runCheck(ctx)
+			j.reconcileActivations(ctx)
+		case <-j.stopChan:
+			log.Println("[scanner-update] stopped")
+			return
+		case <-ctx.Done():
+			log.Println("[scanner-update] context cancelled")
+			return
+		}
+	}
+}
+
+// TriggerCheck sends a non-blocking signal to run a check immediately.
+// If a check is already queued, this call is a no-op.
+func (j *ScannerUpdateJob) TriggerCheck() {
+	select {
+	case j.manualCh <- struct{}{}:
+	default:
+	}
+}
+
+// Stop signals the background loop to exit.
+func (j *ScannerUpdateJob) Stop() {
+	close(j.stopChan)
+}
+
+// runCheck queries upstream for the latest release of the configured tool and,
+// if newer than the active/expected version and not already discovered,
+// downloads+verifies it into a versioned present-but-inactive path, records it,
+// and notifies admins.
+func (j *ScannerUpdateJob) runCheck(ctx context.Context) {
+	tool := j.scanCfg.Tool
+	if j.scanCfg.InstallDir == "" {
+		log.Println("[scanner-update] scanning.install_dir is not configured; skipping check")
+		return
+	}
+
+	latest, err := j.check(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir}, tool)
+	if err != nil {
+		log.Printf("[scanner-update] failed to check latest version for %s: %v", tool, err)
+		return
+	}
+
+	current := j.scanCfg.ExpectedVersion
+	if active, err := j.sbvRepo.GetActive(ctx, tool); err == nil && active != nil {
+		current = active.Version
+	}
+	if strings.TrimPrefix(latest.LatestVersion, "v") == strings.TrimPrefix(current, "v") {
+		log.Printf("[scanner-update] %s is up to date (version %s)", tool, latest.LatestVersion)
+		return
+	}
+
+	if existing, err := j.sbvRepo.GetByToolVersion(ctx, tool, latest.LatestVersion); err == nil && existing != nil {
+		// Already discovered on a previous check/tick.
+		return
+	}
+
+	res, err := j.download(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir}, tool, latest.LatestVersion)
+	if err != nil {
+		log.Printf("[scanner-update] failed to download %s %s: %v", tool, latest.LatestVersion, err)
+		failed := &models.ScannerBinaryVersion{
+			ID:         uuid.New(),
+			Tool:       tool,
+			Version:    latest.LatestVersion,
+			SyncStatus: "failed",
+		}
+		if upErr := j.sbvRepo.Upsert(ctx, failed); upErr != nil {
+			log.Printf("[scanner-update] failed to record failed download for %s %s: %v", tool, latest.LatestVersion, upErr)
+		}
+		return
+	}
+
+	var existingVersions []string
+	if rows, err := j.sbvRepo.ListForTool(ctx, tool); err == nil {
+		for _, row := range rows {
+			existingVersions = append(existingVersions, row.Version)
+		}
+	}
+
+	status, autoRule := j.resolveScannerApproval(latest.LatestVersion, res.SignatureVerified, existingVersions)
+
+	v := &models.ScannerBinaryVersion{
+		ID:                uuid.New(),
+		Tool:              tool,
+		Version:           latest.LatestVersion,
+		SourceURL:         &res.SourceURL,
+		Sha256:            &res.Sha256,
+		SignatureVerified: res.SignatureVerified,
+		SignatureType:     res.SignatureType,
+		SyncStatus:        "downloaded",
+		BinaryPath:        &res.BinaryPath,
+		ApprovalStatus:    status,
+	}
+	if err := j.sbvRepo.Upsert(ctx, v); err != nil {
+		log.Printf("[scanner-update] failed to record discovered version %s %s: %v", tool, latest.LatestVersion, err)
+		return
+	}
+
+	if autoRule != "" && j.approvalRepo != nil {
+		rule := autoRule
+		if err := j.approvalRepo.RecordEvent(ctx, &models.VersionApprovalEvent{
+			ScannerBinaryVersionID: &v.ID,
+			Action:                 models.VersionApprovalActionAuto,
+			AutoApproveRule:        &rule,
+		}); err != nil {
+			log.Printf("[scanner-update] failed to record auto-approve event for %s %s: %v", tool, latest.LatestVersion, err)
+		}
+	}
+
+	j.notify(ctx, v, status)
+}
+
+// resolveScannerApproval decides the approval_status for a freshly discovered
+// scanner version. It returns an approved pointer immediately when the operator
+// has opted out of approval gating, a pending pointer when review is required,
+// or an approved pointer plus the matched rule name when an auto-approve rule
+// fires.
+func (j *ScannerUpdateJob) resolveScannerApproval(version string, signatureVerified bool, existing []string) (*string, string) {
+	pending := models.VersionApprovalStatusPending
+	approved := models.VersionApprovalStatusApproved
+
+	if !j.scanCfg.AutoUpdate.RequiresApproval {
+		return &approved, ""
+	}
+
+	rules, err := mirror.ParseAutoApproveRules(&j.scanCfg.AutoUpdate.AutoApproveRules)
+	if err != nil {
+		log.Printf("[scanner-update] invalid scanning.auto_update.auto_approve_rules: %v", err)
+		return &pending, ""
+	}
+	if rules == nil {
+		return &pending, ""
+	}
+
+	matched, rule := mirror.EvaluateAutoApprove(rules, mirror.AutoApproveInput{
+		Version:          version,
+		GPGVerified:      signatureVerified,
+		ExistingVersions: existing,
+		VersionAge:       0, // just discovered; delay_hours rules never match immediately
+	})
+	if matched {
+		return &approved, rule
+	}
+	return &pending, ""
+}
+
+// reconcileActivations picks up approved-but-inactive scanner versions and
+// activates them.
+func (j *ScannerUpdateJob) reconcileActivations(ctx context.Context) {
+	rows, err := j.sbvRepo.ListApprovedInactive(ctx)
+	if err != nil {
+		log.Printf("[scanner-update] failed to list approved-inactive versions: %v", err)
+		return
+	}
+	for i := range rows {
+		row := rows[i]
+		if err := j.Activate(ctx, &row); err != nil {
+			log.Printf("[scanner-update] failed to activate %s %s: %v", row.Tool, row.Version, err)
+		}
+	}
+}
+
+// Activate installs the given already-downloaded version as the running scanner
+// binary: it updates the scanning configuration (binary path + expected
+// version), persists it, restarts ModuleScannerJob, marks the version active,
+// and best-effort cleans up superseded versioned binaries for the tool. Shared
+// by the activation reconciler and the manual install+activate admin endpoint.
+func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinaryVersion) error {
+	if v.BinaryPath == nil {
+		return fmt.Errorf("scanner binary version %s (%s %s) has no binary_path", v.ID, v.Tool, v.Version)
+	}
+
+	if j.scanCfg.InstallDir != "" {
+		cleanBinary := filepath.Clean(*v.BinaryPath)
+		cleanInstall := filepath.Clean(j.scanCfg.InstallDir)
+		if !strings.HasPrefix(cleanBinary, cleanInstall+string(filepath.Separator)) {
+			return fmt.Errorf("binary_path %q is outside the scanner install directory", *v.BinaryPath)
+		}
+	}
+
+	j.scanCfg.BinaryPath = *v.BinaryPath
+	j.scanCfg.ExpectedVersion = v.Version
+
+	persisted := struct {
+		Enabled           bool   `json:"enabled"`
+		Tool              string `json:"tool"`
+		BinaryPath        string `json:"binary_path"`
+		ExpectedVersion   string `json:"expected_version"`
+		SeverityThreshold string `json:"severity_threshold"`
+		TimeoutSecs       int    `json:"timeout_secs"`
+		WorkerCount       int    `json:"worker_count"`
+		ScanIntervalMins  int    `json:"scan_interval_mins"`
+		InstallDir        string `json:"install_dir"`
+	}{
+		Enabled:           j.scanCfg.Enabled,
+		Tool:              j.scanCfg.Tool,
+		BinaryPath:        j.scanCfg.BinaryPath,
+		ExpectedVersion:   j.scanCfg.ExpectedVersion,
+		SeverityThreshold: j.scanCfg.SeverityThreshold,
+		TimeoutSecs:       int(j.scanCfg.Timeout.Seconds()),
+		WorkerCount:       j.scanCfg.WorkerCount,
+		ScanIntervalMins:  j.scanCfg.ScanIntervalMins,
+		InstallDir:        j.scanCfg.InstallDir,
+	}
+	jsonBytes, err := json.Marshal(persisted)
+	if err != nil {
+		return fmt.Errorf("marshal scanning config: %w", err)
+	}
+	if j.oidcCfgRepo != nil {
+		if err := j.oidcCfgRepo.SetScanningConfig(ctx, jsonBytes); err != nil {
+			return fmt.Errorf("persist scanning config: %w", err)
+		}
+	}
+
+	if j.scannerJob != nil {
+		_ = j.scannerJob.Stop()
+		go func() {
+			if err := j.scannerJob.Start(context.Background()); err != nil {
+				log.Printf("[scanner-update] scanner job failed to restart after activation: %v", err)
+			}
+		}()
+	}
+
+	if err := j.sbvRepo.MarkActive(ctx, v.ID); err != nil {
+		return fmt.Errorf("mark scanner binary version active: %w", err)
+	}
+
+	j.cleanupSuperseded(ctx, v)
+	return nil
+}
+
+// cleanupSuperseded best-effort removes versioned install directories for other
+// versions of the tool now that v is active. Never fails activation; errors are
+// logged only. Only removes directories that match the {InstallDir}/{tool}-{version}
+// pattern used by installer.DownloadVerified, so an activated version's symlink
+// target (bare {InstallDir}/{tool}) is never touched.
+func (j *ScannerUpdateJob) cleanupSuperseded(ctx context.Context, active *models.ScannerBinaryVersion) {
+	rows, err := j.sbvRepo.ListForTool(ctx, active.Tool)
+	if err != nil {
+		log.Printf("[scanner-update] cleanup: failed to list versions for %s: %v", active.Tool, err)
+		return
+	}
+
+	versionedPrefix := filepath.Join(j.scanCfg.InstallDir, active.Tool+"-")
+	for _, row := range rows {
+		if row.ID == active.ID || row.BinaryPath == nil {
+			continue
+		}
+		dir := filepath.Dir(*row.BinaryPath)
+		if !strings.HasPrefix(dir, versionedPrefix) {
+			continue // not a versioned dir (e.g. the active symlink path) — never remove
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("[scanner-update] cleanup: failed to remove superseded dir %s: %v", dir, err)
+		}
+	}
+}
+
+// notify sends an admin notification email about a newly discovered scanner
+// version, guarded by notifications being enabled/configured and recipients
+// being present. Never fails the caller; send errors are logged only.
+func (j *ScannerUpdateJob) notify(_ context.Context, v *models.ScannerBinaryVersion, status *string) {
+	if j.notifCfg == nil || !j.notifCfg.Enabled || j.notifCfg.SMTP.Host == "" || len(j.cveCfg.EmailRecipients) == 0 {
+		return
+	}
+
+	approved := status != nil && *status == models.VersionApprovalStatusApproved
+
+	var subject string
+	var body strings.Builder
+	if approved {
+		subject = fmt.Sprintf("[Security] Scanner update available: %s %s (approved/auto)", v.Tool, v.Version)
+	} else {
+		subject = fmt.Sprintf("[Security] Scanner update available: %s %s (pending approval)", v.Tool, v.Version)
+	}
+
+	fmt.Fprintf(&body, "A new version of the %s security scanner has been discovered.\n\n", v.Tool)
+	fmt.Fprintf(&body, "Tool: %s\nVersion: %s\nSignature type: %s\nSignature verified: %t\n\n", v.Tool, v.Version, v.SignatureType, v.SignatureVerified)
+	if approved {
+		body.WriteString("This version was automatically approved and will be activated automatically.\n")
+	} else {
+		body.WriteString("This version is pending approval. Log in to review and approve it before it is activated.\n")
+	}
+
+	if err := j.mailer.Send(j.cveCfg.EmailRecipients, subject, body.String()); err != nil {
+		log.Printf("[scanner-update] failed to send notification email: %v", err)
+	}
+}

--- a/backend/internal/jobs/scanner_update_job_test.go
+++ b/backend/internal/jobs/scanner_update_job_test.go
@@ -1,0 +1,135 @@
+// scanner_update_job_test.go contains pure-logic unit tests for ScannerUpdateJob
+// that require no live database: resolveScannerApproval decision logic and the
+// non-blocking TriggerCheck channel semantics. Full runCheck/Activate flows need
+// a live Postgres and are intentionally not covered here.
+package jobs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// newTestScannerUpdateJob builds a ScannerUpdateJob with only scanCfg populated,
+// sufficient for resolveScannerApproval which reads scanCfg exclusively.
+func newTestScannerUpdateJob(scanCfg *config.ScanningConfig) *ScannerUpdateJob {
+	return NewScannerUpdateJob(
+		scanCfg,
+		&config.NotificationsConfig{},
+		&config.CVEConfig{},
+		nil, // sbvRepo
+		nil, // approvalRepo
+		nil, // oidcCfgRepo
+		nil, // scannerJob
+		nil, // check (defaults to installer.CheckLatest, unused here)
+		nil, // download (defaults to installer.DownloadVerified, unused here)
+	)
+}
+
+func TestResolveScannerApproval(t *testing.T) {
+	tests := []struct {
+		name              string
+		requiresApproval  bool
+		autoApproveRules  string
+		version           string
+		signatureVerified bool
+		existing          []string
+		wantStatus        string // "" means expect nil pointer
+		wantRule          string
+	}{
+		{
+			name:             "requires_approval false always approves, no rule",
+			requiresApproval: false,
+			version:          "0.53.0",
+			wantStatus:       "approved",
+			wantRule:         "",
+		},
+		{
+			name:             "requires_approval true, no rules configured -> pending",
+			requiresApproval: true,
+			autoApproveRules: "",
+			version:          "0.53.0",
+			wantStatus:       "pending_approval",
+			wantRule:         "",
+		},
+		{
+			name:              "requires_approval true, matching patch_only + gpg_verified rule -> approved",
+			requiresApproval:  true,
+			autoApproveRules:  `{"mode":"any","rules":[{"type":"patch_only"},{"type":"gpg_verified"}]}`,
+			version:           "0.53.1",
+			signatureVerified: true,
+			existing:          []string{"0.53.0"},
+			wantStatus:        "approved",
+			wantRule:          "patch_only",
+		},
+		{
+			name:              "requires_approval true, non-matching rule -> pending",
+			requiresApproval:  true,
+			autoApproveRules:  `{"mode":"any","rules":[{"type":"patch_only"}]}`,
+			version:           "1.0.0",
+			signatureVerified: true,
+			existing:          []string{"0.53.0"},
+			wantStatus:        "pending_approval",
+			wantRule:          "",
+		},
+		{
+			name:             "requires_approval true, invalid rules JSON -> pending",
+			requiresApproval: true,
+			autoApproveRules: "not json",
+			version:          "0.53.0",
+			wantStatus:       "pending_approval",
+			wantRule:         "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanCfg := &config.ScanningConfig{
+				AutoUpdate: config.ScannerAutoUpdateConfig{
+					RequiresApproval: tt.requiresApproval,
+					AutoApproveRules: tt.autoApproveRules,
+				},
+			}
+			job := newTestScannerUpdateJob(scanCfg)
+
+			status, rule := job.resolveScannerApproval(tt.version, tt.signatureVerified, tt.existing)
+
+			if tt.wantStatus == "" {
+				if status != nil {
+					t.Fatalf("status = %v, want nil", *status)
+				}
+			} else {
+				if status == nil {
+					t.Fatalf("status = nil, want %q", tt.wantStatus)
+				}
+				if *status != tt.wantStatus {
+					t.Errorf("status = %q, want %q", *status, tt.wantStatus)
+				}
+			}
+			if rule != tt.wantRule {
+				t.Errorf("rule = %q, want %q", rule, tt.wantRule)
+			}
+		})
+	}
+}
+
+func TestScannerUpdateJob_TriggerCheck_NonBlocking(t *testing.T) {
+	job := newTestScannerUpdateJob(&config.ScanningConfig{})
+
+	// Fill the buffered channel, then confirm further triggers don't block.
+	job.TriggerCheck()
+
+	done := make(chan struct{})
+	go func() {
+		job.TriggerCheck()
+		job.TriggerCheck()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TriggerCheck blocked with a full buffer")
+	}
+}

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -191,6 +191,8 @@ func getResourceType(c *gin.Context) string {
 	case strings.HasPrefix(fullPath, "/api/v1/admin/scanning"),
 		strings.HasPrefix(fullPath, "/api/v1/admin/security-scanning"):
 		return "scanning"
+	case strings.HasPrefix(fullPath, "/api/v1/admin/notifications"):
+		return "notifications"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/approvals"):
 		return "approval"
 	// The hosted binary-mirror admin API lives under /admin/terraform-mirror*

--- a/backend/internal/notify/mailer.go
+++ b/backend/internal/notify/mailer.go
@@ -1,0 +1,92 @@
+// mailer.go implements Mailer, a shared SMTP email sender used by background jobs
+// (CVE polling, API key expiry notifications, scanner update notifications). It
+// centralizes the SMTP send logic that was previously duplicated across jobs.
+package notify
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// Mailer sends plain-text notification emails using the configured SMTP server.
+type Mailer struct {
+	cfg config.SMTPConfig
+}
+
+// New constructs a Mailer for the given SMTP configuration.
+func New(cfg config.SMTPConfig) *Mailer {
+	return &Mailer{cfg: cfg}
+}
+
+// Send composes RFC822 headers plus a plain-text body and delivers the message to
+// all recipients. When cfg.UseTLS is set, an implicit TLS connection is attempted
+// first, falling back to STARTTLS (via smtp.SendMail) on dial failure; otherwise
+// plain smtp.SendMail is used.
+// coverage:skip:integration-only — calls smtp.SendMail / TLS dial; requires live SMTP.
+func (m *Mailer) Send(to []string, subject, body string) error {
+	headers := fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n",
+		m.cfg.From, strings.Join(to, ", "), subject,
+	)
+	msg := []byte(headers + body + "\r\n")
+
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.Port)
+	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
+
+	if m.cfg.UseTLS {
+		return sendMailTLS(addr, m.cfg.Host, auth, m.cfg.From, to, msg)
+	}
+	return smtp.SendMail(addr, auth, m.cfg.From, to, msg)
+}
+
+// sendMailTLS connects via implicit TLS (port 465 / SMTPS) and sends a message.
+// Use this when UseTLS=true and the port is 465; for port 587 STARTTLS,
+// smtp.SendMail handles the upgrade automatically — but we call this path for
+// both so the config is unambiguous: UseTLS=true always means an encrypted connection.
+func sendMailTLS(addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	tlsConfig := &tls.Config{
+		ServerName: host,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	conn, err := tls.Dial("tcp", addr, tlsConfig)
+	if err != nil {
+		// Fall back to STARTTLS via the standard smtp.SendMail path (port 587 pattern)
+		return smtp.SendMail(addr, auth, from, to, msg)
+	}
+	defer conn.Close()
+
+	hostname, _, _ := net.SplitHostPort(addr)
+	c, err := smtp.NewClient(conn, hostname)
+	if err != nil {
+		return fmt.Errorf("smtp new client: %w", err)
+	}
+	defer c.Quit() //nolint:errcheck
+
+	if auth != nil {
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+	for _, addr := range to {
+		if err := c.Rcpt(addr); err != nil {
+			return fmt.Errorf("smtp RCPT TO %s: %w", addr, err)
+		}
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("smtp write: %w", err)
+	}
+	return w.Close()
+}

--- a/backend/internal/notify/mailer.go
+++ b/backend/internal/notify/mailer.go
@@ -14,12 +14,17 @@ import (
 )
 
 // Mailer sends plain-text notification emails using the configured SMTP server.
+// cfg is held by pointer so that a runtime configuration update (e.g. via the
+// admin notifications API) is observed by background jobs without recreating
+// the Mailer.
 type Mailer struct {
-	cfg config.SMTPConfig
+	cfg *config.SMTPConfig
 }
 
-// New constructs a Mailer for the given SMTP configuration.
-func New(cfg config.SMTPConfig) *Mailer {
+// New constructs a Mailer for the given SMTP configuration. cfg is stored by
+// reference; callers should pass a pointer to the live config struct (e.g.
+// &cfg.Notifications.SMTP) so runtime updates are reflected in Send.
+func New(cfg *config.SMTPConfig) *Mailer {
 	return &Mailer{cfg: cfg}
 }
 
@@ -29,6 +34,9 @@ func New(cfg config.SMTPConfig) *Mailer {
 // plain smtp.SendMail is used.
 // coverage:skip:integration-only — calls smtp.SendMail / TLS dial; requires live SMTP.
 func (m *Mailer) Send(to []string, subject, body string) error {
+	if m.cfg == nil {
+		return fmt.Errorf("mailer: nil smtp config")
+	}
 	headers := fmt.Sprintf(
 		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n",
 		m.cfg.From, strings.Join(to, ", "), subject,

--- a/backend/internal/notify/mailer_test.go
+++ b/backend/internal/notify/mailer_test.go
@@ -1,0 +1,40 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// TestNew_HoldsLivePointer verifies that Mailer stores the *config.SMTPConfig
+// by reference: mutating the referenced struct after construction is observed
+// by the Mailer, without recreating it. This is the fix that lets a runtime
+// admin config update reach background jobs that built their Mailer once at
+// startup.
+func TestNew_HoldsLivePointer(t *testing.T) {
+	cfg := &config.SMTPConfig{Host: "old.example.com", From: "old@example.com"}
+	m := New(cfg)
+
+	cfg.Host = "new.example.com"
+	cfg.From = "new@example.com"
+
+	if m.cfg.Host != "new.example.com" {
+		t.Errorf("m.cfg.Host = %q, want %q (live pointer not observed)", m.cfg.Host, "new.example.com")
+	}
+	if m.cfg.From != "new@example.com" {
+		t.Errorf("m.cfg.From = %q, want %q (live pointer not observed)", m.cfg.From, "new@example.com")
+	}
+}
+
+// TestSend_NilConfig_ReturnsError verifies the nil guard at the top of Send.
+func TestSend_NilConfig_ReturnsError(t *testing.T) {
+	m := &Mailer{cfg: nil}
+
+	err := m.Send([]string{"to@example.com"}, "subject", "body")
+	if err == nil {
+		t.Fatal("expected error for nil smtp config, got nil")
+	}
+	if err.Error() != "mailer: nil smtp config" {
+		t.Errorf("err = %q, want %q", err.Error(), "mailer: nil smtp config")
+	}
+}

--- a/backend/internal/scanner/installer/catalog.go
+++ b/backend/internal/scanner/installer/catalog.go
@@ -17,13 +17,52 @@ type AssetSpec struct {
 	VersionedAPI string
 	// AssetPattern matches the release asset .Name for this OS/arch.
 	AssetPattern *regexp.Regexp
-	// ChecksumsPattern matches the checksums asset .Name for this version.
+	// ChecksumsPattern matches the checksums asset .Name for this version. Leave nil when
+	// the release publishes no checksums file and UseAssetDigest is used instead (checkov).
 	ChecksumsPattern *regexp.Regexp
+	// SignaturePattern optionally matches an additional signature/attestation asset .Name
+	// (e.g. a Sigstore bundle). Only set when Signature.Type is "gpg" or "sigstore".
+	SignaturePattern *regexp.Regexp
+	// Signature describes optional cryptographic signature verification for this tool.
+	// SHA256 checksum verification is always mandatory; this is additive.
+	Signature SignatureSpec
+	// UseAssetDigest, when true, verifies the downloaded archive's SHA256 against the
+	// archive asset's GitHub-reported `digest` field instead of a checksums file/asset.
+	UseAssetDigest bool
 	// BinaryInArchive is the path inside the archive to extract (e.g. "trivy").
 	BinaryInArchive string
 	// ArchiveFormat is the archive type: "tar.gz" or "zip".
 	ArchiveFormat string
 }
+
+// SignatureSpec describes optional signature/provenance verification for a tool's release
+// artifacts, on top of the mandatory SHA256 checksum check.
+type SignatureSpec struct {
+	// Type is "", "none", "gpg", or "sigstore".
+	Type string
+	// Identity is the expected Sigstore keyless-signing identity (e.g. a GitHub Actions
+	// workflow URI template, which may contain a "%s" placeholder for the version).
+	Identity string
+	// Issuer is the expected Sigstore OIDC token issuer.
+	Issuer string
+	// KeyURL is the well-known URL to fetch the ASCII-armored GPG public key (gpg only).
+	KeyURL string
+	// Fingerprint pins the expected GPG primary key fingerprint (gpg only).
+	Fingerprint string
+}
+
+// trivySignature documents trivy's Sigstore keyless-signing provenance. Verification
+// of the Sigstore bundle itself is not implemented yet (tracked as a follow-up); the
+// generic signature hook logs a notice and never blocks the download for this type.
+var trivySignature = SignatureSpec{
+	Type:     "sigstore",
+	Identity: "https://github.com/aquasecurity/trivy/.github/workflows/release.yaml@refs/tags/v%s",
+	Issuer:   "https://token.actions.githubusercontent.com",
+}
+
+// noSignature marks tools whose upstream releases ship no cryptographic signature;
+// integrity relies on the mandatory SHA256 checksum check alone.
+var noSignature = SignatureSpec{Type: "none"}
 
 // Catalog maps tool name → "GOOS/GOARCH" → AssetSpec.
 var Catalog = map[string]map[string]AssetSpec{
@@ -33,6 +72,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			VersionedAPI:     "https://api.github.com/repos/aquasecurity/trivy/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_Linux-64bit\.tar\.gz$`),
 			ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+			SignaturePattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt\.sigstore\.json$`),
+			Signature:        trivySignature,
 			BinaryInArchive:  "trivy",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -41,6 +82,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			VersionedAPI:     "https://api.github.com/repos/aquasecurity/trivy/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_Linux-ARM64\.tar\.gz$`),
 			ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+			SignaturePattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt\.sigstore\.json$`),
+			Signature:        trivySignature,
 			BinaryInArchive:  "trivy",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -49,6 +92,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			VersionedAPI:     "https://api.github.com/repos/aquasecurity/trivy/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_macOS-64bit\.tar\.gz$`),
 			ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+			SignaturePattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt\.sigstore\.json$`),
+			Signature:        trivySignature,
 			BinaryInArchive:  "trivy",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -57,6 +102,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			VersionedAPI:     "https://api.github.com/repos/aquasecurity/trivy/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_macOS-ARM64\.tar\.gz$`),
 			ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+			SignaturePattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt\.sigstore\.json$`),
+			Signature:        trivySignature,
 			BinaryInArchive:  "trivy",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -66,7 +113,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/tenable/terrascan/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/tenable/terrascan/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^terrascan_[\d.]+_Linux_x86_64\.tar\.gz$`),
-			ChecksumsPattern: regexp.MustCompile(`^terrascan_[\d.]+_checksums\.txt$`),
+			ChecksumsPattern: regexp.MustCompile(`^(terrascan_[\d.]+_)?checksums\.txt$`),
+			Signature:        noSignature,
 			BinaryInArchive:  "terrascan",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -74,7 +122,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/tenable/terrascan/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/tenable/terrascan/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^terrascan_[\d.]+_Linux_arm64\.tar\.gz$`),
-			ChecksumsPattern: regexp.MustCompile(`^terrascan_[\d.]+_checksums\.txt$`),
+			ChecksumsPattern: regexp.MustCompile(`^(terrascan_[\d.]+_)?checksums\.txt$`),
+			Signature:        noSignature,
 			BinaryInArchive:  "terrascan",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -82,7 +131,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/tenable/terrascan/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/tenable/terrascan/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^terrascan_[\d.]+_Darwin_x86_64\.tar\.gz$`),
-			ChecksumsPattern: regexp.MustCompile(`^terrascan_[\d.]+_checksums\.txt$`),
+			ChecksumsPattern: regexp.MustCompile(`^(terrascan_[\d.]+_)?checksums\.txt$`),
+			Signature:        noSignature,
 			BinaryInArchive:  "terrascan",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -90,7 +140,8 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/tenable/terrascan/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/tenable/terrascan/releases/tags/v%s",
 			AssetPattern:     regexp.MustCompile(`^terrascan_[\d.]+_Darwin_arm64\.tar\.gz$`),
-			ChecksumsPattern: regexp.MustCompile(`^terrascan_[\d.]+_checksums\.txt$`),
+			ChecksumsPattern: regexp.MustCompile(`^(terrascan_[\d.]+_)?checksums\.txt$`),
+			Signature:        noSignature,
 			BinaryInArchive:  "terrascan",
 			ArchiveFormat:    "tar.gz",
 		},
@@ -100,7 +151,9 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/bridgecrewio/checkov/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/bridgecrewio/checkov/releases/tags/%s",
 			AssetPattern:     regexp.MustCompile(`^checkov_linux_X86_64\.zip$`),
-			ChecksumsPattern: regexp.MustCompile(`^checkov_linux_X86_64\.zip\.sha256$`),
+			ChecksumsPattern: nil,
+			UseAssetDigest:   true,
+			Signature:        noSignature,
 			BinaryInArchive:  "checkov",
 			ArchiveFormat:    "zip",
 		},
@@ -108,7 +161,9 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/bridgecrewio/checkov/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/bridgecrewio/checkov/releases/tags/%s",
 			AssetPattern:     regexp.MustCompile(`^checkov_linux_arm64\.zip$`),
-			ChecksumsPattern: regexp.MustCompile(`^checkov_linux_arm64\.zip\.sha256$`),
+			ChecksumsPattern: nil,
+			UseAssetDigest:   true,
+			Signature:        noSignature,
 			BinaryInArchive:  "checkov",
 			ArchiveFormat:    "zip",
 		},
@@ -116,7 +171,9 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/bridgecrewio/checkov/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/bridgecrewio/checkov/releases/tags/%s",
 			AssetPattern:     regexp.MustCompile(`^checkov_darwin_X86_64\.zip$`),
-			ChecksumsPattern: regexp.MustCompile(`^checkov_darwin_X86_64\.zip\.sha256$`),
+			ChecksumsPattern: nil,
+			UseAssetDigest:   true,
+			Signature:        noSignature,
 			BinaryInArchive:  "checkov",
 			ArchiveFormat:    "zip",
 		},
@@ -124,7 +181,9 @@ var Catalog = map[string]map[string]AssetSpec{
 			LatestReleaseAPI: "https://api.github.com/repos/bridgecrewio/checkov/releases/latest",
 			VersionedAPI:     "https://api.github.com/repos/bridgecrewio/checkov/releases/tags/%s",
 			AssetPattern:     regexp.MustCompile(`^checkov_darwin_arm64\.zip$`),
-			ChecksumsPattern: regexp.MustCompile(`^checkov_darwin_arm64\.zip\.sha256$`),
+			ChecksumsPattern: nil,
+			UseAssetDigest:   true,
+			Signature:        noSignature,
 			BinaryInArchive:  "checkov",
 			ArchiveFormat:    "zip",
 		},

--- a/backend/internal/scanner/installer/installer.go
+++ b/backend/internal/scanner/installer/installer.go
@@ -73,6 +73,10 @@ var (
 // InstallFunc is the handler-facing type alias so tests can inject a stub.
 type InstallFunc func(ctx context.Context, cfg InstallConfig, tool, pinnedVersion string) (*Result, error)
 
+// CheckFunc is the handler/job-facing type alias for CheckLatest so tests and
+// callers (e.g. ScannerUpdateJob) can inject a stub.
+type CheckFunc func(ctx context.Context, cfg InstallConfig, tool string) (*LatestInfo, error)
+
 // ghRelease is the subset of the GitHub release JSON we need.
 type ghRelease struct {
 	TagName string    `json:"tag_name"`

--- a/backend/internal/scanner/installer/installer.go
+++ b/backend/internal/scanner/installer/installer.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -22,6 +23,8 @@ import (
 	"time"
 
 	goversion "github.com/hashicorp/go-version"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
 // Size caps to prevent zip-bomb / decompression-bomb DoS.
@@ -47,6 +50,12 @@ type Result struct {
 	Version    string `json:"version"`
 	Sha256     string `json:"sha256"`
 	SourceURL  string `json:"source_url"`
+	// SignatureVerified indicates whether an additional cryptographic signature
+	// (beyond the mandatory SHA256 checksum) was verified for this artifact.
+	SignatureVerified bool `json:"signature_verified"`
+	// SignatureType is "none", "gpg", or "sigstore" — the signature scheme configured
+	// for this tool, regardless of whether SignatureVerified is true.
+	SignatureType string `json:"signature_type,omitempty"`
 }
 
 // Typed errors for common failure modes.
@@ -74,6 +83,9 @@ type ghAsset struct {
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
 	Size               int64  `json:"size"`
+	// Digest is GitHub's reported content digest, e.g. "sha256:<hex>". Used for tools
+	// (e.g. checkov) whose releases publish no separate checksums file/asset.
+	Digest string `json:"digest"`
 }
 
 // Install resolves, downloads, verifies, and installs a scanner binary.
@@ -108,77 +120,15 @@ func Install(ctx context.Context, cfg InstallConfig, tool, pinnedVersion string)
 	version := strings.TrimPrefix(release.TagName, "v")
 
 	// 4. Find matching assets.
-	var archiveAsset, checksumsAsset *ghAsset
-	for i := range release.Assets {
-		a := &release.Assets[i]
-		if archiveAsset == nil && spec.AssetPattern.MatchString(a.Name) {
-			archiveAsset = a
-		}
-		if checksumsAsset == nil && spec.ChecksumsPattern.MatchString(a.Name) {
-			checksumsAsset = a
-		}
-	}
-	if archiveAsset == nil || checksumsAsset == nil {
+	archiveAsset, checksumsAsset, sigAsset := matchAssets(spec, release)
+	if archiveAsset == nil || (checksumsAsset == nil && !spec.UseAssetDigest) {
 		return nil, fmt.Errorf("%w: tool=%s version=%s os=%s arch=%s", ErrAssetNotFound, tool, version, runtime.GOOS, runtime.GOARCH)
 	}
 
-	// 5. Validate HTTPS-only.
-	if !strings.HasPrefix(archiveAsset.BrowserDownloadURL, "https://") {
-		return nil, fmt.Errorf("%w: %s", ErrNonHTTPS, archiveAsset.BrowserDownloadURL)
-	}
-	if !strings.HasPrefix(checksumsAsset.BrowserDownloadURL, "https://") {
-		return nil, fmt.Errorf("%w: %s", ErrNonHTTPS, checksumsAsset.BrowserDownloadURL)
-	}
-
-	// Create a temp dir for downloads.
-	tmpDir, err := os.MkdirTemp(cfg.InstallDir, "tmp-install-")
-	if err != nil {
-		return nil, fmt.Errorf("create temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir) // always clean up temp
-
-	// 6. Download archive with size cap.
-	archivePath := filepath.Join(tmpDir, archiveAsset.Name)
-	archiveHash, err := downloadFile(ctx, client, archiveAsset.BrowserDownloadURL, archivePath, maxArchiveSize)
+	// 5-9. Download, verify (checksum + optional signature), and extract.
+	targetBinary, sha256hex, sourceURL, sigVerified, sigType, err := downloadExtract(ctx, client, cfg, spec, tool, version, archiveAsset, checksumsAsset, sigAsset)
 	if err != nil {
 		return nil, err
-	}
-
-	// Download checksums file.
-	checksumsPath := filepath.Join(tmpDir, checksumsAsset.Name)
-	_, err = downloadFile(ctx, client, checksumsAsset.BrowserDownloadURL, checksumsPath, maxChecksumsSize)
-	if err != nil {
-		return nil, fmt.Errorf("download checksums: %w", err)
-	}
-
-	// 7. Verify checksum.
-	if err := verifyChecksum(checksumsPath, archiveAsset.Name, archiveHash); err != nil {
-		return nil, err
-	}
-
-	// 8. Extract binary from archive.
-	versionDir := filepath.Join(cfg.InstallDir, tool+"-"+version)
-	if err := os.MkdirAll(versionDir, 0o755); err != nil { // #nosec G301 -- scanner binary directory needs execute permission
-		return nil, fmt.Errorf("create version dir: %w", err)
-	}
-
-	targetBinary := filepath.Join(versionDir, filepath.Base(spec.BinaryInArchive))
-	switch spec.ArchiveFormat {
-	case "tar.gz":
-		err = extractFromTarGz(archivePath, spec.BinaryInArchive, targetBinary)
-	case "zip":
-		err = extractFromZip(archivePath, spec.BinaryInArchive, targetBinary)
-	default:
-		err = fmt.Errorf("unsupported archive format: %s", spec.ArchiveFormat)
-	}
-	if err != nil {
-		os.RemoveAll(versionDir) // #nosec G104 -- best-effort cleanup on extraction failure
-		return nil, err
-	}
-
-	// 9. Make executable.
-	if err := os.Chmod(targetBinary, 0o755); err != nil { // #nosec G302 -- scanner binary must be executable
-		return nil, fmt.Errorf("chmod: %w", err)
 	}
 
 	// 10. Atomically swap symlink.
@@ -188,10 +138,283 @@ func Install(ctx context.Context, cfg InstallConfig, tool, pinnedVersion string)
 	}
 
 	return &Result{
-		BinaryPath: symlinkPath,
-		Version:    version,
-		Sha256:     hex.EncodeToString(archiveHash),
-		SourceURL:  archiveAsset.BrowserDownloadURL,
+		BinaryPath:        symlinkPath,
+		Version:           version,
+		Sha256:            sha256hex,
+		SourceURL:         sourceURL,
+		SignatureVerified: sigVerified,
+		SignatureType:     sigType,
+	}, nil
+}
+
+// matchAssets locates the archive, checksums, and (optional) signature assets for a
+// release given a catalog spec. Signature matching only occurs when spec.SignaturePattern
+// is set.
+func matchAssets(spec AssetSpec, release *ghRelease) (archive, checksums, sig *ghAsset) {
+	for i := range release.Assets {
+		a := &release.Assets[i]
+		if archive == nil && spec.AssetPattern.MatchString(a.Name) {
+			archive = a
+		}
+		if checksums == nil && spec.ChecksumsPattern != nil && spec.ChecksumsPattern.MatchString(a.Name) {
+			checksums = a
+		}
+		if sig == nil && spec.SignaturePattern != nil && spec.SignaturePattern.MatchString(a.Name) {
+			sig = a
+		}
+	}
+	return archive, checksums, sig
+}
+
+// downloadExtract downloads the matched archive (and checksums/signature assets),
+// verifies its integrity, and extracts the target binary to the versioned install
+// path {cfg.InstallDir}/{tool}-{version}/{basename(spec.BinaryInArchive)}. It is
+// shared by Install and DownloadVerified; neither creates/updates the {tool} symlink.
+func downloadExtract(ctx context.Context, client *http.Client, cfg InstallConfig, spec AssetSpec, tool, version string, archiveAsset, checksumsAsset, sigAsset *ghAsset) (versionedBinaryPath, sha256hex, sourceURL string, sigVerified bool, sigType string, err error) {
+	// Validate HTTPS-only.
+	if !strings.HasPrefix(archiveAsset.BrowserDownloadURL, "https://") {
+		return "", "", "", false, "", fmt.Errorf("%w: %s", ErrNonHTTPS, archiveAsset.BrowserDownloadURL)
+	}
+	if checksumsAsset != nil && !strings.HasPrefix(checksumsAsset.BrowserDownloadURL, "https://") {
+		return "", "", "", false, "", fmt.Errorf("%w: %s", ErrNonHTTPS, checksumsAsset.BrowserDownloadURL)
+	}
+
+	// Create a temp dir for downloads.
+	tmpDir, mkErr := os.MkdirTemp(cfg.InstallDir, "tmp-install-")
+	if mkErr != nil {
+		return "", "", "", false, "", fmt.Errorf("create temp dir: %w", mkErr)
+	}
+	defer os.RemoveAll(tmpDir) // always clean up temp
+
+	// Download archive with size cap.
+	archivePath := filepath.Join(tmpDir, archiveAsset.Name)
+	archiveHash, dlErr := downloadFile(ctx, client, archiveAsset.BrowserDownloadURL, archivePath, maxArchiveSize)
+	if dlErr != nil {
+		return "", "", "", false, "", dlErr
+	}
+
+	// Verify integrity: either a checksums file/asset or the GitHub asset digest.
+	var checksumsData []byte
+	switch {
+	case checksumsAsset != nil:
+		checksumsPath := filepath.Join(tmpDir, checksumsAsset.Name)
+		if _, dlErr := downloadFile(ctx, client, checksumsAsset.BrowserDownloadURL, checksumsPath, maxChecksumsSize); dlErr != nil {
+			return "", "", "", false, "", fmt.Errorf("download checksums: %w", dlErr)
+		}
+		if verErr := verifyChecksum(checksumsPath, archiveAsset.Name, archiveHash); verErr != nil {
+			return "", "", "", false, "", verErr
+		}
+		checksumsData, _ = os.ReadFile(checksumsPath) // #nosec G304 -- path is inside InstallDir temp directory
+	case spec.UseAssetDigest:
+		if verErr := verifyAssetDigest(archiveAsset.Digest, archiveHash); verErr != nil {
+			return "", "", "", false, "", verErr
+		}
+	}
+
+	// Optional signature verification (additive; never blocks except a genuine gpg failure).
+	verified, verSigType, sigErr := verifyArtifactSignature(ctx, client, spec, sigAsset, checksumsData)
+	if sigErr != nil {
+		return "", "", "", false, "", sigErr
+	}
+
+	// Extract binary from archive.
+	versionDir := filepath.Join(cfg.InstallDir, tool+"-"+version)
+	if mkErr := os.MkdirAll(versionDir, 0o755); mkErr != nil { // #nosec G301 -- scanner binary directory needs execute permission
+		return "", "", "", false, "", fmt.Errorf("create version dir: %w", mkErr)
+	}
+
+	targetBinary := filepath.Join(versionDir, filepath.Base(spec.BinaryInArchive))
+	var extractErr error
+	switch spec.ArchiveFormat {
+	case "tar.gz":
+		extractErr = extractFromTarGz(archivePath, spec.BinaryInArchive, targetBinary)
+	case "zip":
+		extractErr = extractFromZip(archivePath, spec.BinaryInArchive, targetBinary)
+	default:
+		extractErr = fmt.Errorf("unsupported archive format: %s", spec.ArchiveFormat)
+	}
+	if extractErr != nil {
+		os.RemoveAll(versionDir) // #nosec G104 -- best-effort cleanup on extraction failure
+		return "", "", "", false, "", extractErr
+	}
+
+	// Make executable.
+	if chmodErr := os.Chmod(targetBinary, 0o755); chmodErr != nil { // #nosec G302 -- scanner binary must be executable
+		return "", "", "", false, "", fmt.Errorf("chmod: %w", chmodErr)
+	}
+
+	return targetBinary, hex.EncodeToString(archiveHash), archiveAsset.BrowserDownloadURL, verified, verSigType, nil
+}
+
+// verifyAssetDigest verifies archiveHash against the GitHub asset's reported `digest`
+// field (e.g. "sha256:<hex>"), used for tools that publish no checksums file/asset.
+func verifyAssetDigest(digest string, archiveHash []byte) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(digest, prefix) {
+		return fmt.Errorf("%w: asset digest missing or not sha256 (%q)", ErrChecksumMismatch, digest)
+	}
+	expected, err := hex.DecodeString(strings.TrimPrefix(digest, prefix))
+	if err != nil {
+		return fmt.Errorf("%w: malformed asset digest %q", ErrChecksumMismatch, digest)
+	}
+	if subtle.ConstantTimeCompare(expected, archiveHash) != 1 {
+		return fmt.Errorf("%w: expected %s, got %s", ErrChecksumMismatch, hex.EncodeToString(expected), hex.EncodeToString(archiveHash))
+	}
+	return nil
+}
+
+// verifyArtifactSignature optionally verifies a release's signature per spec.Signature.
+// SHA256 checksum verification is mandatory and handled by the caller before this is
+// invoked; this is additive: a genuine "gpg" verification failure blocks the install,
+// but "sigstore" is not yet implemented and never blocks (logs a one-line notice).
+func verifyArtifactSignature(ctx context.Context, client *http.Client, spec AssetSpec, sig *ghAsset, checksums []byte) (verified bool, sigType string, err error) {
+	switch spec.Signature.Type {
+	case "", "none":
+		return false, "none", nil
+	case "gpg":
+		if sig == nil {
+			return false, "gpg", fmt.Errorf("gpg signature verification configured but no signature asset found")
+		}
+		if !strings.HasPrefix(sig.BrowserDownloadURL, "https://") {
+			return false, "gpg", fmt.Errorf("%w: %s", ErrNonHTTPS, sig.BrowserDownloadURL)
+		}
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, sig.BrowserDownloadURL, nil)
+		if reqErr != nil {
+			return false, "gpg", reqErr
+		}
+		resp, doErr := client.Do(req)
+		if doErr != nil {
+			return false, "gpg", doErr
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return false, "gpg", fmt.Errorf("download signature: HTTP %d", resp.StatusCode)
+		}
+		sigBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, maxChecksumsSize))
+		if readErr != nil {
+			return false, "gpg", readErr
+		}
+		key, _, keyErr := mirror.FetchReleasesKey(ctx, client, spec.Signature.KeyURL, spec.Signature.Fingerprint)
+		if keyErr != nil {
+			return false, "gpg", fmt.Errorf("fetch signing key: %w", keyErr)
+		}
+		if verErr := validation.VerifySignature(key, checksums, sigBytes); verErr != nil {
+			return false, "gpg", fmt.Errorf("signature verification failed: %w", verErr)
+		}
+		return true, "gpg", nil
+	case "sigstore":
+		log.Printf("scanner installer: Sigstore signature verification is not implemented yet; skipping (tracked as a follow-up)")
+		return false, "sigstore", nil
+	default:
+		return false, spec.Signature.Type, nil
+	}
+}
+
+// LatestInfo describes the latest available upstream release for a scanner tool on
+// the current server OS/arch, without downloading anything.
+type LatestInfo struct {
+	Tool               string `json:"tool"`
+	LatestVersion      string `json:"latest_version"`
+	ArchiveURL         string `json:"archive_url"`
+	ChecksumsURL       string `json:"checksums_url,omitempty"`
+	SignatureURL       string `json:"signature_url,omitempty"`
+	SignatureSupported bool   `json:"signature_supported"`
+}
+
+// CheckLatest queries the upstream GitHub release for the latest version of tool
+// available for the current server OS/arch. It does not download or install anything.
+func CheckLatest(ctx context.Context, cfg InstallConfig, tool string) (*LatestInfo, error) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Minute
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+
+	spec, ok := Lookup(tool, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		if !Supports(tool) {
+			return nil, fmt.Errorf("%w: %s (supported: %v)", ErrUnsupportedTool, tool, SupportedTools())
+		}
+		return nil, fmt.Errorf("%w: %s on %s/%s", ErrUnsupportedPlatform, tool, runtime.GOOS, runtime.GOARCH)
+	}
+
+	release, err := resolveRelease(ctx, client, spec, "")
+	if err != nil {
+		return nil, fmt.Errorf("resolve release: %w", err)
+	}
+	version := strings.TrimPrefix(release.TagName, "v")
+
+	archiveAsset, checksumsAsset, sigAsset := matchAssets(spec, release)
+	if archiveAsset == nil || (checksumsAsset == nil && !spec.UseAssetDigest) {
+		return nil, fmt.Errorf("%w: tool=%s version=%s os=%s arch=%s", ErrAssetNotFound, tool, version, runtime.GOOS, runtime.GOARCH)
+	}
+
+	info := &LatestInfo{
+		Tool:               tool,
+		LatestVersion:      version,
+		ArchiveURL:         archiveAsset.BrowserDownloadURL,
+		SignatureSupported: spec.Signature.Type == "gpg" || spec.Signature.Type == "sigstore",
+	}
+	if checksumsAsset != nil {
+		info.ChecksumsURL = checksumsAsset.BrowserDownloadURL
+	}
+	if sigAsset != nil {
+		info.SignatureURL = sigAsset.BrowserDownloadURL
+	}
+	return info, nil
+}
+
+// DownloadVerified resolves, downloads, verifies, and extracts a scanner binary to its
+// versioned install path {cfg.InstallDir}/{tool}-{version}/{basename} WITHOUT creating
+// or replacing the {cfg.InstallDir}/{tool} symlink — i.e. the binary is present on disk
+// but not activated. This is the "present-but-inactive" path for the pending-approval
+// update flow; Install remains the one-step download+activate entry point.
+func DownloadVerified(ctx context.Context, cfg InstallConfig, tool, pinnedVersion string) (*Result, error) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Minute
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+
+	if err := ensureWritableDir(cfg.InstallDir); err != nil {
+		return nil, err
+	}
+
+	spec, ok := Lookup(tool, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		if !Supports(tool) {
+			return nil, fmt.Errorf("%w: %s (supported: %v)", ErrUnsupportedTool, tool, SupportedTools())
+		}
+		return nil, fmt.Errorf("%w: %s on %s/%s", ErrUnsupportedPlatform, tool, runtime.GOOS, runtime.GOARCH)
+	}
+
+	release, err := resolveRelease(ctx, client, spec, pinnedVersion)
+	if err != nil {
+		return nil, fmt.Errorf("resolve release: %w", err)
+	}
+	version := strings.TrimPrefix(release.TagName, "v")
+
+	archiveAsset, checksumsAsset, sigAsset := matchAssets(spec, release)
+	if archiveAsset == nil || (checksumsAsset == nil && !spec.UseAssetDigest) {
+		return nil, fmt.Errorf("%w: tool=%s version=%s os=%s arch=%s", ErrAssetNotFound, tool, version, runtime.GOOS, runtime.GOARCH)
+	}
+
+	targetBinary, sha256hex, sourceURL, sigVerified, sigType, err := downloadExtract(ctx, client, cfg, spec, tool, version, archiveAsset, checksumsAsset, sigAsset)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Result{
+		BinaryPath:        targetBinary,
+		Version:           version,
+		Sha256:            sha256hex,
+		SourceURL:         sourceURL,
+		SignatureVerified: sigVerified,
+		SignatureType:     sigType,
 	}, nil
 }
 

--- a/backend/internal/scanner/installer/installer_test.go
+++ b/backend/internal/scanner/installer/installer_test.go
@@ -104,6 +104,67 @@ func setupTestServer(t *testing.T, version string, archiveName, checksumsName st
 	return server, spec
 }
 
+// setupTestServerFull is like setupTestServer but optionally serves a signature asset
+// and/or sets the archive asset's GitHub `digest` field. Pass "" for checksumsName to
+// omit the checksums asset entirely (for UseAssetDigest-style tools like checkov);
+// pass "" for sigName to omit the signature asset.
+func setupTestServerFull(t *testing.T, version string, archiveName, checksumsName, sigName string, archiveData, checksumsData, sigData []byte, archiveDigest string) (*httptest.Server, AssetSpec) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	assets := []ghAsset{
+		{Name: archiveName, BrowserDownloadURL: server.URL + "/assets/" + archiveName, Digest: archiveDigest},
+	}
+	if checksumsName != "" {
+		assets = append(assets, ghAsset{Name: checksumsName, BrowserDownloadURL: server.URL + "/assets/" + checksumsName})
+	}
+	if sigName != "" {
+		assets = append(assets, ghAsset{Name: sigName, BrowserDownloadURL: server.URL + "/assets/" + sigName})
+	}
+	release := ghRelease{TagName: "v" + version, Assets: assets}
+
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(release)
+	})
+	mux.HandleFunc("/releases/tags/", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(release)
+	})
+	mux.HandleFunc("/assets/"+archiveName, func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archiveData)
+	})
+	if checksumsName != "" {
+		mux.HandleFunc("/assets/"+checksumsName, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(checksumsData)
+		})
+	}
+	if sigName != "" {
+		mux.HandleFunc("/assets/"+sigName, func(w http.ResponseWriter, r *http.Request) {
+			w.Write(sigData)
+		})
+	}
+
+	spec := AssetSpec{
+		LatestReleaseAPI: server.URL + "/releases/latest",
+		VersionedAPI:     server.URL + "/releases/tags/v%s",
+		AssetPattern:     mustCompile(t, `^`+regexp_escape(archiveName)+`$`),
+		BinaryInArchive:  "trivy",
+		ArchiveFormat:    "tar.gz",
+	}
+	if checksumsName != "" {
+		spec.ChecksumsPattern = mustCompile(t, `^`+regexp_escape(checksumsName)+`$`)
+	} else {
+		spec.UseAssetDigest = true
+	}
+	if sigName != "" {
+		spec.SignaturePattern = mustCompile(t, `^`+regexp_escape(sigName)+`$`)
+	}
+
+	return server, spec
+}
+
 func regexp_escape(s string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(s, ".", `\.`), "+", `\+`)
 }
@@ -729,5 +790,191 @@ func TestHandle_InstallerError(t *testing.T) {
 	}
 	if !strings.Contains(msg, "checksum") {
 		t.Errorf("message should mention checksum: %s", msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase C: CheckLatest, DownloadVerified, digest verification, signature hook
+// ---------------------------------------------------------------------------
+
+func TestCheckLatest_ReturnsLatestVersionAndURLs(t *testing.T) {
+	archiveName := "trivy_0.53.0_Linux-64bit.tar.gz"
+	checksumsName := "trivy_0.53.0_checksums.txt"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	checksums := []byte(checksumLine(archive, archiveName) + "\n")
+
+	server, spec := setupTestServer(t, "0.53.0", archiveName, checksumsName, archive, checksums)
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	info, err := CheckLatest(context.Background(), InstallConfig{HTTPClient: server.Client()}, "trivy")
+	if err != nil {
+		t.Fatalf("CheckLatest: %v", err)
+	}
+	if info.LatestVersion != "0.53.0" {
+		t.Errorf("LatestVersion = %q, want 0.53.0", info.LatestVersion)
+	}
+	if info.ArchiveURL == "" {
+		t.Error("ArchiveURL empty")
+	}
+	if info.ChecksumsURL == "" {
+		t.Error("ChecksumsURL empty")
+	}
+	if info.SignatureSupported {
+		t.Error("SignatureSupported should be false when spec.Signature.Type is unset")
+	}
+}
+
+func TestDownloadVerified_WritesVersionedDir_NoSymlink(t *testing.T) {
+	archiveName := "trivy_0.54.0_Linux-64bit.tar.gz"
+	checksumsName := "trivy_0.54.0_checksums.txt"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	checksums := []byte(checksumLine(archive, archiveName) + "\n")
+
+	server, spec := setupTestServer(t, "0.54.0", archiveName, checksumsName, archive, checksums)
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	installDir := t.TempDir()
+	result, err := DownloadVerified(context.Background(), InstallConfig{
+		InstallDir: installDir,
+		HTTPClient: server.Client(),
+	}, "trivy", "0.54.0")
+	if err != nil {
+		t.Fatalf("DownloadVerified: %v", err)
+	}
+	if result.Version != "0.54.0" {
+		t.Errorf("version = %q, want 0.54.0", result.Version)
+	}
+	if !strings.Contains(result.BinaryPath, "trivy-0.54.0") {
+		t.Errorf("BinaryPath = %q, want to contain trivy-0.54.0", result.BinaryPath)
+	}
+
+	symlinkPath := filepath.Join(installDir, "trivy")
+	if _, statErr := os.Lstat(symlinkPath); statErr == nil {
+		t.Errorf("symlink %q should not exist after DownloadVerified", symlinkPath)
+	} else if !os.IsNotExist(statErr) {
+		t.Errorf("unexpected error checking symlink: %v", statErr)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(result.BinaryPath)
+		if statErr != nil {
+			t.Fatalf("Stat: %v", statErr)
+		}
+		if info.Mode()&0o111 == 0 {
+			t.Error("binary is not executable")
+		}
+	}
+}
+
+func TestDownloadExtract_AssetDigest_Success(t *testing.T) {
+	archiveName := "trivy_0.55.0_Linux-64bit.tar.gz"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	h := sha256.Sum256(archive)
+	digest := "sha256:" + hex.EncodeToString(h[:])
+
+	server, spec := setupTestServerFull(t, "0.55.0", archiveName, "", "", archive, nil, nil, digest)
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	result, err := Install(context.Background(), InstallConfig{
+		InstallDir: t.TempDir(),
+		HTTPClient: server.Client(),
+	}, "trivy", "0.55.0")
+	if err != nil {
+		t.Fatalf("Install (asset-digest verification): %v", err)
+	}
+	if result.Version != "0.55.0" {
+		t.Errorf("version = %q, want 0.55.0", result.Version)
+	}
+}
+
+func TestDownloadExtract_AssetDigest_Mismatch(t *testing.T) {
+	archiveName := "trivy_0.55.0_Linux-64bit.tar.gz"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	wrongDigest := "sha256:" + strings.Repeat("aa", 32)
+
+	server, spec := setupTestServerFull(t, "0.55.0", archiveName, "", "", archive, nil, nil, wrongDigest)
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	_, err := Install(context.Background(), InstallConfig{
+		InstallDir: t.TempDir(),
+		HTTPClient: server.Client(),
+	}, "trivy", "0.55.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Errorf("expected checksum mismatch error, got: %v", err)
+	}
+}
+
+func TestInstall_BareChecksumsFile_Matches(t *testing.T) {
+	// Mirrors the real terrascan catalog fix: a bare "checksums.txt" (no tool/version
+	// prefix) must match the fixed ChecksumsPattern.
+	archiveName := "terrascan_1.19.9_Linux_x86_64.tar.gz"
+	checksumsName := "checksums.txt"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	checksums := []byte(checksumLine(archive, archiveName) + "\n")
+
+	server, spec := setupTestServer(t, "1.19.9", archiveName, checksumsName, archive, checksums)
+	spec.ChecksumsPattern = mustCompile(t, `^(terrascan_[\d.]+_)?checksums\.txt$`)
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	result, err := Install(context.Background(), InstallConfig{
+		InstallDir: t.TempDir(),
+		HTTPClient: server.Client(),
+	}, "trivy", "1.19.9")
+	if err != nil {
+		t.Fatalf("Install (bare checksums.txt): %v", err)
+	}
+	if result.Version != "1.19.9" {
+		t.Errorf("version = %q, want 1.19.9", result.Version)
+	}
+}
+
+func TestInstall_SigstoreSignature_DoesNotBlock_SetsSignatureType(t *testing.T) {
+	archiveName := "trivy_0.56.0_Linux-64bit.tar.gz"
+	checksumsName := "trivy_0.56.0_checksums.txt"
+	sigName := "trivy_0.56.0_checksums.txt.sigstore.json"
+	archive := buildTarGz(t, map[string][]byte{"trivy": stubBinary})
+	checksums := []byte(checksumLine(archive, archiveName) + "\n")
+	sigBundle := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle+json;version=0.1"}`)
+
+	server, spec := setupTestServerFull(t, "0.56.0", archiveName, checksumsName, sigName, archive, checksums, sigBundle, "")
+	spec.Signature = SignatureSpec{Type: "sigstore"}
+
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	result, err := Install(context.Background(), InstallConfig{
+		InstallDir: t.TempDir(),
+		HTTPClient: server.Client(),
+	}, "trivy", "0.56.0")
+	if err != nil {
+		t.Fatalf("Install should not fail on unimplemented sigstore verification: %v", err)
+	}
+	if result.SignatureVerified {
+		t.Error("SignatureVerified should be false (sigstore verification not implemented yet)")
+	}
+	if result.SignatureType != "sigstore" {
+		t.Errorf("SignatureType = %q, want sigstore", result.SignatureType)
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -20,13 +20,13 @@ database:
   max_connections: 25
 
 storage:
-  default_backend: local  # Options: azure, s3, local
+  default_backend: local # Options: azure, s3, local
 
   azure:
     account_name: ${AZURE_STORAGE_ACCOUNT}
     account_key: ${AZURE_STORAGE_KEY}
     container_name: terraform-registry
-    cdn_url: ""  # Optional CDN URL for faster downloads
+    cdn_url: "" # Optional CDN URL for faster downloads
 
   s3:
     endpoint: https://s3.amazonaws.com
@@ -37,13 +37,13 @@ storage:
 
   local:
     base_path: ./storage
-    serve_directly: true  # Serve files directly instead of redirecting
+    serve_directly: true # Serve files directly instead of redirecting
 
 auth:
   # API key authentication (recommended for CLI and automation)
   api_keys:
     enabled: true
-    prefix: "tfr_"  # All API keys will start with this prefix
+    prefix: "tfr_" # All API keys will start with this prefix
 
   # Generic OIDC provider (Okta, Auth0, Google, etc.)
   oidc:
@@ -108,14 +108,14 @@ auth:
     default_role: ""
 
 multi_tenancy:
-  enabled: false  # Set to true for multi-organization support
+  enabled: false # Set to true for multi-organization support
   default_organization: default
-  allow_public_signup: false  # Allow users to create organizations
+  allow_public_signup: false # Allow users to create organizations
 
 security:
   cors:
     allowed_origins:
-      - http://localhost:5173  # Vite dev server
+      - http://localhost:5173 # Vite dev server
       - http://localhost:8080
     allowed_methods:
       - GET
@@ -135,9 +135,9 @@ security:
     key_file: /etc/certs/tls.key
 
 logging:
-  level: info  # Options: debug, info, warn, error
-  format: json  # Options: json, text
-  output: stdout  # Options: stdout, or file path like /var/log/registry.log
+  level: info # Options: debug, info, warn, error
+  format: json # Options: json, text
+  output: stdout # Options: stdout, or file path like /var/log/registry.log
 
 telemetry:
   enabled: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -180,6 +180,14 @@ scanning:
   # scan_args: ["scan", "--format", "json"]
   # output_format is only used when tool is "custom": "sarif" or "json"
   # output_format: sarif
+  # auto_update controls the scheduled job that checks upstream for newer scanner
+  # releases. Disabled by default; newly discovered versions are downloaded, verified,
+  # and filed as pending version approvals unless auto-approved.
+  # auto_update:
+  #   enabled: false
+  #   interval_hours: 24
+  #   requires_approval: true
+  #   auto_approve_rules: ""
 
 # CVE vulnerability polling — periodically queries OSV.dev for advisories affecting
 # Terraform/OpenTofu binaries, registered providers, and the configured scanner binary.


### PR DESCRIPTION
Backend for admin-managed security-scanning tool updates (manual + scheduled-with-approval).

- Phase A: scanning.auto_update config; notifications persistence (migration 000043); shared internal/notify mailer (de-dupes SMTP).
- Phase C: installer CheckLatest + DownloadVerified (versioned, non-activating); pluggable SignatureSpec hook (SHA256 now); fixed terrascan/checkov catalog; GET /admin/scanning/latest.
- Phase D: scanner_binary_versions (migration 000044) wired into version-approval workflow as type=scanner; ScannerUpdateJob (check→download→verify→pending approval→email) + activation reconciler; install {activate}; POST /admin/scanning/check.
- Phase B: admin notification endpoints (GET/PUT/test) with tokenCipher-sealed SMTP password; mailer reads config live (runtime propagation).

Follow-ups: Sigstore verification for Trivy (needs sigstore-go dep, currently a logged no-op); admin endpoint to edit auto-update settings.

Full go test ./... green.