### PR TITLE
fix(security): harden SCM connector HTTP clients with timeouts and body caps

### DIFF
--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -373,8 +373,8 @@
 		}
 	],
 	"Stats": {
-		"files": 231,
-		"lines": 60419,
+		"files": 232,
+		"lines": 60462,
 		"nosec": 167,
 		"found": 23
 	},

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -136,14 +136,14 @@ func (c *AzureDevOpsConnector) CompleteAuthorization(ctx context.Context, authCo
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
 		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
 	}
 
@@ -155,7 +155,7 @@ func (c *AzureDevOpsConnector) CompleteAuthorization(ctx context.Context, authCo
 		Scope        string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode token response: %w", err)
 	}
 
@@ -188,7 +188,7 @@ func (c *AzureDevOpsConnector) RenewToken(ctx context.Context, refreshToken stri
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to refresh token", err)
 	}
@@ -205,7 +205,7 @@ func (c *AzureDevOpsConnector) RenewToken(ctx context.Context, refreshToken stri
 		RefreshToken string `json:"refresh_token"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode refresh response: %w", err)
 	}
 
@@ -238,7 +238,7 @@ func (c *AzureDevOpsConnector) FetchRepositories(ctx context.Context, creds *scm
 		}
 		c.setAuthHeaders(req, creds)
 		// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := scm.HTTPClient.Do(req)
 		if err != nil {
 			continue
 		}
@@ -247,7 +247,7 @@ func (c *AzureDevOpsConnector) FetchRepositories(ctx context.Context, creds *scm
 			Value []adoRepo `json:"value"`
 		}
 
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 			_ = resp.Body.Close()
 			continue
 		}
@@ -273,7 +273,7 @@ func (c *AzureDevOpsConnector) FetchRepository(ctx context.Context, creds *scm.A
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
 	}
@@ -287,7 +287,7 @@ func (c *AzureDevOpsConnector) FetchRepository(ctx context.Context, creds *scm.A
 	}
 
 	var adoRepo adoRepo
-	if err := json.NewDecoder(resp.Body).Decode(&adoRepo); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&adoRepo); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode repository: %w", err)
 	}
 
@@ -325,7 +325,7 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
 	}
@@ -342,7 +342,7 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 		} `json:"value"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode branches: %w", err)
 	}
 
@@ -370,7 +370,7 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
 	}
@@ -395,7 +395,7 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 		} `json:"value"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode tags: %w", err)
 	}
 
@@ -441,7 +441,7 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
 	}
@@ -465,7 +465,7 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 		RemoteURL string `json:"remoteUrl"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&adoCommit); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&adoCommit); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode commit: %w", err)
 	}
 
@@ -505,12 +505,12 @@ func (c *AzureDevOpsConnector) DownloadSourceArchive(ctx context.Context, creds 
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
 		_ = resp.Body.Close()
 		return nil, scm.WrapRemoteError(resp.StatusCode, fmt.Sprintf("failed to download archive: %s", string(body)), nil)
 	}
@@ -595,7 +595,7 @@ func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return "", "", scm.WrapRemoteError(0, "failed to fetch repository IDs", err)
 	}
@@ -609,7 +609,7 @@ func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds
 			ID string `json:"id"`
 		} `json:"project"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return "", "", fmt.Errorf("decode repository: %w", err)
 	}
 	return result.Project.ID, result.ID, nil
@@ -653,7 +653,7 @@ func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create service hook subscription", err)
 	}
@@ -664,7 +664,7 @@ func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 	var result struct {
 		ID string `json:"id"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("azuredevops: decode subscription response: %w", err)
 	}
 	return &scm.WebhookInfo{
@@ -684,7 +684,7 @@ func (c *AzureDevOpsConnector) RemoveWebhook(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete service hook subscription", err)
 	}
@@ -803,7 +803,7 @@ func (c *AzureDevOpsConnector) fetchProjects(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)
 	}
