### PR TITLE
fix(security): enforce origin allowlist on browser-context Bearer mutations (CSRF)

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -917,7 +917,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		// Authenticated-only endpoints
 		authenticatedGroup := apiV1.Group("")
 		authenticatedGroup.Use(middleware.AuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo))
-		authenticatedGroup.Use(middleware.CSRFMiddleware()) // double-submit cookie CSRF protection
+		authenticatedGroup.Use(middleware.CSRFMiddleware(cfg)) // double-submit cookie CSRF protection + browser-origin Bearer allowlist
 		authenticatedGroup.Use(middleware.PrincipalRateLimitMiddleware(generalRateLimiter, principalOverrides))
 		authenticatedGroup.Use(middleware.OrgRateLimitMiddleware(generalRateLimiter, orgRateLimiter))
 		authenticatedGroup.Use(middleware.AuditMiddleware(auditRepo)) // Audit all authenticated actions

--- a/backend/internal/middleware/csrf.go
+++ b/backend/internal/middleware/csrf.go
@@ -11,6 +11,15 @@
 // Because an attacker on a different origin cannot read the cookie value (SameSite
 // + secure flag), they cannot construct a valid X-CSRF-Token header.
 //
+// Bearer-authenticated requests are NOT unconditionally exempt: a browser can
+// carry a Bearer token too (the frontend historically did exactly that), which
+// would make the control bypassable-by-construction. Instead, browser context is
+// detected via the Origin header (Referer as fallback) and browser-context Bearer
+// mutations must come from an allowed origin (server public URL / base URL /
+// configured CORS origins). Requests with no Origin/Referer (terraform CLI, curl,
+// CI scripts) remain exempt because a CSRF attack always executes in a browser,
+// and browsers always attach Origin to cross-origin mutating requests.
+//
 // Safe methods (GET, HEAD, OPTIONS) are exempt because they must be side-effect-free
 // per HTTP semantics.
 package middleware
@@ -20,9 +29,11 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
 const (
@@ -80,12 +91,91 @@ func ClearCSRFCookie(w http.ResponseWriter) {
 	})
 }
 
+// canonicalOrigin reduces a URL or Origin-header value to a comparable
+// "scheme://host" form: lowercased, with default ports (http:80, https:443)
+// stripped. It returns "" for anything that does not parse to a scheme+host
+// (including the literal "null" origin browsers send for opaque contexts).
+func canonicalOrigin(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Host)
+	switch scheme {
+	case "http":
+		host = strings.TrimSuffix(host, ":80")
+	case "https":
+		host = strings.TrimSuffix(host, ":443")
+	}
+	return scheme + "://" + host
+}
+
+// csrfOriginAllowlist builds the set of browser origins allowed to send
+// Bearer-authenticated mutations. It reuses the deployment's existing sources
+// of truth rather than introducing a new knob: server.public_url,
+// server.base_url, and security.cors.allowed_origins. A CORS wildcard ("*")
+// is deliberately NOT honored here — it does not identify this deployment's
+// own origins, and honoring it would disable the check entirely.
+func csrfOriginAllowlist(cfg *config.Config) map[string]struct{} {
+	allowed := make(map[string]struct{})
+	if cfg == nil {
+		return allowed
+	}
+	candidates := []string{cfg.Server.GetPublicURL(), cfg.Server.BaseURL}
+	candidates = append(candidates, cfg.Security.CORS.AllowedOrigins...)
+	for _, candidate := range candidates {
+		if candidate == "*" {
+			continue
+		}
+		if origin := canonicalOrigin(candidate); origin != "" {
+			allowed[origin] = struct{}{}
+		}
+	}
+	return allowed
+}
+
+// requestOrigin returns the canonical browser origin of a request: the Origin
+// header when present, falling back to the Referer's scheme+host. An empty
+// return means the request carried neither — i.e. a non-browser client.
+func requestOrigin(c *gin.Context) string {
+	if origin := c.GetHeader("Origin"); origin != "" {
+		// "null" (sandboxed/opaque contexts) canonicalizes to "" — treat it as
+		// browser context that can never match the allowlist, not as absent.
+		if canonical := canonicalOrigin(origin); canonical != "" {
+			return canonical
+		}
+		return "null"
+	}
+	if referer := c.GetHeader("Referer"); referer != "" {
+		if canonical := canonicalOrigin(referer); canonical != "" {
+			return canonical
+		}
+		return "null"
+	}
+	return ""
+}
+
 // CSRFMiddleware enforces the double-submit cookie pattern on mutating HTTP methods.
 // Safe methods (GET, HEAD, OPTIONS) pass through unconditionally.
 // Requests authenticated via API key (Authorization: Bearer <api_key>) are exempt
 // because API keys are not sent automatically by the browser — they are only used
 // by programmatic clients (Terraform CLI, CI scripts) that are not vulnerable to CSRF.
