### PR TITLE
feat(scanning): optional dedicated scan-worker mode for horizontal scaling

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -27,10 +27,12 @@
 // @tag.description  Prometheus metrics and profiling are served on a dedicated side-channel port (default: 9090) that is separate from the main API server. This keeps the scrape path off the public ingress and avoids rate-limiting middleware. Configure the port with TFR_TELEMETRY_METRICS_PROMETHEUS_PORT. The endpoint path is always GET /metrics. pprof (if enabled via TFR_TELEMETRY_PROFILING_ENABLED=true) is served on TFR_TELEMETRY_PROFILING_PORT (default: 6060) at the standard /debug/pprof/ paths. Neither endpoint is part of the OpenAPI spec because they are not served by the Gin router.
 
 // Package main is the entry point for the Terraform Registry server binary.
-// It dispatches three subcommands — serve, migrate, and version — via a simple
-// switch on os.Args so the binary's full CLI surface is readable in one place
-// without requiring a cobra dependency. The serve command runs auto-migration on
-// startup so freshly deployed containers never need a separate migration step.
+// It dispatches subcommands — serve, migrate, version, upgrade, and scan-worker —
+// via a simple switch on os.Args so the binary's full CLI surface is readable in
+// one place without requiring a cobra dependency. The serve command runs
+// auto-migration on startup so freshly deployed containers never need a separate
+// migration step. The scan-worker command runs only the module security scanner
+// loop so scanning can scale horizontally on dedicated pods.
 package main
 
 import (
@@ -63,6 +65,8 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/jobs"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -111,8 +115,10 @@ func run() error {
 		return nil
 	case "upgrade":
 		return runUpgrade(configPath)
+	case "scan-worker":
+		return scanWorker(cfg)
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade", command)
+		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker", command)
 	}
 }
 
@@ -148,6 +154,74 @@ func runUpgrade(configPath string) error {
 		os.Exit(code)
 	}
 	return nil