@@ -824,7 +824,7 @@ func (c *AzureDevOpsConnector) fetchProjects(ctx context.Context, creds *scm.Acc
 		Value []adoProject `json:"value"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to parse project list", err)
 	}
 

--- a/backend/internal/scm/azuredevops/connector_test.go
+++ b/backend/internal/scm/azuredevops/connector_test.go
@@ -568,7 +568,7 @@ func TestReadErrorBody_WithContent(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // redirectTransport redirects all HTTP(S) requests to a fixed base URL,
-// preserving the path and query — used to intercept http.DefaultClient calls
+// preserving the path and query — used to intercept scm.HTTPClient calls
 // that use hard-coded external URLs (e.g. Entra token endpoint).
 // ---------------------------------------------------------------------------
 
@@ -583,12 +583,12 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 	return http.DefaultTransport.RoundTrip(redirected)
 }
 
-// withRedirectClient temporarily replaces http.DefaultTransport and restores it via t.Cleanup.
+// withRedirectClient temporarily replaces scm.HTTPClient's transport and restores it via t.Cleanup.
 func withRedirectClient(t *testing.T, srv *httptest.Server) {
 	t.Helper()
-	orig := http.DefaultClient.Transport
-	http.DefaultClient.Transport = &redirectTransport{base: srv.URL}
-	t.Cleanup(func() { http.DefaultClient.Transport = orig })
+	orig := scm.HTTPClient.Transport
+	scm.HTTPClient.Transport = &redirectTransport{base: srv.URL}
+	t.Cleanup(func() { scm.HTTPClient.Transport = orig })
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/scm/bitbucket/connector.go
+++ b/backend/internal/scm/bitbucket/connector.go
@@ -280,7 +280,7 @@ func (c *BitbucketDCConnector) DownloadSourceArchive(ctx context.Context, creds 
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -329,7 +329,7 @@ func (c *BitbucketDCConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 	c.setAuthHeaders(req, creds)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
 	}
@@ -339,7 +339,7 @@ func (c *BitbucketDCConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to create webhook", nil)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("bitbucket: decode webhook response: %w", err)
 	}
 
@@ -361,7 +361,7 @@ func (c *BitbucketDCConnector) RemoveWebhook(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)
 	}
@@ -466,7 +466,7 @@ func (c *BitbucketDCConnector) doJSON(ctx context.Context, creds *scm.AccessToke
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return scm.WrapRemoteError(0, "request failed", err)
 	}
@@ -483,7 +483,7 @@ func (c *BitbucketDCConnector) doJSON(ctx context.Context, creds *scm.AccessToke
 	}
 
 	if result != nil {
-		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(result); err != nil {
 			return fmt.Errorf("failed to decode response: %w", err)
 		}
 	}

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -89,14 +89,14 @@ func (c *GitHubConnector) CompleteAuthorization(ctx context.Context, authCode st
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
 		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
 	}
 
@@ -106,7 +106,7 @@ func (c *GitHubConnector) CompleteAuthorization(ctx context.Context, authCode st
 		Scope       string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("github: decode token response: %w", err)
 	}
 
@@ -161,7 +161,7 @@ func (c *GitHubConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
 	}
@@ -175,7 +175,7 @@ func (c *GitHubConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 
 	var ghRepo githubRepo
-	if err := json.NewDecoder(resp.Body).Decode(&ghRepo); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghRepo); err != nil {
 		return nil, fmt.Errorf("github: decode repository: %w", err)
 	}
 
@@ -202,7 +202,7 @@ func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "search failed", err)
 	}
@@ -217,7 +217,7 @@ func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 		Items      []githubRepo `json:"items"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("github: decode search results: %w", err)
 	}
 
@@ -253,7 +253,7 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
 	}
@@ -271,7 +271,7 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 		Protected bool `json:"protected"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&ghBranches); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghBranches); err != nil {
 		return nil, fmt.Errorf("github: decode branches: %w", err)
 	}
 
@@ -306,7 +306,7 @@ func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
 	}
@@ -324,7 +324,7 @@ func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&ghTags); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghTags); err != nil {
 		return nil, fmt.Errorf("github: decode tags: %w", err)
 	}
 
@@ -349,7 +349,7 @@ func (c *GitHubConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
 	}
@@ -371,7 +371,7 @@ func (c *GitHubConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 		} `json:"object"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&ref); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ref); err != nil {
 		return nil, fmt.Errorf("github: decode tag ref: %w", err)
 	}
 
@@ -391,7 +391,7 @@ func (c *GitHubConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
 	}
@@ -417,7 +417,7 @@ func (c *GitHubConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&ghCommit); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghCommit); err != nil {
 		return nil, fmt.Errorf("github: decode commit: %w", err)
 	}
 
