### PR TITLE
fix(security): batch 3 of quick-win findings from 2026-07-09 audit

### DIFF
--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -27,8 +27,8 @@
 			"rule_id": "G201",
 			"details": "SQL string formatting",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\db\\repositories\\provider_repository.go",
-			"code": "700: \t// Query with pagination and JOIN for created_by_name\n701: \tsearchQuery := fmt.Sprintf(`\n702: \t\tSELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,\n703: \t\t       p.created_by, u.name as created_by_name, p.created_at, p.updated_at\n704: \t\tFROM providers p\n705: \t\tLEFT JOIN users u ON p.created_by = u.id\n706: \t\t%s\n707: \t\tORDER BY p.created_at DESC\n708: \t\tLIMIT $%d OFFSET $%d\n709: \t`, whereClause, argCount+1, argCount+2)\n710: \n",
-			"line": "701-709",
+			"code": "796: \t// Query with pagination and JOIN for created_by_name\n797: \tsearchQuery := fmt.Sprintf(`\n798: \t\tSELECT p.id, p.organization_id, p.namespace, p.type, p.description, p.source,\n799: \t\t       p.created_by, u.name as created_by_name, p.created_at, p.updated_at\n800: \t\tFROM providers p\n801: \t\tLEFT JOIN users u ON p.created_by = u.id\n802: \t\t%s\n803: \t\tORDER BY p.created_at DESC\n804: \t\tLIMIT $%d OFFSET $%d\n805: \t`, whereClause, argCount+1, argCount+2)\n806: \n",
+			"line": "797-805",
 			"column": "17",
 			"nosec": false,
 			"suppressions": null
@@ -43,8 +43,8 @@
 			"rule_id": "G201",
 			"details": "SQL string formatting",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\db\\repositories\\provider_repository.go",
-			"code": "692: \t// Count total results\n693: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM providers p %s\", whereClause)\n694: \tvar total int\n",
-			"line": "693",
+			"code": "788: \t// Count total results\n789: \tcountQuery := fmt.Sprintf(\"SELECT COUNT(*) FROM providers p %s\", whereClause)\n790: \tvar total int\n",
+			"line": "789",
 			"column": "16",
 			"nosec": false,
 			"suppressions": null
@@ -92,62 +92,14 @@
 			"rule_id": "G304",
 			"details": "Potential file inclusion via variable",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\services\\scm_publisher.go",