-func CSRFMiddleware() gin.HandlerFunc {
+//
+// Enforcement matrix for mutating methods:
+//
+//	auth_method  Origin/Referer  enforcement
+//	api_key      any             exempt (API keys are never auto-sent by browsers)
+//	jwt (Bearer) absent          exempt (programmatic client: CLI, CI, curl)
+//	jwt (Bearer) present         origin allowlist — 403 unless scheme+host matches
+//	                             server public/base URL or a configured CORS origin
+//	jwt_cookie   any             double-submit token validation
+//
+// Bearer browser clients may not hold the tfr_csrf cookie (they never went
+// through the cookie-issuing login flow), so the double-submit check cannot
+// apply; the origin allowlist provides the equivalent cross-site guarantee.
+func CSRFMiddleware(cfg *config.Config) gin.HandlerFunc {
+	allowedOrigins := csrfOriginAllowlist(cfg)
 	return func(c *gin.Context) {
 		// Safe methods are exempt — they must be side-effect-free.
 		method := strings.ToUpper(c.Request.Method)
@@ -105,12 +195,25 @@ func CSRFMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		// If the request was authenticated via cookie (auth_method == "jwt_cookie"),
-		// enforce CSRF. If authenticated via Authorization header JWT, exempt as well
-		// since that requires explicit JS action.
+		// Bearer header JWT (auth_method == "jwt"). Historically exempted as
+		// "programmatic", but a browser can carry a Bearer token too. Detect
+		// browser context via Origin (Referer fallback): no Origin/Referer means
+		// a non-browser client and stays exempt; a browser origin must match the
+		// deployment's own origins or the request is rejected.
 		if authMethod, exists := c.Get("auth_method"); exists {
 			if am, ok := authMethod.(string); ok && am == "jwt" {
-				// Bearer header JWT — not auto-sent by browser, exempt from CSRF.
+				origin := requestOrigin(c)
+				if origin == "" {
+					// No browser context — programmatic client, exempt.
+					c.Next()
+					return
+				}
+				if _, ok := allowedOrigins[origin]; !ok {
+					c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+						"error": "request origin not allowed",
+					})
+					return
+				}
 				c.Next()
 				return
 			}

--- a/backend/internal/middleware/csrf_test.go
+++ b/backend/internal/middleware/csrf_test.go
@@ -4,18 +4,36 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+// csrfTestConfig returns a config whose CSRF origin allowlist contains the
+// server public URL plus one explicitly configured CORS origin.
+func csrfTestConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Server.BaseURL = "http://localhost:8080"
+	cfg.Security.CORS.AllowedOrigins = []string{"https://app.example.com"}
+	return cfg
+}
+
 // csrfRouter builds a test router with CSRFMiddleware. It pre-sets the given
 // auth_method in context (simulating what AuthMiddleware would do) so that
 // CSRF enforcement can branch correctly.
 func csrfRouter(authMethod string) *gin.Engine {
+	return csrfRouterWithConfig(authMethod, csrfTestConfig())
+}
+
+func csrfRouterWithConfig(authMethod string, cfg *config.Config) *gin.Engine {
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		if authMethod != "" {
@@ -23,7 +41,7 @@ func csrfRouter(authMethod string) *gin.Engine {
 		}
 		c.Next()
 	})
-	r.Use(CSRFMiddleware())
+	r.Use(CSRFMiddleware(cfg))
 	r.GET("/safe", func(c *gin.Context) { c.Status(http.StatusOK) })
 	r.POST("/mutate", func(c *gin.Context) { c.Status(http.StatusOK) })
 	r.PUT("/mutate", func(c *gin.Context) { c.Status(http.StatusOK) })
@@ -55,7 +73,20 @@ func TestCSRF_APIKeyExempt(t *testing.T) {
 	}
 }
 
