### PR TITLE
security: suppress G118 false positive on scanner job restart

### DIFF
--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -350,7 +350,11 @@ func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinary
 
 	if j.scannerJob != nil {
 		_ = j.scannerJob.Stop()
-		go func() {
+		// ModuleScannerJob is a long-lived daemon (indefinite polling loop). Its restart
+		// must outlive the caller's ctx — which, via the admin install+activate handler,
+		// is the HTTP request context and would cancel the job the moment the request
+		// returns. context.Background() is therefore intentional here, not a leak.
+		go func() { // #nosec G118 -- long-lived daemon restart must not inherit the request-scoped caller ctx
 			if err := j.scannerJob.Start(context.Background()); err != nil {
 				log.Printf("[scanner-update] scanner job failed to restart after activation: %v", err)
 			}


### PR DESCRIPTION
The five auto-filed gosec issues are all the same finding: G118 on the ModuleScannerJob restart in ScannerUpdateJob.Activate.

It is a false positive — the restarted job is a long-lived daemon (indefinite polling loop) that must outlive the caller ctx; via the admin install+activate handler that ctx is the HTTP request context and would cancel the job as soon as the request returns. context.Background() is intentional. Annotated with #nosec G118 + justification; gosec honors #nosec so the finding leaves the results and the baseline comparison passes.

Closes #533, #534, #535, #537, #539.