### PR TITLE
fix(scm): make webhook state writes execute — unused $2 killed auto-publish

### DIFF
--- a/backend/internal/db/repositories/scm_repository.go
+++ b/backend/internal/db/repositories/scm_repository.go
@@ -313,16 +313,37 @@ func (r *SCMRepository) ListWebhookLogs(ctx context.Context, repoID uuid.UUID, l
 	return logs, err
 }
 
-// UpdateWebhookLogState updates the processing state of a webhook log
+// UpdateWebhookLogState updates the processing state of a webhook log.
+//
+// The table has no state column — the state string maps onto the processing
+// flag columns instead: "processing" stamps processing_started_at and leaves
+// the event unprocessed; every other state ("completed"/"failed"/"skipped")
+// is terminal and sets processed/processed_at/error/result_version_id. A
+// failed event that should be retried is flipped back to processed=false by
+// MarkWebhookForRetry immediately after.
+//
+// Every bound parameter must appear in the statement: PostgreSQL rejects a
+// parameterized query with an unused placeholder gap at parse time (42P18),
+// which is exactly the bug that previously made every call here fail and
+// left webhook auto-publish dead (#583).
 func (r *SCMRepository) UpdateWebhookLogState(ctx context.Context, id uuid.UUID, state string, errorMsg *string, versionID *uuid.UUID) error {
 	now := time.Now()
+
+	if state == "processing" {
+		query := `
+			UPDATE scm_webhook_events SET
+				processing_started_at = $2
+			WHERE id = $1`
+		_, err := r.db.ExecContext(ctx, query, id, now)
+		return err
+	}
+
 	query := `
 		UPDATE scm_webhook_events SET
-			processed = true, processed_at = $3,
-			error = $4, result_version_id = $5
+			processed = true, processed_at = $2,
+			error = $3, result_version_id = $4
 		WHERE id = $1`
-
-	_, err := r.db.ExecContext(ctx, query, id, state, now, errorMsg, versionID)
+	_, err := r.db.ExecContext(ctx, query, id, now, errorMsg, versionID)
 	return err
 }
 

--- a/backend/internal/db/repositories/scm_repository_test.go
+++ b/backend/internal/db/repositories/scm_repository_test.go
@@ -640,14 +640,43 @@ func TestSCMListWebhookLogs_Empty(t *testing.T) {
 // UpdateWebhookLogState
 // ---------------------------------------------------------------------------
 
-func TestSCMUpdateWebhookLogState_Success(t *testing.T) {
+// The terminal branch must bind exactly the parameters its statement
+// references — an unused placeholder gap is a hard PostgreSQL parse error
+// (42P18) that killed every state write and with it webhook auto-publish
+// (#583). WithArgs pins the count and order of bound parameters.
+func TestSCMUpdateWebhookLogState_TerminalBindsAllParams(t *testing.T) {
 	repo, mock := newSCMRepo(t)
-	mock.ExpectExec("UPDATE scm_webhook_events").
+	id := uuid.New()
+	versionID := uuid.New()
+	errMsg := "some error"
+
+	mock.ExpectExec(`UPDATE scm_webhook_events SET\s+processed = true, processed_at = \$2,\s+error = \$3, result_version_id = \$4\s+WHERE id = \$1`).
+		WithArgs(id, sqlmock.AnyArg(), &errMsg, &versionID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	errMsg := "some error"
-	if err := repo.UpdateWebhookLogState(context.Background(), uuid.New(), "failed", &errMsg, nil); err != nil {
+	if err := repo.UpdateWebhookLogState(context.Background(), id, "failed", &errMsg, &versionID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+// "processing" is not terminal: it stamps processing_started_at and must NOT
+// mark the event processed (the retry job selects on processed = false).
+func TestSCMUpdateWebhookLogState_ProcessingStampsStartOnly(t *testing.T) {
+	repo, mock := newSCMRepo(t)
+	id := uuid.New()
+
+	mock.ExpectExec(`UPDATE scm_webhook_events SET\s+processing_started_at = \$2\s+WHERE id = \$1`).
+		WithArgs(id, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := repo.UpdateWebhookLogState(context.Background(), id, "processing", nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
 	}
 }
 

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -119,8 +119,12 @@ func (p *SCMPublisher) resolveSourceToken(ctx context.Context, createdBy *string
 // ProcessTagPush processes a tag push webhook and publishes a new version
 // coverage:skip:integration-only — requires live SCM connector, DB, and storage
 func (p *SCMPublisher) ProcessTagPush(ctx context.Context, logID uuid.UUID, moduleSourceRepo *scm.ModuleSourceRepoRecord, hook *scm.IncomingHook, connector scm.Connector) {
-	// Update webhook log to processing
+	// Update webhook log to processing. Returning silently on a state-write
+	// error is what let #583 (every state write failing with 42P18) go
+	// unnoticed — always leave a trace before bailing.
 	if err := p.scmRepo.UpdateWebhookLogState(ctx, logID, "processing", nil, nil); err != nil {
+		slog.Error("webhook processing aborted: failed to mark event as processing",
+			"log_id", logID, "error", err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

`UpdateWebhookLogState` bound 5 parameters against a 4-placeholder SQL statement (an unused `$2`), so every call failed with Postgres error `42P18` (`could not determine data type of parameter`). Reproduced live against the registry's own postgres:16 container. This silently killed webhook-driven auto-publish end to end: every webhook event's state transition write failed, and the "processing" write failure was previously swallowed with no log line.

## Changes

- Split `UpdateWebhookLogState` into two branches — a 2-param `processing` update and a 4-param terminal (`processed`/`error`/`result_version_id`) update — matching what each call site actually needs, instead of one query trying to bind both shapes.
- Added `slog.Error` logging on the early-return path in `scm_publisher.go` when the "processing" write fails (previously silent).
- Added `TestSCMUpdateWebhookLogState_TerminalBindsAllParams` and `TestSCMUpdateWebhookLogState_ProcessingStampsStartOnly`, using `sqlmock.WithArgs` to pin the exact bound-parameter count/order — the existing test only regex-matched the query text and never caught the unused-placeholder bug.

Closes #583.

## Test plan

- [x] Reproduced the `42P18` failure against a live postgres:16 container with the original SQL, confirmed the fix resolves it
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes, including new parameter-binding tests