@@ -446,7 +446,7 @@ func (c *GitHubConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -484,7 +484,7 @@ func (c *GitHubConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 	c.setAuthHeaders(req, creds)
 	req.Header.Set("Content-Type", "application/json")
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
 	}
@@ -495,7 +495,7 @@ func (c *GitHubConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 	var result struct {
 		ID int64 `json:"id"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("github: decode webhook response: %w", err)
 	}
 	return &scm.WebhookInfo{
@@ -515,7 +515,7 @@ func (c *GitHubConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)
 	}
@@ -624,7 +624,7 @@ func (c *GitHubConnector) fetchRepoList(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repositories", err)
 	}
@@ -635,7 +635,7 @@ func (c *GitHubConnector) fetchRepoList(ctx context.Context, creds *scm.AccessTo
 	}
 
 	var ghRepos []githubRepo
-	if err := json.NewDecoder(resp.Body).Decode(&ghRepos); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghRepos); err != nil {
 		return nil, fmt.Errorf("github: decode repo list: %w", err)
 	}
 

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -87,14 +87,14 @@ func (c *GitLabConnector) CompleteAuthorization(ctx context.Context, authCode st
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
 		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
 	}
 
@@ -106,7 +106,7 @@ func (c *GitLabConnector) CompleteAuthorization(ctx context.Context, authCode st
 		Scope        string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("gitlab: decode token response: %w", err)
 	}
 
@@ -139,7 +139,7 @@ func (c *GitLabConnector) RenewToken(ctx context.Context, refreshToken string) (
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to refresh token", err)
 	}
@@ -156,7 +156,7 @@ func (c *GitLabConnector) RenewToken(ctx context.Context, refreshToken string) (
 		RefreshToken string `json:"refresh_token"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("gitlab: decode refresh response: %w", err)
 	}
 
@@ -189,7 +189,7 @@ func (c *GitLabConnector) FetchRepositories(ctx context.Context, creds *scm.Acce
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)
 	}
@@ -200,7 +200,7 @@ func (c *GitLabConnector) FetchRepositories(ctx context.Context, creds *scm.Acce
 	}
 
 	var glProjects []gitlabProject
-	if err := json.NewDecoder(resp.Body).Decode(&glProjects); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProjects); err != nil {
 		return nil, fmt.Errorf("gitlab: decode projects: %w", err)
 	}
 
@@ -228,7 +228,7 @@ func (c *GitLabConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch project", err)
 	}
@@ -242,7 +242,7 @@ func (c *GitLabConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 
 	var glProject gitlabProject
-	if err := json.NewDecoder(resp.Body).Decode(&glProject); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProject); err != nil {
 		return nil, fmt.Errorf("gitlab: decode project: %w", err)
 	}
 
@@ -269,7 +269,7 @@ func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "search failed", err)
 	}
@@ -280,7 +280,7 @@ func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 
 	var glProjects []gitlabProject
-	if err := json.NewDecoder(resp.Body).Decode(&glProjects); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProjects); err != nil {
 		return nil, fmt.Errorf("gitlab: decode search results: %w", err)
 	}
 
@@ -316,7 +316,7 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
 	}
@@ -335,7 +335,7 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 		Default   bool `json:"default"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&glBranches); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glBranches); err != nil {
 		return nil, fmt.Errorf("gitlab: decode branches: %w", err)
 	}
 
@@ -372,7 +372,7 @@ func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
 	}
@@ -393,7 +393,7 @@ func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&glTags); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glTags); err != nil {
 		return nil, fmt.Errorf("gitlab: decode tags: %w", err)
 	}
 
@@ -422,7 +422,7 @@ func (c *GitLabConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
 	}
@@ -444,7 +444,7 @@ func (c *GitLabConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&glTag); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glTag); err != nil {
 		return nil, fmt.Errorf("gitlab: decode tag: %w", err)
 	}
 
@@ -467,7 +467,7 @@ func (c *GitLabConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
 	}
@@ -490,7 +490,7 @@ func (c *GitLabConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 		WebURL        string    `json:"web_url"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&glCommit); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glCommit); err != nil {
 		return nil, fmt.Errorf("gitlab: decode commit: %w", err)
 	}
 
