### PR TITLE
fix: setup/status 500 - map notifications columns in SystemSettings

### DIFF
--- a/backend/internal/db/models/storage_config.go
+++ b/backend/internal/db/models/storage_config.go
@@ -28,6 +28,12 @@ type SystemSettings struct {
 	LDAPConfigured   bool         `db:"ldap_configured" json:"ldap_configured"`
 	LDAPConfiguredAt sql.NullTime `db:"ldap_configured_at" json:"ldap_configured_at,omitempty"`
 	LDAPConfig       []byte       `db:"ldap_config" json:"ldap_config,omitempty"`
+	// Notifications/SMTP setup (migration 000043). These columns are read by the
+	// SELECT * queries in GetEnhancedSetupStatus / GetSystemSettings; sqlx (not in
+	// Unsafe mode) errors on any table column that has no struct field here.
+	NotificationsConfigured   bool         `db:"notifications_configured" json:"notifications_configured"`
+	NotificationsConfiguredAt sql.NullTime `db:"notifications_configured_at" json:"notifications_configured_at,omitempty"`
+	NotificationsConfig       []byte       `db:"notifications_config" json:"notifications_config,omitempty"`
 	// Audit retention (migration 000023)
 	AuditRetentionDays int       `db:"audit_retention_days" json:"audit_retention_days"`
 	CreatedAt          time.Time `db:"created_at" json:"created_at"`

--- a/backend/internal/db/repositories/oidc_config_repository_test.go
+++ b/backend/internal/db/repositories/oidc_config_repository_test.go
@@ -525,6 +525,52 @@ func TestGetEnhancedSetupStatus_PendingFeature(t *testing.T) {
 	}
 }
 
+// TestGetEnhancedSetupStatus_FullSchemaColumns guards the `SELECT * FROM
+// system_settings` scan against schema/struct drift. The other tests above mock
+// only a subset of columns, so they pass even when the SystemSettings struct is
+// missing a field for a real column (sqlx only errors on a returned column that
+// has no destination field). This test returns the COMPLETE column set produced
+// by all migrations — including the notifications columns added in migration
+// 000043 — so that a future migration adding a system_settings column without a
+// matching struct field fails here instead of only surfacing as a runtime 500 on
+// /api/v1/setup/status (regression: PR #531 / migration 000043; same class as PR #187).
+func TestGetEnhancedSetupStatus_FullSchemaColumns(t *testing.T) {
+	repo, mock := newOIDCConfigRepo(t)
+
+	// Every column present on system_settings after all migrations are applied.
+	settingsCols := []string{
+		"id", "storage_configured", "storage_configured_at", "storage_configured_by",
+		"setup_completed", "setup_token_hash", "oidc_configured", "pending_admin_email",
+		"scanning_configured", "scanning_configured_at", "scanning_config",
+		"audit_retention_days",
+		"auth_method", "ldap_configured", "ldap_configured_at", "ldap_config",
+		"notifications_configured", "notifications_configured_at", "notifications_config",
+		"created_at", "updated_at",
+	}
+	now := time.Now()
+	mock.ExpectQuery("SELECT.*FROM system_settings").
+		WillReturnRows(sqlmock.NewRows(settingsCols).AddRow(
+			1, true, now, nil,
+			true, nil, true, "admin@example.com",
+			true, now, nil,
+			30,
+			"oidc", false, nil, nil,
+			true, now, []byte(`{"smtp_host":"smtp.example.com"}`),
+			now, now,
+		))
+
+	status, err := repo.GetEnhancedSetupStatus(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error scanning full system_settings schema: %v", err)
+	}
+	if !status.SetupCompleted {
+		t.Error("expected SetupCompleted = true")
+	}
+	if status.AuthMethod != "oidc" {
+		t.Errorf("expected AuthMethod = oidc, got %q", status.AuthMethod)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CreateOIDCConfig
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`GET /api/v1/setup/status` returns **HTTP 500** against a fully-migrated database. This breaks the frontend E2E gate (setup-wizard redirect + logout tests) and, in turn, the frontend weekly security scan (sethbacon/terraform-registry-frontend#465).

## Root cause

`GetEnhancedSetupStatus` and `GetSystemSettings` run `SELECT * FROM system_settings` into `models.SystemSettings` via sqlx (not in `Unsafe` mode). Migration `000043_setup_notifications` added `notifications_configured`, `notifications_configured_at`, and `notifications_config`, but the struct was never updated — so sqlx fails to scan the unmapped columns (`missing destination name …`) and the handler returns 500.

Unit tests use `sqlmock` with only a subset of columns, so they never exercised the real schema and didn't catch it. This is the same class of bug as #187 (scanning/audit columns).

## Fix

- Add the three `notifications_*` fields to `SystemSettings`.
- Add `TestGetEnhancedSetupStatus_FullSchemaColumns`, which mocks the complete 21-column `system_settings` schema (including the notifications columns) so future column/struct drift fails as a unit-test failure instead of a runtime 500.

## Testing

- `go test ./internal/db/repositories/ ./internal/api/setup/` — pass (including the new regression test)
- `go build ./...` — pass

## Related

- Fixes the backend root cause behind sethbacon/terraform-registry-frontend#465.
- A backend release is required so the frontend E2E (which pulls `:latest`) picks up the fix.
