### PR TITLE
fix(security): close quick-win findings from 2026-07-09 audit

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -38,6 +38,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -422,6 +423,7 @@ func serve(cfg *config.Config) error {
 		WriteTimeout:      cfg.Server.WriteTimeout,
 		ReadHeaderTimeout: 10 * time.Second,  // Prevents Slowloris attacks
 		IdleTimeout:       120 * time.Second, // Close idle keep-alive connections
+		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12}, // Explicit floor instead of relying on crypto/tls defaults
 	}
 
 	// Start server in a goroutine

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -89,6 +89,18 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			return
 		}
 
+		// Registry protocol paths are built from these segments — validate them the
+		// same way module upload does, so unvalidated identifiers never reach the
+		// DB or the storage key builder.
+		for field, val := range map[string]string{"namespace": namespace, "type": providerType} {
+			if err := validation.ValidateRegistrySegment(val); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": fmt.Sprintf("Invalid %s: %v", field, err),
+				})
+				return
+			}
+		}
+
 		// Validate semantic versioning
 		if err := validation.ValidateSemver(version); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -739,7 +739,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	policyAdminHandler := admin.NewPolicyHandler(policyEngine, cfg.Policy)
 
 	// Initialize SCM webhook handler
-	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher)
+	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher, tokenCipher)
 	approvalWebhookHandler := webhooks.NewApprovalHandler(rbacRepo)
 
 	// Initialize rate limiters (conditionally, based on config)
@@ -1211,8 +1211,8 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			// Role Templates management
 			roleTemplatesGroup := authenticatedGroup.Group("/admin/role-templates")
 			{
-				roleTemplatesGroup.GET("", rbacHandlers.ListRoleTemplates)
-				roleTemplatesGroup.GET("/:id", rbacHandlers.GetRoleTemplate)
+				roleTemplatesGroup.GET("", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.ListRoleTemplates)
+				roleTemplatesGroup.GET("/:id", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.GetRoleTemplate)
 				roleTemplatesGroup.POST("", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.CreateRoleTemplate)
 				roleTemplatesGroup.PUT("/:id", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.UpdateRoleTemplate)
 				roleTemplatesGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.DeleteRoleTemplate)
@@ -1585,10 +1585,12 @@ func CORSMiddleware(cfg *config.Config) gin.HandlerFunc {
 				// Wildcard config but specific origin present —
 				// reflect origin WITHOUT credentials (safer than true wildcard)
 				c.Header("Access-Control-Allow-Origin", origin)
+				c.Header("Vary", "Origin")
 			} else {
 				// Specific origin match — credentials allowed
 				c.Header("Access-Control-Allow-Origin", origin)
 				c.Header("Access-Control-Allow-Credentials", "true")
+				c.Header("Vary", "Origin")
 			}
 			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization, X-Requested-With")