+}
+
+// scanWorker runs the module security scanner loop as a standalone process,
+// decoupled from the API server so scanning can scale horizontally across
+// dedicated pods. The API server is expected to run with
+// scanning.embedded_worker=false (it still creates pending scans and installs
+// scanner binaries via the control plane), while one or more scan-worker
+// processes consume the shared module_version_scans queue. Claiming is race-safe
+// via an atomic UPDATE, so any number of workers can run concurrently.
+//
+// Unlike serve(), the worker does NOT run database migrations (the API server
+// owns the schema) and does NOT start the HTTP API, metrics endpoint, or
+// control-plane jobs. Scanning must be enabled via env/YAML config
+// (TFR_SCANNING_*); the worker forces scanning.embedded_worker=true for its own
+// process regardless of the API-server setting.
+func scanWorker(cfg *config.Config) error {
+	telemetry.SetupLogger(cfg.Logging.Format, cfg.Logging.Level)
+
+	// This process IS the scan worker: always run the scanner loop in-process,
+	// even when the shared config disables the embedded worker on the API server.
+	cfg.Scanning.EmbeddedWorker = true
+
+	if !cfg.Scanning.Enabled {
+		slog.Warn("scan-worker: scanning is disabled (scanning.enabled=false); the worker will idle until scanning is enabled via TFR_SCANNING_ENABLED / config")
+	}
+
+	// Connect to the database. The worker shares the API server's schema and must
+	// NOT run migrations (the API server owns migrations).
+	database, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer database.Close()
+	slog.Info("scan-worker: connected to database")
+
+	storageBackend, err := storage.NewStorage(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to initialize storage backend: %w", err)
+	}
+
+	scanRepo := repositories.NewModuleScanRepository(database)
+	moduleRepo := repositories.NewModuleRepository(database)
+	scannerJob := jobs.NewModuleScannerJob(&cfg.Scanning, scanRepo, moduleRepo, storageBackend)
+
+	// Handle SIGINT/SIGTERM for graceful shutdown (Kubernetes sends SIGTERM on
+	// pod termination). Cancelling ctx stops the scanner loop.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("scan-worker: starting", "version", Version, "build_date", BuildDate)
+
+	// Start blocks while the scan loop runs and returns nil early when the scanner
+	// is not yet ready (binary missing, version mismatch, or scanning disabled).
+	// In the not-ready case, wait and retry so the worker comes online
+	// automatically once the control plane installs the scanner binary on the
+	// shared volume, rather than crash-looping the pod.
+	for {
+		if err := scannerJob.Start(ctx); err != nil {
+			slog.Error("scan-worker: scanner loop error", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			slog.Info("scan-worker: shutting down")
+			return nil
+		case <-time.After(30 * time.Second):
+			slog.Info("scan-worker: scanner not ready, retrying")
+		}
+	}
 }
 
 func serve(cfg *config.Config) error {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -186,6 +186,12 @@ type ScanningConfig struct {
 	WorkerCount int `mapstructure:"worker_count"`
 	// ScanIntervalMins is how often the scanner job polls for pending scans (default 5).
 	ScanIntervalMins int `mapstructure:"scan_interval_mins"`
+	// EmbeddedWorker controls whether this process runs the module scanner loop
+	// in-process (default true). Set false on the API server when scans are handled
+	// by dedicated `scan-worker` pods; the scan-worker entrypoint forces it true so
+	// the same env/YAML can disable in-process scanning on the API server while the
+	// worker still runs.
+	EmbeddedWorker bool `mapstructure:"embedded_worker"`
 	// VersionArgs is the CLI arguments used to obtain the binary version string.
 	// Required when tool is "custom"; ignored otherwise.
 	VersionArgs []string `mapstructure:"version_args"`
@@ -856,6 +862,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"scanning.timeout",
 		"scanning.worker_count",
 		"scanning.scan_interval_mins",
+		"scanning.embedded_worker",
 		"scanning.version_args",
 		"scanning.scan_args",
 		"scanning.output_format",
@@ -1059,6 +1066,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("scanning.timeout", 5*time.Minute)
 	v.SetDefault("scanning.worker_count", 2)
 	v.SetDefault("scanning.scan_interval_mins", 5)
+	v.SetDefault("scanning.embedded_worker", true)
 	v.SetDefault("scanning.install_dir", "/app/scanners")
 	v.SetDefault("scanning.signature_verification", "enforce")
 	v.SetDefault("scanning.auto_update.enabled", false)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -623,6 +623,45 @@ func TestScanningConfig_DefaultInstallDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ScanningConfig — EmbeddedWorker default + env override
+// ---------------------------------------------------------------------------
+
+func TestScanningConfig_DefaultEmbeddedWorker(t *testing.T) {
+	// Clear any env that might override the default.
+	for _, key := range os.Environ() {
+		if strings.HasPrefix(key, "TFR_SCANNING_") {
+			parts := strings.SplitN(key, "=", 2)
+			os.Unsetenv(parts[0])
+		}
+	}
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Scanning.EmbeddedWorker {
+		t.Error("Scanning.EmbeddedWorker = false, want true (default: the API server runs the scanner in-process)")
+	}
+}
+
+func TestScanningConfig_EmbeddedWorkerEnvOverride(t *testing.T) {
+	for _, key := range os.Environ() {
+		if strings.HasPrefix(key, "TFR_SCANNING_") {
+			parts := strings.SplitN(key, "=", 2)
+			os.Unsetenv(parts[0])
+		}
+	}
+	t.Setenv("TFR_SCANNING_EMBEDDED_WORKER", "false")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Scanning.EmbeddedWorker {
+		t.Error("Scanning.EmbeddedWorker = true, want false (TFR_SCANNING_EMBEDDED_WORKER=false)")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // SuiteConfig.RoleSeedOwner / ShouldSeedRoles
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -100,6 +100,53 @@ func (r *ModuleScanRepository) ListPendingScans(ctx context.Context, limit int) 
 	return scans, rows.Err()
 }
 
+// ClaimPendingScans atomically claims up to limit pending scan records for the
+// calling worker, transitioning them from 'pending' to 'scanning' in a single
+// statement and returning the claimed rows. It uses FOR UPDATE SKIP LOCKED so
+// concurrent workers claim disjoint batches without blocking or racing on the
+// same rows, which lets scan workers scale horizontally without wasted
+// contention. The returned records are already marked 'scanning'; callers must
+// NOT call MarkScanning for them.
+func (r *ModuleScanRepository) ClaimPendingScans(ctx context.Context, limit int) ([]*models.ModuleScan, error) {
+	const q = `
+		UPDATE module_version_scans
+		SET status = 'scanning', updated_at = NOW()
+		WHERE id IN (
+			SELECT id FROM module_version_scans
+			WHERE status = 'pending'
+			ORDER BY created_at
+			LIMIT $1
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, module_version_id, scanner, scanner_version, expected_version,
+		          status, scanned_at, critical_count, high_count, medium_count, low_count,
+		          raw_results, error_message, execution_log, created_at, updated_at
+	`
+	rows, err := r.db.QueryContext(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("claim pending scans: %w", err)
+	}
+	defer rows.Close()
+
+	var scans []*models.ModuleScan
+	for rows.Next() {
+		s := &models.ModuleScan{}
+		var rawResults []byte
+		if err := rows.Scan(
+			&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
+			&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
+			&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		if len(rawResults) > 0 {
+			s.RawResults = json.RawMessage(rawResults)
+		}
+		scans = append(scans, s)
+	}
+	return scans, rows.Err()
+}
+
 // MarkScanning transitions a pending scan to 'scanning'.
 // Uses a conditional UPDATE to prevent two workers from claiming the same record.
 // Returns ErrScanAlreadyClaimed if no rows are updated.

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -114,6 +114,58 @@ func TestListPendingScans_DBError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ClaimPendingScans
+// ---------------------------------------------------------------------------
+
+func TestClaimPendingScans_Success(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("UPDATE module_version_scans.*FOR UPDATE SKIP LOCKED").
+		WithArgs(4).
+		WillReturnRows(sampleScanRow())
+
+	scans, err := repo.ClaimPendingScans(context.Background(), 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(scans) != 1 {
+		t.Errorf("len(scans) = %d, want 1", len(scans))
+	}
+	if scans[0].ID != "scan-1" {
+		t.Errorf("scan ID = %q, want scan-1", scans[0].ID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations: %v", err)
+	}
+}
+
+func TestClaimPendingScans_Empty(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("UPDATE module_version_scans.*FOR UPDATE SKIP LOCKED").
+		WithArgs(4).
+		WillReturnRows(sqlmock.NewRows(scanCols))
+
+	scans, err := repo.ClaimPendingScans(context.Background(), 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(scans) != 0 {
+		t.Errorf("expected empty, got %d", len(scans))
+	}
+}
+
+func TestClaimPendingScans_DBError(t *testing.T) {
+	repo, mock := newScanRepo(t)
+	mock.ExpectQuery("UPDATE module_version_scans.*FOR UPDATE SKIP LOCKED").
+		WithArgs(4).
+		WillReturnError(errors.New("db error"))
+
+	_, err := repo.ClaimPendingScans(context.Background(), 4)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // MarkScanning
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/jobs/module_scanner_job.go
+++ b/backend/internal/jobs/module_scanner_job.go
@@ -4,7 +4,6 @@ package jobs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -58,6 +57,10 @@ func (j *ModuleScannerJob) Name() string { return "module-scanner" }
 func (j *ModuleScannerJob) Start(ctx context.Context) error {
 	if !j.cfg.Enabled {
 		slog.Info("module scanner: disabled (scanning.enabled=false)")
+		return nil
+	}
+	if !j.cfg.EmbeddedWorker {
+		slog.Info("module scanner: in-process scanning disabled (scanning.embedded_worker=false); scans are handled by dedicated scan-worker pods")
 		return nil
 	}
 	if j.cfg.BinaryPath == "" {
@@ -156,39 +159,42 @@ func (j *ModuleScannerJob) runScanCycle(ctx context.Context, s scanner.Scanner, 
 		workerCount = 2
 	}
 
-	pending, err := j.scanRepo.ListPendingScans(ctx, workerCount*2)
-	if err != nil {
-		slog.Error("module scanner: failed to list pending scans", "error", err)
-		return
-	}
-	if len(pending) == 0 {
-		return
-	}
+	// Drain the queue: keep atomically claiming and processing batches until no
+	// pending scans remain. ClaimPendingScans uses FOR UPDATE SKIP LOCKED, so when
+	// multiple scan-worker pods run concurrently they claim disjoint batches
+	// without contending on the same rows.
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		claimed, err := j.scanRepo.ClaimPendingScans(ctx, workerCount*2)
+		if err != nil {
+			slog.Error("module scanner: failed to claim pending scans", "error", err)
+			return
+		}
+		if len(claimed) == 0 {
+			return
+		}
 
-	sem := make(chan struct{}, workerCount)
-	var wg sync.WaitGroup
-	for _, scan := range pending {
-		scan := scan
-		sem <- struct{}{}
-		wg.Add(1)
-		safego.Go(func() {
-			defer func() { <-sem; wg.Done() }()
-			j.scanOne(ctx, s, scan.ID, scan.ModuleVersionID, version)
-		})
+		sem := make(chan struct{}, workerCount)
+		var wg sync.WaitGroup
+		for _, scan := range claimed {
+			scan := scan
+			sem <- struct{}{}
+			wg.Add(1)
+			safego.Go(func() {
+				defer func() { <-sem; wg.Done() }()
+				j.scanOne(ctx, s, scan.ID, scan.ModuleVersionID, version)
+			})
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 }
 
 // coverage:skip:integration-only — requires real scanner binary, DB, and storage
 func (j *ModuleScannerJob) scanOne(ctx context.Context, s scanner.Scanner, scanID, moduleVersionID, actualVersion string) {
-	if err := j.scanRepo.MarkScanning(ctx, scanID); err != nil {
-		if errors.Is(err, repositories.ErrScanAlreadyClaimed) {
-			return // another worker got it first
-		}
-		slog.Error("module scanner: failed to mark scanning", "scan_id", scanID, "error", err)
-		return
-	}
-
+	// The scan record was already atomically claimed (status='scanning') by
+	// ClaimPendingScans in runScanCycle, so there is no MarkScanning step here.
 	mv, err := j.moduleRepo.GetVersionByID(ctx, moduleVersionID)
 	if err != nil || mv == nil {
 		_ = j.scanRepo.MarkError(ctx, scanID, "module version not found")

--- a/backend/internal/jobs/module_scanner_job_test.go
+++ b/backend/internal/jobs/module_scanner_job_test.go
@@ -13,8 +13,9 @@ import (
 // Start() returns immediately without attempting to exec a binary.
 func newTestScannerJob(enabled bool, binaryPath string) *ModuleScannerJob {
 	cfg := &config.ScanningConfig{
-		Enabled:    enabled,
-		BinaryPath: binaryPath,
+		Enabled:        enabled,
+		EmbeddedWorker: true,
+		BinaryPath:     binaryPath,
 	}
 	return NewModuleScannerJob(cfg, nil, nil, nil)
 }
@@ -71,6 +72,24 @@ func TestModuleScannerJob_Start_Disabled(t *testing.T) {
 	job := newTestScannerJob(false, "")
 	if err := job.Start(context.Background()); err != nil {
 		t.Errorf("Start (disabled) error = %v", err)
+	}
+}
+
+func TestModuleScannerJob_Start_EmbeddedWorkerDisabled(t *testing.T) {
+	// Enabled with a binary path but the embedded worker turned off: Start must be
+	// a no-op because scans are handled by dedicated scan-worker pods. It must
+	// return before setting started (a true no-op, not a started loop).
+	cfg := &config.ScanningConfig{
+		Enabled:        true,
+		EmbeddedWorker: false,
+		BinaryPath:     "/nonexistent/path/to/scanner",
+	}
+	job := NewModuleScannerJob(cfg, nil, nil, nil)
+	if err := job.Start(context.Background()); err != nil {
+		t.Errorf("Start (embedded worker disabled) error = %v", err)
+	}
+	if job.started {
+		t.Error("Start (embedded worker disabled) should not set started")
 	}
 }
 


### PR DESCRIPTION
## Why

Module scanning runs in-process in the backend, which is pinned to a **single replica** (in-memory rate limiting, no Redis). Combined with the per-cycle cap (`workerCount*2` per `scanIntervalMins`), throughput tops out around ~48 scans/hr, so a large upload burst (1,300+ pending) drains very slowly. Scanner workers serve no HTTP and don't rate-limit, so they can scale freely — this PR makes that an **opt-in** deployment mode.

## What (Phase 1 — backend only)

- **`scanning.embedded_worker` config** (`TFR_SCANNING_EMBEDDED_WORKER`, default **true**). Backend behaves exactly as today unless set false, so single-node installs are unaffected.
- **`scan-worker` subcommand** (same image, `command: ["...","scan-worker"]`): wires DB + storage + `ModuleScannerJob` only — no HTTP server — and retries until scanning config/binary is ready.
- **`ClaimPendingScans`**: atomic `UPDATE ... WHERE status='pending' ... FOR UPDATE SKIP LOCKED` batch claim, so N workers pull **disjoint** rows without contending. `runScanCycle` now **drains in a loop**, keeping workers saturated instead of one capped batch per tick.
- Builds on the existing `MarkScanning` compare-and-swap + `ResetStaleScanningRecords` (visibility-timeout requeue), which already made the queue distributed-safe.

Control plane (backend, 1 replica) still owns install/activate/approve of the scanner binary; data plane (workers, N replicas) just consumes it.

## Validation

- Unit tests for `ClaimPendingScans`, the `EmbeddedWorker` gate, and the config default/env-override.
- Full suite green; filtered coverage **80.0%** (>=80 gate); `go vet` clean; no swagger diff; gosec `New: 0`.

## Follow-up (Phase 2)

Helm `scanner-worker` Deployment + KEDA `ScaledObject` scaling on pending-scan count, behind a values flag (separate PR).