@@ -522,7 +522,7 @@ func (c *GitLabConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -557,7 +557,7 @@ func (c *GitLabConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
 	}
@@ -568,7 +568,7 @@ func (c *GitLabConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 	var result struct {
 		ID int64 `json:"id"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("gitlab: decode webhook response: %w", err)
 	}
 	return &scm.WebhookInfo{
@@ -589,7 +589,7 @@ func (c *GitLabConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)
 	}

--- a/backend/internal/scm/httpclient.go
+++ b/backend/internal/scm/httpclient.go
@@ -1,0 +1,43 @@
+// httpclient.go provides the shared HTTP client and response-body size caps used by all
+// SCM connectors (GitHub, GitLab, Bitbucket Data Center, Azure DevOps) for API calls and
+// OAuth token exchanges.
+package scm
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+// HTTPClient is the shared HTTP client every SCM connector should use instead of
+// http.DefaultClient, which has a zero Timeout. Self-hosted/enterprise SCM instance
+// base URLs are admin-configurable, so a slow or hung instance could otherwise block
+// a request-handling goroutine indefinitely.
+var HTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+const (
+	// MaxResponseBodyBytes bounds successful SCM API response bodies (repository
+	// listings, commit/tag/branch metadata, OAuth token responses). These are small
+	// JSON documents in legitimate use; the cap guards against a misbehaving or
+	// adversarial SCM instance returning an unbounded body that would otherwise be
+	// fully buffered in memory by io.ReadAll/json.Decode.
+	MaxResponseBodyBytes = 10 << 20 // 10 MB
+
+	// MaxErrorBodyBytes bounds non-2xx response bodies read only for inclusion in a
+	// returned error message.
+	MaxErrorBodyBytes = 4096
+)
+
+// LimitBody wraps r in an io.LimitReader capped at MaxResponseBodyBytes, for use before
+// io.ReadAll or json.NewDecoder(...).Decode on a successful SCM API response body.
+func LimitBody(r io.Reader) io.Reader {
+	return io.LimitReader(r, MaxResponseBodyBytes)
+}
+
+// LimitErrorBody wraps r in an io.LimitReader capped at MaxErrorBodyBytes, for use before
+// io.ReadAll on a non-2xx SCM API response consumed only for an error message.
+func LimitErrorBody(r io.Reader) io.Reader {
+	return io.LimitReader(r, MaxErrorBodyBytes)
+}


### PR DESCRIPTION
Closes #562

## Summary
Fully closes #562 (resilience & outbound-HTTP robustness), the last two findings after #573/#574 addressed goroutine panic recovery, the rate-limiter double-consume, upstream OAuth error leakage, and unbounded mirror response reads.

- **finding [35]** - all four SCM connectors (GitHub, GitLab, Bitbucket Data Center, Azure DevOps) called `http.DefaultClient.Do`, which has a zero `Timeout`, for every API call and OAuth token exchange. Self-hosted/enterprise SCM instance base URLs are admin-configurable, so a slow or hung instance could block a request-handling goroutine indefinitely. Response bodies (repository/branch/tag/commit metadata, OAuth token responses) were also read/decoded with no size cap.
- **finding [41]** - the OAuth token-exchange and request/response boilerplate (build client, `Do`, status-code check, `io.ReadAll`/`json.Decode`) was duplicated near-verbatim across all four connectors with no shared client construction, unlike bitbucket's own `doJSON` helper which still used the unbounded default client.

## Changes
- New `internal/scm/httpclient.go`: a shared `scm.HTTPClient` (`*http.Client` with a 30s `Timeout`), plus `LimitBody`/`LimitErrorBody` helpers (10MB / 4KB `io.LimitReader` wraps) for successful-metadata and error-only response bodies respectively.
- All ~40 `http.DefaultClient.Do` call sites across `internal/scm/{github,gitlab,bitbucket,azuredevops}/connector.go` now use `scm.HTTPClient`, with error-body reads and JSON metadata decodes wrapped in the new limit helpers.
- Raw archive/binary download bodies (`DownloadSourceArchive`) are deliberately left unbounded - those are the actual module/provider payloads (can legitimately be large), not small API metadata, and are already size-gated once they reach `validation.ValidateArchive`/`archiver.ExtractTarGz` downstream. Only their error-path bodies got the new cap.
- `azuredevops/connector_test.go`'s transport-redirect helper (used to intercept the hard-coded Entra token endpoint in tests) now patches `scm.HTTPClient.Transport` instead of `http.DefaultClient.Transport`, since production code no longer touches the global default client.
- Regenerated `gosec-baseline.json` (only the file-count stat changed, 231->232, from the new file; no new findings).

## Changelog
- fix: replace http.DefaultClient with a shared 30s-timeout client across all SCM connectors
- fix: cap SCM API response body reads to prevent unbounded memory growth from a misbehaving/adversarial SCM instance

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] gosec baseline regenerated, no new findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
