### PR TITLE
feat: scanner auto-update settings (admin view/edit)

### DIFF
--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -15,16 +15,25 @@ import (
 
 // ScanningConfigResponse is the public view of the scanning config.
 type ScanningConfigResponse struct {
-	Enabled           bool    `json:"enabled"`
-	Tool              string  `json:"tool"`
-	ExpectedVersion   string  `json:"expected_version,omitempty"`
-	SeverityThreshold string  `json:"severity_threshold"`
-	Timeout           string  `json:"timeout"`
-	WorkerCount       int     `json:"worker_count"`
-	ScanIntervalMins  int     `json:"scan_interval_mins"`
-	BinaryPath        string  `json:"binary_path,omitempty"`
-	BinaryFound       bool    `json:"binary_found"`
-	DetectedVersion   *string `json:"detected_version,omitempty"`
+	Enabled           bool                       `json:"enabled"`
+	Tool              string                     `json:"tool"`
+	ExpectedVersion   string                     `json:"expected_version,omitempty"`
+	SeverityThreshold string                     `json:"severity_threshold"`
+	Timeout           string                     `json:"timeout"`
+	WorkerCount       int                        `json:"worker_count"`
+	ScanIntervalMins  int                        `json:"scan_interval_mins"`
+	BinaryPath        string                     `json:"binary_path,omitempty"`
+	BinaryFound       bool                       `json:"binary_found"`
+	DetectedVersion   *string                    `json:"detected_version,omitempty"`
+	AutoUpdate        ScanningAutoUpdateResponse `json:"auto_update"`
+}
+
+// ScanningAutoUpdateResponse is the public view of the scanner auto-update settings.
+type ScanningAutoUpdateResponse struct {
+	Enabled          bool   `json:"enabled"`
+	IntervalHours    int    `json:"interval_hours"`
+	RequiresApproval bool   `json:"requires_approval"`
+	AutoApproveRules string `json:"auto_approve_rules,omitempty"`
 }
 
 // ScanningStatsResponse aggregates scan counts by status and recent activity.
@@ -75,6 +84,12 @@ func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 			WorkerCount:       cfg.WorkerCount,
 			ScanIntervalMins:  cfg.ScanIntervalMins,
 			BinaryPath:        cfg.BinaryPath,
+			AutoUpdate: ScanningAutoUpdateResponse{
+				Enabled:          cfg.AutoUpdate.Enabled,
+				IntervalHours:    cfg.AutoUpdate.IntervalHours,
+				RequiresApproval: cfg.AutoUpdate.RequiresApproval,
+				AutoApproveRules: cfg.AutoUpdate.AutoApproveRules,
+			},
 		}
 
 		if cfg.Enabled {

--- a/backend/internal/api/admin/scanning_auto_update.go
+++ b/backend/internal/api/admin/scanning_auto_update.go
@@ -1,0 +1,142 @@
+// scanning_auto_update.go implements the admin endpoint for viewing and
+// updating the scheduled scanner auto-update settings (enabled, check
+// interval, approval gating, auto-approve rules). Reads/writes the same
+// system_settings.scanning_config JSON column as the setup wizard and the
+// activation reconciler (config.ScanningConfigDB), preserving the other
+// scanning-config fields on write. Applies the new settings at runtime by
+// restarting ScannerUpdateJob.
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+)
+
+// scanningAutoUpdateInput is the PUT /api/v1/admin/scanning/auto-update request body.
+type scanningAutoUpdateInput struct {
+	Enabled          bool   `json:"enabled"`
+	IntervalHours    int    `json:"interval_hours"`
+	RequiresApproval bool   `json:"requires_approval"`
+	AutoApproveRules string `json:"auto_approve_rules"`
+}
+
+// ScanningAutoUpdateHandler handles the admin scanner auto-update settings endpoint.
+type ScanningAutoUpdateHandler struct {
+	cfg       *config.ScanningConfig
+	repo      *repositories.OIDCConfigRepository
+	updateJob *jobs.ScannerUpdateJob
+}
+
+// NewScanningAutoUpdateHandler constructs a ScanningAutoUpdateHandler. cfg must be
+// a pointer to the live config.Scanning struct so updates take effect in-place for
+// the running ScannerUpdateJob.
+func NewScanningAutoUpdateHandler(
+	cfg *config.ScanningConfig,
+	repo *repositories.OIDCConfigRepository,
+	updateJob *jobs.ScannerUpdateJob,
+) *ScanningAutoUpdateHandler {
+	return &ScanningAutoUpdateHandler{
+		cfg:       cfg,
+		repo:      repo,
+		updateJob: updateJob,
+	}
+}
+
+// @Summary      Update scanner auto-update settings
+// @Description  Updates the scheduled scanner version-check job's settings (enabled, check interval, approval gating, auto-approve rules), persists them, and restarts the job so the new settings apply immediately. Requires admin scope.
+// @Tags         Security Scanning
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        body  body      scanningAutoUpdateInput  true  "Auto-update settings"
+// @Success      200  {object}  ScanningAutoUpdateResponse
+// @Failure      400  {object}  map[string]interface{}  "Invalid request"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/scanning/auto-update [put]
+func (h *ScanningAutoUpdateHandler) Put(c *gin.Context) {
+	var input scanningAutoUpdateInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if input.IntervalHours <= 0 {
+		input.IntervalHours = 24
+	}
+	if input.IntervalHours < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "interval_hours must be at least 1"})
+		return
+	}
+
+	if _, err := mirror.ParseAutoApproveRules(&input.AutoApproveRules); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid auto_approve_rules: %v", err)})
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	// Read-modify-write: preserve the other persisted scanning-config fields.
+	// If no row exists yet, db is left zero-valued and re-seeded from the live
+	// config below, so we never blank the row.
+	var db config.ScanningConfigDB
+	if existing, err := h.repo.GetScanningConfig(ctx); err == nil && existing != nil {
+		_ = json.Unmarshal(existing, &db)
+	}
+
+	db.AutoUpdate = config.ScannerAutoUpdateDB{
+		Enabled:          input.Enabled,
+		IntervalHours:    input.IntervalHours,
+		RequiresApproval: input.RequiresApproval,
+		AutoApproveRules: input.AutoApproveRules,
+	}
+	db.Enabled = h.cfg.Enabled
+	db.Tool = h.cfg.Tool
+	db.BinaryPath = h.cfg.BinaryPath
+	db.ExpectedVersion = h.cfg.ExpectedVersion
+	db.SeverityThreshold = h.cfg.SeverityThreshold
+	db.TimeoutSecs = int(h.cfg.Timeout.Seconds())
+	db.WorkerCount = h.cfg.WorkerCount
+	db.ScanIntervalMins = h.cfg.ScanIntervalMins
+	db.InstallDir = h.cfg.InstallDir
+
+	jsonBytes, err := json.Marshal(db)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal scanning configuration"})
+		return
+	}
+	if err := h.repo.SetScanningConfig(ctx, jsonBytes); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save scanning configuration"})
+		return
+	}
+
+	// Update the in-memory config in place (never reassign h.cfg) so other
+	// holders of the same pointer observe the change immediately.
+	h.cfg.AutoUpdate.Enabled = input.Enabled
+	h.cfg.AutoUpdate.IntervalHours = input.IntervalHours
+	h.cfg.AutoUpdate.RequiresApproval = input.RequiresApproval
+	h.cfg.AutoUpdate.AutoApproveRules = input.AutoApproveRules
+
+	// Restart the job so the new enabled/interval settings apply (the job only
+	// reads AutoUpdate at Start()).
+	if h.updateJob != nil {
+		h.updateJob.Stop()
+		go h.updateJob.Start(context.Background())
+	}
+
+	c.JSON(http.StatusOK, ScanningAutoUpdateResponse{
+		Enabled:          h.cfg.AutoUpdate.Enabled,
+		IntervalHours:    h.cfg.AutoUpdate.IntervalHours,
+		RequiresApproval: h.cfg.AutoUpdate.RequiresApproval,
+		AutoApproveRules: h.cfg.AutoUpdate.AutoApproveRules,
+	})
+}

