### PR TITLE
fix(security): bind SAML assertions to request ID and gate IdP-initiated SSO

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -208,7 +208,7 @@ func (h *AuthHandlers) LoginHandler() gin.HandlerFunc {
 					})
 					return
 				}
-				redirectURL, err := sp.MakeAuthenticationRequest(state)
+				redirectURL, reqID, err := sp.MakeAuthenticationRequest(state)
 				if err != nil {
 					slog.Error("saml: failed to create AuthnRequest", "idp", idpName, "error", err)
 					c.JSON(http.StatusInternalServerError, gin.H{
@@ -217,7 +217,9 @@ func (h *AuthHandlers) LoginHandler() gin.HandlerFunc {
 					return
 				}
 				// Update session state with the specific IdP name for callback routing
+				// and bind the AuthnRequest ID so the ACS can enforce InResponseTo.
 				sessionState.ProviderType = "saml:" + idpName
+				sessionState.SAMLRequestID = reqID
 				_ = h.stateStore.Save(c.Request.Context(), state, sessionState, 10*time.Minute)
 				authURL = redirectURL.String()
 			} else {
@@ -1067,6 +1069,9 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 		// The RelayState may contain our session state key which includes the IdP name.
 		var provider *samlpkg.Provider
 		var idpName string
+		// possibleRequestIDs binds the assertion to an AuthnRequest this SP issued
+		// (SP-initiated). It stays empty only for genuine IdP-initiated responses.
+		var possibleRequestIDs []string
 
 		if relayState != "" {
 			// Try to load session state from relay state (which is our CSRF state token)
@@ -1076,6 +1081,9 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 				if strings.HasPrefix(sessionState.ProviderType, "saml:") {
 					idpName = strings.TrimPrefix(sessionState.ProviderType, "saml:")
 					provider = h.samlProviders[idpName]
+				}
+				if sessionState.SAMLRequestID != "" {
+					possibleRequestIDs = []string{sessionState.SAMLRequestID}
 				}
 			}
 		}
@@ -1094,15 +1102,43 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Validate the SAML response
-		// For SP-initiated flows, we should validate against the request ID.
-		// For IdP-initiated flows, we pass empty possible request IDs.
-		possibleRequestIDs := []string{}
-		userInfo, err := provider.ValidateResponse(c.Request, possibleRequestIDs, h.cfg.Auth.SAML.GroupAttributeName)
+		// Reject unsolicited (IdP-initiated) responses unless the operator has
+		// explicitly enabled them. Without a bound request ID such a response is
+		// not tied to a login this SP initiated, enabling replay and login CSRF.
+		if len(possibleRequestIDs) == 0 && !provider.AllowIDPInitiated() {
+			slog.Warn("saml: rejected unsolicited response; IdP-initiated SSO is disabled", "idp", idpName)
+			callbackError("idp_initiated_disabled", "Unsolicited IdP-initiated SAML login is not enabled.")
+			return
+		}
+
+		// Validate the SAML response. When possibleRequestIDs is populated the
+		// crewjam SP enforces InResponseTo; for enabled IdP-initiated flows the
+		// binding is skipped and replay is mitigated by the cache below.
+		userInfo, assertionMeta, err := provider.ValidateResponse(c.Request, possibleRequestIDs, h.cfg.Auth.SAML.GroupAttributeName)
 		if err != nil {
 			slog.Error("saml: assertion validation failed", "idp", idpName, "error", err)
 			callbackError("assertion_invalid", "SAML assertion validation failed.")
 			return
+		}
+
+		// Assertion replay protection for IdP-initiated flows (no InResponseTo
+		// binding). Dedupe on the assertion ID until it expires (NotOnOrAfter).
+		if provider.AllowIDPInitiated() && assertionMeta != nil && assertionMeta.ID != "" {
+			ttl := time.Until(assertionMeta.NotOnOrAfter)
+			if ttl <= 0 || ttl > 15*time.Minute {
+				ttl = 15 * time.Minute
+			}
+			reserved, resErr := h.stateStore.Reserve(c.Request.Context(), "saml_assertion:"+assertionMeta.ID, ttl)
+			if resErr != nil {
+				slog.Error("saml: assertion replay check failed", "idp", idpName, "error", resErr)
+				callbackError("assertion_invalid", "SAML assertion validation failed.")
+				return
+			}
+			if !reserved {
+				slog.Warn("saml: rejected replayed assertion", "idp", idpName, "assertion_id", assertionMeta.ID)
+				callbackError("assertion_replayed", "This SAML assertion has already been used.")
+				return
+			}
 		}
 
 		if userInfo.Email == "" && userInfo.NameID == "" {

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -1324,6 +1324,87 @@ func TestIdentityGroupMappingsHandler_WithSAMLAndLDAP(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// SAMLACSHandler — IdP-initiated guard (finding [1])
+// ---------------------------------------------------------------------------
+
+const samlTestIdPMetadata = `<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`
+
+// newSAMLACSHandler builds an AuthHandlers with a single SAML IdP configured.
+func newSAMLACSHandler(t *testing.T, allowIDPInitiated bool) *AuthHandlers {
+	t.Helper()
+	samlCfg := &config.SAMLConfig{
+		Enabled:           true,
+		ACSURL:            "https://registry.example.com/api/v1/auth/saml/acs",
+		EntityID:          "https://registry.example.com",
+		AllowIDPInitiated: allowIDPInitiated,
+	}
+	prov, err := samlpkg.NewProvider(samlCfg, &config.SAMLIdPConfig{Name: "test-idp", MetadataXML: samlTestIdPMetadata})
+	if err != nil {
+		t.Fatalf("samlpkg.NewProvider: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Auth.SAML = *samlCfg
+	return &AuthHandlers{
+		cfg:           cfg,
+		samlProviders: map[string]*samlpkg.Provider{"test-idp": prov},
+		stateStore:    auth.NewMemoryStateStore(time.Hour),
+	}
+}
+
+// postToACS posts a (bogus) SAMLResponse with no RelayState — the shape of an
+// unsolicited IdP-initiated response.
+func postToACS(h *AuthHandlers) *httptest.ResponseRecorder {
+	r := gin.New()
+	r.POST("/api/v1/auth/saml/acs", h.SAMLACSHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs", strings.NewReader("SAMLResponse=Zm9v"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestSAMLACSHandler_RejectsUnsolicitedWhenIDPInitiatedDisabled(t *testing.T) {
+	h := newSAMLACSHandler(t, false)
+	defer h.stateStore.Close()
+
+	w := postToACS(h)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	if loc := w.Header().Get("Location"); !strings.Contains(loc, "error=idp_initiated_disabled") {
+		t.Errorf("Location = %q, want error=idp_initiated_disabled", loc)
+	}
+}
+
+func TestSAMLACSHandler_AllowsIDPInitiatedWhenEnabled(t *testing.T) {
+	h := newSAMLACSHandler(t, true)
+	defer h.stateStore.Close()
+
+	w := postToACS(h)
+
+	// The unsolicited guard is bypassed; the bogus assertion then fails
+	// signature/parse validation instead of being rejected up-front.
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if strings.Contains(loc, "error=idp_initiated_disabled") {
+		t.Errorf("guard should be bypassed when IdP-initiated is enabled; Location = %q", loc)
+	}
+	if !strings.Contains(loc, "error=assertion_invalid") {
+		t.Errorf("Location = %q, want error=assertion_invalid", loc)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // MTLSConfigHandler — Phase 2 enterprise identity
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/auth/saml/provider.go
+++ b/backend/internal/auth/saml/provider.go
@@ -24,8 +24,9 @@ import (
 // Provider wraps a crewjam/saml ServiceProvider and exposes methods needed
 // by the auth handlers. One Provider instance is created per configured IdP.
 type Provider struct {
-	sp   saml.ServiceProvider
-	name string
+	sp                saml.ServiceProvider
+	name              string
+	allowIDPInitiated bool
 }
 
 // UserInfo holds the attributes extracted from a SAML assertion.
@@ -34,6 +35,17 @@ type UserInfo struct {
 	Email  string
 	Name   string
 	Groups []string
+}
+
+// AssertionMeta carries replay-relevant metadata extracted from a validated
+// assertion. It is used by the ACS handler to deduplicate assertion IDs when
+// IdP-initiated SSO is enabled (there is no InResponseTo binding in that flow).
+type AssertionMeta struct {
+	// ID is the SAML assertion ID (unique per issued assertion).
+	ID string
+	// NotOnOrAfter is the end of the assertion validity window; a replay-cache
+	// entry need only be retained until this time.
+	NotOnOrAfter time.Time
 }
 
 // NewProvider creates a SAML Service Provider for the given IdP configuration.
@@ -56,7 +68,7 @@ func NewProvider(cfg *config.SAMLConfig, idpCfg *config.SAMLIdPConfig) (*Provide
 	sp := saml.ServiceProvider{
 		EntityID:          entityID,
 		AcsURL:            *acsURL,
-		AllowIDPInitiated: true,
+		AllowIDPInitiated: cfg.AllowIDPInitiated,
 	}
 
 	// Load SP signing cert/key if provided
@@ -85,8 +97,9 @@ func NewProvider(cfg *config.SAMLConfig, idpCfg *config.SAMLIdPConfig) (*Provide
 	sp.IDPMetadata = idpMetadata
 
 	return &Provider{
-		sp:   sp,
-		name: idpCfg.Name,
+		sp:                sp,
+		name:              idpCfg.Name,
+		allowIDPInitiated: cfg.AllowIDPInitiated,
 	}, nil
 }
 
@@ -95,28 +108,38 @@ func (p *Provider) Name() string {
 	return p.name
 }
 
+// AllowIDPInitiated reports whether unsolicited IdP-initiated SSO responses are
+// accepted for this IdP. When false, only solicited SP-initiated responses
+// bound to a server-issued AuthnRequest ID (InResponseTo) are accepted.
+func (p *Provider) AllowIDPInitiated() bool {
+	return p.allowIDPInitiated
+}
+
 // GetMetadata returns the SP metadata XML for publishing to IdPs.
 func (p *Provider) GetMetadata() *saml.EntityDescriptor {
 	return p.sp.Metadata()
 }
 
 // MakeAuthenticationRequest creates a SAML AuthnRequest URL for SP-initiated login.
-func (p *Provider) MakeAuthenticationRequest(relayState string) (*url.URL, error) {
+// It returns the redirect URL and the generated AuthnRequest ID. The caller must
+// persist the request ID (keyed to the RelayState/state token) and supply it as
+// a possible request ID at the ACS so the assertion's InResponseTo is enforced.
+func (p *Provider) MakeAuthenticationRequest(relayState string) (*url.URL, string, error) {
 	authReq, err := p.sp.MakeAuthenticationRequest(
 		p.sp.GetSSOBindingLocation(saml.HTTPRedirectBinding),
 		saml.HTTPRedirectBinding,
 		saml.HTTPPostBinding,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("saml: failed to create AuthnRequest: %w", err)
+		return nil, "", fmt.Errorf("saml: failed to create AuthnRequest: %w", err)
 	}
 
 	redirectURL, err := authReq.Redirect(relayState, &p.sp)
 	if err != nil {
-		return nil, fmt.Errorf("saml: failed to build redirect URL: %w", err)
+		return nil, "", fmt.Errorf("saml: failed to build redirect URL: %w", err)
 	}
 
-	return redirectURL, nil
+	return redirectURL, authReq.ID, nil
 }
 
 // ParseResponse validates a SAML Response (from the ACS POST) and extracts user info.
@@ -137,14 +160,22 @@ func (p *Provider) ParseResponse(samlResponse string, groupAttr string) (*UserIn
 	return assertionInfo, nil
 }
 
-// ValidateResponse validates a SAML response from an HTTP request and returns user info.
-func (p *Provider) ValidateResponse(r *http.Request, possibleRequestIDs []string, groupAttr string) (*UserInfo, error) {
+// ValidateResponse validates a SAML response from an HTTP request and returns
+// user info plus replay-relevant assertion metadata. possibleRequestIDs must
+// contain the AuthnRequest ID issued for this login (SP-initiated); when the
+// provider does not allow IdP-initiated SSO, an empty list rejects the response.
+func (p *Provider) ValidateResponse(r *http.Request, possibleRequestIDs []string, groupAttr string) (*UserInfo, *AssertionMeta, error) {
 	assertion, err := p.sp.ParseResponse(r, possibleRequestIDs)
 	if err != nil {
-		return nil, fmt.Errorf("saml: failed to validate response: %w", err)
+		return nil, nil, fmt.Errorf("saml: failed to validate response: %w", err)
 	}
 
-	return extractUserInfo(assertion, groupAttr), nil
+	meta := &AssertionMeta{ID: assertion.ID}
+	if assertion.Conditions != nil {
+		meta.NotOnOrAfter = assertion.Conditions.NotOnOrAfter
+	}
+
+	return extractUserInfo(assertion, groupAttr), meta, nil
 }
 
 // extractUserInfo pulls user attributes from a validated SAML assertion.

--- a/backend/internal/auth/saml/provider_test.go
+++ b/backend/internal/auth/saml/provider_test.go
@@ -233,6 +233,56 @@ func TestFetchIdPMetadata_RequiresHTTPS(t *testing.T) {
 	}
 }
 
+func TestMakeAuthenticationRequest_ReturnsRequestID(t *testing.T) {
+	cfg := &config.SAMLConfig{
+		Enabled:  true,
+		ACSURL:   "https://registry.example.com/api/v1/auth/saml/acs",
+		EntityID: "https://registry.example.com",
+	}
+	idpCfg := &config.SAMLIdPConfig{Name: "test-idp", MetadataXML: minimalIdPMetadata}
+
+	p, err := NewProvider(cfg, idpCfg)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	u, reqID, err := p.MakeAuthenticationRequest("state-token")
+	if err != nil {
+		t.Fatalf("MakeAuthenticationRequest: %v", err)
+	}
+	if u == nil {
+		t.Fatal("expected a non-nil redirect URL")
+	}
+	if reqID == "" {
+		t.Error("expected a non-empty AuthnRequest ID for InResponseTo binding")
+	}
+}
+
+func TestAllowIDPInitiated_ReflectsConfig(t *testing.T) {
+	build := func(allow bool) *Provider {
+		t.Helper()
+		cfg := &config.SAMLConfig{
+			Enabled:           true,
+			ACSURL:            "https://registry.example.com/api/v1/auth/saml/acs",
+			EntityID:          "https://registry.example.com",
+			AllowIDPInitiated: allow,
+		}
+		idpCfg := &config.SAMLIdPConfig{Name: "test-idp", MetadataXML: minimalIdPMetadata}
+		p, err := NewProvider(cfg, idpCfg)
+		if err != nil {
+			t.Fatalf("NewProvider: %v", err)
+		}
+		return p
+	}
+
+	if build(false).AllowIDPInitiated() {
+		t.Error("AllowIDPInitiated() = true, want false (secure default)")
+	}
+	if !build(true).AllowIDPInitiated() {
+		t.Error("AllowIDPInitiated() = false, want true when enabled in config")
+	}
+}
+
 // minimalIdPMetadata is a valid SAML IdP metadata XML for testing.
 const minimalIdPMetadata = `<?xml version="1.0"?>
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"

--- a/backend/internal/auth/statestore.go
+++ b/backend/internal/auth/statestore.go
@@ -14,6 +14,10 @@ type SessionState struct {
 	CreatedAt    time.Time `json:"created_at"`
 	RedirectURL  string    `json:"redirect_url"`
 	ProviderType string    `json:"provider_type"` // "oidc", "azuread", or "saml"
+	// SAMLRequestID is the ID of the AuthnRequest issued for an SP-initiated
+	// SAML login. It is echoed back by the IdP as InResponseTo and validated
+	// at the ACS to bind the assertion to a request this SP actually made.
+	SAMLRequestID string `json:"saml_request_id,omitempty"`
 }
 
 // StateStore is the interface for OIDC session state persistence.
@@ -28,6 +32,12 @@ type StateStore interface {
 	// Delete removes a session state entry. Implementations should treat
 	// deleting a non-existent key as a no-op.
 	Delete(ctx context.Context, state string) error
+	// Reserve atomically records a single-use marker under key for the given
+	// TTL. It returns reserved=true when the key did not previously exist
+	// (first use) and reserved=false when the key was already present, which
+	// callers use to detect replays (e.g. an already-consumed SAML assertion
+	// ID). Implementations must perform the check-and-set atomically.
+	Reserve(ctx context.Context, key string, ttl time.Duration) (reserved bool, err error)
 	// Close releases resources held by the store (stop goroutines, close connections).
 	Close() error
 }

--- a/backend/internal/auth/statestore_memory.go
+++ b/backend/internal/auth/statestore_memory.go
@@ -88,6 +88,22 @@ func (s *MemoryStateStore) Delete(_ context.Context, state string) error {
 	return nil
 }
 
+// Reserve atomically records key for the given TTL. It returns true when key
+// was newly created (first use) and false when a non-expired entry already
+// exists (a replay).
+func (s *MemoryStateStore) Reserve(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.entries[key]; ok && time.Now().Before(e.expiresAt) {
+		return false, nil
+	}
+	s.entries[key] = &memoryEntry{
+		data:      &SessionState{State: key, CreatedAt: time.Now()},
+		expiresAt: time.Now().Add(ttl),
+	}
+	return true, nil
+}
+
 // Close stops the cleanup goroutine.
 func (s *MemoryStateStore) Close() error {
 	close(s.stopCh)

--- a/backend/internal/auth/statestore_redis.go
+++ b/backend/internal/auth/statestore_redis.go
@@ -91,6 +91,17 @@ func (s *RedisStateStore) Delete(ctx context.Context, state string) error {
 	return s.client.Del(ctx, stateKeyPrefix+state).Err()
 }
 
+// Reserve atomically records key for the given TTL using SET NX. It returns
+// true when the key was newly created (first use) and false when the key
+// already existed (a replay).
+func (s *RedisStateStore) Reserve(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	ok, err := s.client.SetNX(ctx, stateKeyPrefix+key, "1", ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis state store: reserve error: %w", err)
+	}
+	return ok, nil
+}
+
 // Close shuts down the Redis connection.
 func (s *RedisStateStore) Close() error {
 	return s.client.Close()

--- a/backend/internal/auth/statestore_redis_test.go
+++ b/backend/internal/auth/statestore_redis_test.go
@@ -123,6 +123,37 @@ func TestRedisStateStore_SaveTTLExpiry(t *testing.T) {
 	}
 }
 
+func TestRedisStateStore_Reserve(t *testing.T) {
+	store, mr := newTestRedisStore(t)
+	ctx := context.Background()
+
+	first, err := store.Reserve(ctx, "assertion-1", time.Minute)
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if !first {
+		t.Fatal("first Reserve() = false, want true (newly reserved)")
+	}
+
+	second, err := store.Reserve(ctx, "assertion-1", time.Minute)
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if second {
+		t.Error("second Reserve() = true, want false (replay must be detected)")
+	}
+
+	// After the TTL passes the assertion ID may be reserved again.
+	mr.FastForward(2 * time.Minute)
+	third, err := store.Reserve(ctx, "assertion-1", time.Minute)
+	if err != nil {
+		t.Fatalf("Reserve after expiry: %v", err)
+	}
+	if !third {
+		t.Error("Reserve() after expiry = false, want true (expired entry is reusable)")
+	}
+}
+
 func TestNewRedisStateStore_ConnectionError(t *testing.T) {
 	// Point at a port with nothing listening; the constructor's Ping must fail.
 	_, err := NewRedisStateStore(&config.RedisConfig{

--- a/backend/internal/auth/statestore_test.go
+++ b/backend/internal/auth/statestore_test.go
@@ -48,6 +48,42 @@ func TestMemoryStateStore_SaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestMemoryStateStore_Reserve(t *testing.T) {
+	store := NewMemoryStateStore(time.Hour)
+	defer store.Close()
+	ctx := context.Background()
+
+	first, err := store.Reserve(ctx, "assertion-1", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Reserve() error: %v", err)
+	}
+	if !first {
+		t.Fatal("first Reserve() = false, want true (newly reserved)")
+	}
+
+	second, err := store.Reserve(ctx, "assertion-1", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("Reserve() error: %v", err)
+	}
+	if second {
+		t.Error("second Reserve() = true, want false (replay must be detected)")
+	}
+}
+
+func TestMemoryStateStore_ReserveExpires(t *testing.T) {
+	store := NewMemoryStateStore(time.Hour)
+	defer store.Close()
+	ctx := context.Background()
+
+	if ok, _ := store.Reserve(ctx, "assertion-2", 5*time.Millisecond); !ok {
+		t.Fatal("first Reserve() = false, want true")
+	}
+	time.Sleep(15 * time.Millisecond)
+	if ok, _ := store.Reserve(ctx, "assertion-2", time.Minute); !ok {
+		t.Error("Reserve() after expiry = false, want true (expired entry is reusable)")
+	}
+}
+
 func TestMemoryStateStore_LoadNonExistent(t *testing.T) {
 	store := NewMemoryStateStore(time.Hour)
 	defer store.Close()

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -490,6 +490,13 @@ type SAMLConfig struct {
 	CertFile string `mapstructure:"cert_file"`
 	KeyFile  string `mapstructure:"key_file"`
 
+	// AllowIDPInitiated permits unsolicited IdP-initiated SSO responses, which
+	// are not bound to a server-issued AuthnRequest (no InResponseTo check).
+	// It defaults to false so that only solicited SP-initiated responses bound
+	// to a single-use request ID are accepted. When enabled, an assertion-ID
+	// replay cache is used to mitigate assertion replay.
+	AllowIDPInitiated bool `mapstructure:"allow_idp_initiated"`
+
 	// IdPs lists one or more SAML Identity Providers.
 	IdPs []SAMLIdPConfig `mapstructure:"idps"`
 


### PR DESCRIPTION
Addresses finding **[1]** of #559 (SAML assertions not bound to a server-issued request ID; IdP-initiated SSO unconditionally enabled — replay + login CSRF).

## Problem

`crewjam/saml` was constructed with `AllowIDPInitiated: true` and the ACS always passed an empty `possibleRequestIDs`. With `AllowIDPInitiated` on, the library skips `InResponseTo` validation entirely, so:
- a signed `SAMLResponse` captured on the wire (or a crafted IdP-initiated one) could be **replayed** to `/api/v1/auth/saml/acs` within the assertion window to mint a session, and
- an attacker could force a victim's browser to complete login as the attacker's identity (**login CSRF**), since the flow was not bound to the victim's single-use state token.

## Changes

- **Bind assertions to a server-issued AuthnRequest ID.** `MakeAuthenticationRequest` now returns the generated request ID; the SP-initiated handler persists it on the session state (`SessionState.SAMLRequestID`, keyed to the single-use state/RelayState token). At the ACS the stored ID is passed as `possibleRequestIDs`, so `crewjam` enforces `InResponseTo`. Because the state entry is single-use (consumed/deleted on first callback), a replayed response no longer matches and is rejected.
- **`AllowIDPInitiated` is now configuration-driven and defaults to `false`** (`config.SAMLConfig.AllowIDPInitiated`, `mapstructure:"allow_idp_initiated"`). With the secure default, unsolicited responses (no bound request ID) are refused up-front with `idp_initiated_disabled`.
- **Assertion-ID replay cache for the opt-in IdP-initiated path.** When an operator explicitly enables IdP-initiated SSO (no `InResponseTo` binding is possible), each accepted assertion ID is deduplicated until its `NotOnOrAfter` via a new atomic `StateStore.Reserve(key, ttl)` primitive (Redis `SET NX` / in-memory check-and-set), so a signed assertion cannot be replayed.

### `StateStore.Reserve`

Added because `Load` is consume-on-read in the Redis implementation (single-use), so it can't be used as a presence check. `Reserve` is the correct atomic set-if-absent primitive and is HA-safe (shared via Redis). Implemented for both `MemoryStateStore` and `RedisStateStore`.

## Verification

- `go build ./...`, `go test ./...` (incl. `internal/auth/...`, `internal/api/admin/...`, `internal/config/...`), `go vet ./...`, `gofmt -l` — all clean.
- gosec baseline comparison: **0 new findings** (21 active, unchanged).
- New tests: `MakeAuthenticationRequest` returns a request ID; `AllowIDPInitiated()` reflects config; memory + Redis `Reserve` (first-use / replay / expiry); ACS handler rejects unsolicited responses when IdP-initiated is disabled and bypasses the guard (falling through to normal validation) when enabled.

## Notes

- Branched off `main` after #581 merged; independent of the other #559 findings.
- OIDC nonce/PKCE (finding [2]) lives in the external `terraform-suite-identity` repo and is handled in a separate PR there.

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files
- [x] gosec baseline — no new findings
- [x] PR targets `main`
