### PR TITLE
style: gofmt comment alignment in server struct literal

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -421,8 +421,8 @@ func serve(cfg *config.Config) error {
 		Handler:           router,
 		ReadTimeout:       cfg.Server.ReadTimeout,
 		WriteTimeout:      cfg.Server.WriteTimeout,
-		ReadHeaderTimeout: 10 * time.Second,  // Prevents Slowloris attacks
-		IdleTimeout:       120 * time.Second, // Close idle keep-alive connections
+		ReadHeaderTimeout: 10 * time.Second,                          // Prevents Slowloris attacks
+		IdleTimeout:       120 * time.Second,                         // Close idle keep-alive connections
 		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12}, // Explicit floor instead of relying on crypto/tls defaults
 	}
 


### PR DESCRIPTION
## Summary
Formatting-only follow-up to #569. The `TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12}` line added there has a long trailing comment, so `gofmt` realigns the adjacent `ReadHeaderTimeout`/`IdleTimeout` trailing comments to the same column. The merged code was left one step short of gofmt-canonical.

CI runs `golangci-lint run ./...` with no `gofmt`/`gofumpt` linter enabled (see `backend/.golangci.yml`), so the discrepancy did not fail the #569 checks. This restores `gofmt -l` cleanliness for `cmd/server/main.go`.

No behavior change.

## Changelog
- chore: gofmt comment alignment in server struct literal

## Checklist

- [x] `go build ./...` passes
- [x] `gofmt -l cmd/server/main.go` clean
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
