### PR TITLE
fix(security): warn on low-entropy ENCRYPTION_KEY at startup

### DIFF
--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -373,8 +373,8 @@
 		}
 	],
 	"Stats": {
-		"files": 232,
-		"lines": 60462,
+		"files": 233,
+		"lines": 60519,
 		"nosec": 167,
 		"found": 23
 	},

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -323,6 +323,14 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	if encryptionKey == "" {
 		log.Fatal("ENCRYPTION_KEY environment variable must be set for SCM integration")
 	}
+	// ENCRYPTION_KEY is used directly as raw AES-256 key bytes (no KDF/hashing), so its
+	// real-world entropy determines the actual strength of the cipher. This is a
+	// heuristic warning only — it cannot prove or disprove true randomness — for
+	// operators who set ENCRYPTION_KEY to a human-typed passphrase instead of following
+	// the documented `openssl rand -hex 16` generation method (see docs/secrets-rotation.md).
+	if crypto.IsLikelyLowEntropySecret([]byte(encryptionKey)) {
+		log.Printf("WARNING: ENCRYPTION_KEY has low estimated entropy and may not have been generated with a CSPRNG. Generate one with: openssl rand -hex 16")
+	}
 	encryptionKeyPrevious := os.Getenv("ENCRYPTION_KEY_PREVIOUS")
 
 	// Initialize token cipher for encrypting OAuth tokens.

--- a/backend/internal/crypto/entropy.go
+++ b/backend/internal/crypto/entropy.go
@@ -1,0 +1,49 @@
+package crypto
+
+import "math"
+
+// MinRecommendedEntropyBitsPerByte is the Shannon-entropy threshold (bits per byte)
+// below which a secret is flagged as likely low-entropy (e.g. a human-typed
+// passphrase rather than CSPRNG output). Random hex output (the documented way to
+// generate ENCRYPTION_KEY / TFR_JWT_SECRET, e.g. `openssl rand -hex 16`) draws from
+// a 16-character alphabet with a near-uniform distribution, so it lands close to
+// its theoretical maximum of 4 bits/byte. Ordinary typed text/passphrases are
+// comfortably below this threshold due to repeated characters and limited alphabet
+// diversity. The threshold is intentionally conservative to avoid false positives
+// on legitimate hex/base64 keys.
+const MinRecommendedEntropyBitsPerByte = 3.0
+
+// EstimateShannonEntropy returns the Shannon entropy of data, in bits per byte.
+// Uniformly random bytes over the full 0-255 range approach 8 bits/byte; uniformly
+// random hex/base64 text approaches ~4/6 bits/byte respectively; typed passphrases
+// and other natural-language-like text are typically well below that.
+func EstimateShannonEntropy(data []byte) float64 {
+	if len(data) == 0 {
+		return 0
+	}
+
+	var freq [256]int
+	for _, b := range data {
+		freq[b]++
+	}
+
+	entropy := 0.0
+	n := float64(len(data))
+	for _, count := range freq {
+		if count == 0 {
+			continue
+		}
+		p := float64(count) / n
+		entropy -= p * math.Log2(p)
+	}
+	return entropy
+}
+
+// IsLikelyLowEntropySecret reports whether data's estimated Shannon entropy falls
+// below MinRecommendedEntropyBitsPerByte, suggesting it was human-typed rather than
+// generated with a CSPRNG (e.g. `openssl rand -hex 16`). This is a heuristic, not a
+// security boundary: it can neither prove nor disprove true randomness, so callers
+// should only use it to emit an operator-facing warning, never to reject a key outright.
+func IsLikelyLowEntropySecret(data []byte) bool {
+	return EstimateShannonEntropy(data) < MinRecommendedEntropyBitsPerByte
+}

