### PR TITLE
fix(security): enforce namespace-org object authorization on module/provider mutations (BOLA/BFLA)

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -9383,6 +9383,17 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Organization still owns namespace claims",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "content": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -7571,6 +7571,13 @@
                             "additionalProperties": true
                         }
                     },
+                    "409": {
+                        "description": "Organization still owns namespace claims",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -22,17 +22,24 @@ type OrganizationHandlers struct {
 	claimRepo *repositories.NamespaceClaimRepository
 }
 
-// NewOrganizationHandlers creates a new OrganizationHandlers instance
-func NewOrganizationHandlers(cfg *config.Config, db *sql.DB) *OrganizationHandlers {
+// NewOrganizationHandlers creates a new OrganizationHandlers instance.
+//
+// claimRepo is accepted as a parameter rather than constructed internally
+// from db: db here is identityDB, but namespace_claims is a feature table
+// that only ever receives this repo's own migrations on the registry's own
+// db connection (see router.go's "feature repositories... stay on db"
+// comment) -- in the documented shared/separate identity-database deployment
+// mode, identityDB can be a genuinely different physical Postgres instance
+// with no namespace_claims table at all. Callers must pass the SAME
+// *NamespaceClaimRepository instance wired to db that the NamespaceAuthorizer
+// middleware uses, so the pre-delete ownership check in
+// DeleteOrganizationHandler queries the database that actually has the data.
+func NewOrganizationHandlers(cfg *config.Config, db *sql.DB, claimRepo *repositories.NamespaceClaimRepository) *OrganizationHandlers {
 	return &OrganizationHandlers{
-		cfg:     cfg,
-		db:      db,
-		orgRepo: repositories.NewOrganizationRepository(db),
-		// namespace_claims is a feature table (not identity data); when db here
-		// is identityDB post-cutover it still resolves via the public
-		// search_path fallback, same as the other feature-table repos in
-		// router.go.
-		claimRepo: repositories.NewNamespaceClaimRepository(db),
+		cfg:       cfg,
+		db:        db,
+		orgRepo:   repositories.NewOrganizationRepository(db),
+		claimRepo: claimRepo,
 	}
 }
 
@@ -444,6 +451,32 @@ func (h *OrganizationHandlers) DeleteOrganizationHandler() gin.HandlerFunc {
 		if claimCount > 0 {
 			c.JSON(http.StatusConflict, gin.H{
 				"error": "Organization still owns namespace claims; release or reassign its namespaces before deleting it",
+			})
+			return
+		}
+
+		// Also refuse when the organization directly owns module/provider
+		// rows with no namespace_claims row at all -- a namespace whose
+		// artifacts already span more than one organization is deliberately
+		// left unclaimed (ambiguous ownership, admin-only at runtime), so the
+		// claim count check above is 0 for it even though this organization
+		// still owns rows there. modules/providers' organization_id FK is
+		// still ON DELETE CASCADE (unrelated to the namespace_claims RESTRICT
+		// above); deleting this organization would silently remove its rows
+		// from the shared namespace, collapsing it from admin-only ambiguous
+		// to unchecked sole ownership by whichever organization's rows
+		// survive -- the same defect this table exists to close, reached via
+		// a shared namespace instead of via a claim.
+		ownsArtifacts, err := h.claimRepo.OwnsArtifacts(c.Request.Context(), orgID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to check organization artifact ownership",
+			})
+			return
+		}
+		if ownsArtifacts {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Organization still owns modules or providers; remove or reassign them before deleting it",
 			})
 			return
 		}

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -16,9 +16,10 @@ import (
 
 // OrganizationHandlers handles organization management endpoints
 type OrganizationHandlers struct {
-	cfg     *config.Config
-	db      *sql.DB
-	orgRepo *repositories.OrganizationRepository
+	cfg       *config.Config
+	db        *sql.DB
+	orgRepo   *repositories.OrganizationRepository
+	claimRepo *repositories.NamespaceClaimRepository
 }
 
 // NewOrganizationHandlers creates a new OrganizationHandlers instance
@@ -27,6 +28,11 @@ func NewOrganizationHandlers(cfg *config.Config, db *sql.DB) *OrganizationHandle
 		cfg:     cfg,
 		db:      db,
 		orgRepo: repositories.NewOrganizationRepository(db),
+		// namespace_claims is a feature table (not identity data); when db here
+		// is identityDB post-cutover it still resolves via the public
+		// search_path fallback, same as the other feature-table repos in
+		// router.go.
+		claimRepo: repositories.NewNamespaceClaimRepository(db),
 	}
 }
 
@@ -394,6 +400,7 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 // @Success      200  {object}  admin.MessageResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Organization not found"
+// @Failure      409  {object}  map[string]interface{}  "Organization still owns namespace claims"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/organizations/{id} [delete]
 // DeleteOrganizationHandler deletes an organization
@@ -414,6 +421,29 @@ func (h *OrganizationHandlers) DeleteOrganizationHandler() gin.HandlerFunc {
 		if org == nil {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "Organization not found",
+			})
+			return
+		}
+
+		// Refuse to delete an organization that still owns namespace claims
+		// (CWE-639, issue #555). Cascading the delete onto namespace_claims
+		// would silently fall the namespace back to resolveOwnerOrg's
+		// artifact-row fallback, which — since every write handler stamps
+		// organization_id from the default organization regardless of the
+		// real caller — reliably re-attributes ownership to the default org
+		// rather than leaving it (correctly) unowned. The namespace_claims FK
+		// is ON DELETE RESTRICT as a fail-closed backstop; this check exists
+		// to surface the reason with a clear 409 instead of an opaque 500.
+		claimCount, err := h.claimRepo.CountByOrganization(c.Request.Context(), orgID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to check namespace ownership",
+			})
+			return
+		}
+		if claimCount > 0 {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Organization still owns namespace claims; release or reassign its namespaces before deleting it",
 			})
 			return
 		}

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -10,6 +10,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
 // ---------------------------------------------------------------------------
@@ -57,7 +58,7 @@ func newOrgRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	}
 	t.Cleanup(func() { db.Close() })
 
-	h := NewOrganizationHandlers(&config.Config{}, db)
+	h := NewOrganizationHandlers(&config.Config{}, db, repositories.NewNamespaceClaimRepository(db))
 
 	r := gin.New()
 	r.GET("/organizations", h.ListOrganizationsHandler())
