### PR TITLE
ci: auto-dispatch release build when release-please cuts a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,27 @@ jobs:
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
 
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062 # v5
         with:
           token: ${{ steps.token.outputs.token }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # When a release is cut, release-please creates a DRAFT GitHub Release and
+      # tag using the app token. A tag pushed by an app/bot token does not fire
+      # release.yml's `on: push: tags` trigger, so the draft would otherwise
+      # never be built or published (this is what stalled earlier releases).
+      # Explicitly dispatch release.yml against the new tag using the same app
+      # token — which, unlike the default GITHUB_TOKEN, is permitted to start
+      # workflow runs. release.yml uploads the built artifacts to the draft and
+      # publishes it, which in turn fires the `release: published` event that
+      # wiki-sync.yml listens for.
+      - name: Dispatch release build for the new tag
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ steps.release.outputs.tag_name }}"


### PR DESCRIPTION
## Problem

release-please creates a **draft** GitHub Release + tag using the `RELEASE_DISPATCH` app token. A tag pushed by an app/bot token does **not** fire `release.yml`'s `on: push: tags` trigger, so the draft was never built or published automatically. This stalled the 2.7.0 release entirely and forced manual `gh workflow run release.yml --ref vX.Y.Z` for 2.7.1 and 2.7.2.

## Fix

Add a step to `release-please.yml` that, when a release is cut (`release_created == 'true'`), dispatches `release.yml` against the new tag using the **same app token** — which, unlike the default `GITHUB_TOKEN`, is permitted to start workflow runs.

This uses the already-proven `workflow_dispatch` path: `release.yml` builds artifacts, uploads them to the **draft** (still mutable), and publishes it — which in turn fires the `release: published` event that `wiki-sync.yml` already listens for. Fully hands-free, and aligned with the existing draft→upload→publish design.

Note: `release: [published]` would **not** work here — it fires after the release is already published/immutable, too late for `publish-release` to upload assets.

## Risk

Additive and low-risk: if the app lacks `actions: write` the dispatch step simply fails without affecting release-please creating the PR/release (i.e. no worse than today's manual flow). No change to `release.yml` itself.