### PR TITLE
feat(helm): scan-worker deployment + optional KEDA autoscaling (Phase 2)

### DIFF
--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -85,6 +85,9 @@ data:
   # Module security scanning
   TFR_SCANNING_ENABLED: {{ .Values.scanning.enabled | quote }}
   {{- if .Values.scanning.enabled }}
+  # When dedicated scan-workers are enabled, disable the backend's in-process
+  # scanner so the workers own the queue (workers force this on themselves).
+  TFR_SCANNING_EMBEDDED_WORKER: {{ not .Values.scannerWorker.enabled | quote }}
   TFR_SCANNING_TOOL: {{ .Values.scanning.tool | quote }}
   TFR_SCANNING_BINARY_PATH: {{ .Values.scanning.binaryPath | quote }}
   {{- if .Values.scanning.expectedVersion }}

--- a/deployments/helm/templates/scanner-worker-deployment.yaml
+++ b/deployments/helm/templates/scanner-worker-deployment.yaml
@@ -1,0 +1,139 @@
+{{- if and .Values.scanning.enabled .Values.scannerWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-scanner-worker
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner-worker
+spec:
+  {{- if not .Values.scannerWorker.keda.enabled }}
+  # When KEDA is enabled the ScaledObject owns the replica count (and can scale
+  # to zero), so we omit replicas here to avoid fighting the autoscaler.
+  replicas: {{ .Values.scannerWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "terraform-registry.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: scanner-worker
+  template:
+    metadata:
+      labels:
+        {{- include "terraform-registry.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: scanner-worker
+        # Azure Workload Identity: label is required on the pod for the
+        # mutating webhook to inject the OIDC federated token volume.
+        # Safe to include on non-AKS clusters (label is ignored without the webhook).
+        azure.workload.identity/use: "true"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "terraform-registry.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
+      containers:
+        - name: scanner-worker
+          image: {{ include "terraform-registry.backendImage" . }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.backend.securityContext | nindent 12 }}
+          # Overrides the image CMD (["serve"]); keeps the ENTRYPOINT binary.
+          # scan-worker runs the scan queue drainer with no HTTP server.
+          args: ["scan-worker"]
+          envFrom:
+            - configMapRef:
+                name: {{ include "terraform-registry.fullname" . }}-config
+            - secretRef:
+                name: {{ include "terraform-registry.secretName" . }}
+          {{- if .Values.externalDatabase.existingSecret }}
+            - secretRef:
+                name: {{ .Values.externalDatabase.existingSecret }}
+          {{- end }}
+          {{- $workerEnv := concat (.Values.backend.extraEnv | default list) (.Values.scannerWorker.extraEnv | default list) }}
+          {{- with $workerEnv }}
+          # backend.extraEnv is applied so workers share the backend's storage
+          # and database credentials (e.g. storage account key secretKeyRef).
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.scannerWorker.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if eq .Values.storage.backend "local" }}
+            - name: storage
+              mountPath: {{ .Values.storage.local.basePath }}
+            {{- end }}
+            {{- if .Values.scanning.installDir }}
+            # Read-only: the backend (control plane) installs scanner binaries
+            # onto the shared PVC; workers only execute them.
+            - name: scanners
+              mountPath: {{ .Values.scanning.installDir }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.keyVault.enabled }}
+            - name: secrets-store
+              mountPath: /mnt/secrets-store
+              readOnly: true
+            {{- end }}
+            {{- with .Values.backend.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if eq .Values.storage.backend "local" }}
+        - name: storage
+          {{- if .Values.storage.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.persistence.existingClaim | default (printf "%s-storage" (include "terraform-registry.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.scanning.installDir }}
+        - name: scanners
+          {{- if .Values.scanning.installDirPVC }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.scanning.installDirPVC }}
+          {{- else }}
+          # NOTE: worker mode expects scanning.installDirPVC (a shared RWX PVC)
+          # so workers can see the binary the backend installed. An emptyDir here
+          # would be empty and the worker would have no scanner to run.
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.keyVault.enabled }}
+        - name: secrets-store
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "terraform-registry.fullname" . }}-secrets
+        {{- end }}
+        {{- with .Values.backend.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.scannerWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scannerWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scannerWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scannerWorker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deployments/helm/templates/scanner-worker-scaledobject.yaml
+++ b/deployments/helm/templates/scanner-worker-scaledobject.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.scanning.enabled .Values.scannerWorker.enabled .Values.scannerWorker.keda.enabled }}
+{{- /*
+  Requires the KEDA operator (https://keda.sh) to be installed in the cluster.
+  KEDA scales the scanner-worker Deployment on the number of pending rows in
+  module_version_scans, and can scale to zero when the queue is empty.
+  The DB password is read from the same secret the app uses; host/port/user/db
+  come from externalDatabase values (mirrors the configmap).
+*/}}
+{{- $dbSecret := .Values.externalDatabase.existingSecret | default (include "terraform-registry.secretName" .) }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-scanner-worker-pg
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner-worker
+spec:
+  secretTargetRef:
+    - parameter: password
+      name: {{ $dbSecret }}
+      key: TFR_DATABASE_PASSWORD
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "terraform-registry.fullname" . }}-scanner-worker
+  labels:
+    {{- include "terraform-registry.labels" . | nindent 4 }}
+    app.kubernetes.io/component: scanner-worker
+spec:
+  scaleTargetRef:
+    name: {{ include "terraform-registry.fullname" . }}-scanner-worker
+  pollingInterval: {{ .Values.scannerWorker.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.scannerWorker.keda.cooldownPeriod }}
+  minReplicaCount: {{ .Values.scannerWorker.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.scannerWorker.keda.maxReplicaCount }}
+  triggers:
+    - type: postgresql
+      metadata:
+        host: {{ .Values.externalDatabase.host | quote }}
+        port: {{ .Values.externalDatabase.port | quote }}
+        userName: {{ .Values.externalDatabase.user | quote }}
+        dbName: {{ .Values.externalDatabase.name | quote }}
+        sslmode: {{ .Values.externalDatabase.sslMode | quote }}
+        # Scale on the depth of the pending scan queue. Desired replicas is
+        # approximately ceil(pending / targetQueryValue).
+        query: "SELECT count(*) FROM module_version_scans WHERE status = 'pending'"
+        targetQueryValue: {{ .Values.scannerWorker.keda.targetPendingScans | quote }}
+      authenticationRef:
+        name: {{ include "terraform-registry.fullname" . }}-scanner-worker-pg
+{{- end }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -325,6 +325,49 @@ scanning:
   #    survive pod restarts. Leave empty to disable auto-install.
   installDir: "/app/scanners"
 
+# -- Dedicated scan-worker deployment for horizontally scaling module scanning.
+#    When enabled, the backend stops scanning in-process (the configmap sets
+#    TFR_SCANNING_EMBEDDED_WORKER=false) and these workers drain the shared
+#    scan queue instead. Requires scanning.enabled and, in practice,
+#    scanning.installDirPVC (a shared RWX PVC) so workers can read the scanner
+#    binary the backend installs. See docs/scanner-worker.md.
+scannerWorker:
+  # -- Deploy dedicated scan-worker pods
+  enabled: false
+  # -- Static replica count (ignored when keda.enabled is true)
+  replicaCount: 2
+  # -- Resource requests and limits (scanning is CPU/memory intensive)
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  # -- Additional environment variables for worker pods. backend.extraEnv is
+  #    always applied first so workers share the backend's storage/DB
+  #    credentials; these are appended after it.
+  extraEnv: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  # -- KEDA event-driven autoscaling on the pending scan queue.
+  #    Requires the KEDA operator (https://keda.sh). When enabled, KEDA owns
+  #    the replica count (replicaCount is ignored) and can scale to zero.
+  keda:
+    enabled: false
+    # -- Target pending scans per replica (KEDA targetQueryValue)
+    targetPendingScans: 20
+    # -- Minimum replicas (0 enables scale-to-zero)
+    minReplicaCount: 0
+    # -- Maximum replicas
+    maxReplicaCount: 10
+    # -- How often (seconds) KEDA polls the queue depth
+    pollingInterval: 30
+    # -- Seconds to wait before scaling back down after the last trigger
+    cooldownPeriod: 300
+
 # -- Audit logging configuration
 audit:
   # -- Enable audit logging

--- a/docs/module-scanning.md
+++ b/docs/module-scanning.md
@@ -165,6 +165,7 @@ All options live under the `scanning:` key in `config.yaml` or use the `TFR_SCAN
 | `timeout`            | `TFR_SCANNING_TIMEOUT`            | duration | `5m`    | Maximum time a single scan may run before it is killed.                                                                   |
 | `worker_count`       | `TFR_SCANNING_WORKER_COUNT`       | int      | `2`     | Number of scans to run concurrently.                                                                                      |
 | `scan_interval_mins` | `TFR_SCANNING_SCAN_INTERVAL_MINS` | int      | `5`     | How often (in minutes) the job polls for pending scans.                                                                   |
+| `embedded_worker`    | `TFR_SCANNING_EMBEDDED_WORKER`    | bool     | `true`  | Run the scanner in-process in the backend. Set `false` when running dedicated [scan-worker pods](scanner-worker.md) so only the workers drain the queue. |
 | `version_args`       | `TFR_SCANNING_VERSION_ARGS`       | string[] | —       | **Custom tool only.** CLI arguments to retrieve the binary version, e.g. `["--version"]`.                                 |
 | `scan_args`          | `TFR_SCANNING_SCAN_ARGS`          | string[] | —       | **Custom tool only.** CLI arguments passed before the target directory, e.g. `["iac", "test", "--json"]`.                 |
 | `output_format`      | `TFR_SCANNING_OUTPUT_FORMAT`      | string   | —       | **Custom tool only.** How to parse the tool's output: `sarif` or `json`.                                                  |

--- a/docs/scanner-worker.md
+++ b/docs/scanner-worker.md
@@ -1,0 +1,114 @@
+<!-- markdownlint-disable MD013 -->
+
+# Dedicated Scan Workers
+
+By default the backend scans modules **in-process**: a background job in the API
+server polls the queue and runs the scanner. Because the backend runs as a
+single replica (in-memory rate limiting, no shared cache), scanning throughput is
+capped regardless of cluster size. For large upload bursts you can instead run
+**dedicated scan-worker pods** that scale horizontally and independently of the
+API server.
+
+This is an **opt-in** deployment mode. Single-node and default installs are
+unaffected — the backend keeps scanning in-process unless you enable workers.
+
+## How it works
+
+Scanning is queue-driven via the `module_version_scans` table. Claims are atomic
+(`UPDATE ... WHERE status = 'pending' ... FOR UPDATE SKIP LOCKED`) and stale
+`scanning` rows are automatically requeued after a visibility timeout, so any
+number of workers can drain the queue concurrently without double-scanning.
+
+```mermaid
+flowchart LR
+    U[Upload / re-scan] --> Q[(module_version_scans<br/>status=pending)]
+    B[Backend API<br/>1 replica<br/>control plane] -- installs scanner binary --> PVC[(scanners PVC<br/>RWX)]
+    Q --> W1[scan-worker 1]
+    Q --> W2[scan-worker 2]
+    Q --> Wn[scan-worker N]
+    PVC -. read-only .-> W1 & W2 & Wn
+    W1 & W2 & Wn --> R[(scan results)]
+```
+
+- **Control plane** — the backend (1 replica) still owns install / activate /
+  approve of the scanner binary and writes it to the shared scanners PVC.
+- **Data plane** — worker pods (N replicas) mount that PVC **read-only** and
+  execute the binary to drain the queue.
+
+When workers are enabled the Helm chart sets `TFR_SCANNING_EMBEDDED_WORKER=false`
+on the backend so it stops scanning in-process; the workers force the flag on for
+themselves. The `scan-worker` process runs no HTTP server, exposes no ports, and
+retries startup until the scanner binary is installed and activated.
+
+## Requirements
+
+- **Shared scanner binary storage.** Set `scanning.installDirPVC` to a
+  **ReadWriteMany** PVC (e.g. Azure Files) so the backend can write the binary
+  and every worker can read it. An `emptyDir` would be empty on each worker.
+- **Image with the `scan-worker` subcommand.** Use a backend image that supports
+  `terraform-registry scan-worker` (2.8.0+).
+- **KEDA operator** (only if you enable `scannerWorker.keda`).
+
+## Enabling workers (Helm)
+
+```yaml
+scanning:
+  enabled: true
+  tool: trivy
+  installDir: /app/scanners
+  installDirPVC: terraform-registry-scanners # shared RWX PVC
+
+scannerWorker:
+  enabled: true
+  replicaCount: 2 # static count when KEDA is disabled
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+```
+
+The workers reuse `backend.extraEnv`, the config ConfigMap, and the app Secret, so
+they inherit the same database and storage credentials as the backend
+(for example an Azure storage account key injected via `backend.extraEnv`).
+
+## Autoscaling with KEDA
+
+Enable [KEDA](https://keda.sh) to scale workers on the depth of the pending
+queue, including **scale-to-zero** when idle:
+
+```yaml
+scannerWorker:
+  enabled: true
+  keda:
+    enabled: true
+    targetPendingScans: 20 # desired replicas ≈ ceil(pending / 20)
+    minReplicaCount: 0 # scale to zero when the queue is empty
+    maxReplicaCount: 10
+    pollingInterval: 30
+    cooldownPeriod: 300
+```
+
+The chart renders a `ScaledObject` with a PostgreSQL trigger that counts pending
+scans, plus a `TriggerAuthentication` that reads the DB password from the same
+secret the app uses (`TFR_DATABASE_PASSWORD`). When KEDA is enabled it owns the
+replica count, so `replicaCount` is ignored.
+
+## Operational notes
+
+- **Activating or updating the scanner requires a worker rollout.** The backend
+  writes the binary to the PVC, but each worker resolves the binary at startup.
+  After installing or upgrading the scanner, restart the workers:
+
+  ```bash
+  kubectl rollout restart deployment/<release>-scanner-worker -n <namespace>
+  ```
+
+- **Rollback.** Set `scannerWorker.enabled=false` to remove the workers; the
+  backend automatically resumes in-process scanning (`TFR_SCANNING_EMBEDDED_WORKER`
+  returns to `true`) on its next config reload/restart.
+
+See [module-scanning.md](module-scanning.md) for scanner setup and the full
+configuration reference.


### PR DESCRIPTION
## Why

Follow-up to #548 (Phase 1 backend `scan-worker` mode). This is Phase 2: the Helm deployment side so scanning can actually scale horizontally on the cluster.

## What (Phase 2 — chart + docs)

- **`scanner-worker` Deployment** (`templates/scanner-worker-deployment.yaml`): runs the backend image with `args: ["scan-worker"]` — no HTTP server, ports, or probes. Mounts `/tmp` (emptyDir), the shared scanners PVC **read-only** (backend installs the binary, workers only execute it), storage/secrets like the backend, and reuses `backend.extraEnv` so workers share the same DB/storage credentials.
- **Config wiring** (`configmap.yaml`): `TFR_SCANNING_EMBEDDED_WORKER` is now emitted — **`false` when `scannerWorker.enabled`** so the backend stops scanning in-process and hands the queue to the workers, `true` otherwise (unchanged behavior).
- **KEDA autoscaling** (`templates/scanner-worker-scaledobject.yaml`, opt-in): `ScaledObject` with a PostgreSQL trigger on `count(*) ... WHERE status='pending'` and **scale-to-zero**, plus a `TriggerAuthentication` that reads the DB password from the existing app secret. When KEDA owns the count, the Deployment omits `replicas`.
- **Values** (`scannerWorker` block, default **off**): `enabled`, `replicaCount`, `resources`, scheduling, and a `keda` sub-block (`targetPendingScans`, min/max replicas, polling/cooldown).
- **Docs**: new `docs/scanner-worker.md` (architecture, requirements, enable/KEDA/rollback, operational notes) + an `embedded_worker` row in `docs/module-scanning.md`.

## Validation

`helm lint` clean and `helm template` verified across all paths:

- workers + KEDA → worker Deployment (no `replicas`) + `ScaledObject` + `TriggerAuthentication`, `EMBEDDED_WORKER=false`
- workers, KEDA off → worker Deployment with static `replicas: 2`, no `ScaledObject`
- workers off (default) → no worker resources, `EMBEDDED_WORKER=true`

## Dependencies / activation

- Depends on #548 (the image must support the `scan-worker` subcommand, 2.8.0+).
- Requires `scanning.installDirPVC` to be a **ReadWriteMany** PVC so workers can read the backend-installed binary.
- **Do not enable in the AKS env until the 2.8.0+ image ships.** To activate later: set `scannerWorker.enabled: true` (+ optional `keda.enabled: true`) in `terraform-registry-aks/helm/values-aks-ent.yaml`, and `kubectl rollout restart` the workers whenever the scanner binary is (re)installed.
