### PR TITLE
fix(security): populate provider signing key_id from OpenPGP key

### DIFF
--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -374,7 +374,7 @@
 	],
 	"Stats": {
 		"files": 233,
-		"lines": 60519,
+		"lines": 60544,
 		"nosec": 167,
 		"found": 23
 	},

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -237,9 +237,13 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		gpgPublicKeys := []gin.H{}
 		if providerVersion.GPGPublicKey != "" {
 			gpgKey := resolveProviderGPGKey(providerVersion.GPGPublicKey)
+			keyID, err := validation.ExtractKeyID(gpgKey)
+			if err != nil {
+				slog.Warn("failed to extract GPG key_id for provider signing key", "namespace", namespace, "type", providerType, "error", err)
+			}
 			gpgPublicKeys = []gin.H{
 				{
-					"key_id":      "", // Could be extracted from GPG key if needed
+					"key_id":      keyID,
 					"ascii_armor": gpgKey,
 				},
 			}

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -1241,6 +1243,51 @@ func TestDownloadHandler_SuccessWithGPGKey(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "ascii_armor") {
 		t.Errorf("response should contain ascii_armor for GPG key; body: %s", w.Body.String())
+	}
+}
+
+// Issue #564 finding [33]: signing_keys.gpg_public_keys[].key_id must be populated
+// from the armored key's real long key ID, not left empty.
+func TestDownloadHandler_SuccessWithGPGKey_PopulatesKeyID(t *testing.T) {
+	entity, err := openpgp.NewEntity("Test User", "test", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("openpgp.NewEntity() error: %v", err)
+	}
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode() error: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("entity.Serialize() error: %v", err)
+	}
+	w.Close()
+	armoredKey := buf.String()
+	wantKeyID := entity.PrimaryKey.KeyIdString()
+
+	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
+	mock, r := newDownloadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(
+		sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON,
+				armoredKey,
+				"", "",
+				nil, nil, // shasum_storage_key, shasum_signature_storage_key
+				nil, false, nil, nil, time.Now()),
+	)
+	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").WillReturnRows(sqlmock.NewRows([]string{"approval_status"}).AddRow(nil))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(samplePlatformRow())
+
+	w2 := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
+	if w2.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w2.Code, w2.Body.String())
+	}
+	if !strings.Contains(w2.Body.String(), `"key_id":"`+wantKeyID+`"`) {
+		t.Errorf("response should contain key_id %q; body: %s", wantKeyID, w2.Body.String())
 	}
 }
 

--- a/backend/internal/validation/gpg.go
+++ b/backend/internal/validation/gpg.go
@@ -36,6 +36,27 @@ func ParseGPGPublicKey(keyArmored string) error {
 	return nil
 }
 
+// ExtractKeyID parses an ASCII-armored GPG public key and returns its primary key's
+// long key ID as an uppercase 16-character hex string (RFC 4880 KeyIdString format,
+// e.g. "34365D9472D7468F"), matching the format HashiCorp's own registry uses for
+// signing_keys.gpg_public_keys[].key_id in the Provider Registry Protocol.
+func ExtractKeyID(keyArmored string) (string, error) {
+	if keyArmored == "" {
+		return "", fmt.Errorf("GPG public key cannot be empty")
+	}
+
+	keyReader := strings.NewReader(keyArmored)
+	entities, err := openpgp.ReadArmoredKeyRing(keyReader)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse GPG public key: %w", err)
+	}
+	if len(entities) == 0 || entities[0].PrimaryKey == nil {
+		return "", fmt.Errorf("GPG public key has no primary key")
+	}
+
+	return entities[0].PrimaryKey.KeyIdString(), nil
+}
+
 // VerifySignature verifies a GPG signature against data using the provided public key
 func VerifySignature(publicKeyArmored string, data []byte, signature []byte) error {
 	// Validate the public key format first

--- a/backend/internal/validation/gpg_test.go
+++ b/backend/internal/validation/gpg_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -79,6 +80,42 @@ func TestParseGPGPublicKey(t *testing.T) {
 		corrupted := "-----BEGIN PGP PUBLIC KEY BLOCK-----\nnotvalidbase64!!!\n-----END PGP PUBLIC KEY BLOCK-----\n"
 		if err := ParseGPGPublicKey(corrupted); err == nil {
 			t.Error("ParseGPGPublicKey() expected error for corrupted body, got nil")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ExtractKeyID
+// ---------------------------------------------------------------------------
+
+func TestExtractKeyID(t *testing.T) {
+	t.Run("valid generated key returns 16-char uppercase hex key ID", func(t *testing.T) {
+		armoredKey, entity := generateTestGPGEntity(t)
+		keyID, err := ExtractKeyID(armoredKey)
+		if err != nil {
+			t.Fatalf("ExtractKeyID() unexpected error: %v", err)
+		}
+		want := entity.PrimaryKey.KeyIdString()
+		if keyID != want {
+			t.Errorf("ExtractKeyID() = %q, want %q", keyID, want)
+		}
+		if len(keyID) != 16 {
+			t.Errorf("ExtractKeyID() length = %d, want 16", len(keyID))
+		}
+		if keyID != strings.ToUpper(keyID) {
+			t.Errorf("ExtractKeyID() = %q, want uppercase", keyID)
+		}
+	})
+
+	t.Run("empty key returns error", func(t *testing.T) {
+		if _, err := ExtractKeyID(""); err == nil {
+			t.Error("ExtractKeyID(\"\") expected error, got nil")
+		}
+	})
+
+	t.Run("invalid armored key returns error", func(t *testing.T) {
+		if _, err := ExtractKeyID("not a valid key"); err == nil {
+			t.Error("ExtractKeyID() expected error for invalid input, got nil")
 		}
 	})
 }


### PR DESCRIPTION
Closes #564

## Summary
Findings [31] (CORS default), [32] (`Vary: Origin`), and [14] (provider namespace/type segment validation) were already fixed in a prior commit on `main` — only finding **[33]** remained.

**[33] Provider signing-key advertisement always omits `key_id`** — the Provider Registry Protocol''s `signing_keys.gpg_public_keys[]` entries are documented to include a `key_id`, but this implementation always sent an empty string, so tooling/UIs that display or match on `key_id` (rather than parsing the full armored key) can''t identify which key was used.

## Changes
- `internal/validation/gpg.go`: new `ExtractKeyID(keyArmored string) (string, error)` parses the armored key and returns the primary key''s RFC 4880 long key ID (16-char uppercase hex, e.g. `34365D9472D7468F`) via `entities[0].PrimaryKey.KeyIdString()` — matching the format HashiCorp''s own registry uses.
- `internal/api/providers/download.go`: `DownloadHandler` now calls `ExtractKeyID` and populates `key_id` in the response; a parse failure only logs a warning and leaves `key_id` empty (never fails the download).
- Tests: unit tests for `ExtractKeyID` (validation package) and a new handler-level test (`TestDownloadHandler_SuccessWithGPGKey_PopulatesKeyID`) that generates a real OpenPGP entity and asserts the JSON response contains the matching `key_id`.
- Regenerated `gosec-baseline.json` (file/line-count stats only; no new findings).

Terraform CLI validates provider signatures using the armored key material itself, so this was a protocol-completeness/UX gap, not an exploitable vulnerability (as the issue itself notes).

## Changelog
- fix: populate provider signing key signing_keys[].key_id from the OpenPGP key

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] gosec baseline regenerated, no new findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