-func TestCSRF_BearerJWTExempt(t *testing.T) {
+func TestCSRF_APIKeyExempt_WithBrowserOrigin(t *testing.T) {
+	r := csrfRouter("api_key")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("API-key-authenticated POST should stay exempt even with a browser Origin; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_NoOrigin_Exempt(t *testing.T) {
 	r := csrfRouter("jwt")
 
 	req := httptest.NewRequest("POST", "/mutate", nil)
@@ -63,7 +94,122 @@ func TestCSRF_BearerJWTExempt(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("Bearer-JWT-authenticated POST should be exempt from CSRF; got %d", w.Code)
+		t.Errorf("Bearer-JWT POST without Origin/Referer (programmatic) should be exempt; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_DisallowedOrigin(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Bearer-JWT POST with disallowed browser Origin should be 403; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_AllowedPublicURLOrigin(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://registry.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Bearer-JWT POST from the public URL origin should pass; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_AllowedCORSOrigin(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Bearer-JWT POST from a configured CORS origin should pass; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_AllowedBaseURLOrigin(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "http://localhost:8080")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Bearer-JWT POST from the base URL origin should pass; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_DefaultPortNormalization(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://registry.example.com:443")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("explicit default port should match the portless public URL; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_RefererFallback(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	// Disallowed referer origin → 403 even without an Origin header.
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Referer", "https://evil.example.com/some/page")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Bearer-JWT POST with disallowed Referer should be 403; got %d", w.Code)
+	}
+
+	// Allowed referer origin (path stripped) → passes.
+	req = httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Referer", "https://registry.example.com/admin/modules")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Bearer-JWT POST with allowed Referer origin should pass; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_NullOrigin(t *testing.T) {
+	r := csrfRouter("jwt")
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "null")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Bearer-JWT POST with opaque 'null' Origin should be 403; got %d", w.Code)
+	}
+}
+
+func TestCSRF_BearerJWT_WildcardCORSNotHonored(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"*"}
+	r := csrfRouterWithConfig("jwt", cfg)
+
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("CORS wildcard must not disable the Bearer origin check; got %d", w.Code)
 	}
 }
 
