### PR TITLE
fix(security): harden auth/session controls per audit findings

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -244,6 +244,19 @@ func serve(cfg *config.Config) error {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
+	// Issue #559 findings [5]/[11]: DEV_MODE unlocks unauthenticated admin-session
+	// minting (/api/v1/dev/login, /api/v1/dev/impersonate) gated only by this one
+	// environment variable. Defaults closed and also requires a seeded
+	// admin@dev.local account, but give operators a loud, unmissable signal if
+	// it's ever set, since there is no other startup-time indication.
+	if devMode := os.Getenv("DEV_MODE"); devMode == "true" || devMode == "1" {
+		log.Println("WARNING: ==========================================================")
+		log.Println("WARNING: DEV_MODE is enabled. Unauthenticated admin-session minting")
+		log.Println("WARNING: endpoints (/api/v1/dev/login, /api/v1/dev/impersonate) are")
+		log.Println("WARNING: ACTIVE. This must never be set in a production deployment.")
+		log.Println("WARNING: ==========================================================")
+	}
+
 	// Validate JWT secret configuration (fails in production if not set)
 	if err := auth.ValidateJWTSecret(); err != nil {
 		return fmt.Errorf("security configuration error: %w", err)

--- a/backend/gosec-baseline.json
+++ b/backend/gosec-baseline.json
@@ -374,7 +374,7 @@
 	],
 	"Stats": {
 		"files": 233,
-		"lines": 60623,
+		"lines": 60666,
 		"nosec": 167,
 		"found": 23
 	},

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -571,7 +571,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Module Registry endpoints (v1) - Terraform Protocol
 	// These are public endpoints that support optional authentication
 	v1Modules := router.Group("/v1/modules")
-	v1Modules.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo))
+	v1Modules.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo))
 	{
 		v1Modules.GET("/:namespace/:name/:system/versions", modules.ListVersionsHandler(db, cfg))
 		v1Modules.GET("/:namespace/:name/:system/:version/download", modules.DownloadHandler(db, storageBackend, cfg, auditRepo))
@@ -583,7 +583,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Provider Registry endpoints (v1)
 	// These are for the standard Provider Registry Protocol
 	v1Providers := router.Group("/v1/providers")
-	v1Providers.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo))
+	v1Providers.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo))
 	{
 		v1Providers.GET("/:namespace/:type/versions", providers.ListVersionsHandler(db, cfg))
 		v1Providers.GET("/:namespace/:type/:version/download/:os/:arch", providers.DownloadHandler(db, storageBackend, cfg, auditRepo))
@@ -904,7 +904,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		// Public detail endpoints — no auth required; optional auth populates user context if a
 		// token is present (used by the frontend to conditionally show management actions).
 		publicDetailGroup := apiV1.Group("")
-		publicDetailGroup.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo))
+		publicDetailGroup.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo))
 		publicDetailGroup.Use(middleware.RateLimitMiddleware(generalRateLimiter))
 		{
 			publicDetailGroup.GET("/modules/:namespace/:name/:system", moduleAdminHandlers.GetModule)

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -110,6 +110,15 @@ func ValidateJWTSecret() error {
 
 		storeSecret(resolved)
 		tokenManager = identityauth.NewTokenManager(resolved, jwtIssuer)
+		// Pin validation to this service's own issuer. Without this, Validate
+		// accepts a token bearing ANY iss claim as long as it is signed with the
+		// current secret — in a coupled suite deployment sharing TFR_JWT_SECRET
+		// with a sibling app (per ADR 012), that sibling's tokens (or a token
+		// crafted with a spoofed iss) would be silently accepted here (issue #559
+		// finding [0]). This does not add audience enforcement (the shared
+		// TokenManager has no audience support yet); that half of the finding
+		// requires a change to the terraform-suite-identity library itself.
+		tokenManager.SetAllowedIssuers([]string{jwtIssuer})
 	})
 
 	return jwtSecretErr

--- a/backend/internal/auth/ldap/provider.go
+++ b/backend/internal/auth/ldap/provider.go
@@ -65,6 +65,17 @@ func NewProvider(cfg *config.LDAPConfig) (*Provider, error) {
 		cfgCopy.GroupMemberAttr = "member"
 	}
 
+	// Issue #559 finding [6]: InsecureSkipVerify disables LDAPS/StartTLS server
+	// certificate verification, exposing the service-account bind password and
+	// every user's submitted password to on-path interception. It requires
+	// intentional misconfiguration (defaults to false), but there is otherwise
+	// no signal to an operator that this control is disabled.
+	if cfgCopy.InsecureSkipVerify {
+		slog.Warn("LDAP TLS certificate verification is DISABLED (insecure_skip_verify=true) — " +
+			"bind credentials and user passwords are exposed to on-path interception. " +
+			"This should never be set outside development; prefer distributing a custom CA bundle instead.")
+	}
+
 	return &Provider{
 		cfg: &cfgCopy,
 	}, nil

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -201,7 +201,7 @@ func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, a
 }
 
 // OptionalAuthMiddleware - same as AuthMiddleware but doesn't abort if no auth