--- a/backend/internal/api/webhooks/scm_webhook.go
+++ b/backend/internal/api/webhooks/scm_webhook.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
@@ -23,17 +24,19 @@ import (
 
 // SCMWebhookHandler handles incoming SCM webhooks
 type SCMWebhookHandler struct {
-	scmRepo    *repositories.SCMRepository
-	publisher  *services.SCMPublisher
-	connectors map[scm.ProviderType]scm.Connector
+	scmRepo     *repositories.SCMRepository
+	publisher   *services.SCMPublisher
+	connectors  map[scm.ProviderType]scm.Connector
+	tokenCipher *crypto.TokenCipher
 }
 
 // NewSCMWebhookHandler creates a new webhook handler
-func NewSCMWebhookHandler(scmRepo *repositories.SCMRepository, publisher *services.SCMPublisher) *SCMWebhookHandler {
+func NewSCMWebhookHandler(scmRepo *repositories.SCMRepository, publisher *services.SCMPublisher, tokenCipher *crypto.TokenCipher) *SCMWebhookHandler {
 	return &SCMWebhookHandler{
-		scmRepo:    scmRepo,
-		publisher:  publisher,
-		connectors: make(map[scm.ProviderType]scm.Connector),
+		scmRepo:     scmRepo,
+		publisher:   publisher,
+		connectors:  make(map[scm.ProviderType]scm.Connector),
+		tokenCipher: tokenCipher,
 	}
 }
 
@@ -115,11 +118,16 @@ func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
 	if provider.BaseURL != nil {
 		baseURL = *provider.BaseURL
 	}
+	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
+		return
+	}
 	connector, err := scm.BuildConnector(&scm.ConnectorSettings{
 		Kind:            provider.ProviderType,
 		InstanceBaseURL: baseURL,
 		ClientID:        provider.ClientID,
-		ClientSecret:    provider.ClientSecretEncrypted, // Will need decryption
+		ClientSecret:    clientSecret,
 		CallbackURL:     "",
 	})
 	if err != nil {

--- a/backend/internal/api/webhooks/scm_webhook_test.go
+++ b/backend/internal/api/webhooks/scm_webhook_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 
 	// Register SCM connectors so scm.BuildConnector works in tests
@@ -27,6 +28,19 @@ import (
 var webhookErrDB = errors.New("db error")
 
 const webhookTestUUID = "11111111-1111-1111-1111-111111111111"
+
+// testTokenCipher returns a TokenCipher backed by a fixed 32-byte key, used to
+// seal realistic ciphertext for client_secret_encrypted test fixtures so the
+// handler's tokenCipher.Open call exercises real decryption rather than
+// failing on a placeholder string.
+func testTokenCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	tc, err := crypto.NewTokenCipher([]byte("01234567890123456789012345678901"))
+	if err != nil {
+		t.Fatalf("crypto.NewTokenCipher: %v", err)
+	}
+	return tc
+}
 
 // ---------------------------------------------------------------------------
 // Column definitions (db tags from ModuleSCMRepo / SCMProvider structs)
@@ -94,7 +108,7 @@ func newWebhookRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	scmRepo := repositories.NewSCMRepository(sqlxDB)
-	h := NewSCMWebhookHandler(scmRepo, nil) // nil publisher OK for early-exit tests
+	h := NewSCMWebhookHandler(scmRepo, nil, testTokenCipher(t)) // nil publisher OK for early-exit tests
 
 	r := gin.New()
 	r.POST("/webhooks/scm/:module_source_repo_id/:secret", h.HandleWebhook)
@@ -199,12 +213,17 @@ func TestWebhook_GetProvider_NotFound(t *testing.T) {
 	}
 }
 
-func sampleProviderRow(id uuid.UUID, providerType string) *sqlmock.Rows {
+func sampleProviderRow(t *testing.T, id uuid.UUID, providerType string) *sqlmock.Rows {
+	t.Helper()
 	baseURL := "https://bitbucket.example.com"
+	encryptedSecret, err := testTokenCipher(t).Seal("test-client-secret")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
 	return sqlmock.NewRows(scmProviderCols).AddRow(
 		id, uuid.New(), providerType, "Test Provider",
 		&baseURL, nil, "client-id",
-		"encrypted-secret", "", // empty webhook_secret
+		encryptedSecret, "", // empty webhook_secret
 		true, time.Now(), time.Now(),
 	)
 }
@@ -217,7 +236,7 @@ func TestWebhook_InvalidConnectorType(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
 		WillReturnRows(sampleModuleSourceRepoRow(providerID))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRow(providerID, "unknown_type"))
+		WillReturnRows(sampleProviderRow(t, providerID, "unknown_type"))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", nil))
@@ -255,7 +274,7 @@ func TestWebhook_InvalidConnectorTypeMismatch(t *testing.T) {
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRow(providerID, "unknown_provider_type"))
+		WillReturnRows(sampleProviderRow(t, providerID, "unknown_provider_type"))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", nil))
@@ -275,7 +294,7 @@ func TestWebhook_InvalidHMACSignature(t *testing.T) {
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRow(providerID, "bitbucket_dc"))
+		WillReturnRows(sampleProviderRow(t, providerID, "bitbucket_dc"))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", nil))
@@ -418,12 +437,17 @@ const testWebhookSecret = "test-webhook-secret-123"
 
 // sampleProviderRowWithSecret is like sampleProviderRow but sets a non-empty webhook_secret
 // so HMAC-based signature verification can pass.
-func sampleProviderRowWithSecret(id uuid.UUID, providerType, webhookSecret string) *sqlmock.Rows {
+func sampleProviderRowWithSecret(t *testing.T, id uuid.UUID, providerType, webhookSecret string) *sqlmock.Rows {
+	t.Helper()
 	baseURL := "https://bitbucket.example.com"
+	encryptedSecret, err := testTokenCipher(t).Seal("test-client-secret")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
 	return sqlmock.NewRows(scmProviderCols).AddRow(
 		id, uuid.New(), providerType, "Test Provider",
 		&baseURL, nil, "client-id",
-		"encrypted-secret", webhookSecret,
+		encryptedSecret, webhookSecret,
 		true, time.Now(), time.Now(),
 	)
 }
@@ -446,7 +470,7 @@ func TestWebhook_ParseDeliveryError(t *testing.T) {
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRowWithSecret(providerID, "bitbucket_dc", testWebhookSecret))
+		WillReturnRows(sampleProviderRowWithSecret(t, providerID, "bitbucket_dc", testWebhookSecret))
 
 	req := httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123",
 		bytes.NewReader(payload))
@@ -470,7 +494,7 @@ func TestWebhook_CreateWebhookLogError(t *testing.T) {
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRowWithSecret(providerID, "bitbucket_dc", testWebhookSecret))
+		WillReturnRows(sampleProviderRowWithSecret(t, providerID, "bitbucket_dc", testWebhookSecret))
 	mock.ExpectExec("INSERT INTO scm_webhook_events").
 		WillReturnError(errors.New("db error"))
 
@@ -496,7 +520,7 @@ func TestWebhook_Success(t *testing.T) {
 		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
 			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
-		WillReturnRows(sampleProviderRowWithSecret(providerID, "bitbucket_dc", testWebhookSecret))
+		WillReturnRows(sampleProviderRowWithSecret(t, providerID, "bitbucket_dc", testWebhookSecret))
 	mock.ExpectExec("INSERT INTO scm_webhook_events").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 


### PR DESCRIPTION
Closes #561

## Summary
Implements the smallest, most self-contained findings from the 2026-07-09 backend security audit (tracking issue #568):

- **#561** (fully closed) — `GET /admin/role-templates` and `/:id` had no `RequireScope`, letting any authenticated user enumerate the full RBAC model. Both routes now require `ScopeAdmin`, matching the write verbs in the same group and every sibling admin sub-group.
- **#560 finding [17]** — the SCM webhook handler assigned `provider.ClientSecretEncrypted` (AES-256-GCM ciphertext) directly to `ConnectorSettings.ClientSecret` instead of decrypting it first. Now decrypts via `tokenCipher.Open`, consistent with `scm_oauth.go`.
- **#560 finding [20]** — the HTTP server relied on `crypto/tls` defaults for TLS version/cipher policy. Now sets an explicit `tls.Config{MinVersion: tls.VersionTLS12}`.
- **#564 finding [32]** — `CORSMiddleware` reflected the request `Origin` dynamically but never sent `Vary: Origin`, allowing a caching intermediary/CDN to serve one origin'"'"'s CORS response to another. Now sets `Vary: Origin` whenever the allow-origin header is computed from the request.
- **#564 finding [14]** — provider upload validated only `version`/`os`/`arch`, unlike module upload which validates `namespace`/`name`/`system` with `ValidateRegistrySegment`. Provider `namespace`/`type` now go through the same validation before the storage key is built.

Only #561 is fully resolved by this PR (both of its findings share the same fix); #560 and #564 are bundles with additional findings tracked separately and remain open for the rest of their items.

## Changelog
- fix: gate role-template reads with RequireScope (#561)
- fix: decrypt SCM webhook client secret before connector construction
- fix: set explicit TLS MinVersion on HTTP server
- fix: add Vary: Origin header to dynamic CORS responses
- fix: validate provider namespace/type segments on upload

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./internal/api/webhooks/... ./internal/api/providers/...` passes
- [x] `go vet ./...` clean
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