@@ -135,6 +281,84 @@ func TestCSRF_CookieAuth_PUTAndDELETE(t *testing.T) {
 		if w.Code != http.StatusOK {
 			t.Errorf("%s with valid CSRF token should be 200; got %d", method, w.Code)
 		}
+	}
+}
+
+func TestCSRF_CookieAuth_DoubleSubmitGovernsRegardlessOfOrigin(t *testing.T) {
+	r := csrfRouter("jwt_cookie")
+
+	// Valid double-submit passes even with an Origin header present …
+	token := "matching-csrf-token"
+	req := httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://registry.example.com")
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: token})
+	req.Header.Set(CSRFHeaderName, token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("cookie-auth POST with valid CSRF token and Origin should be 200; got %d", w.Code)
+	}
+
+	// … and a missing token fails even from an allowed origin.
+	req = httptest.NewRequest("POST", "/mutate", nil)
+	req.Header.Set("Origin", "https://registry.example.com")
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: token})
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("cookie-auth POST without CSRF header should be 403 even from an allowed origin; got %d", w.Code)
+	}
+}
+
+// TestCSRF_Integration_CookieSession_HeaderStripped runs the real middleware
+// chain (AuthMiddleware → CSRFMiddleware) against a mutation route with a valid
+// JWT session cookie: stripping the X-CSRF-Token header must yield 403, and
+// echoing the double-submit token must succeed.
+func TestCSRF_Integration_CookieSession_HeaderStripped(t *testing.T) {
+	_ = auth.ValidateJWTSecret()
+	jwtToken := generateTestJWT(t, "user-570")
+
+	newRouter := func() (*gin.Engine, sqlmock.Sqlmock) {
+		userRepo, userMock := newUserRepo(t)
+		orgRepo, _ := newOrgRepo(t)
+		r := gin.New()
+		r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil))
+		r.Use(CSRFMiddleware(csrfTestConfig()))
+		r.POST("/api/v1/admin/modules/create", func(c *gin.Context) { c.Status(http.StatusCreated) })
+		return r, userMock
+	}
+
+	expectUserLookup := func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery("SELECT.*FROM users WHERE id").
+			WillReturnRows(sqlmock.NewRows(jwtUserCols).
+				AddRow("user-570", "test@example.com", "Test", "sub-570", time.Now(), time.Now()))
+	}
+
+	// CSRF header stripped → 403 despite a fully valid auth cookie.
+	r, userMock := newRouter()
+	expectUserLookup(userMock)
+	req := httptest.NewRequest("POST", "/api/v1/admin/modules/create", nil)
+	req.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: jwtToken})
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: "csrf-570"})
+	req.Header.Set("Origin", "https://registry.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("mutation with cookie session and stripped CSRF header should be 403; got %d", w.Code)
+	}
+
+	// Same request with the double-submit token echoed → handler runs.
+	r, userMock = newRouter()
+	expectUserLookup(userMock)
+	req = httptest.NewRequest("POST", "/api/v1/admin/modules/create", nil)
+	req.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: jwtToken})
+	req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: "csrf-570"})
+	req.Header.Set(CSRFHeaderName, "csrf-570")
+	req.Header.Set("Origin", "https://registry.example.com")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("mutation with cookie session and echoed CSRF token should be 201; got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the backend CR2 obligation from #570 (the CR1 half — dropping the raw JWT from LDAP/dev response bodies and removing `/auth/exchange-token` — was already resolved on `main` by the cookie-only auth migration, #584).

The CSRF middleware exempted *any* `auth_method == "jwt"` (Bearer) request from the double-submit check, on the assumption that Bearer tokens are only ever sent programmatically (never auto-attached by a browser, so CSRF doesn't apply). That assumption is violated by the frontend itself: browsers using `Authorization: Bearer` from JS-accessible storage are exactly the case CSRF protection needs to cover, and this exemption made the double-submit control inert for any session carrying such a token — collapsing residual protection to `SameSite=Lax`, which doesn't cover a same-site attacker.

## Changes

- Replaced the blanket `auth_method == "jwt"` CSRF exemption with browser-context detection based on `Origin`/`Referer`.
- Enforcement matrix:
  - `api_key`: always exempt (unchanged)
  - `jwt` (Bearer) with **no** `Origin`/`Referer`: exempt (genuinely programmatic — CLI, service-to-service)
  - `jwt` with an **allowed** `Origin`: passes
  - `jwt` with a **disallowed** `Origin` (including `Origin: null`): 403
  - `jwt_cookie`: unchanged, double-submit token still required regardless of `Origin`
- Allowlist is the canonical `scheme://host` of `server.public_url`, `server.base_url`, and `security.cors.allowed_origins` — a CORS `"*"` is deliberately **not** honored here (would defeat the point).

Closes #570.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes
- [x] New tests cover each branch of the enforcement matrix, including the `Origin: null` case