-			"code": "637: \tif p.moduleDocsRepo != nil {\n638: \t\tif f, err := os.Open(archivePath); err == nil { // G304: archivePath is a temp file created by this process\n639: \t\t\tdefer f.Close()\n",
-			"line": "638",
+			"code": "684: \tif p.moduleDocsRepo != nil {\n685: \t\tif f, err := os.Open(archivePath); err == nil { // G304: archivePath is a temp file created by this process\n686: \t\t\tdefer f.Close()\n",
+			"line": "685",
 			"column": "16",
 			"nosec": false,
 			"suppressions": null,
 			"autofix": "Consider using os.Root to scope file access under a fixed root (Go \u003e=1.24). Prefer root.Open/root.Stat over os.Open/os.Stat to prevent directory traversal."
 		},
 		{
-			"severity": "MEDIUM",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "276",
-				"url": "https://cwe.mitre.org/data/definitions/276.html"
-			},
-			"rule_id": "G302",
-			"details": "Expect file permissions to be 0600 or less",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\scanner\\installer\\installer.go",
-			"code": "179: \t// 9. Make executable.\n180: \tif err := os.Chmod(targetBinary, 0o755); err != nil { // #nosec G302 -- scanner binary must be executable\n181: \t\treturn nil, fmt.Errorf(\"chmod: %w\", err)\n",
-			"line": "180",
-			"column": "12",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "MEDIUM",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "276",
-				"url": "https://cwe.mitre.org/data/definitions/276.html"
-			},
-			"rule_id": "G301",
-			"details": "Expect directory permissions to be 0750 or less",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\scanner\\installer\\installer.go",
-			"code": "202: \t}\n203: \tif err := os.MkdirAll(dir, 0o755); err != nil { // #nosec G301 -- scanner install directory needs execute permission\n204: \t\treturn fmt.Errorf(\"%w: %v\", ErrInstallDirNotWritable, err)\n",
-			"line": "203",
-			"column": "12",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "MEDIUM",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "276",
-				"url": "https://cwe.mitre.org/data/definitions/276.html"
-			},
-			"rule_id": "G301",
-			"details": "Expect directory permissions to be 0750 or less",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\scanner\\installer\\installer.go",
-			"code": "160: \tversionDir := filepath.Join(cfg.InstallDir, tool+\"-\"+version)\n161: \tif err := os.MkdirAll(versionDir, 0o755); err != nil { // #nosec G301 -- scanner binary directory needs execute permission\n162: \t\treturn nil, fmt.Errorf(\"create version dir: %w\", err)\n",
-			"line": "161",
-			"column": "12",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
 			"severity": "LOW",
 			"confidence": "HIGH",
 			"cwe": {
@@ -157,199 +109,7 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "522: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n523: \t\tresp.Body.Close()\n524: \t\tif decodeErr != nil {\n",
-			"line": "523",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "516: \t\t\tbody, _ := io.ReadAll(resp.Body)\n517: \t\t\tresp.Body.Close()\n518: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "517",
-			"column": "4",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "462: \t\tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n463: \t\tresp.Body.Close()\n464: \t\tif decodeErr != nil {\n",
-			"line": "463",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "457: \t\t\tbody, _ := io.ReadAll(resp.Body)\n458: \t\t\tresp.Body.Close()\n459: \t\t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "458",
-			"column": "4",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "427: \tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026provResp)\n428: \tresp.Body.Close()\n429: \tif decodeErr != nil {\n",
-			"line": "428",
-			"column": "2",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "422: \t\tbody, _ := io.ReadAll(resp.Body)\n423: \t\tresp.Body.Close()\n424: \t\treturn \"\", fmt.Errorf(\"v2 provider lookup failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "423",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
-			"code": "308: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n309: \t\tresp.Body.Close()\n310: \t\treturn nil, fmt.Errorf(\"download failed with status %d: %s\", resp.StatusCode, string(body))\n",
-			"line": "309",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\terraform_releases.go",
-			"code": "464: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n465: \t\tresp.Body.Close()\n466: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
-			"line": "465",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\github_releases.go",
-			"code": "315: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n316: \t\tresp.Body.Close()\n317: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
-			"line": "316",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
-			"code": "545: \twritten, copyErr := io.Copy(tmpFile, io.TeeReader(body, hasher))\n546: \tbody.Close()\n547: \tif copyErr != nil {\n",
-			"line": "546",
-			"column": "2",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
-			"code": "540: \t\ttmpFile.Close()\n541: \t\tos.Remove(tmpFile.Name())\n542: \t}()\n",
-			"line": "541",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
-			"code": "539: \tdefer func() {\n540: \t\ttmpFile.Close()\n541: \t\tos.Remove(tmpFile.Name())\n",
-			"line": "540",
-			"column": "3",
-			"nosec": false,
-			"suppressions": null
-		},
-		{
-			"severity": "LOW",
-			"confidence": "HIGH",
-			"cwe": {
-				"id": "703",
-				"url": "https://cwe.mitre.org/data/definitions/703.html"
-			},
-			"rule_id": "G104",
-			"details": "Errors unhandled",
-			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
-			"code": "533: \tif tmpErr != nil {\n534: \t\tbody.Close()\n535: \t\terrStr := fmt.Sprintf(\"failed to create temp file: %v\", tmpErr)\n",
+			"code": "533: \t\tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026page)\n534: \t\tresp.Body.Close()\n535: \t\tif decodeErr != nil {\n",
 			"line": "534",
 			"column": "3",
 			"nosec": false,
@@ -364,9 +124,201 @@
 			},
 			"rule_id": "G104",
 			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "527: \t\t\tbody, _ := io.ReadAll(resp.Body)\n528: \t\t\tresp.Body.Close()\n529: \t\t\treturn nil, fmt.Errorf(\"v2 provider doc index request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "528",