-func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository) gin.HandlerFunc {
+func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository, tokenRepo *repositories.TokenRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 		var fromCookie bool
@@ -228,22 +228,32 @@ func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepos
 
 		// Try JWT first
 		if claims, err := auth.ValidateJWT(token); err == nil {
-			// JWT is valid, load user and set in context
-			user, err := userRepo.GetUserByID(c.Request.Context(), claims.UserID)
-			if err == nil && user != nil {
-				c.Set("user", user)
-				c.Set("user_id", user.ID)
-				if fromCookie {
-					c.Set("auth_method", "jwt_cookie")
-				} else {
-					c.Set("auth_method", "jwt")
+			// Check revocation — same check as AuthMiddleware, but a revoked
+			// token here means "continue as unauthenticated" rather than abort,
+			// since this middleware guards optionally-authenticated public
+			// registry-protocol endpoints (issue #559 finding [4]).
+			revoked := false
+			if claims.JTI != "" && tokenRepo != nil {
+				revoked, _ = tokenRepo.IsTokenRevoked(c.Request.Context(), claims.JTI)
+			}
+			if !revoked {
+				// JWT is valid, load user and set in context
+				user, err := userRepo.GetUserByID(c.Request.Context(), claims.UserID)
+				if err == nil && user != nil {
+					c.Set("user", user)
+					c.Set("user_id", user.ID)
+					if fromCookie {
+						c.Set("auth_method", "jwt_cookie")
+					} else {
+						c.Set("auth_method", "jwt")
+					}
+					// Use scopes embedded in JWT claims (avoids DB query per request)
+					scopes := claims.Scopes
+					if scopes == nil {
+						scopes = []string{}
+					}
+					c.Set("scopes", scopes)
 				}
-				// Use scopes embedded in JWT claims (avoids DB query per request)
-				scopes := claims.Scopes
-				if scopes == nil {
-					scopes = []string{}
-				}
-				c.Set("scopes", scopes)
 			}
 			c.Next()
 			return

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -77,7 +77,7 @@ func newAuthRouter() *gin.Engine {
 // newOptionalAuthRouter builds a router with OptionalAuthMiddleware using nil repos.
 func newOptionalAuthRouter() *gin.Engine {
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return r
 }
@@ -553,7 +553,7 @@ func TestOptionalAuthMiddleware_ValidJWT_SetsUser(t *testing.T) {
 	orgRepo, orgMock := newOrgRepo(t)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := generateTestJWT(t, "user-1")
@@ -575,12 +575,47 @@ func TestOptionalAuthMiddleware_ValidJWT_SetsUser(t *testing.T) {
 	}
 }
 
+// Issue #559 finding [4]: a revoked token must not silently grant identity on
+// the optional-auth path — assert it falls through as unauthenticated instead
+// of setting user context (unlike AuthMiddleware, which aborts with 401).
+func TestOptionalAuthMiddleware_JWTRevoked_ContinuesUnauthenticated(t *testing.T) {
+	userRepo, userMock := newUserRepo(t)
+	orgRepo, _ := newOrgRepo(t)
+	tokenRepo, tokenMock := newTokenRepo(t)
+
+	token := generateTestJWT(t, "user-1")
+
+	tokenMock.ExpectQuery("SELECT EXISTS").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	var userWasSet bool
+	r := gin.New()
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, tokenRepo))
+	r.GET("/", func(c *gin.Context) {
+		_, userWasSet = c.Get("user")
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (optional auth always passes through)", w.Code)
+	}
+	if userWasSet {
+		t.Error("user should not be set in context for a revoked token")
+	}
+	_ = userMock // user lookup is not expected to run — revocation check short-circuits first
+}
+
 func TestOptionalAuthMiddleware_ValidJWT_UserNotFound_PassesThrough(t *testing.T) {
 	userRepo, userMock := newUserRepo(t)
 	orgRepo, _ := newOrgRepo(t)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := generateTestJWT(t, "nonexistent-user")
@@ -609,7 +644,7 @@ func TestOptionalAuthMiddleware_APIKey_Valid_SetsContext(t *testing.T) {
 	userRepo := repositories.NewUserRepository(userDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, apiKeyRepo, nil))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, apiKeyRepo, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := "tfr_optional_test9"
@@ -643,7 +678,7 @@ func TestOptionalAuthMiddleware_APIKey_Expired_PassesThrough(t *testing.T) {
 	apiKeyRepo := repositories.NewAPIKeyRepository(apiKeyDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := "tfr_expired_key9"
@@ -675,7 +710,7 @@ func TestOptionalAuthMiddleware_APIKey_NoMatch_PassesThrough(t *testing.T) {
 	apiKeyRepo := repositories.NewAPIKeyRepository(apiKeyDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	// Return empty rows — no matching key


### PR DESCRIPTION
Partially addresses #559

## Summary
Implements 4 of the 10 findings in #559 (auth/SSO/session hardening bundle) — the ones that are entirely backend-repo-local, low-risk, and don''t require external-repo or frontend coordination. The remaining 6 findings are explicitly NOT addressed here; see the breakdown below.

## Changes

- **[0] JWT validation enforced no audience and did not pin the issuer** — the shared `terraform-suite-identity` TokenManager (already a dependency, v0.16.0) exposes `SetAllowedIssuers`, so this is callable from this repo without a library change. Added `tokenManager.SetAllowedIssuers([]string{jwtIssuer})` at startup in `ValidateJWTSecret()`, restricting validation to tokens actually minted by this service. **Audience enforcement is NOT included** — the pinned TokenManager version has no `aud` claim support at all (`Generate`/`Validate` have no audience parameter); adding it requires a `terraform-suite-identity` release, tracked as a follow-up, not in scope for this repo alone.
- **[4] Token revocation was not enforced on the optional-auth path** — `OptionalAuthMiddleware` now accepts a `*repositories.TokenRepository` (mirroring `AuthMiddleware`''s existing pattern) and checks revocation after JWT validation. Per the issue''s own suggested fix, a revoked token here means **continue as unauthenticated**, not abort — this middleware guards public registry-protocol endpoints (module/provider listing and downloads) that must keep working for anonymous callers. Updated all 3 call sites in `router.go` and all existing tests; added `TestOptionalAuthMiddleware_JWTRevoked_ContinuesUnauthenticated` asserting the request still succeeds but does **not** set user context.
- **[6] LDAP `InsecureSkipVerify` had no operator-facing signal when enabled** — added a `slog.Warn` in `ldap.NewProvider` when the config flag is set, describing the credential-exposure risk (mirrors the existing `TFR_JWT_SECRET`/`ENCRYPTION_KEY` startup-warning pattern already used elsewhere in this codebase).
- **[5]/[11] `DEV_MODE` unauthenticated admin-session minting had no startup signal** — added a loud, multi-line `WARNING` block in `cmd/server/main.go`''s `serve()` when `DEV_MODE=true`/`1`, so it can''t go unnoticed in deployment logs. I deliberately did **not** implement the issue''s stronger suggestion of "refuse to boot when DEV_MODE is set together with a production indicator" — this codebase has no existing config concept for "production indicator" (no `APP_ENV`/`GO_ENV`-equivalent; `gin.Mode()` is driven by `cfg.Logging.Level`, not a reliable production signal), and inventing one unilaterally felt like scope creep beyond a quick-batch fix. Flagging this as a design decision that needs explicit input rather than silently skipping it.

## Explicitly deferred (not in this PR)

- **[1] SAML replay / IdP-initiated login CSRF** — real design work (persisted AuthnRequest ID cache, configurable `AllowIDPInitiated` default). Needs a dedicated session.
- **[2] OIDC nonce/PKCE** — location is `terraform-suite-identity/identity/auth/oidc/provider.go`, the **external** shared library repo, not this one.
- **[3] mTLS advertised but non-functional** — the issue itself frames this as a binary choice ("either remove... or wire it correctly"); that''s a product decision I''m not comfortable making unilaterally.
- **[7] JWT relocated to localStorage** — `info` severity, explicitly noted in the issue as "primarily a frontend concern."
- **[9] Privilege-revocation delay (JWT scopes not re-checked on role/org change)** — a real architecture change (per-request scope re-resolution or a token-epoch/version claim), sized for its own session.
- Cross-repo coordination for #570 (FE↔BE cookie-only migration) is unrelated to this PR and still needs frontend work per that issue.

## Verification
- `go build ./...`, full `go test ./...`, `go vet ./...` all clean.
- `gofmt -l` clean on all changed files.
- gosec baseline regenerated — file/line-count stats only, no new findings.
- New `TestOptionalAuthMiddleware_JWTRevoked_ContinuesUnauthenticated` test passes; all pre-existing `OptionalAuthMiddleware`/`AuthMiddleware` tests updated for the new `tokenRepo` parameter and still pass.

## Changelog
- fix: pin JWT validation to this service''s own issuer (SetAllowedIssuers)
- fix: enforce token revocation on the optional-auth path (continues unauthenticated, not abort)
- fix: warn at startup when LDAP InsecureSkipVerify is enabled
- fix: add a loud startup warning when DEV_MODE is enabled

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes (full suite)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on all changed files
- [x] gosec baseline regenerated, no new findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
