### PR TITLE
fix(scanning): stop scanner update from deleting the just-installed binary

### DIFF
--- a/backend/internal/db/repositories/scanner_binary_version_repository.go
+++ b/backend/internal/db/repositories/scanner_binary_version_repository.go
@@ -25,10 +25,15 @@ func NewScannerBinaryVersionRepository(db *sqlx.DB) *ScannerBinaryVersionReposit
 	return &ScannerBinaryVersionRepository{db: db}
 }
 
-// Upsert inserts a discovered version row, or does nothing if (tool, version)
-// already exists. Returns the resulting row (including generated fields).
-// approval_status is intentionally NOT touched on conflict: a re-discovery
-// must never reset an already-decided version back to pending.
+// Upsert inserts a discovered version row, or returns the existing row unchanged
+// when (tool, version) already exists. Either way v is populated with the
+// canonical row — including its real id and other generated fields — so callers
+// can safely reference v.ID afterwards. (A stale id previously caused
+// approval-event FK violations and made cleanup delete the active version.)
+// The ON CONFLICT clause performs a no-op UPDATE (tool = itself) solely so
+// RETURNING yields the existing row; no meaningful column is modified, and
+// approval_status in particular is never reset, so a re-discovery cannot move an
+// already-decided version back to pending.
 func (r *ScannerBinaryVersionRepository) Upsert(ctx context.Context, v *models.ScannerBinaryVersion) error {
 	if v.ID == uuid.Nil {
 		v.ID = uuid.New()
@@ -39,7 +44,7 @@ func (r *ScannerBinaryVersionRepository) Upsert(ctx context.Context, v *models.S
 			id, tool, version, source_url, sha256, signature_verified, signature_type,
 			sync_status, approval_status, is_active, binary_path
 		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-		ON CONFLICT (tool, version) DO NOTHING
+		ON CONFLICT (tool, version) DO UPDATE SET tool = EXCLUDED.tool
 		RETURNING id, tool, version, source_url, sha256, signature_verified, signature_type,
 		          sync_status, approval_status, is_active, binary_path, discovered_at, created_at
 	`
@@ -71,10 +76,6 @@ func (r *ScannerBinaryVersionRepository) Upsert(ctx context.Context, v *models.S
 		&v.DiscoveredAt,
 		&v.CreatedAt,
 	)
-	if err == sql.ErrNoRows {
-		// Conflict hit DO NOTHING: row already existed, nothing was returned.
-		return nil
-	}
 	if err != nil {
 		return fmt.Errorf("failed to upsert scanner binary version: %w", err)
 	}

--- a/backend/internal/db/repositories/scanner_binary_version_repository_test.go
+++ b/backend/internal/db/repositories/scanner_binary_version_repository_test.go
@@ -6,7 +6,6 @@ package repositories
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -62,14 +61,30 @@ func TestScannerBinaryVersionRepository_Upsert_Inserted(t *testing.T) {
 	}
 }
 
-func TestScannerBinaryVersionRepository_Upsert_ConflictNoOp(t *testing.T) {
+func TestScannerBinaryVersionRepository_Upsert_ConflictReturnsExisting(t *testing.T) {
 	repo, mock := newScannerBinaryVersionRepo(t)
 
-	mock.ExpectQuery(`INSERT INTO scanner_binary_versions`).WillReturnError(sql.ErrNoRows)
+	// On a (tool, version) conflict the no-op UPDATE returns the EXISTING row, whose
+	// id differs from the caller's throwaway id. Upsert must overwrite v with that
+	// canonical row so callers reference the real id (a stale id previously caused
+	// approval-event FK violations and made cleanup delete the active version).
+	existingID := uuid.New()
+	now := time.Now()
+	rows := sqlmock.NewRows(scannerBinaryVersionCols).AddRow(
+		existingID, "trivy", "0.60.0", nil, nil, false, "",
+		"downloaded", nil, false, nil, now, now,
+	)
+	mock.ExpectQuery(`INSERT INTO scanner_binary_versions`).WillReturnRows(rows)
 
 	v := &models.ScannerBinaryVersion{ID: uuid.New(), Tool: "trivy", Version: "0.60.0"}
 	if err := repo.Upsert(context.Background(), v); err != nil {
-		t.Fatalf("expected nil error on conflict-do-nothing, got: %v", err)
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.ID != existingID {
+		t.Errorf("expected canonical existing id %s, got %s", existingID, v.ID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }
 

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -374,31 +374,48 @@ func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinary
 }
 
 // cleanupSuperseded best-effort removes versioned install directories for other
-// versions of the tool now that v is active. Never fails activation; errors are
-// logged only. Only removes directories that match the {InstallDir}/{tool}-{version}
-// pattern used by installer.DownloadVerified, so an activated version's symlink
-// target (bare {InstallDir}/{tool}) is never touched.
-// coverage:skip:integration-only — requires a live ScannerBinaryVersionRepository (PostgreSQL) plus real filesystem directories under InstallDir; only ever called from Activate.
+// versions of the tool now that active is the current version. Never fails
+// activation; errors are logged only. The set of directories to remove is decided
+// by supersededDirsToRemove (unit-tested); this method performs only the IO.
+// coverage:skip:integration-only — requires a live ScannerBinaryVersionRepository (PostgreSQL) plus real filesystem directories under InstallDir; only ever called from Activate. The removal decision is covered by TestSupersededDirsToRemove.
 func (j *ScannerUpdateJob) cleanupSuperseded(ctx context.Context, active *models.ScannerBinaryVersion) {
 	rows, err := j.sbvRepo.ListForTool(ctx, active.Tool)
 	if err != nil {
 		log.Printf("[scanner-update] cleanup: failed to list versions for %s: %v", active.Tool, err)
 		return
 	}
+	for _, dir := range supersededDirsToRemove(rows, active, j.scanCfg.InstallDir) {
+		if err := os.RemoveAll(dir); err != nil {
+			log.Printf("[scanner-update] cleanup: failed to remove superseded dir %s: %v", dir, err)
+		}
+	}
+}
 
-	versionedPrefix := filepath.Join(j.scanCfg.InstallDir, active.Tool+"-")
+// supersededDirsToRemove returns the versioned install directories safe to remove
+// now that active is the current version. A directory qualifies only when it
+// belongs to a different row, sits under the tool's versioned prefix
+// ({InstallDir}/{tool}-), and is NOT the active version's own directory. That last
+// guard is critical: a stale/duplicate row for the active version (a different id
+// pointing at the same versioned dir) must never cause the just-activated binary to
+// be deleted — the bug this guards against left an empty dir and a dangling symlink.
+func supersededDirsToRemove(rows []models.ScannerBinaryVersion, active *models.ScannerBinaryVersion, installDir string) []string {
+	versionedPrefix := filepath.Join(installDir, active.Tool+"-")
+	activeVersionDir := filepath.Join(installDir, active.Tool+"-"+active.Version)
+	var dirs []string
 	for _, row := range rows {
 		if row.ID == active.ID || row.BinaryPath == nil {
 			continue
 		}
 		dir := filepath.Dir(*row.BinaryPath)
+		if dir == activeVersionDir {
+			continue // never remove the active version's directory
+		}
 		if !strings.HasPrefix(dir, versionedPrefix) {
-			continue // not a versioned dir (e.g. the active symlink path) — never remove
+			continue // not a versioned dir (e.g. the active symlink path)
 		}
-		if err := os.RemoveAll(dir); err != nil {
-			log.Printf("[scanner-update] cleanup: failed to remove superseded dir %s: %v", dir, err)
-		}
+		dirs = append(dirs, dir)
 	}
+	return dirs
 }
 
 // notify sends an admin notification email about a newly discovered scanner

--- a/backend/internal/jobs/scanner_update_job_test.go
+++ b/backend/internal/jobs/scanner_update_job_test.go
@@ -5,10 +5,14 @@
 package jobs
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
 // newTestScannerUpdateJob builds a ScannerUpdateJob with only scanCfg populated,
@@ -25,6 +29,43 @@ func newTestScannerUpdateJob(scanCfg *config.ScanningConfig) *ScannerUpdateJob {
 		nil, // check (defaults to installer.CheckLatest, unused here)
 		nil, // download (defaults to installer.DownloadVerified, unused here)
 	)
+}
+
+func TestSupersededDirsToRemove(t *testing.T) {
+	installDir := t.TempDir()
+	activeID := uuid.New()
+	active := &models.ScannerBinaryVersion{ID: activeID, Tool: "trivy", Version: "0.72.0"}
+
+	activeDir := filepath.Join(installDir, "trivy-0.72.0")
+	supersededDir := filepath.Join(installDir, "trivy-0.71.0")
+	bp := func(s string) *string { return &s }
+
+	rows := []models.ScannerBinaryVersion{
+		// the active row itself — skipped by id
+		{ID: activeID, Tool: "trivy", Version: "0.72.0", BinaryPath: bp(filepath.Join(activeDir, "trivy"))},
+		// a stale DUPLICATE row for the active version with a different id — must be
+		// skipped by the active-version-dir guard (this is the incident scenario)
+		{ID: uuid.New(), Tool: "trivy", Version: "0.72.0", BinaryPath: bp(filepath.Join(activeDir, "trivy"))},
+		// a genuinely superseded version — removable
+		{ID: uuid.New(), Tool: "trivy", Version: "0.71.0", BinaryPath: bp(filepath.Join(supersededDir, "trivy"))},
+		// a row with no recorded binary path — skipped
+		{ID: uuid.New(), Tool: "trivy", Version: "0.70.0", BinaryPath: nil},
+		// the bare symlink path (dir is InstallDir, not a versioned dir) — skipped
+		{ID: uuid.New(), Tool: "trivy", Version: "sym", BinaryPath: bp(filepath.Join(installDir, "trivy"))},
+	}
+
+	got := supersededDirsToRemove(rows, active, installDir)
+
+	if len(got) != 1 || got[0] != supersededDir {
+		t.Fatalf("supersededDirsToRemove = %v, want [%s]", got, supersededDir)
+	}
+	// The active version's directory must never be scheduled for removal, even though
+	// a duplicate row referenced it with a different id.
+	for _, d := range got {
+		if d == activeDir {
+			t.Fatalf("active version dir %q must never be removed", activeDir)
+		}
+	}
 }
 
 func TestResolveScannerApproval(t *testing.T) {

--- a/backend/internal/scanner/installer/sigstore.go
+++ b/backend/internal/scanner/installer/sigstore.go
@@ -31,7 +31,13 @@ var (
 // coverage:skip:integration-only — fetches the real Sigstore public-good trusted root over the network via TUF; no fixture/fake TUF mirror exists to exercise this hermetically.
 func loadTrustedRoot() (*root.TrustedRoot, error) {
 	trustedRootOnce.Do(func() {
-		client, err := tuf.New(tuf.DefaultOptions())
+		// DisableLocalCache lets the TUF client work on a read-only root filesystem
+		// (e.g. Kubernetes pods with readOnlyRootFilesystem: true). Without it the
+		// client tries to mkdir $HOME/.sigstore/tuf, which fails and silently
+		// disables Sigstore verification, falling back to SHA256-only.
+		opts := tuf.DefaultOptions()
+		opts.DisableLocalCache = true
+		client, err := tuf.New(opts)
 		if err != nil {
 			trustedRootErr = fmt.Errorf("create TUF client: %w", err)
 			return


### PR DESCRIPTION
## Problem

On a read-only-root AKS pod, admin "Install & Activate" of Trivy left `/app/scanners/trivy-<ver>/` **empty** with a dangling `trivy` symlink, so the version probe (and scans) failed with `not found` and the UI showed **"Detected Version: not reported by backend"**.

Root cause chain (from pod logs): `Upsert` used `ON CONFLICT (tool,version) DO NOTHING ... RETURNING`, which returns **no row** on conflict, so the in-memory `v.ID` kept a throwaway UUID. That single stale id caused:
1. the `version_approval_events` **FK violation** on install, and
2. `cleanupSuperseded` to key off the wrong id and `RemoveAll` the **active** version's dir (deleting the binary it had just installed).

## Fixes

1. **`Upsert` returns the canonical row** — `ON CONFLICT DO UPDATE SET tool = EXCLUDED.tool ... RETURNING` (no-op update; `approval_status` untouched) so `v.ID` is the real row id. Fixes the FK violation and the cleanup id-mismatch.
2. **`cleanupSuperseded` never deletes the active version's dir** — guards on the version directory, not just the row id. Extracted the decision into the pure, unit-tested `supersededDirsToRemove` (defense-in-depth; the incident scenario — a duplicate active-version row with a different id — is covered by `TestSupersededDirsToRemove`).
3. **Sigstore on read-only FS** — `loadTrustedRoot` sets `tuf.Options.DisableLocalCache` so verification stops silently falling back to SHA256-only (`mkdir \C:\Users\SBACON1/.sigstore: read-only file system`).

## Validation

- `go test ./internal/...` green; new/updated unit tests for the Upsert canonical-id behavior and the cleanup guard.
- Filtered coverage 80.0% (gate: >=80). No swagger diff. gosec `New: 0`.

After release, the cluster fix is simply to re-run **Install & Activate** — the binary now persists.