### PR TITLE
fix(security): prevent email header and path injection (CodeQL)

### DIFF
--- a/backend/internal/notify/mailer.go
+++ b/backend/internal/notify/mailer.go
@@ -37,9 +37,16 @@ func (m *Mailer) Send(to []string, subject, body string) error {
 	if m.cfg == nil {
 		return fmt.Errorf("mailer: nil smtp config")
 	}
+	// Strip CR/LF from header-bound fields to prevent SMTP header (CRLF)
+	// injection: recipients, subject and From must each occupy a single line.
+	// The body is not header-bound, so it is delivered as-is after the blank line.
+	recipients := make([]string, len(to))
+	for i, addr := range to {
+		recipients[i] = sanitizeHeader(addr)
+	}
 	headers := fmt.Sprintf(
 		"From: %s\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n",
-		m.cfg.From, strings.Join(to, ", "), subject,
+		sanitizeHeader(m.cfg.From), strings.Join(recipients, ", "), sanitizeHeader(subject),
 	)
 	msg := []byte(headers + body + "\r\n")
 
@@ -47,9 +54,16 @@ func (m *Mailer) Send(to []string, subject, body string) error {
 	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
 
 	if m.cfg.UseTLS {
-		return sendMailTLS(addr, m.cfg.Host, auth, m.cfg.From, to, msg)
+		return sendMailTLS(addr, m.cfg.Host, auth, m.cfg.From, recipients, msg)
 	}
-	return smtp.SendMail(addr, auth, m.cfg.From, to, msg)
+	return smtp.SendMail(addr, auth, m.cfg.From, recipients, msg)
+}
+
+// sanitizeHeader removes CR and LF characters so a value cannot inject
+// additional SMTP headers (email header / CRLF injection). Per RFC 5322 a
+// header value must occupy a single line.
+func sanitizeHeader(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
 // sendMailTLS connects via implicit TLS (port 465 / SMTPS) and sends a message.

--- a/backend/internal/notify/mailer_test.go
+++ b/backend/internal/notify/mailer_test.go
@@ -38,3 +38,24 @@ func TestSend_NilConfig_ReturnsError(t *testing.T) {
 		t.Errorf("err = %q, want %q", err.Error(), "mailer: nil smtp config")
 	}
 }
+
+// TestSanitizeHeader verifies CR/LF are stripped so a crafted subject or
+// recipient cannot inject additional SMTP headers (email header injection).
+func TestSanitizeHeader(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", "Weekly digest", "Weekly digest"},
+		{"crlf header injection", "Subject\r\nBcc: victim@example.com", "SubjectBcc: victim@example.com"},
+		{"lf only", "line1\nline2", "line1line2"},
+		{"cr only", "a\rb", "ab"},
+		{"address injection", "user@example.com\r\nRCPT TO:<evil@x>", "user@example.comRCPT TO:<evil@x>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeHeader(tt.in); got != tt.want {
+				t.Errorf("sanitizeHeader(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/scanner/installer/installer.go
+++ b/backend/internal/scanner/installer/installer.go
@@ -74,6 +74,7 @@ var (
 	ErrNonHTTPS              = errors.New("refusing to download from non-HTTPS URL")
 	ErrArchiveTooLarge       = errors.New("archive exceeds size cap")
 	ErrPathTraversal         = errors.New("archive contains a path-traversal entry")
+	ErrUnsafePath            = errors.New("unsafe path component in a download name or version")
 )
 
 // InstallFunc is the handler-facing type alias so tests can inject a stub.
@@ -180,6 +181,21 @@ func matchAssets(spec AssetSpec, release *ghRelease) (archive, checksums, sig *g
 // verifies its integrity, and extracts the target binary to the versioned install
 // path {cfg.InstallDir}/{tool}-{version}/{basename(spec.BinaryInArchive)}. It is
 // shared by Install and DownloadVerified; neither creates/updates the {tool} symlink.
+// safeChildPath joins name onto dir and guarantees the result stays within dir.
+// It rejects names containing path separators or parent references ("..") and
+// verifies containment, defending against path traversal from remote-influenced
+// values such as GitHub release asset names and version tags (go/path-injection).
+func safeChildPath(dir, name string) (string, error) {
+	if name == "" || strings.ContainsAny(name, `/\`) || strings.Contains(name, "..") {
+		return "", fmt.Errorf("%w: %q", ErrUnsafePath, name)
+	}
+	p := filepath.Join(dir, name)
+	if !strings.HasPrefix(p, filepath.Clean(dir)+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%w: %q escapes %q", ErrUnsafePath, name, dir)
+	}
+	return p, nil
+}
+
 func downloadExtract(ctx context.Context, client *http.Client, cfg InstallConfig, spec AssetSpec, tool, version string, archiveAsset, checksumsAsset, sigAsset *ghAsset) (versionedBinaryPath, sha256hex, sourceURL string, sigVerified bool, sigType string, err error) {
 	// Validate HTTPS-only.
 	if !strings.HasPrefix(archiveAsset.BrowserDownloadURL, "https://") {
@@ -196,8 +212,12 @@ func downloadExtract(ctx context.Context, client *http.Client, cfg InstallConfig
 	}
 	defer os.RemoveAll(tmpDir) // always clean up temp
 
-	// Download archive with size cap.
-	archivePath := filepath.Join(tmpDir, archiveAsset.Name)
+	// Download archive with size cap. safeChildPath guards against a malicious
+	// release asset name escaping the temp dir (go/path-injection).
+	archivePath, pErr := safeChildPath(tmpDir, archiveAsset.Name)
+	if pErr != nil {
+		return "", "", "", false, "", pErr
+	}
 	archiveHash, dlErr := downloadFile(ctx, client, archiveAsset.BrowserDownloadURL, archivePath, maxArchiveSize)
 	if dlErr != nil {
 		return "", "", "", false, "", dlErr
@@ -207,7 +227,10 @@ func downloadExtract(ctx context.Context, client *http.Client, cfg InstallConfig
 	var checksumsData []byte
 	switch {
 	case checksumsAsset != nil:
-		checksumsPath := filepath.Join(tmpDir, checksumsAsset.Name)
+		checksumsPath, pErr := safeChildPath(tmpDir, checksumsAsset.Name)
+		if pErr != nil {
+			return "", "", "", false, "", fmt.Errorf("checksums: %w", pErr)
+		}
 		if _, dlErr := downloadFile(ctx, client, checksumsAsset.BrowserDownloadURL, checksumsPath, maxChecksumsSize); dlErr != nil {
 			return "", "", "", false, "", fmt.Errorf("download checksums: %w", dlErr)
 		}
@@ -227,8 +250,12 @@ func downloadExtract(ctx context.Context, client *http.Client, cfg InstallConfig
 		return "", "", "", false, "", sigErr
 	}
 
-	// Extract binary from archive.
-	versionDir := filepath.Join(cfg.InstallDir, tool+"-"+version)
+	// Extract binary from archive. safeChildPath guards against a malicious
+	// version tag escaping InstallDir (go/path-injection).
+	versionDir, pErr := safeChildPath(cfg.InstallDir, tool+"-"+version)
+	if pErr != nil {
+		return "", "", "", false, "", pErr
+	}
 	if mkErr := os.MkdirAll(versionDir, 0o755); mkErr != nil { // #nosec G301 -- scanner binary directory needs execute permission
 		return "", "", "", false, "", fmt.Errorf("create version dir: %w", mkErr)
 	}

--- a/backend/internal/scanner/installer/installer_test.go
+++ b/backend/internal/scanner/installer/installer_test.go
@@ -950,6 +950,31 @@ func TestInstall_BareChecksumsFile_Matches(t *testing.T) {
 	}
 }
 
+// TestSafeChildPath verifies the path-traversal guard used when joining
+// remote-influenced download names and version tags onto a base directory.
+func TestSafeChildPath(t *testing.T) {
+	base := t.TempDir()
+
+	// Safe single-component names are accepted and stay within base.
+	for _, name := range []string{"trivy_0.56.0_Linux-64bit.tar.gz", "checksums.txt", "trivy-0.56.0"} {
+		got, err := safeChildPath(base, name)
+		if err != nil {
+			t.Errorf("safeChildPath(%q) unexpected error: %v", name, err)
+			continue
+		}
+		if want := filepath.Join(base, name); got != want {
+			t.Errorf("safeChildPath(%q) = %q, want %q", name, got, want)
+		}
+	}
+
+	// Traversal / separator / empty names are rejected with ErrUnsafePath.
+	for _, name := range []string{"", "..", "../evil", "a/b", `a\b`, "trivy-../../etc", "foo/../../bar"} {
+		if _, err := safeChildPath(base, name); !errors.Is(err, ErrUnsafePath) {
+			t.Errorf("safeChildPath(%q) error = %v, want ErrUnsafePath", name, err)
+		}
+	}
+}
+
 // setupSigstoreCatalog is a shared helper for the sigstore verification tests below:
 // it stands up a test server serving an archive+checksums+sigstore-bundle asset trio
 // for trivy, swaps it into the Catalog for the current platform, and restores the


### PR DESCRIPTION
## Why

CodeQL flagged 6 alerts on the 2.8.0 cut — fixing them for 2.8.1.

| Rule | Severity | File | Count |
|------|----------|------|-------|
| `go/email-injection` | critical | `internal/notify/mailer.go` | 3 |
| `go/path-injection` | high | `internal/scanner/installer/installer.go` | 3 |

## What

**Email header (CRLF) injection — `mailer.go`.** `Send` composed RFC822 headers by interpolating `From`, `To`, and `Subject` straight into the header block. A value containing `\r\n` could inject extra SMTP headers (e.g. `Bcc:`). Added `sanitizeHeader`, which strips CR/LF, and applied it to all three header fields (and the envelope recipients). The body is untouched — it is not header-bound.

**Path injection — `installer.go`.** GitHub release asset names and the version tag (from `release.TagName`) flowed into `filepath.Join` for the download temp files and the versioned install dir, so a malicious release could traverse outside the intended directory. Added `safeChildPath`, which rejects path separators and `..` and verifies the joined path stays within the base dir, and applied it at the three joins. (`tool` was already enum-validated via `Lookup`/`Supports`.)

## Tests

- `TestSanitizeHeader` — CRLF/injection cases stripped.
- `TestSafeChildPath` — safe names accepted; traversal/separator/empty rejected with `ErrUnsafePath`.

## Validation

`go build` + `go vet` clean; package tests pass; gosec **New: 0** vs baseline; filtered coverage **80.0%** (≥80 gate). No API changes (no swagger diff).
