### PR TITLE
test(security): expand security test coverage per audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,21 @@ jobs:
           chmod +x scripts/check_package_coverage.sh
           ./scripts/check_package_coverage.sh
 
+      - name: "List coverage:skip: markers (informational)"
+        # Non-gating — coverage:skip: excludes a function from the unit-test coverage
+        # denominator with no automated check that the exclusion is genuine. This
+        # publishes the full list to the job summary each run so growth in the
+        # exclusion list is visible for periodic manual review (issue #566 [51]).
+        working-directory: backend
+        run: |
+          {
+            echo "## coverage:skip: marked functions"
+            echo ""
+            echo '```'
+            go run ./scripts/coverfilter -list -root .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Go coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -374,7 +374,7 @@
 	],
 	"Stats": {
 		"files": 233,
-		"lines": 60544,
+		"lines": 60623,
 		"nosec": 167,
 		"found": 23
 	},

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -552,6 +552,28 @@ func TestServeFileHandler_Success(t *testing.T) {
 	}
 }
 
+// Issue #566 finding [47]: the path-traversal guard on this unauthenticated,
+// unrated endpoint had zero attack-payload test coverage.
+func TestServeFileHandler_PathTraversal(t *testing.T) {
+	store := &mockStore{existsResult: true}
+	r := newServeRouter(t, store)
+
+	w := doGET(r, "/v1/files/../../etc/passwd")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestServeFileHandler_DoubleSlashTraversal(t *testing.T) {
+	store := &mockStore{existsResult: true}
+	r := newServeRouter(t, store)
+
+	w := doGET(r, "/v1/files/a//b")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // UploadHandler test helpers
 // ---------------------------------------------------------------------------

--- a/backend/internal/archiver/tarball_test.go
+++ b/backend/internal/archiver/tarball_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -148,6 +149,68 @@ func TestExtractTarGz_PathTraversal(t *testing.T) {
 		t.Error("expected path traversal error, got nil")
 	}
 }
+
+// Issue #566 finding [46]: the 100MB cumulative decompression cap was never
+// exercised by any test — assert a single entry exceeding it is rejected.
+func TestExtractTarGz_ExceedsExtractionCap(t *testing.T) {
+	oversized := bytes.Repeat([]byte("A"), maxExtractBytes+1)
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{Name: "huge.bin", Mode: 0644, Size: int64(len(oversized))}); err != nil {
+		t.Fatalf("tar WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(oversized); err != nil {
+		t.Fatalf("tar Write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	dest := t.TempDir()
+	err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest)
+	if err == nil {
+		t.Fatal("expected extraction-size-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "extraction size limit") {
+		t.Errorf("error = %q, want it to mention the extraction size limit", err.Error())
+	}
+}
+
+// Issue #566 finding [46]: tar.TypeSymlink entries have no case in ExtractTarGz's
+// switch (no default), so they are silently no-op'd — assert that's actually true
+// and no symlink is ever created on disk, even one whose target would escape destDir.
+func TestExtractTarGz_SymlinkEntryIgnored(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "evil-link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "../../../etc/passwd",
+		Mode:     0777,
+	}); err != nil {
+		t.Fatalf("tar WriteHeader: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest); err != nil {
+		t.Fatalf("ExtractTarGz should not error on a symlink entry: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "evil-link")); err == nil {
+		t.Error("symlink entry should not have been created on disk")
+	}
+}
+
 
 func TestExtractTarGz_FileContents(t *testing.T) {
 	const tfContent = `variable "region" { default = "us-east-1" }`

--- a/backend/internal/auth/ldap/provider.go
+++ b/backend/internal/auth/ldap/provider.go
@@ -119,14 +119,21 @@ func (p *Provider) Authenticate(username, password string) (*UserInfo, error) {
 	}, nil
 }
 
+// tlsConfig builds the tls.Config used for LDAPS/StartTLS connections from
+// the provider's configuration. Extracted from dial so InsecureSkipVerify's
+// wiring can be asserted directly in tests without opening a real connection.
+func (p *Provider) tlsConfig() *tls.Config {
+	return &tls.Config{
+		ServerName:         p.cfg.Host,
+		InsecureSkipVerify: p.cfg.InsecureSkipVerify, // #nosec G402 -- admin-configurable for dev environments
+	}
+}
+
 // dial creates a new LDAP connection with the configured TLS settings.
 func (p *Provider) dial() (*goldap.Conn, error) {
 	addr := fmt.Sprintf("%s:%d", p.cfg.Host, p.cfg.Port)
 
-	tlsConfig := &tls.Config{
-		ServerName:         p.cfg.Host,
-		InsecureSkipVerify: p.cfg.InsecureSkipVerify, // #nosec G402 -- admin-configurable for dev environments
-	}
+	tlsConfig := p.tlsConfig()
 
 	if p.cfg.UseTLS {
 		// LDAPS: TLS from the start

--- a/backend/internal/auth/ldap/provider_test.go
+++ b/backend/internal/auth/ldap/provider_test.go
@@ -69,6 +69,43 @@ func TestNewProvider_DefaultPorts(t *testing.T) {
 	}
 }
 
+// Issue #566 finding [49]: the InsecureSkipVerify TLS-bypass code path had no
+// test coverage in either direction.
+func TestProvider_TLSConfig_DefaultsToVerify(t *testing.T) {
+	cfg := &config.LDAPConfig{
+		Enabled:    true,
+		Host:       "ldap.example.com",
+		BaseDN:     "dc=example,dc=com",
+		BindDN:     "cn=admin,dc=example,dc=com",
+		UserFilter: "(uid=%s)",
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.tlsConfig().InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should default to false")
+	}
+}
+
+func TestProvider_TLSConfig_InsecureSkipVerifyExplicit(t *testing.T) {
+	cfg := &config.LDAPConfig{
+		Enabled:            true,
+		Host:               "ldap.example.com",
+		BaseDN:             "dc=example,dc=com",
+		BindDN:             "cn=admin,dc=example,dc=com",
+		UserFilter:         "(uid=%s)",
+		InsecureSkipVerify: true,
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !p.tlsConfig().InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true when explicitly set in config")
+	}
+}
+
 func TestNewProvider_DefaultAttributes(t *testing.T) {
 	cfg := &config.LDAPConfig{
 		Enabled:    true,

--- a/backend/internal/db/repositories/module_repository_test.go
+++ b/backend/internal/db/repositories/module_repository_test.go
@@ -398,6 +398,35 @@ func TestSearchModules_Empty(t *testing.T) {
 	}
 }
 
+// Issue #566 finding [50]: no test ever passed a SQL-metacharacter-laden query
+// through SearchModules to lock in that whereClause's fmt.Sprintf only ever
+// builds placeholder numbers, never interpolates the value itself — sqlmock's
+// WithArgs only matches if the raw value is bound as a query argument; if a
+// future edit concatenated it into the SQL text instead, these expectations
+// would fail to match and the test would fail.
+func TestSearchModules_SQLMetacharacterQuery(t *testing.T) {
+	repo, mock := newModuleRepo(t)
+	malicious := "foo' OR '1'='1"
+
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs("%" + malicious + "%").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("%"+malicious+"%", 10, 0).
+		WillReturnRows(sqlmock.NewRows(moduleSearchCols))
+
+	_, total, err := repo.SearchModules(context.Background(), "", malicious, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations (value was not bound as a parameter): %v", err)
+	}
+}
+
 func TestSearchModules_WithOrgAndFilters(t *testing.T) {
 	repo, mock := newModuleRepo(t)
 	mock.ExpectQuery("SELECT COUNT").

--- a/backend/scripts/check_package_coverage.sh
+++ b/backend/scripts/check_package_coverage.sh
@@ -3,19 +3,31 @@
 # Tests only the exact package (not sub-packages) to avoid diluting the total
 # with low-coverage sub-packages like auth/azuread or auth/oidc.
 set -euo pipefail
+
+# "package|minimum" pairs. Minimums follow the risk-based tiering documented
+# in ci.yml's coverage-threshold step comment (85-95% security/core logic),
+# set a few points below each package's actual coverage at the time this gate
+# was added so it catches regressions without blocking on aspirational targets.
 PACKAGES=(
-  "github.com/terraform-registry/terraform-registry/internal/auth"
-  "github.com/terraform-registry/terraform-registry/internal/middleware"
+  "github.com/terraform-registry/terraform-registry/internal/auth|79"
+  "github.com/terraform-registry/terraform-registry/internal/middleware|79"
+  "github.com/terraform-registry/terraform-registry/internal/db/repositories|85"
+  "github.com/terraform-registry/terraform-registry/internal/archiver|80"
+  "github.com/terraform-registry/terraform-registry/internal/api/modules|62"
+  "github.com/terraform-registry/terraform-registry/internal/api/providers|77"
+  "github.com/terraform-registry/terraform-registry/internal/mirror|83"
+  "github.com/terraform-registry/terraform-registry/internal/policy|77"
 )
-MIN=79
-for pkg in "${PACKAGES[@]}"; do
+for entry in "${PACKAGES[@]}"; do
+  pkg="${entry%%|*}"
+  min="${entry##*|}"
   # Test the exact package only (not sub-packages) and discard stdout/stderr.
   go test -coverprofile=/tmp/pkg-coverage.out "${pkg}" >/dev/null 2>&1 || true
   coverage=$(go tool cover -func=/tmp/pkg-coverage.out | grep "^total:" | awk '{print $3}' | tr -d '%')
-  if awk -v cov="${coverage}" -v thr="${MIN}" 'BEGIN { exit !(cov + 0 < thr + 0) }'; then
-    echo "FAIL: ${pkg} coverage ${coverage}% is below minimum ${MIN}%"
+  if awk -v cov="${coverage}" -v thr="${min}" 'BEGIN { exit !(cov + 0 < thr + 0) }'; then
+    echo "FAIL: ${pkg} coverage ${coverage}% is below minimum ${min}%"
     exit 1
   fi
-  echo "PASS: ${pkg} coverage ${coverage}% >= ${MIN}%"
+  echo "PASS: ${pkg} coverage ${coverage}% >= ${min}%"
 done
 echo "All package coverage checks passed"

--- a/backend/scripts/coverfilter/main.go
+++ b/backend/scripts/coverfilter/main.go
@@ -39,7 +39,20 @@ func main() {
 	inPath := flag.String("in", "coverage.out", "input coverage profile")
 	outPath := flag.String("out", "coverage.filtered.out", "output coverage profile")
 	root := flag.String("root", ".", "module root to scan for source files")
+	list := flag.Bool("list", false, "list all coverage:skip: marked functions (for periodic manual review) and exit")
 	flag.Parse()
+
+	if *list {
+		markers, err := listSkipMarkers(*root)
+		if err != nil {
+			log.Fatalf("list skip markers: %v", err)
+		}
+		for _, m := range markers {
+			fmt.Println(m)
+		}
+		fmt.Fprintf(os.Stderr, "coverfilter: %d function(s) marked %s\n", len(markers), skipMarker)
+		return
+	}
 
 	skips, err := collectSkipRanges(*root)
 	if err != nil {
@@ -141,6 +154,65 @@ func collectSkipRanges(root string) (map[string][]skipRange, error) {
 		return nil
 	})
 	return result, err
+}
+
+// listSkipMarkers walks the module rooted at root and returns a
+// "path:line: funcName" entry for every function whose preceding doc comment
+// contains the integration-only marker. Intended for periodic manual review
+// (issue #566 finding [51]) so the exclusion list doesn't silently grow to
+// cover security-relevant code without anyone noticing — CI runs this in an
+// informational (non-gating) step and publishes the list to the job summary.
+func listSkipMarkers(root string) ([]string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	var markers []string
+	fset := token.NewFileSet()
+
+	err = filepath.Walk(absRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == "vendor" || name == ".git" || name == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			return nil
+		}
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Doc == nil {
+				continue
+			}
+			var hasMarker bool
+			for _, c := range fd.Doc.List {
+				if strings.Contains(c.Text, skipMarker) {
+					hasMarker = true
+					break
+				}
+			}
+			if !hasMarker {
+				continue
+			}
+			line := fset.Position(fd.Pos()).Line
+			rel, relErr := filepath.Rel(absRoot, path)
+			if relErr != nil {
+				rel = path
+			}
+			markers = append(markers, fmt.Sprintf("%s:%d: %s", filepath.ToSlash(rel), line, fd.Name.Name))
+		}
+		return nil
+	})
+	return markers, err
 }
 
 // shouldStrip returns true when the coverage block described by the given


### PR DESCRIPTION
Partially addresses #566

## Summary
Implements 6 of the 7 findings in #566 (expand security test coverage). Finding **[48]** (SSRF-rejection tests) is intentionally NOT addressed here — it requires implementing host classification in `ValidateRegistryURL` first, which is the same design work tracked as HIGH severity in #556 finding [12] (shared SSRF-safe HTTP client across mirror/SCM/policy/SAML). Writing tests against a validator that does not yet reject anything would be a no-op; that work belongs in a dedicated session for #555/#556 as previously scoped, not folded in here.

## Changes

- **[45] Per-package coverage gate omitted every security-critical package except auth/middleware** — extended `check_package_coverage.sh`''s PACKAGES list with `internal/db/repositories`, `internal/archiver`, `internal/api/modules`, `internal/api/providers`, `internal/mirror`, `internal/policy`, each with a minimum set a few points below its actual current coverage (so the gate catches regressions without blocking on aspirational targets).
- **[47] Path-traversal guard on the unauthenticated file-serving endpoint had zero attack-payload test coverage** — added `TestServeFileHandler_PathTraversal` (`../../etc/passwd`) and `TestServeFileHandler_DoubleSlashTraversal` (`a//b`), both asserting 400.
- **[46] `ExtractTarGz`''s decompression cap and non-regular-entry handling were untested** — added `TestExtractTarGz_ExceedsExtractionCap` (single entry over the 100MB cumulative cap) and `TestExtractTarGz_SymlinkEntryIgnored` (asserts a `tar.TypeSymlink` entry with an escaping `Linkname` is never materialized on disk).
- **[50] No adversarial-input test for the `fmt.Sprintf` whereClause pattern flagged as the top SQLi review target** — added `TestSearchModules_SQLMetacharacterQuery`, which passes `foo'' OR ''1''=''1` through `SearchModules` and uses sqlmock''s `WithArgs`/`ExpectationsWereMet` to lock in that the value is bound as a parameter, never concatenated into SQL text.
- **[49] LDAP `InsecureSkipVerify` TLS-bypass path had no test coverage in either direction** — extracted the inline `tls.Config` construction in `dial()` into a small `Provider.tlsConfig()` helper (no behavior change) so `TestProvider_TLSConfig_DefaultsToVerify` and `TestProvider_TLSConfig_InsecureSkipVerifyExplicit` can assert it directly without opening a real connection.
- **[51] `coverage:skip:` markers have no guardrail against silent growth** — added a `-list` flag to the `coverfilter` tool that enumerates all skip-marked functions, and a new non-gating "List coverage:skip: markers" CI step that publishes the list to the job summary every run for periodic manual review.

## Verification
- `go build ./...`, full `go test ./...`, `go vet ./...` all clean.
- `gofmt -l` clean on all changed files.
- gosec baseline regenerated — file/line-count stats only, no new findings.
- New/changed workflow YAML validated with `yaml.safe_load` (had to quote the new step name: `coverage:skip:` in a step name is invalid unquoted YAML — `skip: ` parses as a nested mapping key).
- Manually ran `go run ./scripts/coverfilter -list -root .` locally — lists 84 current skip-marked functions, confirming the new flag works end-to-end.

## Changelog
- test: add path-traversal, SQLi-parameterization, decompression-cap, symlink, and LDAP TLS regression tests
- chore: extend per-package coverage gate to more security-critical packages
- chore: add informational coverage:skip: marker audit step to CI

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] gosec baseline regenerated, no new findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