+			"column": "4",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "473: \t\tdecodeErr = json.NewDecoder(resp.Body).Decode(\u0026versionsResp)\n474: \t\tresp.Body.Close()\n475: \t\tif decodeErr != nil {\n",
+			"line": "474",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "468: \t\t\tbody, _ := io.ReadAll(resp.Body)\n469: \t\t\tresp.Body.Close()\n470: \t\t\treturn \"\", fmt.Errorf(\"v2 provider-versions request failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "469",
+			"column": "4",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "438: \tdecodeErr := json.NewDecoder(resp.Body).Decode(\u0026provResp)\n439: \tresp.Body.Close()\n440: \tif decodeErr != nil {\n",
+			"line": "439",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "433: \t\tbody, _ := io.ReadAll(resp.Body)\n434: \t\tresp.Body.Close()\n435: \t\treturn \"\", fmt.Errorf(\"v2 provider lookup failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "434",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\upstream.go",
+			"code": "319: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))\n320: \t\tresp.Body.Close()\n321: \t\treturn nil, fmt.Errorf(\"download failed with status %d: %s\", resp.StatusCode, string(body))\n",
+			"line": "320",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\terraform_releases.go",
+			"code": "468: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n469: \t\tresp.Body.Close()\n470: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
+			"line": "469",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\mirror\\github_releases.go",
+			"code": "447: \t\tbody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))\n448: \t\tresp.Body.Close()\n449: \t\treturn nil, -1, fmt.Errorf(\"upstream returned %d for binary download: %s\", resp.StatusCode, string(body))\n",
+			"line": "448",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "632: \twritten, copyErr := io.Copy(tmpFile, io.TeeReader(body, hasher))\n633: \tbody.Close()\n634: \tif copyErr != nil {\n",
+			"line": "633",
+			"column": "2",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "627: \t\ttmpFile.Close()\n628: \t\tos.Remove(tmpFile.Name())\n629: \t}()\n",
+			"line": "628",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "626: \tdefer func() {\n627: \t\ttmpFile.Close()\n628: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "627",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
+			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\terraform_mirror_sync.go",
+			"code": "620: \tif tmpErr != nil {\n621: \t\tbody.Close()\n622: \t\terrStr := fmt.Sprintf(\"failed to create temp file: %v\", tmpErr)\n",
+			"line": "621",
+			"column": "3",
+			"nosec": false,
+			"suppressions": null
+		},
+		{
+			"severity": "LOW",
+			"confidence": "HIGH",
+			"cwe": {
+				"id": "703",
+				"url": "https://cwe.mitre.org/data/definitions/703.html"
+			},
+			"rule_id": "G104",
+			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "876: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n877: \tstream.Body.Close()\n878: \tif err != nil {\n",
-			"line": "877",
+			"code": "1005: \twritten, err := io.Copy(tmpFile, io.TeeReader(stream.Body, hasher))\n1006: \tstream.Body.Close()\n1007: \tif err != nil {\n",
+			"line": "1006",
 			"column": "2",
 			"nosec": false,
 			"suppressions": null
@@ -381,8 +333,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "870: \t\ttmpFile.Close()\n871: \t\tos.Remove(tmpFile.Name())\n872: \t}()\n",
-			"line": "871",
+			"code": "999: \t\ttmpFile.Close()\n1000: \t\tos.Remove(tmpFile.Name())\n1001: \t}()\n",
+			"line": "1000",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -397,8 +349,8 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "869: \tdefer func() {\n870: \t\ttmpFile.Close()\n871: \t\tos.Remove(tmpFile.Name())\n",
-			"line": "870",
+			"code": "998: \tdefer func() {\n999: \t\ttmpFile.Close()\n1000: \t\tos.Remove(tmpFile.Name())\n",
+			"line": "999",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
@@ -413,18 +365,18 @@
 			"rule_id": "G104",
 			"details": "Errors unhandled",
 			"file": "C:\\dev\\gh\\terraform-registry-backend\\backend\\internal\\jobs\\mirror_sync.go",
-			"code": "865: \tif err != nil {\n866: \t\tstream.Body.Close()\n867: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
-			"line": "866",
+			"code": "994: \tif err != nil {\n995: \t\tstream.Body.Close()\n996: \t\treturn fmt.Errorf(\"failed to create temp file: %w\", err)\n",
+			"line": "995",
 			"column": "3",
 			"nosec": false,
 			"suppressions": null
 		}
 	],
 	"Stats": {
-		"files": 199,
-		"lines": 55711,
-		"nosec": 161,
-		"found": 26
+		"files": 231,
+		"lines": 60419,
+		"nosec": 167,
+		"found": 23
 	},
 	"GosecVersion": "dev"
 }

--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -208,7 +209,13 @@ func (h *SCMOAuthHandlers) HandleOAuthCallback(c *gin.Context) {
 	// Complete OAuth flow
 	oauthToken, err := connector.CompleteAuthorization(c.Request.Context(), code)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("OAuth flow failed: %v", err)})
+		// Log the detailed upstream error server-side only. The raw error can embed
+		// the SCM provider's unbounded token-endpoint response body (see
+		// scm.WrapRemoteError / APIError.Error()), and this callback is public and
+		// unauthenticated, so returning err.Error() verbatim would leak upstream
+		// diagnostic detail to an anonymous caller.
+		slog.Error("oauth code exchange failed", "provider_id", providerID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "OAuth flow failed"})
 		return
 	}
 

--- a/backend/internal/api/log_redaction.go
+++ b/backend/internal/api/log_redaction.go
@@ -1,6 +1,50 @@
 package api
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
+
+// sensitiveQueryParams lists query-string keys that must never be logged verbatim.
+// OAuth/OIDC authorization codes and CSRF state values are single-use-but-replayable
+// bearer credentials during their validity window (e.g. GET /api/v1/auth/callback
+// and GET /api/v1/scm-providers/:id/oauth/callback both put these in the query
+// string), and log aggregation/SIEM pipelines may have broader read access than
+// the application itself.
+var sensitiveQueryParams = map[string]bool{
+	"code":          true,
+	"state":         true,
+	"token":         true,
+	"access_token":  true,
+	"refresh_token": true,
+	"id_token":      true,
+	"client_secret": true,
+	"api_key":       true,
+	"secret":        true,
+}
+
+// redactSensitiveQuery masks known-sensitive query parameter values before logging.
+// Malformed query strings are redacted wholesale rather than risk leaking them verbatim.
+func redactSensitiveQuery(rawQuery string) string {
+	if rawQuery == "" {
+		return rawQuery
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return "[REDACTED]"
+	}
+	redacted := false
+	for key := range values {
+		if sensitiveQueryParams[strings.ToLower(key)] {
+			values.Set(key, "[REDACTED]")
+			redacted = true
+		}
+	}
+	if !redacted {
+		return rawQuery
+	}
+	return values.Encode()
+}
 
 // redactSensitivePath masks secret URL segments before logging.
 //