@@ -374,6 +375,8 @@ func TestDeleteOrganization_Success(t *testing.T) {
 		WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT EXISTS.*FROM modules").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectExec("DELETE FROM organizations").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -411,6 +414,49 @@ func TestDeleteOrganization_ClaimCountDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
 		WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// A namespace whose artifacts already span more than one organization is
+// deliberately left unclaimed (ambiguous ownership, admin-only at runtime),
+// so the namespace_claims count is 0 for it even though this organization
+// still owns rows there directly. Deleting the organization must still be
+// blocked, or the shared namespace collapses from ambiguous to unchecked sole
+// ownership by whichever organization's rows survive the cascade (#555
+// review finding).
+func TestDeleteOrganization_BlockedByArtifactOwnership(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT EXISTS.*FROM modules").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteOrganization_ArtifactOwnershipDBError(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT EXISTS.*FROM modules").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -743,6 +789,10 @@ func TestDeleteOrganization_DeleteDBError(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
 		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery("SELECT EXISTS.*FROM modules").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
 	mock.ExpectExec("DELETE FROM organizations").
 		WillReturnError(errDB)
 

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -372,6 +372,8 @@ func TestDeleteOrganization_Success(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
 		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectExec("DELETE FROM organizations").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -380,6 +382,42 @@ func TestDeleteOrganization_Success(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// An organization that still owns namespace claims must not be deletable:
+// deleting it would cascade the claim away and let resolveOwnerOrg's
+// artifact-row fallback silently re-attribute the namespace to whichever
+// (unrelated) organization the mistagged rows point at (#555 review finding).
+func TestDeleteOrganization_BlockedByNamespaceClaims(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestDeleteOrganization_ClaimCountDBError(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -269,11 +269,14 @@ func TestUpdateOrganization_RenameSuccess(t *testing.T) {
 	// 3. Rename (identity) — single UPDATE, no transaction
 	mock.ExpectExec("UPDATE organizations SET name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// 4. Cascade to denormalized module/provider namespaces (domain) — own transaction
+	// 4. Cascade to denormalized module/provider namespaces and namespace
+	//    ownership claims (domain) — own transaction
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("UPDATE providers SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 	// 5. Regular Update for remaining fields (display_name / idp_type)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -673,7 +673,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// fall back to public via the identity connection's search_path.
 	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, identityDB)
 	userHandlers := admin.NewUserHandlers(cfg, identityDB)
-	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB)
+	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB, nsClaimRepo)
 	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -173,6 +173,14 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	orgRepo := repositories.NewOrganizationRepository(identityDB)
 	tokenRepo := repositories.NewTokenRepository(identityDB)
 
+	// Namespace ownership claims back the object-level authorization on every
+	// module/provider mutation route (issue #555, CWE-639): a namespace binds
+	// to the organization that first publishes into it, and only principals
+	// with write access in that organization (or admins) may mutate its
+	// artifacts. The authorizer is wired per-route below, after RequireScope.
+	nsClaimRepo := repositories.NewNamespaceClaimRepository(db)
+	nsAuthz := middleware.NewNamespaceAuthorizer(orgRepo, nsClaimRepo, moduleRepo, providerRepo)
+
 	// Wrap *sql.DB with sqlx for SCM and mirror repositories (public) and identity
 	// data access (the identity schema when the cutover is enabled).
 	sqlxDB := sqlx.NewDb(db, "postgres")
@@ -936,73 +944,92 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			// Stats endpoints (require auth)
 			authenticatedGroup.GET("/admin/stats/dashboard", statsHandlers.GetDashboardStats)
 
-			// Modules admin endpoints - require write permissions
+			// Modules admin endpoints - require write permissions plus
+			// namespace-org authorization (issue #555)
 			authenticatedGroup.POST("/admin/modules/create",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequirePublishAccessFromJSON(auth.ScopeModulesWrite),
 				moduleAdminHandlers.CreateModuleRecord)
 			authenticatedGroup.GET("/admin/modules/:id",
 				middleware.RequireScope(auth.ScopeModulesRead),
 				moduleAdminHandlers.GetModuleByIDRecord)
 			authenticatedGroup.PUT("/admin/modules/:id",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireModuleUpdateAccess(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UpdateModuleRecord)
 			authenticatedGroup.POST("/modules",
 				middleware.RateLimitMiddleware(uploadRateLimiter), // Stricter rate limit for uploads
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20), // matches the handler's ParseMultipartForm limit
 				modules.UploadHandler(db, storageBackend, cfg, scanRepo, moduleDocsRepo, policyEngine))
 
-			// Providers admin endpoints - require write permissions
+			// Providers admin endpoints - require write permissions plus
+			// namespace-org authorization (issue #555)
 			authenticatedGroup.POST("/providers",
 				middleware.RateLimitMiddleware(uploadRateLimiter), // Stricter rate limit for uploads
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequirePublishAccessFromForm(auth.ScopeProvidersWrite, 32<<20), // gin's default multipart memory limit
 				providers.UploadHandler(db, storageBackend, cfg))
 			authenticatedGroup.DELETE("/providers/:namespace/:type",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeProvidersWrite),
 				providerAdminHandlers.DeleteProvider)
 			authenticatedGroup.DELETE("/providers/:namespace/:type/versions/:version",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeProvidersWrite),
 				providerAdminHandlers.DeleteVersion)
 			authenticatedGroup.POST("/providers/:namespace/:type/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeProvidersWrite),
 				providerAdminHandlers.DeprecateVersion)
 			authenticatedGroup.DELETE("/providers/:namespace/:type/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeProvidersWrite),
 				providerAdminHandlers.UndeprecateVersion)
 
 			// Provider record admin endpoints (create + get by UUID)
 			authenticatedGroup.POST("/admin/providers",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequirePublishAccessFromJSON(auth.ScopeProvidersWrite),
 				providerAdminHandlers.CreateProviderRecord)
 			authenticatedGroup.GET("/admin/providers/:id",
 				middleware.RequireScope(auth.ScopeProvidersRead),
 				providerAdminHandlers.GetProviderByID)
 			authenticatedGroup.PUT("/admin/providers/:id",
 				middleware.RequireScope(auth.ScopeProvidersWrite),
+				nsAuthz.RequireProviderAccessByID(auth.ScopeProvidersWrite),
 				providerAdminHandlers.UpdateProviderRecord)
 
 			// Modules admin endpoints - delete, deprecate (GET moved to publicDetailGroup above)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.DeleteModule)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system/versions/:version",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.DeleteVersion)
 			authenticatedGroup.POST("/modules/:namespace/:name/:system/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.DeprecateVersion)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system/versions/:version/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UndeprecateVersion)
 			authenticatedGroup.POST("/modules/:namespace/:name/:system/versions/:version/reanalyze",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.ReanalyzeVersion)
 
 			// Module-level deprecation
 			authenticatedGroup.POST("/modules/:namespace/:name/:system/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.DeprecateModule)
 			authenticatedGroup.DELETE("/modules/:namespace/:name/:system/deprecate",
 				middleware.RequireScope(auth.ScopeModulesWrite),
+				nsAuthz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 				moduleAdminHandlers.UndeprecateModule)
 
 			authenticatedGroup.GET("/modules/:namespace/:name/:system/versions/:version/scan",
@@ -1158,15 +1185,16 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 			// SCM OAuth callback (public endpoint, no auth required)
 			apiV1.GET("/scm-providers/:id/oauth/callback", scmOAuthHandlers.HandleOAuthCallback)
 
-			// Module SCM linking endpoints
+			// Module SCM linking endpoints. Mutations additionally require
+			// namespace-org authorization for the target module (issue #555).
 			moduleSCMGroup := authenticatedGroup.Group("/admin/modules/:id/scm")
 			moduleSCMGroup.Use(middleware.RequireScope(auth.ScopeModulesWrite))
 			{
-				moduleSCMGroup.POST("", scmLinkingHandler.LinkModuleToSCM)
+				moduleSCMGroup.POST("", nsAuthz.RequireModuleAccessByID(auth.ScopeModulesWrite), scmLinkingHandler.LinkModuleToSCM)
 				moduleSCMGroup.GET("", scmLinkingHandler.GetModuleSCMInfo)
-				moduleSCMGroup.PUT("", scmLinkingHandler.UpdateSCMLink)
-				moduleSCMGroup.DELETE("", scmLinkingHandler.UnlinkModuleFromSCM)
-				moduleSCMGroup.POST("/sync", scmLinkingHandler.TriggerManualSync)
+				moduleSCMGroup.PUT("", nsAuthz.RequireModuleAccessByID(auth.ScopeModulesWrite), scmLinkingHandler.UpdateSCMLink)
+				moduleSCMGroup.DELETE("", nsAuthz.RequireModuleAccessByID(auth.ScopeModulesWrite), scmLinkingHandler.UnlinkModuleFromSCM)
+				moduleSCMGroup.POST("/sync", nsAuthz.RequireModuleAccessByID(auth.ScopeModulesWrite), scmLinkingHandler.TriggerManualSync)
 				moduleSCMGroup.GET("/events", scmLinkingHandler.GetWebhookEvents)
 			}
 

--- a/backend/internal/db/migrations/000045_namespace_org_claims.down.sql
+++ b/backend/internal/db/migrations/000045_namespace_org_claims.down.sql
@@ -1,0 +1,5 @@
+-- 000045_namespace_org_claims.down.sql
+-- Drops the namespace ownership table. Namespace-to-organization bindings are
+-- lost; they are re-derived from existing artifacts if the up migration is
+-- re-applied.
+DROP TABLE IF EXISTS namespace_claims;

--- a/backend/internal/db/migrations/000045_namespace_org_claims.up.sql
+++ b/backend/internal/db/migrations/000045_namespace_org_claims.up.sql
@@ -21,27 +21,55 @@ CREATE INDEX idx_namespace_claims_org ON namespace_claims(organization_id);
 
 -- Foreign keys follow the 000038 pattern: point at the identity schema when
 -- the identity-schema cutover has happened, otherwise at public.
+--
+-- organization_id is ON DELETE RESTRICT, not CASCADE: silently dropping a
+-- claim when its organization is deleted would let resolveOwnerOrg's
+-- artifact-row fallback (namespace_authz.go) re-attribute the namespace to
+-- whichever organization the (unrelated, pre-existing) module/provider rows
+-- happen to be tagged with -- every write handler stamps organization_id
+-- from the default organization regardless of the real caller, so this is
+-- reliably reachable, not a rare edge case. The application layer
+-- (OrganizationHandlers.DeleteOrganizationHandler) checks for and rejects
+-- this case with a clear 409 before ever reaching the database; the FK is
+-- the fail-closed backstop if that check is ever bypassed or forgotten.
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
-    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE RESTRICT;
     ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES identity.users(id) ON DELETE SET NULL;
   ELSE
-    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE RESTRICT;
     ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES public.users(id) ON DELETE SET NULL;
   END IF;
 END $$;
 
--- Backfill: every namespace that already has artifacts is claimed by the
--- organization that owns the earliest-created artifact in it. In the standard
--- single-org deployment every row belongs to the default organization, so this
--- preserves existing behavior exactly.
-INSERT INTO namespace_claims (namespace, organization_id, claimed_by, created_at)
-SELECT DISTINCT ON (namespace) namespace, organization_id, created_by, created_at
-FROM (
-    SELECT namespace, organization_id, created_by, created_at FROM modules   WHERE organization_id IS NOT NULL
+-- Backfill: a namespace whose existing artifacts all belong to exactly one
+-- organization is claimed by that organization (in the standard single-org
+-- deployment this is every namespace, preserving existing behavior exactly).
+-- A namespace whose artifacts already span more than one organization is left
+-- UNCLAIMED rather than assigned to an arbitrary "earliest" winner: the
+-- runtime authorizer already treats multi-org artifact ownership without a
+-- claim as ambiguous and denies non-admin mutation (errAmbiguousOwnership) --
+-- picking a winner here would have been *more* permissive than the fix's own
+-- runtime behavior for the exact same condition.
+WITH artifact_orgs AS (
+    SELECT namespace, organization_id, created_by, created_at
+    FROM modules
+    WHERE organization_id IS NOT NULL
     UNION ALL
-    SELECT namespace, organization_id, created_by, created_at FROM providers WHERE organization_id IS NOT NULL
-) existing_artifacts
-ORDER BY namespace, created_at
+    SELECT namespace, organization_id, created_by, created_at
+    FROM providers
+    WHERE organization_id IS NOT NULL
+),
+unambiguous AS (
+    SELECT namespace
+    FROM artifact_orgs
+    GROUP BY namespace
+    HAVING COUNT(DISTINCT organization_id) = 1
+)
+INSERT INTO namespace_claims (namespace, organization_id, claimed_by, created_at)
+SELECT DISTINCT ON (ao.namespace) ao.namespace, ao.organization_id, ao.created_by, ao.created_at
+FROM artifact_orgs ao
+JOIN unambiguous u ON u.namespace = ao.namespace
+ORDER BY ao.namespace, ao.created_at
 ON CONFLICT (namespace) DO NOTHING;

--- a/backend/internal/db/migrations/000045_namespace_org_claims.up.sql
+++ b/backend/internal/db/migrations/000045_namespace_org_claims.up.sql
@@ -1,0 +1,47 @@
+-- 000045_namespace_org_claims.up.sql
+-- Namespace-to-organization ownership claims (issue #555, CWE-639).
+--
+-- Module and provider namespaces were previously free-text: any authenticated
+-- principal holding modules:write / providers:write could publish into,
+-- overwrite, deprecate, or delete artifacts in ANY namespace. This table binds
+-- each namespace to the organization that first published into it; the
+-- mutation routes verify the caller's organization against this binding before
+-- any write (see internal/middleware/namespace_authz.go).
+--
+-- One row per namespace: a namespace is a single identity shared by modules
+-- and providers, so a claim covers both artifact kinds.
+CREATE TABLE namespace_claims (
+    namespace       VARCHAR(255) PRIMARY KEY,
+    organization_id UUID         NOT NULL,
+    claimed_by      UUID,
+    created_at      TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_namespace_claims_org ON namespace_claims(organization_id);
+
+-- Foreign keys follow the 000038 pattern: point at the identity schema when
+-- the identity-schema cutover has happened, otherwise at public.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id) ON DELETE CASCADE;
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES identity.users(id) ON DELETE SET NULL;
+  ELSE
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+    ALTER TABLE public.namespace_claims ADD CONSTRAINT namespace_claims_claimed_by_fkey FOREIGN KEY (claimed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Backfill: every namespace that already has artifacts is claimed by the
+-- organization that owns the earliest-created artifact in it. In the standard
+-- single-org deployment every row belongs to the default organization, so this
+-- preserves existing behavior exactly.
+INSERT INTO namespace_claims (namespace, organization_id, claimed_by, created_at)
+SELECT DISTINCT ON (namespace) namespace, organization_id, created_by, created_at
+FROM (
+    SELECT namespace, organization_id, created_by, created_at FROM modules   WHERE organization_id IS NOT NULL
+    UNION ALL
+    SELECT namespace, organization_id, created_by, created_at FROM providers WHERE organization_id IS NOT NULL
+) existing_artifacts
+ORDER BY namespace, created_at
+ON CONFLICT (namespace) DO NOTHING;

--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -47,6 +47,11 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000038 | `feature_fk_to_identity`               | ✅ Yes         | Reverts feature-table FKs to `public.{users,organizations}`; no-op when the `identity` schema is absent |
 | 000039 | `add_packer_sentinel_opa_tools`        | ⚠️ Conditional | Restores the original tool CHECK constraint; the down fails if rows use `packer`/`sentinel`/`opa` |
 | 000040 | `terraform_mirror_default_stable_approval` | ✅ Yes     | Reverts column defaults; existing rows are not modified   |
+| 000041 | `scm_shared_app_credentials`           | ⚠️ Conditional | Drops app-credential columns; the down fails while providers still use an app auth mode |
+| 000042 | `add_terraform_docs_tool`              | ⚠️ Conditional | Restores the tool CHECK constraint; the down fails if rows use `terraform-docs` |
+| 000043 | `setup_notifications`                  | ✅ Yes         | Drops notification-config columns; persisted SMTP config lost |
+| 000044 | `scanner_binary_versions`              | ✅ Yes         | Drops the scanner-binary-versions table and approval-event column |
+| 000045 | `namespace_org_claims`                 | ✅ Yes         | Drops the namespace-ownership table; bindings are re-derived from artifacts on re-apply |
 
 ## How to Run Migrations
 

--- a/backend/internal/db/models/namespace_claim.go
+++ b/backend/internal/db/models/namespace_claim.go
@@ -1,0 +1,17 @@
+// Package models - namespace_claim.go defines the namespace-to-organization
+// ownership binding used for object-level authorization on module and provider
+// mutations (issue #555, CWE-639).
+package models
+
+import "time"
+
+// NamespaceClaim binds a module/provider namespace to its owning organization.
+// A namespace is claimed by the organization that first publishes into it;
+// every subsequent mutation of artifacts in that namespace must come from a
+// principal with write access in the owning organization (or an admin).
+type NamespaceClaim struct {
+	Namespace      string    `json:"namespace"`
+	OrganizationID string    `json:"organization_id"`
+	ClaimedBy      *string   `json:"claimed_by,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+}

--- a/backend/internal/db/repositories/namespace_claim_repository.go
+++ b/backend/internal/db/repositories/namespace_claim_repository.go
@@ -127,3 +127,32 @@ func (r *NamespaceClaimRepository) CountByOrganization(ctx context.Context, orga
 	}
 	return count, nil
 }
+
+// OwnsArtifacts reports whether an organization owns any module or provider
+// row directly (in any namespace), independent of namespace_claims. Used
+// alongside CountByOrganization to block organization deletion: a namespace
+// whose artifacts already span more than one organization is deliberately
+// left UNCLAIMED (ambiguous ownership, restricted to admins at runtime —
+// see resolveOwnerOrg), so CountByOrganization alone would return 0 for it
+// even though this organization still owns rows there. modules/providers'
+// organization_id FK is still ON DELETE CASCADE (unrelated to the
+// namespace_claims RESTRICT added alongside this method): deleting this
+// organization would silently remove its rows from that ambiguous namespace,
+// collapsing it from admin-only "ambiguous" to unchecked sole ownership by
+// whichever organization's rows survive — the same "artifact-row fallback
+// re-attributes ownership after an org disappears" defect this table exists
+// to close, reached via a shared/ambiguous namespace instead of via a claim.
+func (r *NamespaceClaimRepository) OwnsArtifacts(ctx context.Context, organizationID string) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM modules   WHERE organization_id = $1
+			UNION ALL
+			SELECT 1 FROM providers WHERE organization_id = $1
+		)
+	`
+	var owns bool
+	if err := r.db.QueryRowContext(ctx, query, organizationID).Scan(&owns); err != nil {
+		return false, fmt.Errorf("failed to check organization artifact ownership: %w", err)
+	}
+	return owns, nil
+}

--- a/backend/internal/db/repositories/namespace_claim_repository.go
+++ b/backend/internal/db/repositories/namespace_claim_repository.go
@@ -111,3 +111,19 @@ func (r *NamespaceClaimRepository) ArtifactOrganizations(ctx context.Context, na
 
 	return orgIDs, nil
 }
+
+// CountByOrganization returns how many namespaces an organization currently
+// owns a claim to. Used to block organization deletion while claims exist:
+// the claims FK is ON DELETE RESTRICT, but that surfaces as an opaque 500 —
+// this backs a clear, actionable 409 instead. Deleting an org out from under
+// its claims would silently fall back namespace ownership to whichever
+// (unrelated) organization the mistagged artifact rows point at, defeating
+// the object-level authorization this table exists to enforce.
+func (r *NamespaceClaimRepository) CountByOrganization(ctx context.Context, organizationID string) (int, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM namespace_claims WHERE organization_id = $1`
+	if err := r.db.QueryRowContext(ctx, query, organizationID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count namespace claims for organization: %w", err)
+	}
+	return count, nil
+}

--- a/backend/internal/db/repositories/namespace_claim_repository.go
+++ b/backend/internal/db/repositories/namespace_claim_repository.go
@@ -1,0 +1,113 @@
+// Package repositories - namespace_claim_repository.go persists the
+// namespace-to-organization ownership bindings used for object-level
+// authorization on module and provider mutations (issue #555, CWE-639).
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// NamespaceClaimRepository handles namespace ownership database operations.
+type NamespaceClaimRepository struct {
+	db *sql.DB
+}
+
+// NewNamespaceClaimRepository creates a new namespace claim repository.
+func NewNamespaceClaimRepository(db *sql.DB) *NamespaceClaimRepository {
+	return &NamespaceClaimRepository{db: db}
+}
+
+// GetClaim returns the ownership claim for a namespace, or nil when the
+// namespace is unclaimed.
+func (r *NamespaceClaimRepository) GetClaim(ctx context.Context, namespace string) (*models.NamespaceClaim, error) {
+	query := `
+		SELECT namespace, organization_id, claimed_by, created_at
+		FROM namespace_claims
+		WHERE namespace = $1
+	`
+
+	claim := &models.NamespaceClaim{}
+	err := r.db.QueryRowContext(ctx, query, namespace).Scan(
+		&claim.Namespace,
+		&claim.OrganizationID,
+		&claim.ClaimedBy,
+		&claim.CreatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // Unclaimed
+		}
+		return nil, fmt.Errorf("failed to get namespace claim: %w", err)
+	}
+
+	return claim, nil
+}
+
+// ClaimNamespace atomically claims a namespace for an organization and returns
+// the winning claim. When two organizations race for the same namespace, the
+// first insert wins (ON CONFLICT DO NOTHING) and the loser receives the
+// winner's claim back — callers must compare the returned organization ID with
+// the one they requested.
+func (r *NamespaceClaimRepository) ClaimNamespace(ctx context.Context, namespace, organizationID string, claimedBy *string) (*models.NamespaceClaim, error) {
+	insert := `
+		INSERT INTO namespace_claims (namespace, organization_id, claimed_by)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (namespace) DO NOTHING
+	`
+
+	if _, err := r.db.ExecContext(ctx, insert, namespace, organizationID, claimedBy); err != nil {
+		return nil, fmt.Errorf("failed to claim namespace: %w", err)
+	}
+
+	claim, err := r.GetClaim(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if claim == nil {
+		// The claim row vanished between insert and select (concurrent org
+		// deletion cascading onto the claim). Treat as a failed claim rather
+		// than inventing ownership.
+		return nil, fmt.Errorf("failed to claim namespace: claim not found after insert")
+	}
+
+	return claim, nil
+}
+
+// ArtifactOrganizations returns the distinct organization IDs that own module
+// or provider rows in a namespace. Used as the ownership fallback for
+// namespaces that predate the claims table or were populated by system paths
+// (mirror sync, pull-through cache) that do not create claims.
+func (r *NamespaceClaimRepository) ArtifactOrganizations(ctx context.Context, namespace string) ([]string, error) {
+	query := `
+		SELECT DISTINCT organization_id FROM (
+			SELECT organization_id FROM modules   WHERE namespace = $1 AND organization_id IS NOT NULL
+			UNION
+			SELECT organization_id FROM providers WHERE namespace = $1 AND organization_id IS NOT NULL
+		) artifact_orgs
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespace artifact organizations: %w", err)
+	}
+	defer rows.Close()
+
+	var orgIDs []string
+	for rows.Next() {
+		var orgID string
+		if err := rows.Scan(&orgID); err != nil {
+			return nil, fmt.Errorf("failed to scan namespace artifact organization: %w", err)
+		}
+		orgIDs = append(orgIDs, orgID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate namespace artifact organizations: %w", err)
+	}
+
+	return orgIDs, nil
+}

--- a/backend/internal/db/repositories/namespace_claim_repository_test.go
+++ b/backend/internal/db/repositories/namespace_claim_repository_test.go
@@ -1,0 +1,159 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+var namespaceClaimCols = []string{"namespace", "organization_id", "claimed_by", "created_at"}
+var artifactOrgIDCols = []string{"organization_id"}
+
+var errClaimDB = errors.New("db error")
+
+func newNamespaceClaimRepo(t *testing.T) (*NamespaceClaimRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewNamespaceClaimRepository(db), mock
+}
+
+func TestGetClaim_Found(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WithArgs("acme").
+		WillReturnRows(sqlmock.NewRows(namespaceClaimCols).AddRow("acme", "org-1", nil, time.Now()))
+
+	claim, err := repo.GetClaim(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("GetClaim: %v", err)
+	}
+	if claim == nil || claim.OrganizationID != "org-1" {
+		t.Fatalf("GetClaim = %+v, want organization_id org-1", claim)
+	}
+}
+
+func TestGetClaim_NotFound(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(namespaceClaimCols))
+
+	claim, err := repo.GetClaim(context.Background(), "ghost")
+	if err != nil {
+		t.Fatalf("GetClaim: %v", err)
+	}
+	if claim != nil {
+		t.Errorf("GetClaim = %+v, want nil for unclaimed namespace", claim)
+	}
+}
+
+func TestGetClaim_DBError(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnError(errClaimDB)
+
+	if _, err := repo.GetClaim(context.Background(), "acme"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestClaimNamespace_FirstClaimWins(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("acme", "org-1", nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WithArgs("acme").
+		WillReturnRows(sqlmock.NewRows(namespaceClaimCols).AddRow("acme", "org-1", nil, time.Now()))
+
+	claim, err := repo.ClaimNamespace(context.Background(), "acme", "org-1", nil)
+	if err != nil {
+		t.Fatalf("ClaimNamespace: %v", err)
+	}
+	if claim.OrganizationID != "org-1" {
+		t.Errorf("claim.OrganizationID = %q, want org-1", claim.OrganizationID)
+	}
+}
+
+func TestClaimNamespace_LoserSeesWinningOrg(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	// org-2 races for "acme" but org-1 already holds it (ON CONFLICT DO NOTHING).
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("acme", "org-2", nil).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WithArgs("acme").
+		WillReturnRows(sqlmock.NewRows(namespaceClaimCols).AddRow("acme", "org-1", nil, time.Now()))
+
+	claim, err := repo.ClaimNamespace(context.Background(), "acme", "org-2", nil)
+	if err != nil {
+		t.Fatalf("ClaimNamespace: %v", err)
+	}
+	if claim.OrganizationID != "org-1" {
+		t.Errorf("claim.OrganizationID = %q, want org-1 (the winner of the race)", claim.OrganizationID)
+	}
+}
+
+func TestClaimNamespace_InsertError(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WillReturnError(errClaimDB)
+
+	if _, err := repo.ClaimNamespace(context.Background(), "acme", "org-1", nil); err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestArtifactOrganizations_Multiple(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs("acme").
+		WillReturnRows(sqlmock.NewRows(artifactOrgIDCols).AddRow("org-1").AddRow("org-2"))
+
+	orgIDs, err := repo.ArtifactOrganizations(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("ArtifactOrganizations: %v", err)
+	}
+	if len(orgIDs) != 2 {
+		t.Fatalf("ArtifactOrganizations = %v, want 2 entries", orgIDs)
+	}
+}
+
+func TestArtifactOrganizations_None(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgIDCols))
+
+	orgIDs, err := repo.ArtifactOrganizations(context.Background(), "ghost")
+	if err != nil {
+		t.Fatalf("ArtifactOrganizations: %v", err)
+	}
+	if len(orgIDs) != 0 {
+		t.Errorf("ArtifactOrganizations = %v, want empty", orgIDs)
+	}
+}
+
+func TestArtifactOrganizations_QueryError(t *testing.T) {
+	repo, mock := newNamespaceClaimRepo(t)
+
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnError(errClaimDB)
+
+	if _, err := repo.ArtifactOrganizations(context.Background(), "acme"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/backend/internal/db/repositories/organization_repository.go
+++ b/backend/internal/db/repositories/organization_repository.go
@@ -22,9 +22,10 @@ type OrganizationRepository = identitystore.OrganizationRepository
 var NewOrganizationRepository = identitystore.NewOrganizationRepository
 
 // CascadeOrganizationRename propagates a renamed organization's new name to the
-// registry's denormalized module and provider namespace columns, in a single
-// transaction on the registry's domain connection. The identity-side rename
-// (organizations.name) is performed separately via OrganizationRepository.Rename.
+// registry's denormalized module and provider namespace columns and to the
+// organization's namespace-ownership claims, in a single transaction on the
+// registry's domain connection. The identity-side rename (organizations.name)
+// is performed separately via OrganizationRepository.Rename.
 func CascadeOrganizationRename(ctx context.Context, db *sql.DB, orgID, oldName, newName string) (retErr error) {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -48,6 +49,13 @@ func CascadeOrganizationRename(ctx context.Context, db *sql.DB, orgID, oldName, 
 		newName, orgID, oldName,
 	); err != nil {
 		return fmt.Errorf("cascade rename to providers: %w", err)
+	}
+
+	if _, err = tx.ExecContext(ctx,
+		`UPDATE namespace_claims SET namespace = $1 WHERE organization_id = $2 AND namespace = $3`,
+		newName, orgID, oldName,
+	); err != nil {
+		return fmt.Errorf("cascade rename to namespace claims: %w", err)
 	}
 
 	return tx.Commit()

--- a/backend/internal/db/repositories/organization_repository_test.go
+++ b/backend/internal/db/repositories/organization_repository_test.go
@@ -66,6 +66,8 @@ func TestCascadeOrganizationRename_Success(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 2))
 	mock.ExpectExec("UPDATE providers SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
 	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err != nil {
@@ -112,6 +114,30 @@ func TestCascadeOrganizationRename_ProvidersError(t *testing.T) {
 
 	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err == nil {
 		t.Error("expected error when the providers cascade fails, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestCascadeOrganizationRename_ClaimsError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE modules SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE providers SET namespace").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").
+		WillReturnError(context.DeadlineExceeded)
+	mock.ExpectRollback()
+
+	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err == nil {
+		t.Error("expected error when the namespace-claims cascade fails, got nil")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -1,0 +1,550 @@
+// Package middleware (namespace_authz.go) enforces object-level authorization
+// on module and provider mutations (issue #555, CWE-639).
+//
+// Global scopes (modules:write, providers:write) only say WHAT a principal may
+// do; this file decides WHERE they may do it. Every namespace is bound to an
+// owning organization via the namespace_claims table (bound on first publish,
+// backfilled from existing artifacts by migration 000045). A mutation of any
+// artifact in a namespace is allowed only when:
+//
+//   - the caller holds the wildcard "admin" scope. Admin deliberately crosses
+//     organization boundaries: registry operators must be able to manage
+//     content in every namespace; or
+//   - the caller authenticated with an API key whose organization binding
+//     equals the owning organization (keys are bound to exactly one
+//     organization at creation time); or
+//   - the caller is a JWT principal whose user is a member of the owning
+//     organization with a role template that grants the required write scope.
+//
+// When no claim exists the ownership falls back to the organization of the
+// existing artifact rows (covers system-created content such as mirror-synced
+// providers), and a first publish into a fully unclaimed namespace binds it to
+// the caller's organization. Requests without a resolvable organization
+// context fail closed.
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/validation"
+)
+
+// errAmbiguousOwnership is returned when a namespace has artifacts in multiple
+// organizations and no claim row to disambiguate them. This cannot happen
+// through the API (claims are created on first publish); it indicates manual
+// data edits, so only admins may act on such a namespace.
+var errAmbiguousOwnership = errors.New("namespace has artifacts in multiple organizations and no claim")
+
+// NamespaceAuthorizer resolves namespace ownership and checks callers against
+// the owning organization. It is wired onto every module/provider mutation
+// route in router.go, after AuthMiddleware and RequireScope.
+type NamespaceAuthorizer struct {
+	orgRepo      *repositories.OrganizationRepository
+	claimRepo    *repositories.NamespaceClaimRepository
+	moduleRepo   *repositories.ModuleRepository
+	providerRepo *repositories.ProviderRepository
+}
+
+// NewNamespaceAuthorizer creates a namespace authorizer. orgRepo must be
+// backed by the identity connection; the remaining repositories use the
+// registry (public schema) connection.
+func NewNamespaceAuthorizer(
+	orgRepo *repositories.OrganizationRepository,
+	claimRepo *repositories.NamespaceClaimRepository,
+	moduleRepo *repositories.ModuleRepository,
+	providerRepo *repositories.ProviderRepository,
+) *NamespaceAuthorizer {
+	return &NamespaceAuthorizer{
+		orgRepo:      orgRepo,
+		claimRepo:    claimRepo,
+		moduleRepo:   moduleRepo,
+		providerRepo: providerRepo,
+	}
+}
+
+// RequireNamespaceAccessFromPath authorizes mutations on routes that carry the
+// namespace as the :namespace path parameter (delete, deprecate, version
+// operations). Unowned namespaces pass through: nothing exists under them, so
+// the handler's own not-found response leaks nothing.
+func (a *NamespaceAuthorizer) RequireNamespaceAccessFromPath(scope auth.Scope) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		namespace := c.Param("namespace")
+		if namespace == "" {
+			abortNamespaceAuthz(c, http.StatusForbidden, "Namespace not present in request path")
+			return
+		}
+		if a.authorizeNamespaceMutation(c, namespace, scope, false) {
+			c.Next()
+		}
+	}
+}
+
+// RequirePublishAccessFromForm authorizes publish routes that carry the
+// namespace as a multipart form field (module and provider uploads). A first
+// publish into an unclaimed namespace binds it to the caller's organization.
+// maxMemory bounds the in-memory portion of the parsed form and should match
+// the handler's own ParseMultipartForm limit.
+func (a *NamespaceAuthorizer) RequirePublishAccessFromForm(scope auth.Scope, maxMemory int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := c.Request.ParseMultipartForm(maxMemory); err != nil {
+			abortNamespaceAuthz(c, http.StatusBadRequest, "Failed to parse multipart form")
+			return
+		}
+		namespace := c.Request.FormValue("namespace")
+		if namespace == "" {
+			// The handler rejects the request as invalid; nothing is targeted.
+			c.Next()
+			return
+		}
+		if a.authorizeNamespaceMutation(c, namespace, scope, true) {
+			c.Next()
+		}
+	}
+}
+
+// RequirePublishAccessFromJSON authorizes create routes that carry the
+// namespace in a JSON body (module/provider record creation). The body is
+// buffered and restored so the handler can bind it again. A first publish into
+// an unclaimed namespace binds it to the caller's organization. When the body
+// carries an organization_id override (provider record creation), a non-admin
+// caller must match the namespace's owning organization.
+func (a *NamespaceAuthorizer) RequirePublishAccessFromJSON(scope auth.Scope) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			abortNamespaceAuthz(c, http.StatusBadRequest, "Failed to read request body")
+			return
+		}
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+
+		var body struct {
+			Namespace      string `json:"namespace"`
+			OrganizationID string `json:"organization_id"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil || body.Namespace == "" {
+			// Malformed JSON or missing namespace: the handler's binding
+			// rejects the request; nothing is targeted.
+			c.Next()
+			return
+		}
+
+		if !a.authorizeNamespaceMutation(c, body.Namespace, scope, true) {
+			return
+		}
+
+		// A non-admin caller must not plant artifact rows in another
+		// organization's row space via an organization_id override.
+		if body.OrganizationID != "" && !callerIsAdmin(c) {
+			ownerOrgID, err := a.resolveOwnerOrg(c.Request.Context(), body.Namespace)
+			if err != nil || ownerOrgID == "" || body.OrganizationID != ownerOrgID {
+				abortNamespaceAuthz(c, http.StatusForbidden, "organization_id does not match the namespace's owning organization")
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// RequireModuleAccessByID authorizes mutations on routes that address a module
+// by its UUID (SCM link operations). Missing modules and malformed IDs pass
+// through so the handler keeps its own not-found/bad-request semantics.
+func (a *NamespaceAuthorizer) RequireModuleAccessByID(scope auth.Scope) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if _, _, ok := a.moduleAccessByID(c, scope); ok {
+			c.Next()
+		}
+	}
+}
+
+// RequireModuleUpdateAccess authorizes PUT /admin/modules/:id, which may also
+// move the module to a different namespace. Moving into a namespace owned by
+// another organization is denied for non-admins; moving into an unclaimed
+// namespace claims it for the module's owning organization.
+func (a *NamespaceAuthorizer) RequireModuleUpdateAccess(scope auth.Scope) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		module, currentOwner, ok := a.moduleAccessByID(c, scope)
+		if !ok {
+			return
+		}
+		if module == nil {
+			// Missing module or malformed ID: handler responds.
+			c.Next()
+			return
+		}
+
+		raw, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			abortNamespaceAuthz(c, http.StatusBadRequest, "Failed to read request body")
+			return
+		}
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+
+		var body struct {
+			Namespace *string `json:"namespace"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil || body.Namespace == nil ||
+			*body.Namespace == "" || *body.Namespace == module.Namespace {
+			// No namespace change requested (or the handler will reject the
+			// body); the current-namespace authorization above suffices.
+			c.Next()
+			return
+		}
+
+		target := *body.Namespace
+		targetOwner, err := a.resolveOwnerOrg(c.Request.Context(), target)
+		if err != nil {
+			if errors.Is(err, errAmbiguousOwnership) {
+				if callerIsAdmin(c) {
+					c.Next()
+					return
+				}
+				abortNamespaceAuthz(c, http.StatusForbidden, "Namespace ownership is ambiguous; contact an administrator")
+				return
+			}
+			abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to resolve namespace ownership")
+			return
+		}
+
+		switch {
+		case targetOwner == "":
+			// Moving into an unclaimed namespace claims it for the module's
+			// owning organization.
+			if err := validation.ValidateRegistrySegment(target); err != nil {
+				abortNamespaceAuthz(c, http.StatusBadRequest, fmt.Sprintf("Invalid namespace: %v", err))
+				return
+			}
+			claim, err := a.claimRepo.ClaimNamespace(c.Request.Context(), target, currentOwner, callerUserID(c))
+			if err != nil {
+				abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to claim namespace")
+				return
+			}
+			if claim.OrganizationID != currentOwner && !callerIsAdmin(c) {
+				abortNamespaceAuthz(c, http.StatusForbidden, "Namespace is owned by another organization")
+				return
+			}
+		case targetOwner != currentOwner:
+			if !callerIsAdmin(c) {
+				abortNamespaceAuthz(c, http.StatusForbidden, "Namespace is owned by another organization")
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// RequireProviderAccessByID authorizes mutations on routes that address a
+// provider by its UUID (PUT /admin/providers/:id). Missing providers and
+// malformed IDs pass through so the handler keeps its own semantics.
+func (a *NamespaceAuthorizer) RequireProviderAccessByID(scope auth.Scope) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := uuid.Parse(id); err != nil {
+			c.Next()
+			return
+		}
+
+		provider, err := a.providerRepo.GetProviderByID(c.Request.Context(), id)
+		if err != nil {
+			abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to get provider")
+			return
+		}
+		if provider == nil {
+			c.Next()
+			return
+		}
+
+		ownerOrgID, err := a.ownerOrgForArtifact(c.Request.Context(), provider.Namespace, provider.OrganizationID)
+		if err != nil {
+			abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to resolve namespace ownership")
+			return
+		}
+		if status, msg := a.authorizeOrgAccess(c, ownerOrgID, scope); status != 0 {
+			abortNamespaceAuthz(c, status, msg)
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// moduleAccessByID loads the module addressed by the :id path parameter and
+// authorizes the caller against its owning organization. It returns
+// (module, ownerOrgID, true) on success, (nil, "", true) when the module is
+// missing or the ID is malformed (the handler responds), and (nil, "", false)
+// after aborting the request.
+func (a *NamespaceAuthorizer) moduleAccessByID(c *gin.Context, scope auth.Scope) (*models.Module, string, bool) {
+	id := c.Param("id")
+	if _, err := uuid.Parse(id); err != nil {
+		return nil, "", true
+	}
+
+	module, err := a.moduleRepo.GetModuleByID(c.Request.Context(), id)
+	if err != nil {
+		abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to get module")
+		return nil, "", false
+	}
+	if module == nil {
+		return nil, "", true
+	}
+
+	ownerOrgID, err := a.ownerOrgForArtifact(c.Request.Context(), module.Namespace, module.OrganizationID)
+	if err != nil {
+		abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to resolve namespace ownership")
+		return nil, "", false
+	}
+	if status, msg := a.authorizeOrgAccess(c, ownerOrgID, scope); status != 0 {
+		abortNamespaceAuthz(c, status, msg)
+		return nil, "", false
+	}
+
+	return module, ownerOrgID, true
+}
+
+// authorizeNamespaceMutation resolves the owning organization of a namespace
+// and checks the caller against it. allowClaim enables the first-publish path
+// that binds an unclaimed namespace to the caller's organization. Returns true
+// when the request may proceed; on false the request has been aborted.
+func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespace string, scope auth.Scope, allowClaim bool) bool {
+	ownerOrgID, err := a.resolveOwnerOrg(c.Request.Context(), namespace)
+	if err != nil {
+		if errors.Is(err, errAmbiguousOwnership) {
+			if callerIsAdmin(c) {
+				return true
+			}
+			abortNamespaceAuthz(c, http.StatusForbidden, "Namespace ownership is ambiguous; contact an administrator")
+			return false
+		}
+		abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to resolve namespace ownership")
+		return false
+	}
+
+	if ownerOrgID != "" {
+		if status, msg := a.authorizeOrgAccess(c, ownerOrgID, scope); status != 0 {
+			abortNamespaceAuthz(c, status, msg)
+			return false
+		}
+		return true
+	}
+
+	// Unowned namespace.
+	if !allowClaim {
+		// Nothing exists under this namespace, so the handler can only
+		// respond not-found. Passing through preserves 404 semantics without
+		// exposing any object.
+		return true
+	}
+
+	// First publish into this namespace: bind it to the caller's organization.
+	if err := validation.ValidateRegistrySegment(namespace); err != nil {
+		abortNamespaceAuthz(c, http.StatusBadRequest, fmt.Sprintf("Invalid namespace: %v", err))
+		return false
+	}
+
+	callerOrgID, status, msg := a.resolveCallerOrg(c)
+	if status != 0 {
+		abortNamespaceAuthz(c, status, msg)
+		return false
+	}
+
+	claim, err := a.claimRepo.ClaimNamespace(c.Request.Context(), namespace, callerOrgID, callerUserID(c))
+	if err != nil {
+		abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to claim namespace")
+		return false
+	}
+	if claim.OrganizationID != callerOrgID {
+		// Lost a concurrent first-publish race to another organization; the
+		// caller must now qualify against the winner.
+		if status, msg := a.authorizeOrgAccess(c, claim.OrganizationID, scope); status != 0 {
+			abortNamespaceAuthz(c, status, msg)
+			return false
+		}
+	}
+
+	return true
+}
+
+// authorizeOrgAccess checks the authenticated caller against the owning
+// organization. It returns (0, "") when access is allowed, otherwise an HTTP
+// status and message. The checks are ordered from cheapest to most expensive
+// and every branch fails closed.
+func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID string, scope auth.Scope) (int, string) {
+	scopesVal, exists := c.Get("scopes")
+	if !exists {
+		return http.StatusForbidden, "Insufficient permissions"
+	}
+	userScopes, ok := scopesVal.([]string)
+	if !ok {
+		return http.StatusForbidden, "Invalid scopes format"
+	}
+
+	// The wildcard admin scope deliberately crosses organization boundaries:
+	// registry operators must be able to manage content in every namespace.
+	if auth.HasScope(userScopes, auth.ScopeAdmin) {
+		return 0, ""
+	}
+
+	// API keys are bound to exactly one organization at creation time; that
+	// binding is authoritative for the key regardless of the owning user's
+	// other memberships.
+	if keyVal, exists := c.Get("api_key"); exists {
+		apiKey, ok := keyVal.(*models.APIKey)
+		if !ok {
+			return http.StatusForbidden, "Invalid API key context"
+		}
+		if apiKey.OrganizationID != "" {
+			if apiKey.OrganizationID == ownerOrgID {
+				return 0, ""
+			}
+			return http.StatusForbidden, "Namespace is owned by another organization"
+		}
+		// Keys without an organization binding (legacy rows) fall through to
+		// the owning user's membership check below.
+	}
+
+	userVal, exists := c.Get("user_id")
+	if !exists {
+		return http.StatusForbidden, "Organization context required"
+	}
+	userID, ok := userVal.(string)
+	if !ok || userID == "" {
+		return http.StatusForbidden, "Invalid user ID format"
+	}
+
+	member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), ownerOrgID, userID)
+	if err != nil {
+		return http.StatusInternalServerError, "Failed to check organization membership"
+	}
+	if member == nil {
+		return http.StatusForbidden, "Namespace is owned by another organization"
+	}
+	if !auth.HasScope(member.RoleTemplateScopes, scope) {
+		return http.StatusForbidden, "Missing required scope in the owning organization"
+	}
+
+	return 0, ""
+}
+
+// resolveOwnerOrg returns the organization that owns a namespace: the claim
+// when one exists, otherwise the single organization owning artifact rows in
+// the namespace (system-created content), otherwise "" for a fully unowned
+// namespace. Multiple artifact organizations without a claim yield
+// errAmbiguousOwnership.
+func (a *NamespaceAuthorizer) resolveOwnerOrg(ctx context.Context, namespace string) (string, error) {
+	claim, err := a.claimRepo.GetClaim(ctx, namespace)
+	if err != nil {
+		return "", err
+	}
+	if claim != nil {
+		return claim.OrganizationID, nil
+	}
+
+	orgIDs, err := a.claimRepo.ArtifactOrganizations(ctx, namespace)
+	if err != nil {
+		return "", err
+	}
+	switch len(orgIDs) {
+	case 0:
+		return "", nil
+	case 1:
+		return orgIDs[0], nil
+	default:
+		return "", errAmbiguousOwnership
+	}
+}
+
+// ownerOrgForArtifact resolves ownership for an already-loaded artifact row:
+// the namespace claim wins; without one the row's own organization is
+// authoritative.
+func (a *NamespaceAuthorizer) ownerOrgForArtifact(ctx context.Context, namespace, artifactOrgID string) (string, error) {
+	claim, err := a.claimRepo.GetClaim(ctx, namespace)
+	if err != nil {
+		return "", err
+	}
+	if claim != nil {
+		return claim.OrganizationID, nil
+	}
+	return artifactOrgID, nil
+}
+
+// resolveCallerOrg determines which organization a first publish should bind a
+// new namespace to. Returns (orgID, 0, "") on success, otherwise an HTTP
+// status and message. Fails closed when no organization can be derived from
+// the caller's identity.
+func (a *NamespaceAuthorizer) resolveCallerOrg(c *gin.Context) (string, int, string) {
+	// Org-scoped API keys carry their organization directly.
+	if keyVal, exists := c.Get("api_key"); exists {
+		if apiKey, ok := keyVal.(*models.APIKey); ok && apiKey.OrganizationID != "" {
+			return apiKey.OrganizationID, 0, ""
+		}
+	}
+
+	if userID := callerUserID(c); userID != nil {
+		memberships, err := a.orgRepo.GetUserMemberships(c.Request.Context(), *userID)
+		if err != nil {
+			return "", http.StatusInternalServerError, "Failed to resolve organization memberships"
+		}
+		if len(memberships) == 1 {
+			return memberships[0].OrganizationID, 0, ""
+		}
+		if len(memberships) > 1 && !callerIsAdmin(c) {
+			return "", http.StatusForbidden, "Ambiguous organization context: use an organization-scoped API key to publish a new namespace"
+		}
+	}
+
+	// Admins without an unambiguous organization bind new namespaces to the
+	// default organization (registry-operator behavior).
+	if callerIsAdmin(c) {
+		org, err := a.orgRepo.GetDefaultOrganization(c.Request.Context())
+		if err != nil {
+			return "", http.StatusInternalServerError, "Failed to get organization context"
+		}
+		if org == nil {
+			return "", http.StatusInternalServerError, "Default organization not found"
+		}
+		return org.ID, 0, ""
+	}
+
+	return "", http.StatusForbidden, "Organization context required"
+}
+
+// callerIsAdmin reports whether the authenticated principal holds the wildcard
+// admin scope.
+func callerIsAdmin(c *gin.Context) bool {
+	scopesVal, exists := c.Get("scopes")
+	if !exists {
+		return false
+	}
+	userScopes, ok := scopesVal.([]string)
+	if !ok {
+		return false
+	}
+	return auth.HasScope(userScopes, auth.ScopeAdmin)
+}
+
+// callerUserID returns the authenticated user ID from context, or nil when
+// absent (e.g. service API keys without an owning user).
+func callerUserID(c *gin.Context) *string {
+	if userVal, exists := c.Get("user_id"); exists {
+		if uid, ok := userVal.(string); ok && uid != "" {
+			return &uid
+		}
+	}
+	return nil
+}
+
+func abortNamespaceAuthz(c *gin.Context, status int, message string) {
+	c.AbortWithStatusJSON(status, gin.H{"error": message})
+}

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -101,7 +101,14 @@ func (a *NamespaceAuthorizer) RequirePublishAccessFromForm(scope auth.Scope, max
 			abortNamespaceAuthz(c, http.StatusBadRequest, "Failed to parse multipart form")
 			return
 		}
-		namespace := c.Request.FormValue("namespace")
+		// PostFormValue (body-only), NOT FormValue: FormValue prefers the URL
+		// query string over the parsed body, but the upload handler reads the
+		// namespace via c.PostForm (body-only, Gin's GetPostForm reads
+		// req.PostForm). Using FormValue here let a caller authorize against a
+		// namespace named in the query string (?namespace=one-they-own) while
+		// the multipart body — what the handler actually persists into —
+		// named a different, victim namespace, bypassing this check entirely.
+		namespace := c.Request.PostFormValue("namespace")
 		if namespace == "" {
 			// The handler rejects the request as invalid; nothing is targeted.
 			c.Next()

--- a/backend/internal/middleware/namespace_authz_test.go
+++ b/backend/internal/middleware/namespace_authz_test.go
@@ -1,0 +1,709 @@
+package middleware
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+const (
+	nsOrgA   = "org-aaa"
+	nsOrgB   = "org-bbb"
+	nsUserID = "user-nsauthz"
+)
+
+var claimCols = []string{"namespace", "organization_id", "claimed_by", "created_at"}
+var artifactOrgCols = []string{"organization_id"}
+var userMembershipCols = []string{
+	"organization_id", "organization_name", "role_template_id", "created_at",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+func newNamespaceAuthzTestDeps(t *testing.T) (sqlmock.Sqlmock, *NamespaceAuthorizer) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	orgRepo := repositories.NewOrganizationRepository(db)
+	claimRepo := repositories.NewNamespaceClaimRepository(db)
+	moduleRepo := repositories.NewModuleRepository(db)
+	providerRepo := repositories.NewProviderRepository(db)
+
+	authz := NewNamespaceAuthorizer(orgRepo, claimRepo, moduleRepo, providerRepo)
+	return mock, authz
+}
+
+func withScopesAndUser(scopes []string, userID string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		c.Set("scopes", scopes)
+		if userID != "" {
+			c.Set("user_id", userID)
+		}
+	}
+}
+
+func withAPIKey(orgID string, scopes []string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		c.Set("scopes", scopes)
+		c.Set("api_key", &models.APIKey{OrganizationID: orgID, Scopes: scopes})
+	}
+}
+
+func doNamespaceReq(r *gin.Engine, method, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(method, path, nil))
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// RequireNamespaceAccessFromPath — path-carried namespace (delete/deprecate)
+// ---------------------------------------------------------------------------
+
+func TestRequireNamespaceAccessFromPath_FailClosed_NoScopes(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system", func(c *gin.Context) {
+		// No scopes/user_id set — simulates a context that somehow reached
+		// here without authentication having populated it.
+	}, authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (fail closed with no scope context): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_CrossOrgPublisher_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	// Namespace "acme" is claimed by org B.
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgB, nil, time.Now()))
+	// Caller (publisher scopes, no admin) is not a member of org B.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (cross-org publisher denied): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_SameOrgPublisher_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub User", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (same-org publisher allowed): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_AdminOverride_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	// Namespace owned by org B, caller has admin scope: no membership lookup
+	// should even occur.
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgB, nil, time.Now()))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeAdmin)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (admin crosses org boundary): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_APIKeyOrgMismatch_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgB, nil, time.Now()))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (API key bound to different org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_APIKeyOrgMatch_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (API key org matches owner): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_UnclaimedNoArtifacts_PassesThrough(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // no claim
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts either
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/ghost/vpc/aws")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (nothing exists, handler will 404): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_AmbiguousOwnership_NonAdminDenied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols).AddRow(nsOrgA).AddRow(nsOrgB))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/weird/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (ambiguous ownership denies non-admin): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_AmbiguousOwnership_AdminAllowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols).AddRow(nsOrgA).AddRow(nsOrgB))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeAdmin)}, nsUserID)),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/weird/vpc/aws")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (admin can act on ambiguous namespace): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireNamespaceAccessFromPath_EmptyNamespaceParam_FailClosed(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+
+	// A route with no :namespace segment at all — c.Param("namespace")
+	// naturally returns "" — simulates a route wired up incorrectly.
+	r := gin.New()
+	r.DELETE("/x", authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := doNamespaceReq(r, "DELETE", "/x")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (missing namespace param fails closed): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// contextSetter adapts a `func(*gin.Context)` context-seeding helper into a
+// gin.HandlerFunc that calls c.Next().
+func contextSetter(setup func(c *gin.Context)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		setup(c)
+		c.Next()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequirePublishAccessFromForm — multipart namespace (module/provider upload)
+// ---------------------------------------------------------------------------
+
+func multipartRequest(t *testing.T, fields map[string]string) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for k, v := range fields {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("multipart Close: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/modules", &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
+}
+
+func TestRequirePublishAccessFromForm_FirstClaim_BindsToCallerOrg(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
+		WillReturnRows(sqlmock.NewRows(userMembershipCols).AddRow(
+			nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`),
+		)) // single membership → unambiguous caller org
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newteam", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (first publish claims namespace): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRequirePublishAccessFromForm_ExistingClaimDifferentOrg_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgB, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW)) // not a member of org B
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "acme", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (namespace owned by another org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequirePublishAccessFromForm_ExistingClaimSameOrg_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "acme", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (same org allowed to publish new version): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequirePublishAccessFromForm_NoNamespaceField_PassesThroughToHandler(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusBadRequest, gin.H{"error": "missing namespace"}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (handler owns the missing-field validation): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequirePublishAccessFromForm_AmbiguousMemberships_NonAdminDenied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
+		WillReturnRows(sqlmock.NewRows(userMembershipCols).
+			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)).
+			AddRow(nsOrgB, "Org B", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (ambiguous membership can't auto-claim): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequirePublishAccessFromForm_APIKeyOrg_FirstClaim(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (API key org claims directly, no membership query): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequirePublishAccessFromJSON — JSON-body namespace (admin create routes)
+// ---------------------------------------------------------------------------
+
+func jsonRequest(path, body string) *http.Request {
+	req := httptest.NewRequest("POST", path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestRequirePublishAccessFromJSON_BodyRestoredForHandler(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+
+	var gotNamespace string
+	r := gin.New()
+	r.POST("/admin/modules/create",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromJSON(auth.ScopeModulesWrite),
+		func(c *gin.Context) {
+			var body struct {
+				Namespace string `json:"namespace"`
+			}
+			if err := c.ShouldBindJSON(&body); err != nil {
+				t.Fatalf("handler could not re-read body: %v", err)
+			}
+			gotNamespace = body.Namespace
+			c.JSON(http.StatusCreated, gin.H{"ok": true})
+		})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonRequest("/admin/modules/create", `{"namespace":"acme","name":"vpc","system":"aws"}`))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if gotNamespace != "acme" {
+		t.Errorf("handler saw namespace %q, want %q (body must be restored)", gotNamespace, "acme")
+	}
+}
+
+func TestRequirePublishAccessFromJSON_OrgOverrideMismatch_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+
+	r := gin.New()
+	r.POST("/admin/providers",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeProvidersWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromJSON(auth.ScopeProvidersWrite),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonRequest("/admin/providers", `{"namespace":"acme","type":"aws","organization_id":"`+nsOrgB+`"}`))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (organization_id override must match owning org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequirePublishAccessFromJSON_OrgOverrideAdmin_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/admin/providers",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeAdmin)}, nsUserID)),
+		authz.RequirePublishAccessFromJSON(auth.ScopeProvidersWrite),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, jsonRequest("/admin/providers", `{"namespace":"acme","type":"aws","organization_id":"`+nsOrgB+`"}`))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (admin may override organization_id): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RequireModuleAccessByID / RequireModuleUpdateAccess / RequireProviderAccessByID
+// ---------------------------------------------------------------------------
+
+var moduleByIDCols = []string{
+	"id", "organization_id", "namespace", "name", "system", "description", "source",
+	"created_by", "created_at", "updated_at", "created_by_name",
+	"deprecated", "deprecated_at", "deprecation_message", "successor_module_id",
+}
+
+var providerByIDCols = []string{
+	"id", "organization_id", "namespace", "type", "description", "source",
+	"created_by", "created_at", "updated_at", "created_by_name",
+}
+
+func TestRequireModuleAccessByID_NotUUID_PassesThrough(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+
+	r := gin.New()
+	r.POST("/admin/modules/:id/scm",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireModuleAccessByID(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "POST", "/admin/modules/not-a-uuid/scm")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (malformed ID left to handler): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireModuleAccessByID_CrossOrg_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	validUUID := "11111111-1111-1111-1111-111111111111"
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sqlmock.NewRows(moduleByIDCols).AddRow(
+			validUUID, nsOrgB, "acme", "vpc", "aws", nil, nil, nil, time.Now(), time.Now(), nil,
+			false, nil, nil, nil,
+		))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // no claim row → fall back to artifact org
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW)) // not a member of org B
+
+	r := gin.New()
+	r.POST("/admin/modules/:id/scm",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireModuleAccessByID(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "POST", "/admin/modules/"+validUUID+"/scm")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (module owned by another org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireProviderAccessByID_SameOrg_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	validUUID := "22222222-2222-2222-2222-222222222222"
+
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WillReturnRows(sqlmock.NewRows(providerByIDCols).AddRow(
+			validUUID, nsOrgA, "acme", "aws", nil, nil, nil, time.Now(), time.Now(), nil,
+		))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["providers:write"]`),
+		))
+
+	r := gin.New()
+	r.PUT("/admin/providers/:id",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeProvidersWrite)}, nsUserID)),
+		authz.RequireProviderAccessByID(auth.ScopeProvidersWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "PUT", "/admin/providers/"+validUUID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (same org allowed): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireModuleUpdateAccess_MoveToUnclaimedNamespace_ClaimsForCurrentOrg(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	validUUID := "33333333-3333-3333-3333-333333333333"
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sqlmock.NewRows(moduleByIDCols).AddRow(
+			validUUID, nsOrgA, "acme", "vpc", "aws", nil, nil, nil, time.Now(), time.Now(), nil,
+			false, nil, nil, nil,
+		))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+	// Target namespace "newhome" is unclaimed and has no artifacts.
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newhome", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.PUT("/admin/modules/:id",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireModuleUpdateAccess(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/admin/modules/"+validUUID, bytes.NewBufferString(`{"namespace":"newhome"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (move into unclaimed namespace claims it): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireModuleUpdateAccess_MoveToOtherOrgNamespace_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	validUUID := "44444444-4444-4444-4444-444444444444"
+
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WillReturnRows(sqlmock.NewRows(moduleByIDCols).AddRow(
+			validUUID, nsOrgA, "acme", "vpc", "aws", nil, nil, nil, time.Now(), time.Now(), nil,
+			false, nil, nil, nil,
+		))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-pub", time.Now(),
+			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
+		))
+	// Target namespace "rivals" is owned by org B.
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("rivals", nsOrgB, nil, time.Now()))
+
+	r := gin.New()
+	r.PUT("/admin/modules/:id",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequireModuleUpdateAccess(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/admin/modules/"+validUUID, bytes.NewBufferString(`{"namespace":"rivals"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (cannot move module into another org's namespace): body=%s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #555. Module and provider mutation endpoints authorized only on the caller's *organization membership*, never on whether that organization actually owns the target *namespace* — any authenticated member of any organization could publish, update, or delete modules/providers in a namespace owned by a different organization (CWE-639, Broken Object/Function-Level Authorization).

## ⚠️ Migration merge order

This PR adds migration `000045_namespace_org_claims.up.sql`. It must merge **before** #559 (`000046`) and #528 (`000047`) — those branches were cut from the same base commit and independently claimed the next sequential migration number. Please merge in the order **555 → 559 → 528**, or rebase the later ones if order is disrupted.

## Design

- New `namespace_claims` table binds each namespace to an owning organization. First publish to a namespace "claims" it atomically (`INSERT ... ON CONFLICT DO NOTHING`).
- New `internal/middleware/namespace_authz.go`: route-wiring variants (`RequireNamespaceAccessFromPath`, `RequirePublishAccessFromForm`, `RequirePublishAccessFromJSON`, `RequireModuleAccessByID`/`RequireModuleUpdateAccess`/`RequireProviderAccessByID`) authorize based on caller-org vs. owning-org.
- Namespaces with ambiguous ownership (artifacts spanning >1 org, no claim) are denied for non-admins rather than guessed at.
- Migration backfill claims namespaces with exactly one distinct owning org; genuinely ambiguous (multi-org) namespaces are deliberately left unclaimed, matching the runtime authorizer's own denial rather than being more permissive than it.

## Review history

This went through two rounds of adversarial multi-agent review (independent "prosecutor" findings, each re-verified by a fresh agent instructed to try to refute it) before being considered ready:

**Round 1** — 2 critical + 1 high confirmed and fixed (`59bd1dc`):
- `RequirePublishAccessFromForm` read the namespace from `FormValue` (which prefers the URL query string over the body) while the upload handler persists the *body's* namespace — an attacker could authorize against `?namespace=mine` while the multipart body named a victim namespace. Fixed by switching to `PostFormValue` (body-only), matching what the handler actually reads.

**Round 2** — 1 medium + 1 high confirmed and fixed (`41e5508`):
- `NewOrganizationHandlers` built its own `NamespaceClaimRepository` internally from whichever `db` handle was passed at the call site — which in the real deployment topology was the *wrong* database (identity DB instead of the domain DB the live authorizer middleware uses), silently disabling the org-deletion guard. Fixed by threading the same `claimRepo` instance used by the live middleware into the handler explicitly.
- Deleting an organization only checked `namespace_claims` row count, missing namespaces left deliberately *unclaimed* due to ambiguous (multi-org) ownership — an org could still directly own module/provider rows in such a namespace with no claim to block the cascade delete. Added `NamespaceClaimRepository.OwnsArtifacts` as a second guard, and changed the claims FK from `ON DELETE CASCADE` to `ON DELETE RESTRICT`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes, including new authorization-bypass regression tests for both rounds' findings