--- a/backend/internal/crypto/entropy_test.go
+++ b/backend/internal/crypto/entropy_test.go
@@ -1,0 +1,49 @@
+package crypto
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateShannonEntropy(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		wantMin float64
+		wantMax float64
+	}{
+		{"empty", []byte{}, 0, 0},
+		{"single repeated byte", []byte(strings.Repeat("k", 32)), 0, 0},
+		{"two alternating bytes", []byte(strings.Repeat("ab", 16)), 0.9, 1.1},
+		{"32 random-looking hex chars", []byte("3f7a9c1e5b2d8046f1a7c3e9b5d2084f"), 3.5, 4.1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EstimateShannonEntropy(tt.data)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("EstimateShannonEntropy(%q) = %v, want in [%v, %v]", tt.data, got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestIsLikelyLowEntropySecret(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"repeated char key (low entropy)", []byte(strings.Repeat("k", 32)), true},
+		{"repeated word passphrase (low entropy)", []byte(strings.Repeat("password", 4)), true},
+		{"random-looking hex key (high entropy)", []byte("3f7a9c1e5b2d8046f1a7c3e9b5d2084f"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLikelyLowEntropySecret(tt.data); got != tt.want {
+				t.Errorf("IsLikelyLowEntropySecret(%q) = %v, want %v", tt.data, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -113,6 +113,13 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
    echo "New key: $NEW_KEY"
    ```
 
+   `ENCRYPTION_KEY` is consumed directly as raw AES-256 key bytes — there is no
+   password-based key derivation. Always generate it with a CSPRNG as shown above;
+   never type a passphrase by hand. At startup the backend logs a `WARNING` if
+   `ENCRYPTION_KEY`'s estimated entropy looks low (e.g. a human-typed passphrase or a
+   repeated pattern) — treat that warning as a sign the key needs to be regenerated
+   and rotated.
+
 2. **Record the current key as the previous key.** Retrieve the current value of `ENCRYPTION_KEY` from your secrets manager.
 
 3. **Update the Kubernetes Secret** with both keys:


### PR DESCRIPTION
Closes #560

## Summary
Closes the last remaining finding of #560 (secret custody, crypto & log-hygiene hardening); findings [16], [17], [18], and [20] were addressed in earlier PRs (#573, #574).

**finding [19]** - `ENCRYPTION_KEY` is consumed directly as raw AES-256 key bytes (`NewTokenCipher` only checks `len(masterKey) != 32`) with no entropy/KDF enforcement. An operator who sets `ENCRYPTION_KEY` to a human-typed 32-character passphrase instead of following the documented `openssl rand -hex 16` generation method gets a valid-length key with far less real entropy than CSPRNG-generated bytes. `DeriveTokenCipher()` (a PBKDF2-based helper) already exists but is never called from production code.

## Changes
- New `internal/crypto/entropy.go`: `EstimateShannonEntropy` and `IsLikelyLowEntropySecret` - a heuristic (explicitly documented as not a security boundary) that flags keys whose Shannon entropy falls below what CSPRNG-generated hex/base64 output would have.
- `router.go` now logs a `WARNING` (mirroring the existing `TFR_JWT_SECRET` length-warning style) when `ENCRYPTION_KEY` looks low-entropy. This does **not** fail startup - existing deployments keep working, but operators get an actionable signal to regenerate and rotate the key.
- Updated `docs/secrets-rotation.md` with a note alongside the existing `openssl rand -hex 16` guidance.
- Regenerated `gosec-baseline.json` (file/line-count stats only; no new findings - learned from earlier PRs to always do this proactively when adding new files/lines).

I deliberately chose a **warning, not a hard failure**, per the issue's own suggested options ("document and *ideally* enforce... via a startup entropy/charset heuristic") - a Shannon-entropy heuristic can produce false positives/negatives (e.g. it doesn't catch predictable-but-diverse patterns like sequential digits), so rejecting startup on it risked breaking real deployments on a fuzzy signal.

## Changelog
- fix: warn at startup when ENCRYPTION_KEY has low estimated entropy

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] gosec baseline regenerated, no new findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