--- a/backend/internal/api/log_redaction_test.go
+++ b/backend/internal/api/log_redaction_test.go
@@ -42,3 +42,49 @@ func TestRedactSensitivePath(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactSensitiveQuery(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty query untouched",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "oauth code and state redacted",
+			in:   "code=abc123&state=userid:providerid",
+			want: "code=%5BREDACTED%5D&state=%5BREDACTED%5D",
+		},
+		{
+			name: "client_secret redacted",
+			in:   "client_secret=s3cr3t",
+			want: "client_secret=%5BREDACTED%5D",
+		},
+		{
+			name: "non-sensitive params untouched",
+			in:   "page=2&limit=50",
+			want: "page=2&limit=50",
+		},
+		{
+			name: "mixed sensitive and non-sensitive",
+			in:   "page=2&token=tok_abc",
+			want: "page=2&token=%5BREDACTED%5D",
+		},
+		{
+			name: "malformed query redacted wholesale",
+			in:   "%zz",
+			want: "[REDACTED]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactSensitiveQuery(tc.in); got != tc.want {
+				t.Errorf("redactSensitiveQuery(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -1,6 +1,7 @@
 package mirror
 
 import (
+	"database/sql"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -348,6 +349,8 @@ func TestPlatformIndex_ListPlatformsDBError(t *testing.T) {
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
+	mock.ExpectQuery("SELECT.*approval_status.*FROM mirrored_provider_versions").
+		WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
 		WillReturnError(mirrorErrDB)
 
@@ -379,6 +382,8 @@ func TestPlatformIndex_StorageInitError(t *testing.T) {
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
+	mock.ExpectQuery("SELECT.*approval_status.*FROM mirrored_provider_versions").
+		WillReturnError(sql.ErrNoRows)
 	// ListPlatforms returns empty (still triggers storage init due to storageOnce.Do)
 	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
 		WillReturnRows(sqlmock.NewRows(mirrorPlatformCols))
@@ -412,6 +417,8 @@ func TestPlatformIndex_Success_EmptyPlatforms(t *testing.T) {
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
+	mock.ExpectQuery("SELECT.*approval_status.*FROM mirrored_provider_versions").
+		WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
 		WillReturnRows(sqlmock.NewRows(mirrorPlatformCols))
 
@@ -463,6 +470,8 @@ func TestPlatformIndex_Success_WithPlatforms(t *testing.T) {
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
+	mock.ExpectQuery("SELECT.*approval_status.*FROM mirrored_provider_versions").
+		WillReturnError(sql.ErrNoRows)
 
 	// Return two platforms — one with h1_hash, one without
 	h1Hash := "h1:abcdef1234567890abcdef1234567890abcdef1234567890"

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -159,6 +159,23 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			}
 		}
 
+		// Enforce the version approval gate: a mirrored version still pending approval
+		// or rejected must not be resolvable here even by direct version reference — it
+		// is already hidden from IndexHandler's version listing and gated on the
+		// Provider Registry download endpoint. Return the same generic 404 as a
+		// missing version so the gate does not reveal that a hidden version exists.
+		approvalStatus, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), providerVersion.ID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to query provider version",
+			})
+			return
+		}
+		if approvalStatus != nil && *approvalStatus != models.VersionApprovalStatusApproved {
+			c.Data(http.StatusNotFound, "application/json", []byte(`{"errors":["provider version not found"]}`))
+			return
+		}
+
 		// Get all platforms for this version
 		platforms, err := providerRepo.ListPlatforms(c.Request.Context(), providerVersion.ID)
 		if err != nil {

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -64,6 +64,33 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			return
 		}
 
+		// Enforce the mirrored-provider-version approval gate before streaming.
+		// Provider files follow the deterministic layout
+		// providers/{namespace}/{type}/{version}/{os}/{arch}/{filename}, so a client
+		// that can derive that layout for a pending/rejected mirrored version (already
+		// hidden from the JSON listing/download endpoints) could otherwise retrieve
+		// the raw archive directly through this route, bypassing the approval
+		// workflow entirely. Return the same "File not found" response as a
+		// genuinely missing file so the gate does not reveal that a hidden version
+		// exists.
+		if providerRepo != nil {
+			if ns, pt, ver, _, _, ok := parseProviderFilePath(filePath); ok {
+				if org, err := orgRepo.GetDefaultOrganization(c.Request.Context()); err == nil && org != nil {
+					if provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, ns, pt); err == nil && provider != nil {
+						if pv, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, ver); err == nil && pv != nil {
+							status, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), pv.ID)
+							if err == nil && status != nil && *status != models.VersionApprovalStatusApproved {
+								c.JSON(http.StatusNotFound, gin.H{
+									"error": "File not found",
+								})
+								return
+							}
+						}
+					}
+				}
+			}
+		}
+
 		// Check if file exists
 		exists, err := storageBackend.Exists(c.Request.Context(), filePath)
 		if err != nil {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -1516,7 +1516,7 @@ func LoggerMiddleware(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		path := redactSensitivePath(c.Request.URL.Path)
-		query := c.Request.URL.RawQuery
+		query := redactSensitiveQuery(c.Request.URL.RawQuery)
 
 		c.Next()
 

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -216,7 +216,7 @@ func TestServiceDiscoveryHandler(t *testing.T) {
 // in proxied deployments. Do not "simplify" this back to cfg.Server.BaseURL.
 func TestServiceDiscoveryHandler_UsesPublicURL(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Server.BaseURL = "http://registry.internal:8080" // internal listen address
+	cfg.Server.BaseURL = "http://registry.internal:8080"  // internal listen address
 	cfg.Server.PublicURL = "https://registry.example.com" // externally reachable URL
 
 	r := gin.New()
@@ -400,7 +400,9 @@ type stubRateLimiterBackend struct{}
 
 var _ middleware.RateLimiterBackend = (*stubRateLimiterBackend)(nil)
 
-func (s *stubRateLimiterBackend) Allow(_ context.Context, _ string) (bool, error) { return true, nil }
+func (s *stubRateLimiterBackend) Allow(_ context.Context, _ string) (bool, int, error) {
+	return true, 100, nil
+}
 func (s *stubRateLimiterBackend) RemainingTokens(_ context.Context, _ string) (int, error) {
 	return 100, nil
 }

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -59,9 +59,16 @@ func UploadRateLimitConfig() RateLimitConfig {
 // Implementations include the in-memory token bucket (MemoryRateLimiter) and
 // the Redis-backed GCRA limiter (RedisRateLimiter).
 type RateLimiterBackend interface {
-	// Allow reports whether a request identified by key should be allowed.
-	Allow(ctx context.Context, key string) (bool, error)
-	// RemainingTokens returns the approximate number of tokens left for key.
+	// Allow reports whether a request identified by key should be allowed, along
+	// with the approximate remaining token count after this call. Callers should
+	// use this returned remaining value for response headers rather than making a
+	// separate RemainingTokens call, which for GCRA-based backends (Redis) would
+	// perform a second Allow probe and silently consume another unit of quota.
+	Allow(ctx context.Context, key string) (allowed bool, remaining int, err error)
+	// RemainingTokens returns the approximate number of tokens left for key. For
+	// the in-memory backend this is a non-consuming read; for the Redis backend
+	// it performs another GCRA probe and DOES consume quota, so prefer the
+	// remaining value returned by Allow when one is already available.
 	RemainingTokens(ctx context.Context, key string) (int, error)
 	// Close releases resources held by the backend (e.g. stop goroutines, close connections).
 	Close() error
@@ -145,7 +152,7 @@ func (rl *MemoryRateLimiter) Close() error {
 // Allow checks if a request from the given key should be allowed.
 // The context parameter satisfies the RateLimiterBackend interface; the
 // in-memory implementation does not use it.
-func (rl *MemoryRateLimiter) Allow(_ context.Context, key string) (bool, error) {
+func (rl *MemoryRateLimiter) Allow(_ context.Context, key string) (bool, int, error) {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
@@ -154,11 +161,12 @@ func (rl *MemoryRateLimiter) Allow(_ context.Context, key string) (bool, error) 
 
 	if !exists {
 		// New client, give them full burst
+		tokens := float64(rl.config.BurstSize) - 1
 		rl.entries[key] = &rateLimitEntry{
-			tokens:     float64(rl.config.BurstSize) - 1,
+			tokens:     tokens,
 			lastUpdate: now,
 		}
-		return true, nil
+		return true, int(tokens), nil
 	}
 
 	// Calculate tokens to add based on time elapsed
@@ -173,10 +181,10 @@ func (rl *MemoryRateLimiter) Allow(_ context.Context, key string) (bool, error) 
 	// Check if we have tokens available
 	if entry.tokens >= 1 {
 		entry.tokens--
-		return true, nil
+		return true, int(entry.tokens), nil
 	}
 
-	return false, nil
+	return false, int(entry.tokens), nil
 }
 
 // RemainingTokens returns how many tokens are left for a key.
@@ -213,7 +221,7 @@ func RateLimitMiddleware(backend RateLimiterBackend) gin.HandlerFunc {
 		// Determine the rate limit key
 		key := getRateLimitKey(c)
 
-		allowed, err := backend.Allow(c.Request.Context(), key)
+		allowed, remaining, err := backend.Allow(c.Request.Context(), key)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "key", key)
 			c.Next()
@@ -221,7 +229,6 @@ func RateLimitMiddleware(backend RateLimiterBackend) gin.HandlerFunc {
 		}
 
 		if !allowed {
-			remaining, _ := backend.RemainingTokens(c.Request.Context(), key)
 			c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 			c.Header("Retry-After", "60")
 			telemetry.RateLimitRejectionsTotal.WithLabelValues(tierFromKey(key), keyTypeFromKey(key)).Inc()
@@ -233,7 +240,6 @@ func RateLimitMiddleware(backend RateLimiterBackend) gin.HandlerFunc {
 		}
 
 		// Add rate limit headers
-		remaining, _ := backend.RemainingTokens(c.Request.Context(), key)
 		c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 
 		c.Next()
@@ -255,7 +261,7 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 		key := getRateLimitKey(c)
 
 		// Individual check
-		allowed, err := individual.Allow(c.Request.Context(), key)
+		allowed, remaining, err := individual.Allow(c.Request.Context(), key)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "key", key)
 			c.Next()
@@ -263,7 +269,6 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 		}
 
 		if !allowed {
-			remaining, _ := individual.RemainingTokens(c.Request.Context(), key)
 			c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 			c.Header("Retry-After", "60")
 			telemetry.RateLimitRejectionsTotal.WithLabelValues("individual", keyTypeFromKey(key)).Inc()
@@ -280,12 +285,11 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 				if id, ok := orgID.(string); ok && id != "" {
 					orgKey := "org:" + id
 
-					orgAllowed, orgErr := orgBackend.Allow(c.Request.Context(), orgKey)
+					orgAllowed, orgRemaining, orgErr := orgBackend.Allow(c.Request.Context(), orgKey)
 					if orgErr != nil {
 						slog.Warn("org rate limiter backend error, allowing request", "error", orgErr, "org_key", orgKey)
 					} else if !orgAllowed {
-						remaining, _ := orgBackend.RemainingTokens(c.Request.Context(), orgKey)
-						c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+						c.Header("X-RateLimit-Remaining", strconv.Itoa(orgRemaining))
 						c.Header("Retry-After", "60")
 						telemetry.RateLimitRejectionsTotal.WithLabelValues("organization", "org").Inc()
 						c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
@@ -298,7 +302,6 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 			}
 		}
 
-		remaining, _ := individual.RemainingTokens(c.Request.Context(), key)
 		c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 
 		c.Next()
@@ -362,7 +365,7 @@ func PrincipalRateLimitMiddleware(defaultBackend RateLimiterBackend, overrides *
 			}
 		}
 
-		allowed, err := backend.Allow(c.Request.Context(), key)
+		allowed, remaining, err := backend.Allow(c.Request.Context(), key)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "key", key)
 			c.Next()
@@ -370,7 +373,6 @@ func PrincipalRateLimitMiddleware(defaultBackend RateLimiterBackend, overrides *
 		}
 
 		if !allowed {
-			remaining, _ := backend.RemainingTokens(c.Request.Context(), key)
 			c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 			c.Header("Retry-After", "60")
 			telemetry.RateLimitRejectionsTotal.WithLabelValues("principal", keyTypeFromKey(key)).Inc()
@@ -381,7 +383,6 @@ func PrincipalRateLimitMiddleware(defaultBackend RateLimiterBackend, overrides *
 			return
 		}
 
-		remaining, _ := backend.RemainingTokens(c.Request.Context(), key)
 		c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
 
 		c.Next()

--- a/backend/internal/middleware/ratelimit_redis.go
+++ b/backend/internal/middleware/ratelimit_redis.go
@@ -68,25 +68,31 @@ func NewRedisRateLimiter(cfg *config.RedisConfig, rlCfg RateLimitConfig) (*Redis
 	}, nil
 }
 
-// Allow checks whether the request identified by key should be permitted.
-func (r *RedisRateLimiter) Allow(ctx context.Context, key string) (bool, error) {
+// Allow checks whether the request identified by key should be permitted, and
+// returns the remaining GCRA quota from the same probe. Callers should use this
+// remaining value directly (e.g. for the X-RateLimit-Remaining header) instead of
+// calling RemainingTokens afterward, which would perform a second Allow probe
+// against redis_rate and silently consume another unit of quota (redis_rate has
+// no peek-only operation).
+func (r *RedisRateLimiter) Allow(ctx context.Context, key string) (bool, int, error) {
 	res, err := r.limiter.Allow(ctx, key, r.limit)
 	if err != nil {
-		return false, fmt.Errorf("redis rate limiter: Allow error: %w", err)
+		return false, 0, fmt.Errorf("redis rate limiter: Allow error: %w", err)
 	}
-	return res.Allowed > 0, nil
+	return res.Allowed > 0, res.Remaining, nil
 }
 
-// RemainingTokens returns the approximate remaining capacity for key.
+// RemainingTokens returns the approximate remaining capacity for key. This
+// performs its own GCRA probe (redis_rate has no peek-only operation) and
+// therefore CONSUMES another unit of quota — it exists only for direct/manual
+// callers. The rate-limit middleware no longer calls this; it uses the
+// remaining value already returned by Allow to avoid double-consuming quota.
 func (r *RedisRateLimiter) RemainingTokens(ctx context.Context, key string) (int, error) {
 	res, err := r.limiter.Allow(ctx, key, redis_rate.Limit{
 		Rate:   r.limit.Rate,
 		Burst:  r.limit.Burst,
 		Period: r.limit.Period,
 	})
-	// We use AllowN with 0 to peek, but redis_rate doesn't have a peek function.
-	// Instead we return the Remaining field from the last Allow call.
-	// Since we already called Allow in the middleware, this is a rough approximation.
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -68,7 +68,7 @@ func TestRateLimiter_NewClientGetsFullBurst(t *testing.T) {
 	defer rl.Stop()
 
 	// First request from a new client always allowed
-	allowed, err := rl.Allow(context.Background(), "client-a")
+	allowed, _, err := rl.Allow(context.Background(), "client-a")
 	if err != nil {
 		t.Fatalf("Allow() unexpected error: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestRateLimiter_AllowsUpToBurstSize(t *testing.T) {
 	ctx := context.Background()
 	allowed := 0
 	for i := 0; i < burst+2; i++ {
-		ok, _ := rl.Allow(ctx, key)
+		ok, _, _ := rl.Allow(ctx, key)
 		if ok {
 			allowed++
 		}
@@ -103,7 +103,7 @@ func TestRateLimiter_TokensRefillOverTime(t *testing.T) {
 	key := "refill-test"
 	ctx := context.Background()
 	for {
-		ok, _ := rl.Allow(ctx, key)
+		ok, _, _ := rl.Allow(ctx, key)
 		if !ok {
 			break
 		}
@@ -111,7 +111,7 @@ func TestRateLimiter_TokensRefillOverTime(t *testing.T) {
 
 	time.Sleep(120 * time.Millisecond)
 
-	ok, err := rl.Allow(ctx, key)
+	ok, _, err := rl.Allow(ctx, key)
 	if err != nil {
 		t.Fatalf("Allow() error: %v", err)
 	}
@@ -126,13 +126,13 @@ func TestRateLimiter_DifferentKeysAreIndependent(t *testing.T) {
 
 	ctx := context.Background()
 	for {
-		ok, _ := rl.Allow(ctx, "key-a")
+		ok, _, _ := rl.Allow(ctx, "key-a")
 		if !ok {
 			break
 		}
 	}
 
-	ok, _ := rl.Allow(ctx, "key-b")
+	ok, _, _ := rl.Allow(ctx, "key-b")
 	if !ok {
 		t.Error("Allow() = false for independent key-b after exhausting key-a")
 	}
@@ -554,7 +554,7 @@ func TestPrincipalOverrideLimiters_OverrideUsed(t *testing.T) {
 
 	// high-volume user should be allowed many requests
 	for i := 0; i < 100; i++ {
-		ok, err := pol.overrides["user:high-volume"].Allow(context.Background(), "user:high-volume")
+		ok, _, err := pol.overrides["user:high-volume"].Allow(context.Background(), "user:high-volume")
 		if err != nil {
 			t.Fatalf("Allow error: %v", err)
 		}
@@ -565,12 +565,12 @@ func TestPrincipalOverrideLimiters_OverrideUsed(t *testing.T) {
 
 	// low-volume API key should be throttled quickly
 	for i := 0; i < 2; i++ {
-		ok, _ := pol.overrides["apikey:ci-key"].Allow(context.Background(), "apikey:ci-key")
+		ok, _, _ := pol.overrides["apikey:ci-key"].Allow(context.Background(), "apikey:ci-key")
 		if !ok {
 			t.Fatalf("expected allow at request %d for ci-key", i)
 		}
 	}
-	ok, _ := pol.overrides["apikey:ci-key"].Allow(context.Background(), "apikey:ci-key")
+	ok, _, _ := pol.overrides["apikey:ci-key"].Allow(context.Background(), "apikey:ci-key")
 	if ok {
 		t.Error("expected ci-key to be rate limited after burst")
 	}

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -31,6 +31,17 @@ type UpstreamRegistry struct {
 	DownloadClient *http.Client // For file downloads (longer timeout)
 }
 
+// maxUpstreamResponseBytes bounds the metadata responses read by the API client
+// (service discovery, version listings, package info). These are small JSON
+// documents in legitimate use; the cap guards against a misbehaving or
+// adversarial upstream registry returning an unbounded body that would
+// otherwise be fully buffered in memory via io.ReadAll/json.Decode.
+const maxUpstreamResponseBytes = 10 << 20 // 10 MB
+
+// maxUpstreamErrorBodyBytes bounds error-response bodies included in returned
+// error messages, matching the cap already used by DownloadFileStream's error path.
+const maxUpstreamErrorBodyBytes = 4096
+
 // NewUpstreamRegistry creates a new upstream registry client
 func NewUpstreamRegistry(baseURL string) *UpstreamRegistry {
 	return &UpstreamRegistry{
@@ -111,12 +122,12 @@ func (u *UpstreamRegistry) DiscoverServices(ctx context.Context) (*ServiceDiscov
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		return nil, fmt.Errorf("discovery request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var discovery ServiceDiscoveryResponse
-	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&discovery); err != nil {
 		return nil, fmt.Errorf("failed to decode discovery response: %w", err)
 	}
 
@@ -159,11 +170,11 @@ func (u *UpstreamRegistry) ListProviderVersions(ctx context.Context, namespace, 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		return nil, fmt.Errorf("versions request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -210,12 +221,12 @@ func (u *UpstreamRegistry) GetProviderPackage(ctx context.Context, namespace, pr
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		return nil, fmt.Errorf("package request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var packageResp ProviderPackageResponse
-	if err := json.NewDecoder(resp.Body).Decode(&packageResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&packageResp); err != nil {
 		return nil, fmt.Errorf("failed to decode package response: %w", err)
 	}
 
@@ -305,7 +316,7 @@ func (u *UpstreamRegistry) DownloadFileStream(ctx context.Context, fileURL strin
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		resp.Body.Close()
 		return nil, fmt.Errorf("download failed with status %d: %s", resp.StatusCode, string(body))
 	}


### PR DESCRIPTION
Closes #557

## Summary
Continues the security-audit remediation started in #569/#573 (tracking issue #568) with the next set of findings:

- **#557** (fully closed) - the mirrored-provider-version approval gate was enforced ad hoc per handler and missing on two serving surfaces:
  - **finding [29]** - the Network Mirror Protocol platform-index endpoint (`PlatformIndexHandler`) resolved the version directly via `GetVersion` with no approval-status check, unlike the sibling `IndexHandler` (which uses `ListVisibleVersions`) and the JSON download endpoint (which explicitly checks `GetVersionApprovalStatus`). Added the same check, returning the same generic 404 for pending/rejected versions.
  - **finding [30]** - the local `/v1/files/*filepath` serving route had no approval-status or authorization gate at all. Provider files follow the deterministic layout `providers/{namespace}/{type}/{version}/{os}/{arch}/{filename}`, so a client that can derive that layout for a gated version could retrieve the raw archive directly. Added the same approval check (via the existing `parseProviderFilePath` helper) before streaming, returning the same "File not found" response as a genuinely missing file.
- **#562 finding [37]** - the Redis-backed rate limiter double-consumed GCRA quota: the middleware called `Allow()` once, then `RemainingTokens()` again for the `X-RateLimit-Remaining` header, and `RemainingTokens` has no peek-only mode (redis_rate has none), so it silently consumed a second unit of quota on every request. `Allow()` now returns the remaining count from its single probe; all three rate-limit middlewares (`RateLimitMiddleware`, `OrgRateLimitMiddleware`, `PrincipalRateLimitMiddleware`) use that value directly instead of probing again. `RemainingTokens` remains on the interface for direct/manual callers, now documented as consuming.
- **#562 finding [36]** - the SCM OAuth callback (`GET /api/v1/scm-providers/:id/oauth/callback`, public/unauthenticated) reflected the raw upstream error - including an unbounded response body from the SCM token endpoint - verbatim to the caller. Now logged server-side via `slog.Error`; the client gets a generic `"OAuth flow failed"` message, consistent with the decrypt/connector-creation error handling a few lines above in the same handler.
- **#562 finding [38]** - `DiscoverServices`, `ListProviderVersions`, and `GetProviderPackage` in the upstream registry client read response bodies with no size cap, unlike `DownloadFileStream`'s error path. Added the same `io.LimitReader` pattern for both error bodies (4KB) and successful metadata responses (10MB).
- **#560 finding [16]** - OAuth authorization codes and CSRF state values were logged verbatim via the request query string (`GET /api/v1/auth/callback?code=...&state=...` and the SCM OAuth callback). `LoggerMiddleware` now redacts known-sensitive query parameters (`code`, `state`, `token`, `access_token`, `refresh_token`, `id_token`, `client_secret`, `api_key`, `secret`) before logging, mirroring the existing `redactSensitivePath` approach already used for paths.

Only #557 is fully resolved by this PR; #560 and #562 are bundles with additional findings tracked separately and remain open for the rest of their items.

## Changelog
- fix: enforce mirrored-version approval gate on platform-index and /v1/files endpoints (#557)
- fix: stop double-consuming Redis rate-limiter quota on the remaining-tokens header
- fix: stop reflecting raw upstream OAuth errors to unauthenticated callers
- fix: cap upstream registry metadata response reads
- fix: redact sensitive query parameters (code, state, tokens) in request logging

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./internal/api/mirror/... ./internal/middleware/... ./internal/api/... ./internal/mirror/... ./internal/api/modules/... ./internal/api/admin/...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files (pre-existing router_test.go comment-alignment drift elsewhere in the file is unrelated to this change and left untouched)
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