--- a/backend/internal/api/admin/scanning_auto_update_test.go
+++ b/backend/internal/api/admin/scanning_auto_update_test.go
@@ -1,0 +1,117 @@
+// scanning_auto_update_test.go tests ScanningAutoUpdateHandler.Put: the merge
+// with existing persisted scanning config, in-place cfg mutation, interval
+// default, and auto_approve_rules validation. Mirrors notifications_test.go's
+// sqlmock harness.
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// newScanningAutoUpdateHandler builds a ScanningAutoUpdateHandler backed by
+// sqlmock, mirroring newNotificationsHandler in notifications_test.go.
+// updateJob is intentionally nil: the handler's `if h.updateJob != nil` guard
+// skips the restart, keeping this test hermetic.
+func newScanningAutoUpdateHandler(t *testing.T) (*ScanningAutoUpdateHandler, *config.ScanningConfig, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	repo := repositories.NewOIDCConfigRepository(sqlx.NewDb(db, "sqlmock"))
+	cfg := &config.ScanningConfig{Tool: "trivy", InstallDir: "/opt/scanners"}
+	return NewScanningAutoUpdateHandler(cfg, repo, nil), cfg, mock
+}
+
+func TestScanningAutoUpdateHandler_Put_Success(t *testing.T) {
+	h, cfg, mock := newScanningAutoUpdateHandler(t)
+
+	existingRow := `{"enabled":true,"tool":"trivy","binary_path":"/opt/scanners/trivy","expected_version":"0.53.0","install_dir":"/opt/scanners"}`
+	mock.ExpectQuery("SELECT scanning_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"scanning_config"}).AddRow([]byte(existingRow)))
+	mock.ExpectExec("UPDATE system_settings").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/auto-update", h.Put)
+	body := `{"enabled":true,"interval_hours":12,"requires_approval":false,"auto_approve_rules":""}`
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/auto-update", jsonBodyAdmin(json.RawMessage(body))))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp ScanningAutoUpdateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Enabled || resp.IntervalHours != 12 || resp.RequiresApproval {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+
+	if !cfg.AutoUpdate.Enabled || cfg.AutoUpdate.IntervalHours != 12 || cfg.AutoUpdate.RequiresApproval {
+		t.Errorf("cfg.AutoUpdate not mutated in place: %+v", cfg.AutoUpdate)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestScanningAutoUpdateHandler_Put_InvalidAutoApproveRules(t *testing.T) {
+	h, _, _ := newScanningAutoUpdateHandler(t)
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/auto-update", h.Put)
+	body := `{"enabled":true,"interval_hours":12,"auto_approve_rules":"not json"}`
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/auto-update", jsonBodyAdmin(json.RawMessage(body))))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestScanningAutoUpdateHandler_Put_IntervalDefaultsTo24(t *testing.T) {
+	h, cfg, mock := newScanningAutoUpdateHandler(t)
+
+	mock.ExpectQuery("SELECT scanning_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"scanning_config"}).AddRow(nil))
+	mock.ExpectExec("UPDATE system_settings").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.PUT("/auto-update", h.Put)
+	body := `{"enabled":true,"interval_hours":0}`
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/auto-update", jsonBodyAdmin(json.RawMessage(body))))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp ScanningAutoUpdateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.IntervalHours != 24 {
+		t.Errorf("IntervalHours = %d, want 24 (default)", resp.IntervalHours)
+	}
+	if cfg.AutoUpdate.IntervalHours != 24 {
+		t.Errorf("cfg.AutoUpdate.IntervalHours = %d, want 24", cfg.AutoUpdate.IntervalHours)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -277,6 +277,22 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			}
 		}
 	}
+	// Always reload persisted auto-update settings, even when scanning itself is
+	// enabled via env/YAML (the gate above only covers the scanning.enabled
+	// toggle). Without this, admin-configured auto-update settings would never
+	// take effect at boot in that case.
+	if scanConfigJSON, err := oidcConfigRepo.GetScanningConfig(context.Background()); err == nil && scanConfigJSON != nil {
+		var dbCfg config.ScanningConfigDB
+		if err := json.Unmarshal(scanConfigJSON, &dbCfg); err != nil {
+			log.Printf("scanner startup: failed to parse persisted scanning config for auto-update reload: %v", err)
+		} else {
+			cfg.Scanning.AutoUpdate.Enabled = dbCfg.AutoUpdate.Enabled
+			cfg.Scanning.AutoUpdate.IntervalHours = dbCfg.AutoUpdate.IntervalHours
+			cfg.Scanning.AutoUpdate.RequiresApproval = dbCfg.AutoUpdate.RequiresApproval
+			cfg.Scanning.AutoUpdate.AutoApproveRules = dbCfg.AutoUpdate.AutoApproveRules
+		}
+	}
+
 	moduleScannerJob := jobs.NewModuleScannerJob(&cfg.Scanning, scanRepo, moduleRepo, storageBackend)
 	go func() {
 		if err := moduleScannerJob.Start(context.Background()); err != nil {
@@ -1006,6 +1022,10 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			authenticatedGroup.GET("/admin/scanning/latest",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScannerLatestHandler(&cfg.Scanning))
+			scanningAutoUpdateHandler := admin.NewScanningAutoUpdateHandler(&cfg.Scanning, oidcConfigRepo, scannerUpdateJob)
+			authenticatedGroup.PUT("/admin/scanning/auto-update",
+				middleware.RequireScope(auth.ScopeAdmin),
+				scanningAutoUpdateHandler.Put)
 
 			// Notifications (SMTP) admin endpoints
 			authenticatedGroup.GET("/admin/notifications/config",

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -219,6 +219,32 @@ type ScannerAutoUpdateConfig struct {
 	AutoApproveRules string `mapstructure:"auto_approve_rules"`
 }
 
+// ScanningConfigDB is the JSON shape persisted in system_settings.scanning_config.
+// It is exported so the setup wizard, the startup reload, the activation
+// reconciler, and the admin auto-update PUT handler all agree on the same shape
+// (a prior ad-hoc anonymous struct in the activation path omitted AutoUpdate,
+// silently wiping persisted auto-update settings on every activation).
+type ScanningConfigDB struct {
+	Enabled           bool                `json:"enabled"`
+	Tool              string              `json:"tool"`
+	BinaryPath        string              `json:"binary_path"`
+	ExpectedVersion   string              `json:"expected_version"`
+	SeverityThreshold string              `json:"severity_threshold"`
+	TimeoutSecs       int                 `json:"timeout_secs"`
+	WorkerCount       int                 `json:"worker_count"`
+	ScanIntervalMins  int                 `json:"scan_interval_mins"`
+	InstallDir        string              `json:"install_dir"`
+	AutoUpdate        ScannerAutoUpdateDB `json:"auto_update"`
+}
+
+// ScannerAutoUpdateDB is the JSON shape of ScanningConfigDB.AutoUpdate.
+type ScannerAutoUpdateDB struct {
+	Enabled          bool   `json:"enabled"`
+	IntervalHours    int    `json:"interval_hours"`
+	RequiresApproval bool   `json:"requires_approval"`
+	AutoApproveRules string `json:"auto_approve_rules,omitempty"`
+}
+
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
 	Host            string        `mapstructure:"host"`

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,6 +43,8 @@ type ScannerUpdateJob struct {
 	download     installer.InstallFunc
 	stopChan     chan struct{}
 	manualCh     chan struct{}
+	mu           sync.Mutex
+	started      bool
 }
 
 // NewScannerUpdateJob constructs a ScannerUpdateJob. check and download default to
@@ -92,6 +95,16 @@ func (j *ScannerUpdateJob) Start(ctx context.Context) {
 		return
 	}
 
+	j.mu.Lock()
+	if j.started {
+		j.mu.Unlock()
+		log.Println("[scanner-update] already running, ignoring duplicate Start")
+		return
+	}
+	j.started = true
+	stopChan := j.stopChan // capture under mutex; Stop() may replace the field concurrently
+	j.mu.Unlock()
+
 	intervalHours := j.scanCfg.AutoUpdate.IntervalHours
 	if intervalHours <= 0 {
 		intervalHours = 24
@@ -116,11 +129,14 @@ func (j *ScannerUpdateJob) Start(ctx context.Context) {
 			log.Println("[scanner-update] manual trigger received")
 			j.runCheck(ctx)
 			j.reconcileActivations(ctx)
-		case <-j.stopChan:
+		case <-stopChan:
 			log.Println("[scanner-update] stopped")
 			return
 		case <-ctx.Done():
 			log.Println("[scanner-update] context cancelled")
+			j.mu.Lock()
+			j.started = false
+			j.mu.Unlock()
 			return
 		}
 	}
@@ -135,9 +151,17 @@ func (j *ScannerUpdateJob) TriggerCheck() {
 	}
 }
 
-// Stop signals the background loop to exit.
+// Stop signals the background loop to exit. Safe to call multiple times and
+// safe to call when the job was never started; a subsequent Start() can run
+// again since the stop channel is replaced with a fresh one.
 func (j *ScannerUpdateJob) Stop() {
-	close(j.stopChan)
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.started {
+		close(j.stopChan)
+		j.stopChan = make(chan struct{}) // fresh channel so Start() can be called again
+		j.started = false
+	}
 }
 
 // runCheck queries upstream for the latest release of the configured tool and,
@@ -297,17 +321,7 @@ func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinary
 	j.scanCfg.BinaryPath = *v.BinaryPath
 	j.scanCfg.ExpectedVersion = v.Version
 
-	persisted := struct {
-		Enabled           bool   `json:"enabled"`
-		Tool              string `json:"tool"`
-		BinaryPath        string `json:"binary_path"`
-		ExpectedVersion   string `json:"expected_version"`
-		SeverityThreshold string `json:"severity_threshold"`
-		TimeoutSecs       int    `json:"timeout_secs"`
-		WorkerCount       int    `json:"worker_count"`
-		ScanIntervalMins  int    `json:"scan_interval_mins"`
-		InstallDir        string `json:"install_dir"`
-	}{
+	persisted := config.ScanningConfigDB{
 		Enabled:           j.scanCfg.Enabled,
 		Tool:              j.scanCfg.Tool,
 		BinaryPath:        j.scanCfg.BinaryPath,
@@ -317,6 +331,12 @@ func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinary
 		WorkerCount:       j.scanCfg.WorkerCount,
 		ScanIntervalMins:  j.scanCfg.ScanIntervalMins,
 		InstallDir:        j.scanCfg.InstallDir,
+		AutoUpdate: config.ScannerAutoUpdateDB{
+			Enabled:          j.scanCfg.AutoUpdate.Enabled,
+			IntervalHours:    j.scanCfg.AutoUpdate.IntervalHours,
+			RequiresApproval: j.scanCfg.AutoUpdate.RequiresApproval,
+			AutoApproveRules: j.scanCfg.AutoUpdate.AutoApproveRules,
+		},
 	}
 	jsonBytes, err := json.Marshal(persisted)
 	if err != nil {

--- a/backend/internal/jobs/scanner_update_job_test.go
+++ b/backend/internal/jobs/scanner_update_job_test.go
@@ -114,6 +114,57 @@ func TestResolveScannerApproval(t *testing.T) {
 	}
 }
 
+// TestScannerUpdateJob_RestartSafety proves Stop() is idempotent and that a
+// stopped job can be re-armed for a subsequent Start() (previously Stop() did
+// a one-shot close() with no reset, so a second Stop() panicked and
+// Start-after-Stop exited immediately on the already-closed channel). This
+// exercises the mutex/started/stopChan bookkeeping directly rather than
+// running the full check/reconcile loop, which needs live repos.
+func TestScannerUpdateJob_RestartSafety(t *testing.T) {
+	scanCfg := &config.ScanningConfig{
+		AutoUpdate: config.ScannerAutoUpdateConfig{Enabled: true},
+	}
+	job := newTestScannerUpdateJob(scanCfg)
+
+	// Stop() before any Start() must not panic (never started).
+	job.Stop()
+	if job.started {
+		t.Fatal("expected started=false after Stop() on a never-started job")
+	}
+
+	// Simulate what Start() does under the mutex without invoking the full
+	// check/reconcile loop.
+	job.mu.Lock()
+	job.started = true
+	job.mu.Unlock()
+
+	job.Stop()
+	if job.started {
+		t.Fatal("expected started=false after Stop()")
+	}
+
+	// A second Stop() call must not panic (previously: double-close panic).
+	job.Stop()
+
+	// stopChan must be a fresh, open channel after Stop() so Start() can run
+	// again (previously the closed channel would make the select's
+	// case <-stopChan fire immediately).
+	job.mu.Lock()
+	stopChan := job.stopChan
+	job.mu.Unlock()
+	select {
+	case <-stopChan:
+		t.Fatal("stopChan should be open (freshly reset) after Stop(), not already closed")
+	default:
+	}
+
+	// Re-arm and stop again to prove the cycle repeats without panicking.
+	job.mu.Lock()
+	job.started = true
+	job.mu.Unlock()
+	job.Stop()
+}
+
 func TestScannerUpdateJob_TriggerCheck_NonBlocking(t *testing.T) {
 	job := newTestScannerUpdateJob(&config.ScanningConfig{})
 


### PR DESCRIPTION
Follow-up #2 from the scanner-update work: let admins view/edit the scheduled auto-update settings from the UI.

- Augment GET /admin/scanning/config with an auto_update object; add PUT /admin/scanning/auto-update (admin scope).
- Persist auto_update via a shared config.ScanningConfigDB; Activate no longer wipes it; always-run reload at startup (outside the enabled-gate) so persisted settings apply even when scanning is enabled via env.
- Make ScannerUpdateJob restart-safe (mutex + started guard, channel reset on Stop) so interval/enable changes take effect at runtime without a pod restart.

Validates auto_approve_rules JSON via mirror.ParseAutoApproveRules. go build + full go test ./... green.