### PR TITLE
fix(security): enforce egress filtering + redirect re-validation on all outbound clients

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -23,6 +23,7 @@ import (
 	samlpkg "github.com/terraform-registry/terraform-registry/internal/auth/saml"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 )
 
@@ -41,12 +42,25 @@ type AuthHandlers struct {
 	// stateStore persists auth CSRF state tokens. When Redis is configured the
 	// store is shared across instances; otherwise an in-memory store is used.
 	stateStore auth.StateStore
+	// samlEgressGuard widens the SSRF deny-list applied when fetching a SAML
+	// IdP's metadata_url (nil = strict). Set via WithSAMLEgressGuard.
+	samlEgressGuard *httpsafe.Guard
+}
+
+// AuthHandlersOption configures optional AuthHandlers construction behavior.
+type AuthHandlersOption func(*AuthHandlers)
+
+// WithSAMLEgressGuard widens the SSRF deny-list applied when fetching a SAML
+// IdP's metadata_url (nil = strict default), for deployments whose IdP is
+// only reachable at an internal address.
+func WithSAMLEgressGuard(g *httpsafe.Guard) AuthHandlersOption {
+	return func(h *AuthHandlers) { h.samlEgressGuard = g }
 }
 
 // NewAuthHandlers creates a new AuthHandlers instance.
 // stateStore must be non-nil; the caller selects the implementation
 // (MemoryStateStore for single-instance, RedisStateStore for HA).
-func NewAuthHandlers(cfg *config.Config, db *sql.DB, oidcConfigRepo *repositories.OIDCConfigRepository, tokenRepo *repositories.TokenRepository, stateStore auth.StateStore) (*AuthHandlers, error) {
+func NewAuthHandlers(cfg *config.Config, db *sql.DB, oidcConfigRepo *repositories.OIDCConfigRepository, tokenRepo *repositories.TokenRepository, stateStore auth.StateStore, opts ...AuthHandlersOption) (*AuthHandlers, error) {
 	h := &AuthHandlers{
 		cfg:            cfg,
 		db:             db,
@@ -55,6 +69,9 @@ func NewAuthHandlers(cfg *config.Config, db *sql.DB, oidcConfigRepo *repositorie
 		oidcConfigRepo: oidcConfigRepo,
 		tokenRepo:      tokenRepo,
 		stateStore:     stateStore,
+	}
+	for _, opt := range opts {
+		opt(h)
 	}
 
 	// Initialize OIDC provider if enabled
@@ -80,7 +97,7 @@ func NewAuthHandlers(cfg *config.Config, db *sql.DB, oidcConfigRepo *repositorie
 		h.samlProviders = make(map[string]*samlpkg.Provider, len(cfg.Auth.SAML.IdPs))
 		for i := range cfg.Auth.SAML.IdPs {
 			idpCfg := &cfg.Auth.SAML.IdPs[i]
-			sp, err := samlpkg.NewProvider(&cfg.Auth.SAML, idpCfg)
+			sp, err := samlpkg.NewProviderWithGuard(&cfg.Auth.SAML, idpCfg, h.samlEgressGuard)
 			if err != nil {
 				return nil, fmt.Errorf("saml idp %q: %w", idpCfg.Name, err)
 			}

--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 
 	"github.com/gin-gonic/gin"
@@ -28,6 +29,10 @@ type MirrorHandler struct {
 	orgRepo      *repositories.OrganizationRepository
 	providerRepo *repositories.ProviderRepository
 	syncJob      MirrorSyncJobInterface
+	// egress is consulted (via mirror.ValidateRegistryURL) on every create/update
+	// so a non-admin "devops"-scoped caller cannot point a mirror at a private
+	// or cloud-metadata address; nil enforces the strict default deny-list.
+	egress *httpsafe.Guard
 }
 
 // NewMirrorHandler creates a new mirror handler
@@ -42,6 +47,14 @@ func NewMirrorHandler(mirrorRepo *repositories.MirrorRepository, orgRepo *reposi
 // SetSyncJob sets the sync job for triggering manual syncs
 func (h *MirrorHandler) SetSyncJob(syncJob MirrorSyncJobInterface) {
 	h.syncJob = syncJob
+}
+
+// SetEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) consulted when validating upstream_registry_url
+// on create/update. Returns the handler for chaining.
+func (h *MirrorHandler) SetEgressGuard(g *httpsafe.Guard) *MirrorHandler {
+	h.egress = g
+	return h
 }
 
 // @Summary      Create mirror configuration
@@ -67,7 +80,7 @@ func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 	}
 
 	// Validate registry URL
-	if err := mirror.ValidateRegistryURL(req.UpstreamRegistryURL); err != nil {
+	if err := mirror.ValidateRegistryURL(req.UpstreamRegistryURL, h.egress); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid registry URL: " + err.Error()})
 		return
 	}
@@ -319,7 +332,7 @@ func (h *MirrorHandler) UpdateMirrorConfig(c *gin.Context) {
 	}
 
 	if req.UpstreamRegistryURL != nil {
-		if err := mirror.ValidateRegistryURL(*req.UpstreamRegistryURL); err != nil {
+		if err := mirror.ValidateRegistryURL(*req.UpstreamRegistryURL, h.egress); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid registry URL: " + err.Error()})
 			return
 		}

--- a/backend/internal/api/admin/mirror_test.go
+++ b/backend/internal/api/admin/mirror_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // ---------------------------------------------------------------------------
@@ -624,6 +626,88 @@ func TestMirrorUpdate_InvalidRegistryURL(t *testing.T) {
 		WillReturnRows(sampleMirrorCfgRow())
 
 	badURL := "not-a-valid-url"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/mirrors/"+knownUUID,
+		jsonBody(map[string]interface{}{"upstream_registry_url": &badURL})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSRF: private / cloud-metadata upstream_registry_url rejected at save
+// ---------------------------------------------------------------------------
+
+func TestMirrorCreate_RejectsCloudMetadataURL(t *testing.T) {
+	_, r := newMirrorRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors",
+		jsonBody(map[string]interface{}{
+			"name":                  "metadata-mirror",
+			"upstream_registry_url": "http://169.254.169.254/latest/meta-data/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "link-local") {
+		t.Errorf("body = %s, want a link-local/metadata rejection reason", w.Body.String())
+	}
+}
+
+func TestMirrorCreate_RejectsPrivateNetworkURL(t *testing.T) {
+	_, r := newMirrorRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors",
+		jsonBody(map[string]interface{}{
+			"name":                  "internal-mirror",
+			"upstream_registry_url": "https://10.0.5.5/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMirrorCreate_AllowlistedPrivateURLSucceeds(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	mirrorRepo := repositories.NewMirrorRepository(sqlxDB)
+	orgRepo := repositories.NewOrganizationRepository(db)
+	h := NewMirrorHandler(mirrorRepo, orgRepo, repositories.NewProviderRepository(db))
+	h.SetEgressGuard(httpsafe.MustGuard("10.0.5.0/24"))
+
+	r := gin.New()
+	r.POST("/mirrors", h.CreateMirrorConfig)
+
+	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE name").
+		WillReturnRows(sqlmock.NewRows(mirrorCfgCols))
+	mock.ExpectExec("INSERT INTO mirror_configurations").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors",
+		jsonBody(map[string]interface{}{
+			"name":                  "allowlisted-internal-mirror",
+			"upstream_registry_url": "https://10.0.5.5/",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMirrorUpdate_RejectsPrivateNetworkURL(t *testing.T) {
+	mock, r := newMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE id").
+		WillReturnRows(sampleMirrorCfgRow())
+
+	badURL := "http://127.0.0.1:8080/"
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("PUT", "/mirrors/"+knownUUID,
 		jsonBody(map[string]interface{}{"upstream_registry_url": &badURL})))

--- a/backend/internal/api/admin/scm_providers.go
+++ b/backend/internal/api/admin/scm_providers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 )
@@ -22,6 +23,11 @@ type SCMProviderHandlers struct {
 	orgRepo     *repositories.OrganizationRepository
 	tokenCipher *crypto.TokenCipher
 	minter      appcreds.SharedMinter
+	// egress is consulted when validating base_url on create/update so a
+	// non-admin "devops"-scoped caller cannot point a self-hosted SCM
+	// connector (and its OAuth token exchange) at a private or cloud-metadata
+	// address; nil enforces the strict default deny-list.
+	egress *httpsafe.Guard
 }
 
 // NewSCMProviderHandlers creates a new SCM provider handlers instance
@@ -38,6 +44,14 @@ func NewSCMProviderHandlers(cfg *config.Config, scmRepo *repositories.SCMReposit
 // app auth mode (entra_app/github_app). Returns the handler for chaining.
 func (h *SCMProviderHandlers) WithMinter(minter appcreds.SharedMinter) *SCMProviderHandlers {
 	h.minter = minter
+	return h
+}
+
+// WithEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) consulted when validating base_url on
+// create/update. Returns the handler for chaining.
+func (h *SCMProviderHandlers) WithEgressGuard(g *httpsafe.Guard) *SCMProviderHandlers {
+	h.egress = g
 	return h
 }
 
@@ -188,6 +202,17 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid auth_mode"})
 		return
+	}
+
+	// base_url is reachable from any auth mode (e.g. a GitHub Enterprise Server
+	// or self-hosted GitLab/Azure DevOps instance) and drives every outbound
+	// connector call including the OAuth code/token exchange, so it is rejected
+	// at save when it targets a private or cloud-metadata address.
+	if req.BaseURL != nil && *req.BaseURL != "" {
+		if err := h.egress.ValidateURL(*req.BaseURL); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid base_url: " + err.Error()})
+			return
+		}
 	}
 
 	// Encrypt client secret
@@ -381,6 +406,12 @@ func (h *SCMProviderHandlers) UpdateProvider(c *gin.Context) {
 		provider.Name = *req.Name
 	}
 	if req.BaseURL != nil {
+		if *req.BaseURL != "" {
+			if err := h.egress.ValidateURL(*req.BaseURL); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid base_url: " + err.Error()})
+				return
+			}
+		}
 		provider.BaseURL = req.BaseURL
 	}
 	if req.TenantID != nil {

--- a/backend/internal/api/admin/scm_providers_test.go
+++ b/backend/internal/api/admin/scm_providers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // ---------------------------------------------------------------------------
@@ -271,6 +272,95 @@ func TestSCMCreate_PATBased_Success(t *testing.T) {
 			"provider_type": "bitbucket_dc",
 			"name":          "test-bdc",
 			"base_url":      "https://bitbucket.example.com",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSRF: private / cloud-metadata base_url rejected at save
+// ---------------------------------------------------------------------------
+
+func TestSCMCreate_RejectsCloudMetadataBaseURL(t *testing.T) {
+	_, r := newSCMProviderRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type": "bitbucket_dc",
+			"name":          "test-bdc",
+			"base_url":      "http://169.254.169.254/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMCreate_RejectsPrivateBaseURL_OAuthMode(t *testing.T) {
+	// base_url is validated regardless of auth mode (e.g. a GitHub Enterprise
+	// Server instance configured with the default oauth_user auth mode).
+	_, r := newSCMProviderRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type": "github",
+			"name":          "test-ghe",
+			"client_id":     "cid",
+			"client_secret": "csec",
+			"base_url":      "http://10.1.2.3/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMUpdate_RejectsPrivateBaseURL(t *testing.T) {
+	mock, r := newSCMProviderRouter(t)
+	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
+		WillReturnRows(sampleSCMProviderRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/scm-providers/"+knownUUID,
+		jsonBody(map[string]interface{}{"base_url": "http://127.0.0.1:8080/"})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMCreate_AllowlistedBaseURLSucceeds(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	scmRepo := repositories.NewSCMRepository(sqlxDB)
+	orgRepo := repositories.NewOrganizationRepository(db)
+	cipher := testTokenCipher(t)
+	h := NewSCMProviderHandlers(&config.Config{}, scmRepo, orgRepo, cipher).
+		WithEgressGuard(httpsafe.MustGuard("10.5.0.0/16"))
+
+	r := gin.New()
+	r.POST("/scm-providers", h.CreateProvider)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}).
+			AddRow(knownUUID, "default", "Default", nil, nil, time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE organization_id").
+		WillReturnRows(sqlmock.NewRows(scmProvCols))
+	mock.ExpectExec("INSERT INTO scm_providers").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/scm-providers",
+		jsonBody(map[string]interface{}{
+			"provider_type": "bitbucket_dc",
+			"name":          "internal-bdc",
+			"base_url":      "https://10.5.1.1/",
 		})))
 
 	if w.Code != http.StatusCreated {

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 
 	"github.com/gin-gonic/gin"
@@ -30,6 +31,11 @@ type TerraformMirrorHandler struct {
 	repo           *repositories.TerraformMirrorRepository
 	syncJob        TerraformMirrorSyncJobInterface
 	storageBackend storage.Storage
+	// egress is consulted when validating upstream_url on create/update so a
+	// non-admin "devops"-scoped caller cannot point the binary mirror at a
+	// private or cloud-metadata address; nil enforces the strict default
+	// deny-list.
+	egress *httpsafe.Guard
 }
 
 // NewTerraformMirrorHandler creates a new TerraformMirrorHandler.
@@ -40,6 +46,13 @@ func NewTerraformMirrorHandler(repo *repositories.TerraformMirrorRepository) *Te
 // SetSyncJob attaches the live sync job so handlers can trigger manual syncs.
 func (h *TerraformMirrorHandler) SetSyncJob(syncJob TerraformMirrorSyncJobInterface) {
 	h.syncJob = syncJob
+}
+
+// SetEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) consulted when validating upstream_url on
+// create/update.
+func (h *TerraformMirrorHandler) SetEgressGuard(g *httpsafe.Guard) {
+	h.egress = g
 }
 
 // SetStorageBackend attaches the object-storage backend so deleting a version
@@ -91,6 +104,11 @@ func (h *TerraformMirrorHandler) CreateConfig(c *gin.Context) {
 	var req models.CreateTerraformMirrorConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.egress.ValidateURL(req.UpstreamURL); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid upstream_url: " + err.Error()})
 		return
 	}
 
@@ -324,6 +342,10 @@ func (h *TerraformMirrorHandler) UpdateConfig(c *gin.Context) {
 		cfg.Tool = *req.Tool
 	}
 	if req.UpstreamURL != nil {
+		if err := h.egress.ValidateURL(*req.UpstreamURL); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid upstream_url: " + err.Error()})
+			return
+		}
 		cfg.UpstreamURL = *req.UpstreamURL
 	}
 	if req.GPGVerify != nil {

--- a/backend/internal/api/admin/terraform_mirror_test.go
+++ b/backend/internal/api/admin/terraform_mirror_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // ---------------------------------------------------------------------------
@@ -113,6 +114,86 @@ func newTerraformMirrorRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	r.GET("/terraform-mirrors/:id/versions/:version/platforms", h.ListPlatforms)
 
 	return mock, r
+}
+
+// ---------------------------------------------------------------------------
+// SSRF: private / cloud-metadata upstream_url rejected at save
+// ---------------------------------------------------------------------------
+
+func TestTMCreateConfig_RejectsCloudMetadataURL(t *testing.T) {
+	_, r := newTerraformMirrorRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors",
+		jsonBody(map[string]interface{}{
+			"name":         "metadata-mirror",
+			"tool":         "terraform",
+			"upstream_url": "http://169.254.169.254/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMCreateConfig_RejectsPrivateURL(t *testing.T) {
+	_, r := newTerraformMirrorRouter(t)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors",
+		jsonBody(map[string]interface{}{
+			"name":         "internal-mirror",
+			"tool":         "terraform",
+			"upstream_url": "https://192.168.1.1/",
+		})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMUpdateConfig_RejectsPrivateURL(t *testing.T) {
+	mock, r := newTerraformMirrorRouter(t)
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE id").
+		WillReturnRows(sampleTMCRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/terraform-mirrors/"+knownUUID,
+		jsonBody(map[string]interface{}{"upstream_url": "http://127.0.0.1:9000/"})))
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTMCreateConfig_AllowlistedURLSucceeds(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewTerraformMirrorRepository(sqlxDB)
+	h := NewTerraformMirrorHandler(repo)
+	h.SetEgressGuard(httpsafe.MustGuard("172.20.0.0/16"))
+
+	r := gin.New()
+	r.POST("/terraform-mirrors", h.CreateConfig)
+
+	mock.ExpectQuery("SELECT.*FROM terraform_mirror_configs WHERE name").
+		WillReturnRows(emptyTMCRows())
+	mock.ExpectQuery("INSERT INTO terraform_mirror_configs").
+		WillReturnRows(sampleTMCRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/terraform-mirrors",
+		jsonBody(map[string]interface{}{
+			"name":         "allowlisted-internal-mirror",
+			"tool":         "terraform",
+			"upstream_url": "https://172.20.5.5/",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -47,9 +47,11 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/policy"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/services"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -156,6 +158,19 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		log.Fatalf("invalid trusted_proxies config: %v", err)
 	}
 
+	// egressGuard widens the SSRF deny-list enforced by every outbound client
+	// this router wires up (mirror sync, SCM connectors, OSV poller, policy
+	// bundle, SAML metadata, ...) per security.egress.allowlist. Config.Validate
+	// already parsed this list once at Load(); a second parse error here would
+	// mean cfg was constructed without going through config.Load.
+	egressGuard, err := httpsafe.NewGuard(cfg.Security.Egress.Allowlist)
+	if err != nil {
+		log.Fatalf("invalid security.egress.allowlist: %v", err)
+	}
+	if err := scm.ConfigureEgress(cfg.Security.Egress.Allowlist); err != nil {
+		log.Fatalf("failed to configure SCM connector egress policy: %v", err)
+	}
+
 	// Initialize storage backend
 	storageBackend, err := storage.NewStorage(cfg)
 	if err != nil {
@@ -189,10 +204,12 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 
 	// Initialize pull-through caching service
 	pullThroughSvc := services.NewPullThroughService(providerRepo, mirrorRepo, orgRepo)
+	pullThroughSvc.SetEgressGuard(egressGuard)
 
 	// Initialize mirror sync job
 	mirrorSyncJob := jobs.NewMirrorSyncJob(mirrorRepo, providerRepo, providerDocsRepo, orgRepo, storageBackend, cfg.Storage.DefaultBackend)
 	mirrorSyncJob.SetApprovalRepo(repositories.NewVersionApprovalRepository(sqlxDB))
+	mirrorSyncJob.SetEgressGuard(egressGuard)
 	// Start background sync job - check every 10 minutes for mirrors that need syncing
 	mirrorSyncJob.Start(context.Background(), 10)
 	log.Println("Mirror sync job started (checking every 10 minutes)")
@@ -200,6 +217,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize Terraform binary mirror repository and sync job
 	tfMirrorRepo := repositories.NewTerraformMirrorRepository(sqlxDB)
 	tfMirrorSyncJob := jobs.NewTerraformMirrorSyncJob(tfMirrorRepo, storageBackend, cfg.Storage.DefaultBackend)
+	tfMirrorSyncJob.SetEgressGuard(egressGuard)
 	tfMirrorSyncJob.Start(context.Background(), 10)
 	log.Println("Terraform binary mirror sync job started (checking every 10 minutes)")
 
@@ -208,7 +226,8 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// terraform mirror sync, so the next sync tick after a successful refresh
 	// uses the cached upstream key instead of the embedded snapshot.
 	releasesKeyRepo := repositories.NewReleasesGPGKeyRepository(sqlxDB)
-	releasesKeyRefreshJob, releasesKeyJobErr := jobs.NewReleasesKeyRefreshJob(&cfg.ReleasesGPGKeys, releasesKeyRepo, nil)
+	releasesKeyHTTPClient := httpsafe.NewClient(30*time.Second, egressGuard)
+	releasesKeyRefreshJob, releasesKeyJobErr := jobs.NewReleasesKeyRefreshJob(&cfg.ReleasesGPGKeys, releasesKeyRepo, releasesKeyHTTPClient)
 	if releasesKeyJobErr != nil {
 		// The only way construction fails is a parse error on the embedded
 		// OpenTofu snapshot — fatal because the fingerprint pin can't be
@@ -627,7 +646,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	}
 
 	var authHandlers *admin.AuthHandlers
-	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore)
+	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore, admin.WithSAMLEgressGuard(egressGuard))
 	if err != nil {
 		log.Fatalf("Failed to initialize auth handlers: %v", err)
 	}
@@ -669,11 +688,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers
+	mirrorHandlers.SetEgressGuard(egressGuard)
 
 	// Initialize Terraform binary mirror admin handler
 	tfMirrorAdminHandler := admin.NewTerraformMirrorHandler(tfMirrorRepo)
 	tfMirrorAdminHandler.SetSyncJob(tfMirrorSyncJob)
 	tfMirrorAdminHandler.SetStorageBackend(storageBackend) // delete stored binaries when a version is removed
+	tfMirrorAdminHandler.SetEgressGuard(egressGuard)
 	releasesGPGKeysAdminHandler := admin.NewReleasesGPGKeysHandler(releasesKeyRepo, tfMirrorRepo, cfg.ReleasesGPGKeys)
 	versionApprovalHandler := admin.NewVersionApprovalHandler(repositories.NewVersionApprovalRepository(sqlxDB))
 	providerAdminHandlers := admin.NewProviderAdminHandlers(db, storageBackend, cfg)
@@ -711,11 +732,12 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize and start the CVE polling job (no-op when cve.enabled=false)
 	cveRepo := repositories.NewCVERepository(db)
 	cvePollJob := jobs.NewCVEPollJob(cveRepo, auditRepo, &cfg.Scanning, &cfg.CVE, &cfg.Notifications)
+	cvePollJob.SetEgressGuard(egressGuard)
 	go cvePollJob.Start(context.Background())
 	log.Println("CVE poll job started")
 
 	// Initialize SCM handlers with the already-created repositories and token cipher
-	scmProviderHandlers := admin.NewSCMProviderHandlers(cfg, scmRepo, orgRepo, tokenCipher).WithMinter(sharedMinter)
+	scmProviderHandlers := admin.NewSCMProviderHandlers(cfg, scmRepo, orgRepo, tokenCipher).WithMinter(sharedMinter).WithEgressGuard(egressGuard)
 	scmOAuthHandlers := admin.NewSCMOAuthHandlers(cfg, scmRepo, userRepo, tokenCipher).WithMinter(sharedMinter)
 	scmLinkingHandler := modules.NewSCMLinkingHandler(scmRepo, moduleRepo, tokenCipher, cfg.Server.BaseURL, scmPublisher).WithMinter(sharedMinter)
 
@@ -738,9 +760,10 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		Enabled:               cfg.Policy.Enabled,
 		Mode:                  cfg.Policy.Mode,
 		BundleURL:             cfg.Policy.BundleURL,
+		BundleSHA256:          cfg.Policy.BundleSHA256,
 		BundleRefreshInterval: cfg.Policy.BundleRefreshInterval,
 	}
-	policyEngine, err := policy.NewPolicyEngine(policyEngineCfg)
+	policyEngine, err := policy.NewPolicyEngineWithGuard(policyEngineCfg, egressGuard)
 	if err != nil {
 		log.Fatalf("failed to initialize policy engine: %v", err)
 	}

--- a/backend/internal/audit/shipper.go
+++ b/backend/internal/audit/shipper.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // LogEntry represents a structured audit log entry
@@ -100,8 +102,16 @@ type MultiShipper struct {
 	mu       sync.RWMutex
 }
 
-// NewMultiShipper creates a new multi-shipper from configs
+// NewMultiShipper creates a new multi-shipper from configs, with the strict
+// egress policy (no allow-list) applied to webhook shippers.
 func NewMultiShipper(configs []ShipperConfig) (*MultiShipper, error) {
+	return NewMultiShipperWithGuard(configs, nil)
+}
+
+// NewMultiShipperWithGuard is NewMultiShipper with an egress guard widening
+// the SSRF deny-list applied to webhook shippers (nil = strict), for
+// deployments whose webhook URL points at an internal SIEM/log aggregator.
+func NewMultiShipperWithGuard(configs []ShipperConfig, egress *httpsafe.Guard) (*MultiShipper, error) {
 	ms := &MultiShipper{
 		shippers: make([]Shipper, 0),
 	}
@@ -124,7 +134,7 @@ func NewMultiShipper(configs []ShipperConfig) (*MultiShipper, error) {
 			if cfg.Webhook == nil {
 				return nil, fmt.Errorf("webhook config is required for webhook shipper")
 			}
-			shipper, err = NewWebhookShipper(cfg.Webhook)
+			shipper, err = NewWebhookShipperWithGuard(cfg.Webhook, egress)
 		case "file":
 			if cfg.File == nil {
 				return nil, fmt.Errorf("file config is required for file shipper")
@@ -185,18 +195,25 @@ type WebhookShipper struct {
 	closeOnce sync.Once
 }
 
-// NewWebhookShipper creates a new webhook shipper
+// NewWebhookShipper creates a new webhook shipper with the strict egress
+// policy (no allow-list). cfg.URL is operator-configurable, so requests are
+// dialed through internal/httpsafe.
 func NewWebhookShipper(cfg *WebhookConfig) (*WebhookShipper, error) {
+	return NewWebhookShipperWithGuard(cfg, nil)
+}
+
+// NewWebhookShipperWithGuard is NewWebhookShipper with an egress guard
+// widening the SSRF deny-list (nil = strict), for deployments whose webhook
+// URL points at an internal SIEM/log aggregator.
+func NewWebhookShipperWithGuard(cfg *WebhookConfig, egress *httpsafe.Guard) (*WebhookShipper, error) {
 	timeout := cfg.Timeout
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
 
 	ws := &WebhookShipper{
-		cfg: cfg,
-		client: &http.Client{
-			Timeout: timeout,
-		},
+		cfg:     cfg,
+		client:  httpsafe.NewClient(timeout, egress),
 		batchCh: make(chan *LogEntry, 1000),
 		batch:   make([]*LogEntry, 0),
 		closeCh: make(chan struct{}),
@@ -303,7 +320,7 @@ func (ws *WebhookShipper) sendRequest(ctx context.Context, data []byte) error {
 		req.Header.Set(k, v)
 	}
 
-	resp, err := ws.client.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := ws.client.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return fmt.Errorf("failed to send webhook: %w", err)
 	}

--- a/backend/internal/audit/shipper_test.go
+++ b/backend/internal/audit/shipper_test.go
@@ -13,7 +13,13 @@ import (
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/audit"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// loopbackGuard allow-lists the httptest.Server addresses used throughout this
+// file (127.0.0.1 / ::1) so tests exercise real HTTP without needing the
+// strict production egress policy to accept a loopback target.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
 // ---------------------------------------------------------------------------
 // MultiShipper — via NewMultiShipper factory
@@ -97,7 +103,7 @@ func TestMultiShipper_ContinuesAfterShipperError(t *testing.T) {
 		{Enabled: true, Type: "webhook", Webhook: &audit.WebhookConfig{URL: srv1.URL, Timeout: time.Second}},
 		{Enabled: true, Type: "webhook", Webhook: &audit.WebhookConfig{URL: srv2.URL, Timeout: time.Second}},
 	}
-	ms, err := audit.NewMultiShipper(cfgs)
+	ms, err := audit.NewMultiShipperWithGuard(cfgs, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewMultiShipper error: %v", err)
 	}
@@ -130,10 +136,10 @@ func TestWebhookShipper_ShipEntry(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, err := audit.NewWebhookShipper(&audit.WebhookConfig{
+	ws, err := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
 		URL:     srv.URL,
 		Timeout: 5 * time.Second,
-	})
+	}, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewWebhookShipper error: %v", err)
 	}
@@ -162,7 +168,7 @@ func TestWebhookShipper_ErrorResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, _ := audit.NewWebhookShipper(&audit.WebhookConfig{URL: srv.URL, Timeout: 5 * time.Second})
+	ws, _ := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{URL: srv.URL, Timeout: 5 * time.Second}, loopbackGuard)
 	defer ws.Close()
 
 	if err := ws.Ship(context.Background(), &audit.LogEntry{Action: "err"}); err == nil {
@@ -178,11 +184,11 @@ func TestWebhookShipper_CustomHeader(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, _ := audit.NewWebhookShipper(&audit.WebhookConfig{
+	ws, _ := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
 		URL:     srv.URL,
 		Timeout: 5 * time.Second,
 		Headers: map[string]string{"X-Auth-Token": "secret"},
-	})
+	}, loopbackGuard)
 	defer ws.Close()
 
 	ws.Ship(context.Background(), &audit.LogEntry{Action: "header.test"})
@@ -287,12 +293,12 @@ func TestWebhookShipper_BatchedShip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, err := audit.NewWebhookShipper(&audit.WebhookConfig{
+	ws, err := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
 		URL:           srv.URL,
 		Timeout:       5 * time.Second,
 		BatchSize:     1, // Batch of 1 triggers flush immediately on first entry
 		FlushInterval: 5 * time.Second,
-	})
+	}, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewWebhookShipper error: %v", err)
 	}
@@ -321,12 +327,12 @@ func TestWebhookShipper_BatchFlushOnInterval(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, _ := audit.NewWebhookShipper(&audit.WebhookConfig{
+	ws, _ := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
 		URL:           srv.URL,
 		Timeout:       5 * time.Second,
 		BatchSize:     100,                   // Large batch, won't fill by count
 		FlushInterval: 50 * time.Millisecond, // Short flush interval
-	})
+	}, loopbackGuard)
 	defer ws.Close()
 
 	// Ship 1 entry — should be flushed by the interval ticker
@@ -350,12 +356,12 @@ func TestWebhookShipper_BatchFlushOnClose(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ws, _ := audit.NewWebhookShipper(&audit.WebhookConfig{
+	ws, _ := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
 		URL:           srv.URL,
 		Timeout:       5 * time.Second,
 		BatchSize:     100,             // Large batch, won't fill by count
 		FlushInterval: 5 * time.Second, // Long interval, won't fire in test
-	})
+	}, loopbackGuard)
 
 	// Ship 1 entry and wait for goroutine to add it to the batch
 	ws.Ship(context.Background(), &audit.LogEntry{Action: "flush-on-close"})

--- a/backend/internal/auth/saml/provider.go
+++ b/backend/internal/auth/saml/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // Provider wraps a crewjam/saml ServiceProvider and exposes methods needed
@@ -48,9 +49,17 @@ type AssertionMeta struct {
 	NotOnOrAfter time.Time
 }
 
-// NewProvider creates a SAML Service Provider for the given IdP configuration.
-// It loads the SP certificate/key pair for signing and fetches IdP metadata.
+// NewProvider creates a SAML Service Provider for the given IdP configuration
+// with the strict egress policy (no allow-list). It loads the SP
+// certificate/key pair for signing and fetches IdP metadata.
 func NewProvider(cfg *config.SAMLConfig, idpCfg *config.SAMLIdPConfig) (*Provider, error) {
+	return NewProviderWithGuard(cfg, idpCfg, nil)
+}
+
+// NewProviderWithGuard is NewProvider with an egress guard widening the SSRF
+// deny-list (nil = strict), for deployments whose SAML IdP metadata_url points
+// at an internal IdP.
+func NewProviderWithGuard(cfg *config.SAMLConfig, idpCfg *config.SAMLIdPConfig, egress *httpsafe.Guard) (*Provider, error) {
 	if cfg.ACSURL == "" {
 		return nil, fmt.Errorf("saml: acs_url is required")
 	}
@@ -90,7 +99,7 @@ func NewProvider(cfg *config.SAMLConfig, idpCfg *config.SAMLIdPConfig) (*Provide
 	}
 
 	// Fetch or parse IdP metadata
-	idpMetadata, err := resolveIdPMetadata(idpCfg)
+	idpMetadata, err := resolveIdPMetadata(idpCfg, egress)
 	if err != nil {
 		return nil, fmt.Errorf("saml: IdP %q: %w", idpCfg.Name, err)
 	}
@@ -234,7 +243,7 @@ func (p *Provider) parseAssertionFromResponse(samlResponse string) (*UserInfo, e
 }
 
 // resolveIdPMetadata fetches or parses IdP metadata from the config.
-func resolveIdPMetadata(idpCfg *config.SAMLIdPConfig) (*saml.EntityDescriptor, error) {
+func resolveIdPMetadata(idpCfg *config.SAMLIdPConfig, egress *httpsafe.Guard) (*saml.EntityDescriptor, error) {
 	if idpCfg.MetadataXML != "" {
 		metadata := &saml.EntityDescriptor{}
 		if err := xml.Unmarshal([]byte(idpCfg.MetadataXML), metadata); err != nil {
@@ -244,14 +253,18 @@ func resolveIdPMetadata(idpCfg *config.SAMLIdPConfig) (*saml.EntityDescriptor, e
 	}
 
 	if idpCfg.MetadataURL != "" {
-		return fetchIdPMetadata(idpCfg.MetadataURL)
+		return fetchIdPMetadata(idpCfg.MetadataURL, egress)
 	}
 
 	return nil, fmt.Errorf("either metadata_url or metadata_xml must be provided")
 }
 
-// fetchIdPMetadata retrieves and parses IdP metadata from a URL.
-func fetchIdPMetadata(metadataURL string) (*saml.EntityDescriptor, error) {
+// fetchIdPMetadata retrieves and parses IdP metadata from a URL. The fetch is
+// routed through the SSRF-safe egress client (internal/httpsafe): scheme is
+// restricted to HTTPS, and (unless the host is allow-listed) the resolved IP
+// is checked against the private/metadata deny-list before dialing, with
+// redirects re-validated per hop.
+func fetchIdPMetadata(metadataURL string, egress *httpsafe.Guard) (*saml.EntityDescriptor, error) {
 	parsedURL, err := url.Parse(metadataURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid metadata URL: %w", err)
@@ -260,7 +273,7 @@ func fetchIdPMetadata(metadataURL string) (*saml.EntityDescriptor, error) {
 		return nil, fmt.Errorf("metadata URL must use HTTPS: %s", metadataURL)
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := httpsafe.NewClient(30*time.Second, egress)
 	resp, err := client.Get(metadataURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch metadata from %s: %w", metadataURL, err)

--- a/backend/internal/auth/saml/provider_test.go
+++ b/backend/internal/auth/saml/provider_test.go
@@ -227,7 +227,7 @@ func TestIsNameAttr(t *testing.T) {
 }
 
 func TestFetchIdPMetadata_RequiresHTTPS(t *testing.T) {
-	_, err := fetchIdPMetadata("http://insecure.example.com/metadata")
+	_, err := fetchIdPMetadata("http://insecure.example.com/metadata", nil)
 	if err == nil {
 		t.Fatal("expected error for non-HTTPS metadata URL")
 	}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,11 +13,14 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/viper"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // Config holds all application configuration
@@ -115,8 +118,13 @@ type PolicyConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 	// Mode controls enforcement: "warn" logs violations and continues; "block" rejects the action.
 	Mode string `mapstructure:"mode"`
-	// BundleURL is the HTTP/HTTPS URL of the .tar.gz Rego bundle.
+	// BundleURL is the HTTPS URL of the .tar.gz Rego bundle. Plain HTTP is only
+	// accepted when the bundle host is covered by security.egress.allowlist.
 	BundleURL string `mapstructure:"bundle_url"`
+	// BundleSHA256 optionally pins the expected SHA-256 (hex) of the bundle
+	// archive. When set, a fetched bundle whose digest does not match is
+	// rejected and the previously loaded policies are kept (fail closed).
+	BundleSHA256 string `mapstructure:"bundle_sha256"`
 	// BundleRefreshInterval is how often (in seconds) the bundle is re-fetched in the background.
 	// 0 means no background refresh.
 	BundleRefreshInterval int `mapstructure:"bundle_refresh_interval"`
@@ -556,6 +564,22 @@ type SecurityConfig struct {
 	RateLimiting RateLimitingConfig `mapstructure:"rate_limiting"`
 	TLS          TLSConfig          `mapstructure:"tls"`
 	MTLS         MTLSConfig         `mapstructure:"mtls"`
+	Egress       EgressConfig       `mapstructure:"egress"`
+}
+
+// EgressConfig controls SSRF egress filtering for outbound HTTP requests whose
+// target URL is operator- or admin-configurable (mirror upstreams, SCM provider
+// base URLs, the policy bundle, the OSV endpoint, SAML IdP metadata, audit
+// webhooks). By default outbound requests may not target loopback, private
+// (RFC 1918 / ULA), link-local (including the cloud metadata endpoint
+// 169.254.169.254), or otherwise non-public addresses.
+type EgressConfig struct {
+	// Allowlist exempts specific hostnames, IPs, or CIDR ranges from the
+	// private-address deny-list, for deployments that legitimately mirror from
+	// internal registries (e.g. ["registry.corp.internal", "10.20.0.0/16"]).
+	// Default empty = deny all private/internal targets.
+	// Env: TFR_SECURITY_EGRESS_ALLOWLIST (comma-separated).
+	Allowlist []string `mapstructure:"allowlist"`
 }
 
 // CORSConfig holds CORS configuration
@@ -829,6 +853,7 @@ func bindEnvVars(v *viper.Viper) error {
 		"security.tls.enabled",
 		"security.tls.cert_file",
 		"security.tls.key_file",
+		"security.egress.allowlist",
 
 		// Logging
 		"logging.level",
@@ -1042,6 +1067,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("security.rate_limiting.org_requests_per_minute", 0)
 	v.SetDefault("security.rate_limiting.org_burst", 0)
 	v.SetDefault("security.tls.enabled", false)
+	v.SetDefault("security.egress.allowlist", []string{})
 
 	// Logging defaults
 	v.SetDefault("logging.level", "info")
@@ -1245,6 +1271,31 @@ func (c *Config) Validate() error {
 		}
 		if !toolValid {
 			return fmt.Errorf("scanning.tool must be one of: %s", strings.Join(validTools, ", "))
+		}
+	}
+
+	// Validate the egress allow-list itself (each entry must be a hostname, IP,
+	// or CIDR) before using it to validate the URLs below.
+	egressGuard, err := httpsafe.NewGuard(c.Security.Egress.Allowlist)
+	if err != nil {
+		return fmt.Errorf("security.egress.allowlist: %w", err)
+	}
+
+	// Validate the policy bundle URL at config-load time: bundle_url is not
+	// exposed through any runtime-writable admin endpoint (only YAML/env), but
+	// it is still operator-configurable and must not resolve to a private or
+	// cloud-metadata address, and must use HTTPS unless the host is
+	// allow-listed (see internal/policy/bundle_loader.go).
+	if c.Policy.Enabled && c.Policy.BundleURL != "" {
+		parsed, err := url.Parse(c.Policy.BundleURL)
+		if err != nil {
+			return fmt.Errorf("policy.bundle_url: invalid URL: %w", err)
+		}
+		if parsed.Scheme != "https" && !egressGuard.HostExempt(parsed.Hostname()) {
+			return fmt.Errorf("policy.bundle_url must use https (got %q); add the host to security.egress.allowlist if plain HTTP to an internal mirror is intentional", parsed.Scheme)
+		}
+		if err := egressGuard.ValidateURL(c.Policy.BundleURL); err != nil {
+			return fmt.Errorf("policy.bundle_url: %w", err)
 		}
 	}
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -365,6 +365,68 @@ func TestValidate(t *testing.T) {
 			}
 		}
 	})
+
+	// -------------------------------------------------------------------
+	// SSRF: security.egress.allowlist + policy.bundle_url
+	// -------------------------------------------------------------------
+
+	t.Run("invalid egress allowlist entry rejected", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Security.Egress.Allowlist = []string{"not a hostname or cidr"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for malformed egress allowlist entry, got nil")
+		}
+	})
+
+	t.Run("policy bundle_url rejects cloud metadata address", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://169.254.169.254/bundle.tar.gz"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for bundle_url targeting cloud metadata, got nil")
+		}
+	})
+
+	t.Run("policy bundle_url rejects private address", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://10.1.2.3/bundle.tar.gz"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for bundle_url targeting a private address, got nil")
+		}
+	})
+
+	t.Run("policy bundle_url requires https", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "http://bundles.example.com/bundle.tar.gz"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for plain-http bundle_url, got nil")
+		}
+	})
+
+	t.Run("policy bundle_url http allowed when host allowlisted", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Security.Egress.Allowlist = []string{"bundles.internal.example.com"}
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "http://bundles.internal.example.com/bundle.tar.gz"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for allow-listed http bundle_url: %v", err)
+		}
+	})
+
+	t.Run("policy bundle_url private address allowed when allowlisted", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Security.Egress.Allowlist = []string{"10.1.2.0/24"}
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://10.1.2.3/bundle.tar.gz"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for allow-listed private bundle_url: %v", err)
+		}
+	})
+
+	t.Run("policy bundle_url ignored when policy disabled", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: false, BundleURL: "http://169.254.169.254/bundle.tar.gz"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error when policy disabled: %v", err)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/cve/osv/client.go
+++ b/backend/internal/cve/osv/client.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 const (
@@ -34,15 +36,24 @@ type Client struct {
 	limiter    *rate.Limiter
 }
 
-// NewClient returns a Client pointed at the given endpoint.
-// Pass an empty string to use the default (https://api.osv.dev).
+// NewClient returns a Client pointed at the given endpoint with the strict
+// egress policy (no allow-list). Pass an empty string to use the default
+// (https://api.osv.dev). The endpoint is operator-configurable
+// (cve.osv_endpoint), so requests are dialed through internal/httpsafe.
 func NewClient(endpoint string) *Client {
+	return NewClientWithGuard(endpoint, nil)
+}
+
+// NewClientWithGuard is NewClient with an egress guard widening the SSRF
+// deny-list (nil = strict), for deployments that point osv_endpoint at an
+// internal OSV mirror.
+func NewClientWithGuard(endpoint string, egress *httpsafe.Guard) *Client {
 	if endpoint == "" {
 		endpoint = defaultEndpoint
 	}
 	return &Client{
 		endpoint:   endpoint,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: httpsafe.NewClient(30*time.Second, egress),
 		limiter:    rate.NewLimiter(rate.Limit(requestsPerSec), requestsPerSec),
 	}
 }

--- a/backend/internal/cve/osv/client_test.go
+++ b/backend/internal/cve/osv/client_test.go
@@ -7,7 +7,14 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// loopbackGuard allow-lists the httptest.Server addresses used throughout this
+// file (127.0.0.1 / ::1) so tests exercise real HTTP without needing the
+// strict production egress policy to accept a loopback target.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
 // ---------------------------------------------------------------------------
 // NormalizeSeverity
@@ -144,7 +151,7 @@ func newTestServer(t *testing.T, handler http.Handler) (*httptest.Server, *Clien
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	return srv, NewClient(srv.URL)
+	return srv, NewClientWithGuard(srv.URL, loopbackGuard)
 }
 
 func TestQueryBatch_Success(t *testing.T) {

--- a/backend/internal/httpsafe/httpsafe.go
+++ b/backend/internal/httpsafe/httpsafe.go
@@ -1,0 +1,319 @@
+// Package httpsafe provides a shared SSRF-safe HTTP client for every outbound
+// request whose target URL is operator- or admin-configurable (mirror upstream
+// registries, SCM provider base URLs, the policy bundle, the OSV endpoint,
+// SAML IdP metadata, audit webhooks) — including second-order URLs returned by
+// those upstreams (download_url, shasums_url, release asset URLs).
+//
+// Enforcement model:
+//
+//   - Scheme allow-list: only http and https requests are dialed.
+//   - Resolve-and-pin: the hostname is resolved by the client itself, every
+//     resolved IP is validated against a deny-list of non-public ranges
+//     (loopback, RFC 1918, link-local including the 169.254.169.254 metadata
+//     endpoint, CGNAT, IPv6 ULA/link-local/loopback, unspecified, multicast,
+//     broadcast), and the connection is dialed to a validated IP. Because the
+//     checked IP is the dialed IP, DNS rebinding between check and dial is
+//     impossible.
+//   - Redirect re-validation: every redirect hop passes through the same
+//     dial-time checks, and CheckRedirect additionally re-validates the hop URL
+//     and strips Authorization/Cookie headers on cross-host redirects.
+//   - Explicit allow-list escape hatch: deployments that legitimately talk to
+//     internal registries list those hosts/IPs/CIDRs in
+//     security.egress.allowlist (default DENY).
+//
+// A nil *Guard is valid and enforces the strict policy with an empty
+// allow-list, so callers can pass nil when no operator allow-list applies.
+package httpsafe
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// resolveTimeout bounds the DNS lookup performed by ValidateURL outside of a
+// live request (config-write validation).
+const resolveTimeout = 5 * time.Second
+
+// maxRedirects mirrors net/http's default redirect cap.
+const maxRedirects = 10
+
+// Guard validates outbound URLs and dial targets against the egress policy.
+// The zero value and nil are both valid strict guards (empty allow-list).
+// Guard is immutable after construction and safe for concurrent use.
+type Guard struct {
+	allowHosts map[string]struct{}
+	allowNets  []*net.IPNet
+
+	// lookupIP overrides DNS resolution in tests of the guard itself.
+	lookupIP func(ctx context.Context, host string) ([]net.IP, error)
+}
+
+// NewGuard builds a Guard from allow-list entries. Each entry may be a
+// hostname ("registry.corp.internal"), an IP ("10.1.2.3"), or a CIDR range
+// ("10.20.0.0/16"). An empty or nil list yields the strict default policy.
+func NewGuard(allowlist []string) (*Guard, error) {
+	g := &Guard{allowHosts: make(map[string]struct{})}
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if _, ipNet, err := net.ParseCIDR(entry); err == nil {
+			g.allowNets = append(g.allowNets, ipNet)
+			continue
+		}
+		if ip := net.ParseIP(entry); ip != nil {
+			bits := 8 * net.IPv6len
+			if ip.To4() != nil {
+				ip = ip.To4()
+				bits = 8 * net.IPv4len
+			}
+			g.allowNets = append(g.allowNets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			continue
+		}
+		if strings.ContainsAny(entry, "/ ") {
+			return nil, fmt.Errorf("egress allowlist entry %q is not a valid hostname, IP, or CIDR", entry)
+		}
+		g.allowHosts[strings.ToLower(entry)] = struct{}{}
+	}
+	return g, nil
+}
+
+// MustGuard is NewGuard for static allow-lists (primarily tests); it panics on
+// an invalid entry.
+func MustGuard(allowlist ...string) *Guard {
+	g, err := NewGuard(allowlist)
+	if err != nil {
+		panic(err)
+	}
+	return g
+}
+
+// HostExempt reports whether host (a hostname or IP literal) is covered by the
+// allow-list, meaning deny-list checks (and the policy bundle's https-only
+// requirement) do not apply to it.
+func (g *Guard) HostExempt(host string) bool {
+	if g == nil {
+		return false
+	}
+	if _, ok := g.allowHosts[strings.ToLower(host)]; ok {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return g.ipAllowlisted(ip)
+	}
+	return false
+}
+
+func (g *Guard) ipAllowlisted(ip net.IP) bool {
+	if g == nil {
+		return false
+	}
+	for _, n := range g.allowNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkIP rejects ip when it falls in a non-public range, unless the IP (or
+// the hostname it was resolved from) is allow-listed.
+func (g *Guard) checkIP(host string, ip net.IP) error {
+	if g.ipAllowlisted(ip) {
+		return nil
+	}
+	if reason := deniedRange(ip); reason != "" {
+		return fmt.Errorf("egress to %q (%s) blocked: %s address — add the host to security.egress.allowlist if this internal target is intentional", host, ip, reason)
+	}
+	return nil
+}
+
+// deniedRange returns a non-empty range description when ip is not publicly
+// routable. IPv4-mapped IPv6 addresses are classified as their IPv4 form.
+func deniedRange(ip net.IP) string {
+	if ip4 := ip.To4(); ip4 != nil {
+		ip = ip4
+	}
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case ip.IsUnspecified():
+		return "unspecified"
+	case ip.IsLinkLocalUnicast():
+		// Includes 169.254.0.0/16 (cloud metadata) and fe80::/10.
+		return "link-local"
+	case ip.IsLinkLocalMulticast(), ip.IsMulticast():
+		return "multicast"
+	case ip.IsPrivate():
+		// RFC 1918 (10/8, 172.16/12, 192.168/16) and IPv6 ULA fc00::/7.
+		return "private"
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		switch {
+		case ip4[0] == 0:
+			return "reserved (0.0.0.0/8)"
+		case ip4[0] == 100 && ip4[1]&0xc0 == 64:
+			return "carrier-grade NAT (100.64.0.0/10)"
+		case ip4.Equal(net.IPv4bcast):
+			return "broadcast"
+		}
+	}
+	return ""
+}
+
+// ValidateURL checks a configured URL against the egress policy: http/https
+// scheme, non-empty host, and — when the host is not allow-listed — no
+// resolution to a denied range. It is intended for config-write time so
+// private/metadata targets are rejected with a clear error at save.
+//
+// A DNS lookup failure is NOT a validation error: the record may only resolve
+// later (or only inside the deployment network), and the dial-time
+// resolve-and-pin check remains the authoritative enforcement point.
+func (g *Guard) ValidateURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL scheme %q not allowed (must be http or https)", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL must have a host")
+	}
+	if g.HostExempt(host) {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return g.checkIP(host, ip)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), resolveTimeout)
+	defer cancel()
+	ips, err := g.resolve(ctx, host)
+	if err != nil {
+		// Fail open on lookup errors (see doc comment); dial-time enforcement
+		// still applies to whatever the name resolves to when actually used.
+		return nil
+	}
+	for _, ip := range ips {
+		if err := g.checkIP(host, ip); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *Guard) resolve(ctx context.Context, host string) ([]net.IP, error) {
+	if g != nil && g.lookupIP != nil {
+		return g.lookupIP(ctx, host)
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		ips = append(ips, a.IP)
+	}
+	return ips, nil
+}
+
+// DialContext resolves addr's host itself, validates EVERY resolved IP against
+// the deny-list, and dials a validated IP directly — the checked IP is the
+// connected IP, so a DNS answer cannot change between check and dial. A name
+// that resolves to any denied address is rejected outright (mixed public +
+// private answers are a rebinding pattern, not a legitimate configuration).
+func (g *Guard) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("egress dial %q: %w", addr, err)
+	}
+
+	// Match http.DefaultTransport's dialer behaviour.
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if err := g.checkIP(host, ip); err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+
+	if g.HostExempt(host) {
+		return dialer.DialContext(ctx, network, addr)
+	}
+
+	ips, err := g.resolve(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("egress dial %q: resolve: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("egress dial %q: no addresses resolved", host)
+	}
+	for _, ip := range ips {
+		if err := g.checkIP(host, ip); err != nil {
+			return nil, err
+		}
+	}
+
+	var dialErr error
+	for _, ip := range ips {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		dialErr = err
+	}
+	return nil, fmt.Errorf("egress dial %q: %w", host, dialErr)
+}
+
+// CheckRedirect re-validates every redirect hop against the egress policy and
+// strips credentials when a hop crosses to a different host. The dial-time
+// resolve-and-pin check still applies to the hop; this adds fast failure with
+// a clear error plus credential hygiene.
+func (g *Guard) CheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	if err := g.ValidateURL(req.URL.String()); err != nil {
+		return fmt.Errorf("redirect blocked: %w", err)
+	}
+	// net/http already strips sensitive headers unless the target is the same
+	// host or a subdomain of the original; be stricter and strip on ANY
+	// cross-host hop.
+	if len(via) > 0 && !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) {
+		req.Header.Del("Authorization")
+		req.Header.Del("Proxy-Authorization")
+		req.Header.Del("Cookie")
+		req.Header.Del("Cookie2")
+	}
+	return nil
+}
+
+// NewClient returns an *http.Client with the given total-request timeout whose
+// transport dials through g (resolve-and-pin) and whose CheckRedirect
+// re-validates every hop. Pass a nil guard for the strict default policy.
+// Other transport parameters mirror http.DefaultTransport.
+func NewClient(timeout time.Duration, g *Guard) *http.Client {
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           g.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	return &http.Client{
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: g.CheckRedirect,
+	}
+}

--- a/backend/internal/httpsafe/httpsafe.go
+++ b/backend/internal/httpsafe/httpsafe.go
@@ -274,10 +274,28 @@ func (g *Guard) DialContext(ctx context.Context, network, addr string) (net.Conn
 	return nil, fmt.Errorf("egress dial %q: %w", host, dialErr)
 }
 
-// CheckRedirect re-validates every redirect hop against the egress policy and
-// strips credentials when a hop crosses to a different host. The dial-time
+// sameOrigin reports whether two URLs share scheme, host, and port. A
+// same-hostname comparison alone is not enough: a redirect from
+// https://git.internal/api to https://git.internal:9999/evil or to
+// http://git.internal/evil is not "the same place" and must not be treated as
+// safe to resend credentials/body to.
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+// CheckRedirect re-validates every redirect hop against the egress policy,
+// strips credentials on a cross-origin hop, and refuses to follow a
+// cross-origin hop that would resend a request body. The dial-time
 // resolve-and-pin check still applies to the hop; this adds fast failure with
 // a clear error plus credential hygiene.
+//
+// Body is refused rather than stripped: Go preserves method and body across
+// 307/308 redirects, and a body can carry credentials a header-only strip
+// would miss entirely (e.g. an OAuth client_secret in a token-exchange POST
+// form). There is no general way to know which body fields are sensitive, so
+// the safe behavior on cross-origin is to not resend it at all — the caller
+// gets the redirect response back instead of an error, exactly as it would
+// for same-origin non-redirect-following clients.
 func (g *Guard) CheckRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxRedirects)
@@ -285,10 +303,10 @@ func (g *Guard) CheckRedirect(req *http.Request, via []*http.Request) error {
 	if err := g.ValidateURL(req.URL.String()); err != nil {
 		return fmt.Errorf("redirect blocked: %w", err)
 	}
-	// net/http already strips sensitive headers unless the target is the same
-	// host or a subdomain of the original; be stricter and strip on ANY
-	// cross-host hop.
-	if len(via) > 0 && !strings.EqualFold(req.URL.Hostname(), via[0].URL.Hostname()) {
+	if len(via) > 0 && !sameOrigin(req.URL, via[0].URL) {
+		if req.GetBody != nil || req.ContentLength != 0 {
+			return fmt.Errorf("refusing to follow cross-origin redirect to %s with a non-empty request body", req.URL.Host)
+		}
 		req.Header.Del("Authorization")
 		req.Header.Del("Proxy-Authorization")
 		req.Header.Del("Cookie")
@@ -301,9 +319,17 @@ func (g *Guard) CheckRedirect(req *http.Request, via []*http.Request) error {
 // transport dials through g (resolve-and-pin) and whose CheckRedirect
 // re-validates every hop. Pass a nil guard for the strict default policy.
 // Other transport parameters mirror http.DefaultTransport.
+//
+// Proxy is deliberately nil (no HTTP_PROXY/HTTPS_PROXY support), not
+// http.ProxyFromEnvironment: when a request is proxied, DialContext only ever
+// dials the *proxy's* address — the guard would validate and pin the proxy,
+// while the real destination is embedded in the forwarded request line (HTTP)
+// or CONNECT target (HTTPS) and is never resolved or checked at all. A
+// forward proxy is trusted infrastructure with its own (unverifiable from
+// here) egress policy, which is a different trust model than this package
+// provides; supporting it safely is out of scope.
 func NewClient(timeout time.Duration, g *Guard) *http.Client {
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           g.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,

--- a/backend/internal/httpsafe/httpsafe.go
+++ b/backend/internal/httpsafe/httpsafe.go
@@ -274,13 +274,24 @@ func (g *Guard) DialContext(ctx context.Context, network, addr string) (net.Conn
 	return nil, fmt.Errorf("egress dial %q: %w", host, dialErr)
 }
 
-// sameOrigin reports whether two URLs share scheme, host, and port. A
-// same-hostname comparison alone is not enough: a redirect from
-// https://git.internal/api to https://git.internal:9999/evil or to
-// http://git.internal/evil is not "the same place" and must not be treated as
-// safe to resend credentials/body to.
-func sameOrigin(a, b *url.URL) bool {
-	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+// safeToFollow reports whether a redirect from `from` to `to` may resend
+// credentials/body. A same-hostname comparison alone is not enough: a
+// redirect from https://git.internal/api to https://git.internal:9999/evil is
+// not "the same place" (host includes port) and must not be treated as safe.
+// Scheme is asymmetric, not just compared for equality: an http -> https
+// upgrade on the same host is safe -- and a common, explicitly-supported
+// pattern, since ValidateURL permits an admin to configure a self-hosted SCM
+// base_url as http:// while its reverse proxy force-upgrades every request to
+// https via a same-host 307/308 -- but the reverse (https -> http) is a
+// downgrade that must never carry credentials/body over plaintext.
+func safeToFollow(from, to *url.URL) bool {
+	if !strings.EqualFold(from.Host, to.Host) {
+		return false
+	}
+	if strings.EqualFold(from.Scheme, to.Scheme) {
+		return true
+	}
+	return strings.EqualFold(from.Scheme, "http") && strings.EqualFold(to.Scheme, "https")
 }
 
 // CheckRedirect re-validates every redirect hop against the egress policy,
@@ -303,7 +314,7 @@ func (g *Guard) CheckRedirect(req *http.Request, via []*http.Request) error {
 	if err := g.ValidateURL(req.URL.String()); err != nil {
 		return fmt.Errorf("redirect blocked: %w", err)
 	}
-	if len(via) > 0 && !sameOrigin(req.URL, via[0].URL) {
+	if len(via) > 0 && !safeToFollow(via[0].URL, req.URL) {
 		if req.GetBody != nil || req.ContentLength != 0 {
 			return fmt.Errorf("refusing to follow cross-origin redirect to %s with a non-empty request body", req.URL.Host)
 		}

--- a/backend/internal/httpsafe/httpsafe_test.go
+++ b/backend/internal/httpsafe/httpsafe_test.go
@@ -3,6 +3,7 @@ package httpsafe
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -333,6 +334,103 @@ func TestClient_SameHostRedirectKeepsCredentials(t *testing.T) {
 
 	if gotAuth != "Bearer keep-me" {
 		t.Errorf("same-host redirect should keep Authorization, got %q", gotAuth)
+	}
+}
+
+// A cross-host redirect that resends a request body must be refused outright,
+// not have its body silently stripped: header stripping alone misses
+// credentials carried in the body itself (e.g. an OAuth client_secret in a
+// token-exchange POST form), which a compromised/MITM'd/typo-squatted
+// upstream can exfiltrate via a single 307/308 to an attacker host.
+func TestClient_CrossHostRedirectWithBodyRefused(t *testing.T) {
+	var attackerReceivedBody bool
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if len(body) > 0 {
+			attackerReceivedBody = true
+		}
+	}))
+	defer attacker.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/steal", http.StatusTemporaryRedirect) // 307 preserves method+body
+	}))
+	defer origin.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost", "127.0.0.1"))
+	req, err := http.NewRequest(http.MethodPost, localhostURL(t, origin),
+		strings.NewReader("client_id=abc&client_secret=SUPERSECRET&code=xyz"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
+	if attackerReceivedBody {
+		t.Fatal("cross-host redirect resent the request body to the redirect target")
+	}
+	if err == nil {
+		t.Fatal("cross-host redirect carrying a body should be refused, not followed")
+	}
+}
+
+// Same hostname but a different port (or scheme) is NOT the same origin: an
+// open-redirect on a self-hosted instance, a misrouted reverse proxy, or a
+// compromised upstream could otherwise retain credentials across the hop.
+func TestClient_SameHostDifferentPortStripsCredentials(t *testing.T) {
+	var gotAuth string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer target.Close()
+	targetHost, targetPort, _ := net.SplitHostPort(strings.TrimPrefix(target.URL, "http://"))
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+targetHost+":"+targetPort+"/after", http.StatusFound)
+	}))
+	defer src.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost", "127.0.0.1"))
+	req, err := http.NewRequest(http.MethodGet, localhostURL(t, src), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if gotAuth != "" {
+		t.Errorf("Authorization header leaked across a port change: %q", gotAuth)
+	}
+}
+
+// NewClient must not honor HTTP_PROXY/HTTPS_PROXY: a proxied request is
+// dialed to the proxy's address, which the guard validates and pins, while
+// the real destination travels inside the forwarded request/CONNECT line and
+// is never resolved or checked at all — silently defeating resolve-and-pin
+// for every guarded egress path whenever a proxy env var is set.
+func TestNewClient_DoesNotHonorEnvironmentProxy(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+
+	client := NewClient(5*time.Second, nil)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		req, _ := http.NewRequest(http.MethodGet, "http://169.254.169.254/", nil)
+		proxyURL, err := transport.Proxy(req)
+		if err == nil && proxyURL != nil {
+			t.Fatalf("transport.Proxy resolved a proxy (%s) despite HTTP_PROXY being set; resolve-and-pin would be bypassed", proxyURL)
+		}
 	}
 }
 

--- a/backend/internal/httpsafe/httpsafe_test.go
+++ b/backend/internal/httpsafe/httpsafe_test.go
@@ -1,0 +1,378 @@
+package httpsafe
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeResolver returns a lookupIP func that always resolves to the given IPs.
+func fakeResolver(ips ...string) func(context.Context, string) ([]net.IP, error) {
+	parsed := make([]net.IP, 0, len(ips))
+	for _, s := range ips {
+		parsed = append(parsed, net.ParseIP(s))
+	}
+	return func(context.Context, string) ([]net.IP, error) {
+		return parsed, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewGuard
+// ---------------------------------------------------------------------------
+
+func TestNewGuard_ValidEntries(t *testing.T) {
+	g, err := NewGuard([]string{"registry.corp.internal", "10.1.2.3", "10.20.0.0/16", "fd00::/8", " ", ""})
+	if err != nil {
+		t.Fatalf("NewGuard: %v", err)
+	}
+	if !g.HostExempt("REGISTRY.corp.INTERNAL") {
+		t.Error("hostname allow-list entry should be case-insensitive")
+	}
+	if !g.HostExempt("10.1.2.3") {
+		t.Error("IP allow-list entry not honored")
+	}
+	if !g.HostExempt("10.20.55.1") {
+		t.Error("CIDR allow-list entry not honored")
+	}
+	if !g.HostExempt("fd00::1") {
+		t.Error("IPv6 CIDR allow-list entry not honored")
+	}
+	if g.HostExempt("10.21.0.1") {
+		t.Error("IP outside allow-listed CIDR should not be exempt")
+	}
+}
+
+func TestNewGuard_InvalidEntry(t *testing.T) {
+	if _, err := NewGuard([]string{"10.0.0.0/99"}); err == nil {
+		t.Error("expected error for malformed CIDR")
+	}
+	if _, err := NewGuard([]string{"host with spaces"}); err == nil {
+		t.Error("expected error for entry with spaces")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateURL — denied ranges
+// ---------------------------------------------------------------------------
+
+func TestValidateURL_DeniedRanges(t *testing.T) {
+	var g *Guard // nil guard = strict default policy
+	denied := []string{
+		"http://127.0.0.1/path",            // IPv4 loopback
+		"http://127.8.9.10/",               // loopback /8
+		"http://[::1]:8080/",               // IPv6 loopback
+		"http://10.0.0.1/",                 // RFC 1918
+		"http://172.16.0.1/",               // RFC 1918
+		"http://172.31.255.254/",           // RFC 1918 upper edge
+		"http://192.168.1.1/",              // RFC 1918
+		"http://169.254.169.254/latest",    // link-local / cloud metadata
+		"http://[fe80::1]/",                // IPv6 link-local
+		"http://[fc00::1]/",                // IPv6 ULA
+		"http://[fd12:3456::1]/",           // IPv6 ULA
+		"http://0.0.0.0/",                  // unspecified
+		"http://0.1.2.3/",                  // 0.0.0.0/8
+		"http://224.0.0.1/",                // multicast
+		"http://[ff02::1]/",                // IPv6 multicast
+		"http://255.255.255.255/",          // broadcast
+		"http://100.64.0.1/",               // carrier-grade NAT
+		"http://[::ffff:127.0.0.1]/",       // IPv4-mapped loopback
+		"http://[::ffff:169.254.169.254]/", // IPv4-mapped metadata
+	}
+	for _, u := range denied {
+		if err := g.ValidateURL(u); err == nil {
+			t.Errorf("ValidateURL(%q) = nil, want blocked", u)
+		}
+	}
+}
+
+func TestValidateURL_PublicAllowed(t *testing.T) {
+	var g *Guard
+	for _, u := range []string{"https://8.8.8.8/", "http://1.1.1.1:8080/x", "https://[2606:4700::1111]/"} {
+		if err := g.ValidateURL(u); err != nil {
+			t.Errorf("ValidateURL(%q) = %v, want nil", u, err)
+		}
+	}
+}
+
+func TestValidateURL_SchemeAndHost(t *testing.T) {
+	var g *Guard
+	if err := g.ValidateURL("ftp://example.com/x"); err == nil {
+		t.Error("expected error for ftp scheme")
+	}
+	if err := g.ValidateURL("file:///etc/passwd"); err == nil {
+		t.Error("expected error for file scheme")
+	}
+	if err := g.ValidateURL("https:///nohost"); err == nil {
+		t.Error("expected error for empty host")
+	}
+}
+
+func TestValidateURL_ResolvedPrivateRejected(t *testing.T) {
+	g := MustGuard()
+	g.lookupIP = fakeResolver("192.168.7.7")
+	if err := g.ValidateURL("https://internal.example.com/"); err == nil {
+		t.Error("hostname resolving to RFC 1918 should be rejected")
+	}
+}
+
+func TestValidateURL_MixedResolutionRejected(t *testing.T) {
+	g := MustGuard()
+	g.lookupIP = fakeResolver("93.184.216.34", "10.0.0.5")
+	if err := g.ValidateURL("https://dual.example.com/"); err == nil {
+		t.Error("hostname resolving to any private address should be rejected")
+	}
+}
+
+func TestValidateURL_ResolvedPublicAllowed(t *testing.T) {
+	g := MustGuard()
+	g.lookupIP = fakeResolver("93.184.216.34")
+	if err := g.ValidateURL("https://public.example.com/"); err != nil {
+		t.Errorf("public resolution should pass, got %v", err)
+	}
+}
+
+func TestValidateURL_LookupFailureFailsOpen(t *testing.T) {
+	g := MustGuard()
+	g.lookupIP = func(context.Context, string) ([]net.IP, error) {
+		return nil, fmt.Errorf("no such host")
+	}
+	// Dial-time enforcement is authoritative; config-write validation must not
+	// reject names that don't resolve from this vantage point.
+	if err := g.ValidateURL("https://unresolvable.example.com/"); err != nil {
+		t.Errorf("lookup failure should fail open at validation time, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ValidateURL — allow-list overrides
+// ---------------------------------------------------------------------------
+
+func TestValidateURL_AllowlistOverrides(t *testing.T) {
+	cases := []struct {
+		allow []string
+		url   string
+	}{
+		{[]string{"127.0.0.1"}, "http://127.0.0.1:8081/"},
+		{[]string{"10.20.0.0/16"}, "https://10.20.4.2/"},
+		{[]string{"registry.corp.internal"}, "https://registry.corp.internal/v1"},
+		{[]string{"169.254.169.254"}, "http://169.254.169.254/"},
+	}
+	for _, tc := range cases {
+		g := MustGuard(tc.allow...)
+		g.lookupIP = fakeResolver("10.20.4.2") // for the hostname case
+		if err := g.ValidateURL(tc.url); err != nil {
+			t.Errorf("allowlist %v: ValidateURL(%q) = %v, want nil", tc.allow, tc.url, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DialContext — resolve-and-pin
+// ---------------------------------------------------------------------------
+
+func TestDialContext_IPLiteralDenied(t *testing.T) {
+	var g *Guard
+	if _, err := g.DialContext(context.Background(), "tcp", "169.254.169.254:80"); err == nil {
+		t.Error("dial to metadata IP should be blocked")
+	}
+	if _, err := g.DialContext(context.Background(), "tcp", "127.0.0.1:80"); err == nil {
+		t.Error("dial to loopback should be blocked")
+	}
+}
+
+func TestDialContext_ResolvedPrivateDenied(t *testing.T) {
+	g := MustGuard()
+	g.lookupIP = fakeResolver("127.0.0.1")
+	if _, err := g.DialContext(context.Background(), "tcp", "rebind.example.com:80"); err == nil {
+		t.Error("hostname resolving to loopback should be blocked at dial time")
+	}
+}
+
+func TestDialContext_PinsValidatedIP(t *testing.T) {
+	// The listener's real address is 127.0.0.1; the guard only permits it via
+	// the CIDR allow-list. The fake resolver maps a fake hostname to the
+	// listener IP, proving the dialed IP is the one that was resolved+checked.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr == nil {
+			conn.Close()
+		}
+	}()
+
+	host, port, _ := net.SplitHostPort(ln.Addr().String())
+	g := MustGuard("127.0.0.0/8")
+	g.lookupIP = fakeResolver(host)
+
+	conn, err := g.DialContext(context.Background(), "tcp", net.JoinHostPort("pinned.example.com", port))
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	conn.Close()
+}
+
+// ---------------------------------------------------------------------------
+// Client — redirects
+// ---------------------------------------------------------------------------
+
+// localhostGuard permits httptest servers via the "localhost" hostname while
+// keeping the 127.0.0.1 IP itself denied, so redirect targets using the IP
+// literal exercise the deny path.
+func localhostURL(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	return "http://localhost:" + port
+}
+
+func TestClient_RedirectToPrivateRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost"))
+	resp, err := client.Get(localhostURL(t, srv))
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("redirect to metadata endpoint should be rejected")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected egress-blocked error, got: %v", err)
+	}
+}
+
+func TestClient_RedirectToLoopbackIPRejected(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Same machine, but via the raw IP that is NOT allow-listed.
+		http.Redirect(w, r, srv.URL+"/internal", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost"))
+	resp, err := client.Get(localhostURL(t, srv))
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("redirect to non-allow-listed loopback IP should be rejected")
+	}
+}
+
+func TestClient_CrossHostRedirectStripsCredentials(t *testing.T) {
+	var gotAuth, gotCookie string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotCookie = r.Header.Get("Cookie")
+	}))
+	defer target.Close()
+
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/after", http.StatusFound) // 127.0.0.1 — different host than "localhost"
+	}))
+	defer src.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost", "127.0.0.1"))
+	req, err := http.NewRequest(http.MethodGet, localhostURL(t, src), nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("Cookie", "session=abc")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if gotAuth != "" {
+		t.Errorf("Authorization header leaked across hosts: %q", gotAuth)
+	}
+	if gotCookie != "" {
+		t.Errorf("Cookie header leaked across hosts: %q", gotCookie)
+	}
+}
+
+func TestClient_SameHostRedirectKeepsCredentials(t *testing.T) {
+	var gotAuth string
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			_, port, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+			http.Redirect(w, r, "http://localhost:"+port+"/after", http.StatusFound)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+
+	client := NewClient(5*time.Second, MustGuard("localhost"))
+	req, err := http.NewRequest(http.MethodGet, localhostURL(t, srv)+"/start", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer keep-me")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	resp.Body.Close()
+
+	if gotAuth != "Bearer keep-me" {
+		t.Errorf("same-host redirect should keep Authorization, got %q", gotAuth)
+	}
+}
+
+func TestClient_AllowlistedFetchSucceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	client := NewClient(5*time.Second, MustGuard("127.0.0.1"))
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestClient_StrictGuardBlocksLoopbackFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	client := NewClient(5*time.Second, nil)
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("strict client should refuse to dial loopback")
+	}
+}
+
+func TestCheckRedirect_TooManyRedirects(t *testing.T) {
+	var g *Guard
+	via := make([]*http.Request, maxRedirects)
+	req, _ := http.NewRequest(http.MethodGet, "https://8.8.8.8/", nil)
+	for i := range via {
+		via[i] = req
+	}
+	if err := g.CheckRedirect(req, via); err == nil {
+		t.Error("expected redirect-limit error")
+	}
+}

--- a/backend/internal/httpsafe/httpsafe_test.go
+++ b/backend/internal/httpsafe/httpsafe_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -460,6 +461,44 @@ func TestClient_StrictGuardBlocksLoopbackFetch(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("strict client should refuse to dial loopback")
+	}
+}
+
+// safeToFollow's scheme handling is asymmetric: an http -> https upgrade on
+// the same host must be followed (a common, explicitly-supported self-hosted
+// SCM pattern -- ValidateURL permits an http:// base_url, and its reverse
+// proxy force-upgrades every request to https via a same-host redirect), but
+// the reverse -- https -> http -- is a downgrade that must never be treated
+// as safe, since it would carry credentials/body over plaintext.
+func TestSafeToFollow_SchemeAsymmetry(t *testing.T) {
+	mustParse := func(t *testing.T, raw string) *url.URL {
+		t.Helper()
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", raw, err)
+		}
+		return u
+	}
+
+	cases := []struct {
+		name string
+		from string
+		to   string
+		want bool
+	}{
+		{"same scheme same host", "https://git.internal/a", "https://git.internal/b", true},
+		{"http to https upgrade, same host", "http://git.internal/oauth/token", "https://git.internal/oauth/token", true},
+		{"https to http downgrade, same host", "https://git.internal/oauth/token", "http://git.internal/oauth/token", false},
+		{"different host, same scheme", "https://git.internal/a", "https://attacker.example/a", false},
+		{"different port, same host and scheme", "https://git.internal:443/a", "https://git.internal:9999/a", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := safeToFollow(mustParse(t, tc.from), mustParse(t, tc.to))
+			if got != tc.want {
+				t.Errorf("safeToFollow(%q, %q) = %v, want %v", tc.from, tc.to, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/backend/internal/jobs/cve_poll.go
+++ b/backend/internal/jobs/cve_poll.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/cve/osv"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
 )
 
@@ -28,6 +29,7 @@ type CVEPollJob struct {
 	matcher   *cve.Matcher
 	cveRepo   *repositories.CVERepository
 	auditRepo *repositories.AuditRepository
+	scanCfg   *config.ScanningConfig
 	cveCfg    *config.CVEConfig
 	notifCfg  *config.NotificationsConfig
 	mailer    *notify.Mailer
@@ -35,7 +37,9 @@ type CVEPollJob struct {
 	manualCh  chan struct{}
 }
 
-// NewCVEPollJob constructs and returns a CVEPollJob.
+// NewCVEPollJob constructs and returns a CVEPollJob. The OSV client uses the
+// strict egress policy; call SetEgressGuard before Start to widen it for a
+// deployment that points cve.osv_endpoint at an internal OSV mirror.
 func NewCVEPollJob(
 	cveRepo *repositories.CVERepository,
 	auditRepo *repositories.AuditRepository,
@@ -43,23 +47,29 @@ func NewCVEPollJob(
 	cveCfg *config.CVEConfig,
 	notifCfg *config.NotificationsConfig,
 ) *CVEPollJob {
-	endpoint := cveCfg.OSVEndpoint
-	if endpoint == "" {
-		endpoint = "https://api.osv.dev"
-	}
-	client := osv.NewClient(endpoint)
+	client := osv.NewClient(cveCfg.OSVEndpoint)
 	matcher := cve.NewMatcher(client, cveRepo, scanCfg)
 
 	return &CVEPollJob{
 		matcher:   matcher,
 		cveRepo:   cveRepo,
 		auditRepo: auditRepo,
+		scanCfg:   scanCfg,
 		cveCfg:    cveCfg,
 		notifCfg:  notifCfg,
 		mailer:    notify.New(&notifCfg.SMTP),
 		stopChan:  make(chan struct{}),
 		manualCh:  make(chan struct{}, 1),
 	}
+}
+
+// SetEgressGuard rebuilds the OSV client and matcher using the
+// operator-configured egress guard (security.egress.allowlist), widening the
+// SSRF deny-list for deployments that point cve.osv_endpoint at an internal
+// OSV mirror. Call before Start.
+func (j *CVEPollJob) SetEgressGuard(g *httpsafe.Guard) {
+	client := osv.NewClientWithGuard(j.cveCfg.OSVEndpoint, g)
+	j.matcher = cve.NewMatcher(client, j.cveRepo, j.scanCfg)
 }
 
 // Start begins the background polling loop. It runs an initial poll immediately

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -87,9 +88,14 @@ type MirrorSyncJob struct {
 	wg                 sync.WaitGroup
 
 	// newUpstream is the factory used to build an UpstreamRegistryClient from a
-	// base URL.  It defaults to mirror.NewUpstreamRegistry; tests may override it
-	// via SetUpstreamFactory to inject a fake client without performing real HTTP.
+	// base URL.  It defaults to mirror.NewUpstreamRegistryWithGuard using this
+	// job's egress guard; tests may override it via SetUpstreamFactory to inject
+	// a fake client without performing real HTTP.
 	newUpstream func(baseURL string) mirror.UpstreamRegistryClient
+
+	// egressGuard widens the SSRF egress deny-list for upstream fetches
+	// (nil = strict). Set via SetEgressGuard before Start.
+	egressGuard *httpsafe.Guard
 }
 
 // NewMirrorSyncJob creates a new mirror sync job
@@ -101,7 +107,7 @@ func NewMirrorSyncJob(
 	storageBackend storage.Storage,
 	storageBackendName string,
 ) *MirrorSyncJob {
-	return &MirrorSyncJob{
+	j := &MirrorSyncJob{
 		mirrorRepo:         mirrorRepo,
 		providerRepo:       providerRepo,
 		providerDocsRepo:   providerDocsRepo,
@@ -112,10 +118,18 @@ func NewMirrorSyncJob(
 		activeSyncsMutex:   sync.Mutex{},
 		stopCh:             make(chan struct{}),
 		startedCh:          make(chan struct{}),
-		newUpstream: func(baseURL string) mirror.UpstreamRegistryClient {
-			return mirror.NewUpstreamRegistry(baseURL)
-		},
 	}
+	j.newUpstream = func(baseURL string) mirror.UpstreamRegistryClient {
+		return mirror.NewUpstreamRegistryWithGuard(baseURL, j.egressGuard)
+	}
+	return j
+}
+
+// SetEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) used by the default upstream-client factory.
+// Call before Start; nil keeps the strict default policy.
+func (j *MirrorSyncJob) SetEgressGuard(g *httpsafe.Guard) {
+	j.egressGuard = g
 }
 
 // SetApprovalRepo wires the version-approval repository so the sync job can log

--- a/backend/internal/jobs/releases_key_refresh_job.go
+++ b/backend/internal/jobs/releases_key_refresh_job.go
@@ -29,6 +29,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
@@ -76,7 +77,11 @@ type toolEndpoint struct {
 // nothing safe to do without a pin.
 func NewReleasesKeyRefreshJob(cfg *config.ReleasesGPGKeysConfig, repo *repositories.ReleasesGPGKeyRepository, httpClient *http.Client) (*ReleasesKeyRefreshJob, error) {
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 30 * time.Second}
+		// hashicorp_url / opentofu_url are operator-configurable, so the
+		// default client is the SSRF-safe strict client (internal/httpsafe);
+		// pass an explicit client built with an egress guard for deployments
+		// that override these to an internal mirror.
+		httpClient = httpsafe.NewClient(30*time.Second, nil)
 	}
 
 	// Derive the OpenTofu fingerprint from the embedded snapshot so a future

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -52,6 +53,10 @@ type TerraformMirrorSyncJob struct {
 
 	// manualTriggerCh carries explicit per-config sync requests from HTTP handlers.
 	manualTriggerCh chan uuid.UUID
+
+	// egressGuard widens the SSRF egress deny-list for upstream fetches
+	// (nil = strict). Set via SetEgressGuard before Start.
+	egressGuard *httpsafe.Guard
 }
 
 // NewTerraformMirrorSyncJob creates a new TerraformMirrorSyncJob.
@@ -69,6 +74,13 @@ func NewTerraformMirrorSyncJob(
 		startedCh:          make(chan struct{}),
 		manualTriggerCh:    make(chan uuid.UUID, 16),
 	}
+}
+
+// SetEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) used when constructing upstream release
+// clients. Call before Start; nil keeps the strict default policy.
+func (j *TerraformMirrorSyncJob) SetEgressGuard(g *httpsafe.Guard) {
+	j.egressGuard = g
 }
 
 // Start begins the background sync loop, checking every intervalMinutes.
@@ -244,15 +256,15 @@ type terraformReleasesClient interface {
 // GitHub URLs (containing "github.com") use the GitHub Releases API; all other
 // URLs use the standard HashiCorp/OpenTofu releases index format.
 // coverage:skip:integration-only — factory that wires a live HTTP client; covered indirectly via integration tests.
-func newReleasesClient(upstreamURL, productName string) (terraformReleasesClient, error) {
+func newReleasesClient(upstreamURL, productName string, egress *httpsafe.Guard) (terraformReleasesClient, error) {
 	if mirror.IsGitHubReleasesURL(upstreamURL) {
 		// GitHub asset filenames use the binary's published prefix, which may differ
 		// from the logical product name. For example, OpenTofu publishes assets as
 		// "tofu_*" even though the product is called "opentofu".
 		binaryPrefix := githubBinaryPrefix(productName)
-		return mirror.NewGitHubReleasesClient(upstreamURL, binaryPrefix)
+		return mirror.NewGitHubReleasesClientWithGuard(upstreamURL, binaryPrefix, egress)
 	}
-	return mirror.NewTerraformReleasesClient(upstreamURL, productName), nil
+	return mirror.NewTerraformReleasesClientWithGuard(upstreamURL, productName, egress), nil
 }
 
 // githubBinaryPrefix returns the filename prefix used in GitHub release assets
@@ -284,7 +296,7 @@ func (j *TerraformMirrorSyncJob) performSync(
 
 	// Derive product name from the tool field for URL path construction.
 	productName := productNameForTool(cfg.Tool)
-	client, clientErr := newReleasesClient(cfg.UpstreamURL, productName)
+	client, clientErr := newReleasesClient(cfg.UpstreamURL, productName, j.egressGuard)
 	if clientErr != nil {
 		return 0, 0, 0, details, fmt.Errorf("failed to create releases client: %w", clientErr)
 	}

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -30,6 +30,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // IsGitHubReleasesURL returns true when the upstream URL refers to a GitHub
@@ -99,8 +101,17 @@ type GitHubReleasesClient struct {
 
 // NewGitHubReleasesClient creates a GitHubReleasesClient from a GitHub URL and
 // product name. productName should match the binary filename prefix ("opentofu",
-// "terraform", or a custom value for third-party repos).
+// "terraform", or a custom value for third-party repos). The strict egress
+// policy applies (see NewGitHubReleasesClientWithGuard).
 func NewGitHubReleasesClient(upstreamURL, productName string) (*GitHubReleasesClient, error) {
+	return NewGitHubReleasesClientWithGuard(upstreamURL, productName, nil)
+}
+
+// NewGitHubReleasesClientWithGuard is NewGitHubReleasesClient with an egress
+// guard widening the SSRF deny-list (nil = strict). API calls and asset
+// downloads (upstream-controlled browser_download_url values) are dialed
+// through internal/httpsafe.
+func NewGitHubReleasesClientWithGuard(upstreamURL, productName string, egress *httpsafe.Guard) (*GitHubReleasesClient, error) {
 	owner, repo, err := ParseGitHubOwnerRepo(upstreamURL)
 	if err != nil {
 		return nil, err
@@ -109,15 +120,11 @@ func NewGitHubReleasesClient(upstreamURL, productName string) (*GitHubReleasesCl
 		productName = repo // fall back to repo name
 	}
 	return &GitHubReleasesClient{
-		Owner:       owner,
-		Repo:        repo,
-		ProductName: productName,
-		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		DownloadClient: &http.Client{
-			Timeout: 10 * time.Minute,
-		},
+		Owner:          owner,
+		Repo:           repo,
+		ProductName:    productName,
+		HTTPClient:     httpsafe.NewClient(30*time.Second, egress),
+		DownloadClient: httpsafe.NewClient(10*time.Minute, egress),
 	}, nil
 }
 
@@ -215,7 +222,7 @@ func (c *GitHubReleasesClient) fetchReleasesPage(ctx context.Context, page int) 
 		req.Header.Set("Authorization", "Bearer "+c.APIToken)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- URL derived from admin-configured upstream
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to call GitHub releases API: %w", err)
 	}
@@ -433,7 +440,7 @@ func (c *GitHubReleasesClient) FetchSHASumsSignature(ctx context.Context, versio
 // DownloadBinary downloads a binary zip from the given URL (already a full URL
 // from the GitHub asset list). Identical to TerraformReleasesClient.DownloadBinary.
 func (c *GitHubReleasesClient) DownloadBinaryStream(ctx context.Context, downloadURL string) (io.ReadCloser, int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- URL from admin-configured upstream
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, -1, fmt.Errorf("failed to build download request: %w", err)
 	}
@@ -502,7 +509,7 @@ func (c *GitHubReleasesClient) fetchReleaseByTag(ctx context.Context, tag string
 		req.Header.Set("Authorization", "Bearer "+c.APIToken)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return gitHubRelease{}, err
 	}
@@ -528,7 +535,7 @@ func (c *GitHubReleasesClient) fetchURL(ctx context.Context, url string, maxByte
 		req.Header.Set("Authorization", "Bearer "+c.APIToken)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/mirror/key_fetcher.go
+++ b/backend/internal/mirror/key_fetcher.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // Fingerprint hex length in characters (20 bytes -> 40 hex chars).
@@ -135,7 +137,9 @@ func ParseReleasesKey(armored string) (*ReleasesKeyInfo, error) {
 // auditability.
 func FetchReleasesKey(ctx context.Context, httpClient *http.Client, url string, allowedFingerprint string) (string, *ReleasesKeyInfo, error) {
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		// Default to the strict SSRF-safe client rather than
+		// http.DefaultClient: the key URL is operator-configurable.
+		httpClient = httpsafe.NewClient(30*time.Second, nil)
 	}
 	if !isAllowedFingerprintShape(allowedFingerprint) {
 		return "", nil, fmt.Errorf("releases key: allowed fingerprint must be %d hex chars, got %q", fingerprintHexLen, allowedFingerprint)

--- a/backend/internal/mirror/terraform_releases.go
+++ b/backend/internal/mirror/terraform_releases.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // HashiCorpReleasesGPGKey is the ASCII-armored public GPG key used by
@@ -219,20 +221,25 @@ type TerraformReleasesClient struct {
 
 // NewTerraformReleasesClient creates a client targeting the given upstream base URL.
 // productName controls the URL path segment; pass "" or "terraform" for the default.
-// Use "opentofu" when targeting the OpenTofu release server.
+// Use "opentofu" when targeting the OpenTofu release server. The strict egress
+// policy applies (see NewTerraformReleasesClientWithGuard).
 func NewTerraformReleasesClient(upstreamURL, productName string) *TerraformReleasesClient {
+	return NewTerraformReleasesClientWithGuard(upstreamURL, productName, nil)
+}
+
+// NewTerraformReleasesClientWithGuard is NewTerraformReleasesClient with an
+// egress guard widening the SSRF deny-list (nil = strict). Index/metadata
+// requests and binary downloads (index-provided URLs) are dialed through
+// internal/httpsafe.
+func NewTerraformReleasesClientWithGuard(upstreamURL, productName string, egress *httpsafe.Guard) *TerraformReleasesClient {
 	if productName == "" {
 		productName = "terraform"
 	}
 	return &TerraformReleasesClient{
-		UpstreamURL: strings.TrimRight(upstreamURL, "/"),
-		ProductName: productName,
-		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		DownloadClient: &http.Client{
-			Timeout: 10 * time.Minute,
-		},
+		UpstreamURL:    strings.TrimRight(upstreamURL, "/"),
+		ProductName:    productName,
+		HTTPClient:     httpsafe.NewClient(30*time.Second, egress),
+		DownloadClient: httpsafe.NewClient(10*time.Minute, egress),
 	}
 }
 
@@ -283,7 +290,7 @@ func (c *TerraformReleasesClient) ListVersions(ctx context.Context) ([]Terraform
 		return nil, fmt.Errorf("failed to build index request: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch terraform index: %w", err)
 	}
@@ -386,7 +393,7 @@ func (c *TerraformReleasesClient) FetchSHASums(ctx context.Context, version stri
 		return nil, nil, fmt.Errorf("failed to build shasums request: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch shasums: %w", err)
 	}
@@ -415,7 +422,7 @@ func (c *TerraformReleasesClient) FetchSHASumsSignature(ctx context.Context, ver
 		return nil, fmt.Errorf("failed to build signature request: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := c.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch signature: %w", err)
 	}
@@ -454,7 +461,7 @@ func ParseSHASums(data []byte) map[string]string {
 // DownloadBinary downloads a Terraform binary zip from the given URL.
 // Returns the raw bytes and the actual SHA256 hex string computed while streaming.
 func (c *TerraformReleasesClient) DownloadBinaryStream(ctx context.Context, downloadURL string) (io.ReadCloser, int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, -1, fmt.Errorf("failed to build download request: %w", err)
 	}

--- a/backend/internal/mirror/terraform_releases_test.go
+++ b/backend/internal/mirror/terraform_releases_test.go
@@ -23,7 +23,7 @@ func newReleasesClient(t *testing.T, handler http.HandlerFunc) (*httptest.Server
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	c := NewTerraformReleasesClient(srv.URL+"/", "terraform")
+	c := NewTerraformReleasesClientWithGuard(srv.URL+"/", "terraform", loopbackGuard)
 	// Keep timeouts short in tests by reusing the HTTPClient for downloads too.
 	c.DownloadClient = c.HTTPClient
 	return srv, c
@@ -335,7 +335,7 @@ func TestDownloadBinaryStream_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewTerraformReleasesClient(srv.URL, "terraform")
+	c := NewTerraformReleasesClientWithGuard(srv.URL, "terraform", loopbackGuard)
 	c.DownloadClient = c.HTTPClient
 
 	body, _, err := c.DownloadBinaryStream(context.Background(), srv.URL+"/terraform_1.5.0_linux_amd64.zip")
@@ -361,7 +361,7 @@ func TestDownloadBinaryStream_NonOKStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewTerraformReleasesClient(srv.URL, "terraform")
+	c := NewTerraformReleasesClientWithGuard(srv.URL, "terraform", loopbackGuard)
 	c.DownloadClient = c.HTTPClient
 
 	_, _, err := c.DownloadBinaryStream(context.Background(), srv.URL+"/missing.zip")

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -22,6 +22,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // UpstreamRegistry represents a client for interacting with an upstream Terraform registry
@@ -42,16 +44,25 @@ const maxUpstreamResponseBytes = 10 << 20 // 10 MB
 // error messages, matching the cap already used by DownloadFileStream's error path.
 const maxUpstreamErrorBodyBytes = 4096
 
-// NewUpstreamRegistry creates a new upstream registry client
+// NewUpstreamRegistry creates a new upstream registry client with the strict
+// egress policy (no allow-list). Both clients are SSRF-safe: the configured
+// base URL and every upstream-returned URL (download_url, shasums_url,
+// shasums_signature_url) are dialed through internal/httpsafe, which refuses
+// loopback/private/link-local/metadata targets at dial time and re-validates
+// redirects.
 func NewUpstreamRegistry(baseURL string) *UpstreamRegistry {
+	return NewUpstreamRegistryWithGuard(baseURL, nil)
+}
+
+// NewUpstreamRegistryWithGuard creates an upstream registry client whose
+// egress policy is widened by the given guard's allow-list (nil = strict).
+// Deployments that mirror from internal registries pass a guard built from
+// security.egress.allowlist.
+func NewUpstreamRegistryWithGuard(baseURL string, egress *httpsafe.Guard) *UpstreamRegistry {
 	return &UpstreamRegistry{
-		BaseURL: strings.TrimRight(baseURL, "/"),
-		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		DownloadClient: &http.Client{
-			Timeout: 10 * time.Minute, // Longer timeout for large provider binaries
-		},
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		HTTPClient:     httpsafe.NewClient(30*time.Second, egress),
+		DownloadClient: httpsafe.NewClient(10*time.Minute, egress), // Longer timeout for large provider binaries
 	}
 }
 
@@ -115,7 +126,7 @@ func (u *UpstreamRegistry) DiscoverServices(ctx context.Context) (*ServiceDiscov
 		return nil, fmt.Errorf("failed to create discovery request: %w", err)
 	}
 
-	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to perform discovery request: %w", err)
 	}
@@ -159,7 +170,7 @@ func (u *UpstreamRegistry) ListProviderVersions(ctx context.Context, namespace, 
 		return nil, fmt.Errorf("failed to create versions request: %w", err)
 	}
 
-	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch provider versions: %w", err)
 	}
@@ -214,7 +225,7 @@ func (u *UpstreamRegistry) GetProviderPackage(ctx context.Context, namespace, pr
 		return nil, fmt.Errorf("failed to create package request: %w", err)
 	}
 
-	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := u.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch provider package info: %w", err)
 	}
@@ -275,7 +286,7 @@ func (u *UpstreamRegistry) downloadFileOnce(ctx context.Context, fileURL string)
 		return nil, fmt.Errorf("failed to create download request: %w", err)
 	}
 
-	resp, err := u.DownloadClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := u.DownloadClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to download file: %w", err)
 	}
@@ -305,7 +316,7 @@ type DownloadStream struct {
 // one attempt (retries on a stream would require re-downloading) and it is the
 // caller's responsibility to close DownloadStream.Body.
 func (u *UpstreamRegistry) DownloadFileStream(ctx context.Context, fileURL string) (*DownloadStream, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil) // #nosec G107 -- URL is admin-controlled
+	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, fmt.Errorf("failed to create download request: %w", err)
 	}
@@ -421,7 +432,7 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 		url.PathEscape(namespace),
 		url.PathEscape(providerName),
 	)
-	req, err := http.NewRequestWithContext(ctx, "GET", providerURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+	req, err := http.NewRequestWithContext(ctx, "GET", providerURL, nil) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return "", fmt.Errorf("failed to create v2 provider lookup request: %w", err)
 	}
@@ -456,7 +467,7 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 			versionPageSize,
 			versionPage,
 		)
-		req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- URL built from admin-controlled mirror configuration
+		req, err = http.NewRequestWithContext(ctx, "GET", versionsURL, nil) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 		if err != nil {
 			return "", fmt.Errorf("failed to create v2 provider-versions request (page %d): %w", versionPage, err)
 		}
@@ -518,7 +529,7 @@ func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, nam
 			return nil, fmt.Errorf("failed to create v2 doc index request (page %d): %w", pageNum, err)
 		}
 
-		resp, err := u.HTTPClient.Do(req) // #nosec G107 -- URL built from admin-controlled mirror configuration
+		resp, err := u.HTTPClient.Do(req) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch v2 provider doc index (page %d): %w", pageNum, err)
 		}
@@ -577,7 +588,7 @@ func (u *UpstreamRegistry) GetProviderDocContent(ctx context.Context, upstreamDo
 		return "", fmt.Errorf("failed to create doc content request: %w", err)
 	}
 
-	resp, err := u.HTTPClient.Do(req) // #nosec G107 -- URL is sourced from admin-controlled mirror configuration
+	resp, err := u.HTTPClient.Do(req) // #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch provider doc content: %w", err)
 	}
@@ -596,8 +607,12 @@ func (u *UpstreamRegistry) GetProviderDocContent(ctx context.Context, upstreamDo
 	return v2Resp.Data.Attributes.Content, nil
 }
 
-// ValidateRegistryURL validates that a registry URL is properly formatted
-func ValidateRegistryURL(registryURL string) error {
+// ValidateRegistryURL validates that a registry URL is properly formatted AND
+// that it does not target a private/metadata address (loopback, RFC 1918,
+// link-local incl. 169.254.169.254, ULA, …) unless the host is covered by the
+// egress guard's allow-list. Pass a nil guard for the strict default policy.
+// Intended for config-write time so bad targets are rejected at save.
+func ValidateRegistryURL(registryURL string, egress *httpsafe.Guard) error {
 	if registryURL == "" {
 		return fmt.Errorf("registry URL cannot be empty")
 	}
@@ -615,5 +630,5 @@ func ValidateRegistryURL(registryURL string) error {
 		return fmt.Errorf("registry URL must have a host")
 	}
 
-	return nil
+	return egress.ValidateURL(registryURL)
 }

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -8,14 +8,21 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// loopbackGuard allow-lists the httptest.Server addresses used throughout this
+// file (127.0.0.1 / ::1) so tests exercise real HTTP without needing the
+// strict production egress policy to accept a loopback target.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
 // newTestRegistry starts a test server and returns an UpstreamRegistry pointing at it.
 func newTestRegistry(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *UpstreamRegistry) {
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	return srv, NewUpstreamRegistry(srv.URL)
+	return srv, NewUpstreamRegistryWithGuard(srv.URL, loopbackGuard)
 }
 
 // newDiscoveryHandler returns an HTTP handler that serves service discovery + additional routes.
@@ -72,7 +79,7 @@ func TestValidateRegistryURL(t *testing.T) {
 		{"https://private.registry.example.com:8443", false},
 	}
 	for _, tt := range tests {
-		err := ValidateRegistryURL(tt.url)
+		err := ValidateRegistryURL(tt.url, nil)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("ValidateRegistryURL(%q) error=%v, wantErr=%v", tt.url, err, tt.wantErr)
 		}
@@ -221,7 +228,7 @@ func TestDownloadFile_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := NewUpstreamRegistry("http://example.com")
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
 	// Override DownloadClient to point at test server (use HTTPClient for simplicity)
 	u.DownloadClient = u.HTTPClient
 
@@ -240,7 +247,7 @@ func TestDownloadFile_Error(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := NewUpstreamRegistry("http://example.com")
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
 	u.DownloadClient = u.HTTPClient
 
 	// DownloadFile retries 3 times before giving up
@@ -262,7 +269,7 @@ func TestDownloadFile_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	u := NewUpstreamRegistry("http://example.com")
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
 	u.DownloadClient = u.HTTPClient
 
 	_, err := u.DownloadFile(ctx, srv.URL+"/file.zip")
@@ -599,7 +606,7 @@ func TestDownloadFileStream_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := NewUpstreamRegistry("http://example.com")
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
 	u.DownloadClient = u.HTTPClient
 
 	stream, err := u.DownloadFileStream(context.Background(), srv.URL+"/binary")
@@ -619,7 +626,7 @@ func TestDownloadFileStream_HTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	u := NewUpstreamRegistry("http://example.com")
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
 	u.DownloadClient = u.HTTPClient
 
 	_, err := u.DownloadFileStream(context.Background(), srv.URL+"/missing")

--- a/backend/internal/policy/bundle_loader.go
+++ b/backend/internal/policy/bundle_loader.go
@@ -2,13 +2,19 @@ package policy
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // regoFile holds the name and source of a single .rego module.
@@ -17,11 +23,31 @@ type regoFile struct {
 	source string
 }
 
-// fetchBundle downloads the bundle archive from bundleURL and returns all .rego files
-// it contains.  Only HTTP/HTTPS URLs are supported; the archive must be a .tar.gz.
-func fetchBundle(ctx context.Context, bundleURL string) ([]regoFile, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundleURL, nil) // #nosec G107 -- URL comes from operator config
+// maxBundleBytes bounds the fully-buffered bundle archive so a misbehaving or
+// adversarial bundle host cannot exhaust memory. The archive is buffered (not
+// streamed) because pinned-SHA-256 verification must run before any of its
+// contents are parsed and loaded as active upload policy.
+const maxBundleBytes = 50 << 20 // 50 MB
+
+// fetchBundle downloads the bundle archive from bundleURL and returns all
+// .rego files it contains. bundleURL must use HTTPS unless its host is
+// covered by egress's allow-list (loopback/internal test mirrors). The
+// request is routed through the SSRF-safe egress client
+// (internal/httpsafe): resolve-and-pin dial-time IP checks and per-hop
+// redirect re-validation. When expectedSHA256 is non-empty, the downloaded
+// archive's digest is verified before parsing and the bundle is rejected
+// (fail closed, previously loaded policies kept) on any mismatch.
+func fetchBundle(ctx context.Context, bundleURL string, expectedSHA256 string, egress *httpsafe.Guard) ([]regoFile, error) {
+	parsed, err := url.Parse(bundleURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid bundle URL: %w", err)
+	}
+	if parsed.Scheme != "https" && !egress.HostExempt(parsed.Hostname()) {
+		return nil, fmt.Errorf("policy bundle_url must use https (got %q); add the host to security.egress.allowlist if plain HTTP to an internal mirror is intentional", parsed.Scheme)
+	}
+
+	client := httpsafe.NewClient(30*time.Second, egress)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundleURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating bundle request: %w", err)
 	}
@@ -36,7 +62,23 @@ func fetchBundle(ctx context.Context, bundleURL string) ([]regoFile, error) {
 		return nil, fmt.Errorf("fetching bundle: status %d", resp.StatusCode)
 	}
 
-	return parseBundleTarGz(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBundleBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading bundle: %w", err)
+	}
+	if len(data) > maxBundleBytes {
+		return nil, fmt.Errorf("bundle exceeds maximum size of %d bytes", maxBundleBytes)
+	}
+
+	if expectedSHA256 != "" {
+		sum := sha256.Sum256(data)
+		got := hex.EncodeToString(sum[:])
+		if !strings.EqualFold(got, expectedSHA256) {
+			return nil, fmt.Errorf("policy bundle sha256 mismatch: got %s, want %s — refusing to load (fail closed)", got, expectedSHA256)
+		}
+	}
+
+	return parseBundleTarGz(bytes.NewReader(data))
 }
 
 // parseBundleTarGz reads a .tar.gz bundle and returns all .rego source files inside it.

--- a/backend/internal/policy/bundle_loader_test.go
+++ b/backend/internal/policy/bundle_loader_test.go
@@ -1,0 +1,141 @@
+package policy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// fetchBundle — scheme enforcement
+// ---------------------------------------------------------------------------
+
+func TestFetchBundle_RequiresHTTPS(t *testing.T) {
+	_, err := fetchBundle(context.Background(), "http://bundles.example.com/bundle.tar.gz", "", nil)
+	if err == nil {
+		t.Fatal("expected error for non-HTTPS bundle_url, got nil")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Errorf("error should mention https requirement: %v", err)
+	}
+}
+
+func TestFetchBundle_HTTPAllowedWhenHostAllowlisted(t *testing.T) {
+	bundleData, err := buildBundle(map[string]string{"deny.rego": denyNamespaceRego})
+	if err != nil {
+		t.Fatalf("building bundle: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bundleData)
+	}))
+	defer srv.Close()
+
+	files, err := fetchBundle(context.Background(), srv.URL+"/bundle.tar.gz", "", loopbackGuard)
+	if err != nil {
+		t.Fatalf("fetchBundle: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 rego file, got %d", len(files))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// fetchBundle — pinned SHA-256 verification (fail closed)
+// ---------------------------------------------------------------------------
+
+func TestFetchBundle_SHA256Mismatch_FailsClosed(t *testing.T) {
+	bundleData, err := buildBundle(map[string]string{"deny.rego": denyNamespaceRego})
+	if err != nil {
+		t.Fatalf("building bundle: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bundleData)
+	}))
+	defer srv.Close()
+
+	wrongSHA := strings.Repeat("a", 64)
+	_, err = fetchBundle(context.Background(), srv.URL+"/bundle.tar.gz", wrongSHA, loopbackGuard)
+	if err == nil {
+		t.Fatal("expected error for sha256 mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "sha256 mismatch") {
+		t.Errorf("error should mention sha256 mismatch: %v", err)
+	}
+}
+
+func TestFetchBundle_SHA256Match_Succeeds(t *testing.T) {
+	bundleData, err := buildBundle(map[string]string{"deny.rego": denyNamespaceRego})
+	if err != nil {
+		t.Fatalf("building bundle: %v", err)
+	}
+	sum := sha256.Sum256(bundleData)
+	expected := hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bundleData)
+	}))
+	defer srv.Close()
+
+	files, err := fetchBundle(context.Background(), srv.URL+"/bundle.tar.gz", expected, loopbackGuard)
+	if err != nil {
+		t.Fatalf("fetchBundle with matching sha256: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 rego file, got %d", len(files))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PolicyEngine — bundle sha256 mismatch keeps previously loaded policies
+// ---------------------------------------------------------------------------
+
+func TestPolicyEngine_Reload_SHA256Mismatch_KeepsPreviousPolicies(t *testing.T) {
+	bundleData, err := buildBundle(map[string]string{"deny.rego": denyNamespaceRego})
+	if err != nil {
+		t.Fatalf("building bundle: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(bundleData)
+	}))
+	defer srv.Close()
+
+	engine, err := NewPolicyEngineWithGuard(Config{
+		Enabled:   true,
+		Mode:      "block",
+		BundleURL: srv.URL + "/bundle.tar.gz",
+	}, loopbackGuard)
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+
+	// Sanity: the deny rule is active before the failed reload.
+	result, err := engine.Evaluate(context.Background(), map[string]interface{}{"namespace": "blocked"})
+	if err != nil {
+		t.Fatalf("Evaluate (before): %v", err)
+	}
+	if result.Allowed {
+		t.Fatal("expected deny rule to fire before reload attempt")
+	}
+
+	// Reload with a deliberately wrong pin — set directly on the engine so
+	// loadBundle picks it up, mirroring a config change plus Reload call.
+	engine.bundleSHA256 = strings.Repeat("b", 64)
+	if err := engine.Reload(context.Background(), srv.URL+"/bundle.tar.gz"); err == nil {
+		t.Fatal("expected Reload to fail on sha256 mismatch")
+	}
+
+	// The previously loaded (and still valid) policy must still be enforced —
+	// fail closed means the bad bundle never takes effect, not that the
+	// engine falls back to allow-everything.
+	result, err = engine.Evaluate(context.Background(), map[string]interface{}{"namespace": "blocked"})
+	if err != nil {
+		t.Fatalf("Evaluate (after failed reload): %v", err)
+	}
+	if result.Allowed {
+		t.Error("a failed reload must not discard the previously loaded policy")
+	}
+}

--- a/backend/internal/policy/engine.go
+++ b/backend/internal/policy/engine.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // PolicyEngine evaluates module-upload (and other) inputs against a loaded Rego policy bundle.
@@ -14,18 +16,31 @@ import (
 //
 // PolicyEngine is safe for concurrent use.
 type PolicyEngine struct {
-	mu      sync.RWMutex
-	queries []*compiledQuery // one per policy file loaded from the bundle
-	enabled bool
-	mode    string // "warn" | "block"
+	mu           sync.RWMutex
+	queries      []*compiledQuery // one per policy file loaded from the bundle
+	enabled      bool
+	mode         string // "warn" | "block"
+	bundleSHA256 string
+	egress       *httpsafe.Guard
 }
 
-// NewPolicyEngine returns a new PolicyEngine configured from cfg.  If cfg.Enabled is false
-// the engine is a no-op: Evaluate always returns an allowed result.
+// NewPolicyEngine returns a new PolicyEngine configured from cfg, with the
+// strict egress policy (no allow-list) applied to the bundle fetch. If
+// cfg.Enabled is false the engine is a no-op: Evaluate always returns an
+// allowed result.
 func NewPolicyEngine(cfg Config) (*PolicyEngine, error) {
+	return NewPolicyEngineWithGuard(cfg, nil)
+}
+
+// NewPolicyEngineWithGuard is NewPolicyEngine with an egress guard widening
+// the SSRF deny-list applied to the bundle fetch (nil = strict), for
+// deployments whose bundle_url points at an internal bundle server.
+func NewPolicyEngineWithGuard(cfg Config, egress *httpsafe.Guard) (*PolicyEngine, error) {
 	e := &PolicyEngine{
-		enabled: cfg.Enabled,
-		mode:    cfg.Mode,
+		enabled:      cfg.Enabled,
+		mode:         cfg.Mode,
+		bundleSHA256: cfg.BundleSHA256,
+		egress:       egress,
 	}
 	if !cfg.Enabled || cfg.BundleURL == "" {
 		return e, nil
@@ -90,9 +105,15 @@ func (e *PolicyEngine) Mode() string {
 }
 
 // loadBundle fetches the bundle from bundleURL, parses .rego files, and replaces the
-// current query set atomically.
+// current query set atomically. On any failure (including a bundleSHA256
+// mismatch) the previously loaded query set is left untouched — fail closed.
 func (e *PolicyEngine) loadBundle(ctx context.Context, bundleURL string) error {
-	regoFiles, err := fetchBundle(ctx, bundleURL)
+	e.mu.RLock()
+	sha := e.bundleSHA256
+	egress := e.egress
+	e.mu.RUnlock()
+
+	regoFiles, err := fetchBundle(ctx, bundleURL, sha, egress)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/policy/engine_test.go
+++ b/backend/internal/policy/engine_test.go
@@ -8,7 +8,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// loopbackGuard allow-lists the httptest.Server addresses used by the
+// bundle-fetch tests below (127.0.0.1 / ::1), both so the strict production
+// egress policy doesn't need to accept a loopback dial target and so
+// bundle_url's HTTPS requirement doesn't reject the plain-HTTP test server.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
 // ─── parseBundleTarGz ────────────────────────────────────────────────────────
 
@@ -128,11 +136,11 @@ func TestPolicyEngine_BundleFromHTTP_DenyFires(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	engine, err := NewPolicyEngine(Config{
+	engine, err := NewPolicyEngineWithGuard(Config{
 		Enabled:   true,
 		Mode:      "block",
 		BundleURL: srv.URL + "/bundle.tar.gz",
-	})
+	}, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewPolicyEngine: %v", err)
 	}
@@ -164,11 +172,11 @@ func TestPolicyEngine_BundleFromHTTP_Allow(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	engine, err := NewPolicyEngine(Config{
+	engine, err := NewPolicyEngineWithGuard(Config{
 		Enabled:   true,
 		Mode:      "warn",
 		BundleURL: srv.URL + "/bundle.tar.gz",
-	})
+	}, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewPolicyEngine: %v", err)
 	}
@@ -199,11 +207,11 @@ func TestPolicyEngine_Reload(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	engine, err := NewPolicyEngine(Config{
+	engine, err := NewPolicyEngineWithGuard(Config{
 		Enabled:   true,
 		Mode:      "block",
 		BundleURL: srv.URL + "/bundle.tar.gz",
-	})
+	}, loopbackGuard)
 	if err != nil {
 		t.Fatalf("NewPolicyEngine: %v", err)
 	}

--- a/backend/internal/policy/types.go
+++ b/backend/internal/policy/types.go
@@ -2,9 +2,13 @@ package policy
 
 // Config holds configuration for the policy engine.
 type Config struct {
-	Enabled               bool   `mapstructure:"enabled"`
-	Mode                  string `mapstructure:"mode"`                    // "warn" | "block"
-	BundleURL             string `mapstructure:"bundle_url"`              // HTTP URL for the Rego bundle tarball
+	Enabled   bool   `mapstructure:"enabled"`
+	Mode      string `mapstructure:"mode"`       // "warn" | "block"
+	BundleURL string `mapstructure:"bundle_url"` // HTTPS URL for the Rego bundle tarball (HTTP only if allow-listed)
+	// BundleSHA256 optionally pins the expected SHA-256 (hex) of the bundle
+	// archive. When set, a fetched bundle whose digest does not match is
+	// rejected and the previously loaded policies are kept (fail closed).
+	BundleSHA256          string `mapstructure:"bundle_sha256"`
 	BundleRefreshInterval int    `mapstructure:"bundle_refresh_interval"` // seconds; 0 = no background refresh
 }
 

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -135,7 +135,7 @@ func (c *AzureDevOpsConnector) CompleteAuthorization(ctx context.Context, authCo
 		return nil, fmt.Errorf("azuredevops: create token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
@@ -187,7 +187,7 @@ func (c *AzureDevOpsConnector) RenewToken(ctx context.Context, refreshToken stri
 		return nil, fmt.Errorf("azuredevops: create refresh request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to refresh token", err)
@@ -237,7 +237,7 @@ func (c *AzureDevOpsConnector) FetchRepositories(ctx context.Context, creds *scm
 			continue
 		}
 		c.setAuthHeaders(req, creds)
-		// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+		// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 		resp, err := scm.HTTPClient.Do(req)
 		if err != nil {
 			continue
@@ -272,7 +272,7 @@ func (c *AzureDevOpsConnector) FetchRepository(ctx context.Context, creds *scm.A
 		return nil, fmt.Errorf("azuredevops: create repo request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
@@ -324,7 +324,7 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 		return nil, fmt.Errorf("azuredevops: create branches request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
@@ -369,7 +369,7 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 		return nil, fmt.Errorf("azuredevops: create tags request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
@@ -440,7 +440,7 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 		return nil, fmt.Errorf("azuredevops: create commit request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
@@ -504,7 +504,7 @@ func (c *AzureDevOpsConnector) DownloadSourceArchive(ctx context.Context, creds 
 		return nil, fmt.Errorf("azuredevops: create archive request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
@@ -594,7 +594,7 @@ func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds
 		return "", "", fmt.Errorf("create request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return "", "", scm.WrapRemoteError(0, "failed to fetch repository IDs", err)
@@ -652,7 +652,7 @@ func (c *AzureDevOpsConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 		return nil, fmt.Errorf("azuredevops: create subscription request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create service hook subscription", err)
@@ -683,7 +683,7 @@ func (c *AzureDevOpsConnector) RemoveWebhook(ctx context.Context, creds *scm.Acc
 		return fmt.Errorf("azuredevops: create delete subscription request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete service hook subscription", err)
@@ -802,7 +802,7 @@ func (c *AzureDevOpsConnector) fetchProjects(ctx context.Context, creds *scm.Acc
 		return nil, fmt.Errorf("azuredevops: create projects request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)

--- a/backend/internal/scm/azuredevops/egress_testmain_test.go
+++ b/backend/internal/scm/azuredevops/egress_testmain_test.go
@@ -1,0 +1,20 @@
+package azuredevops
+
+import (
+	"os"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// TestMain widens the shared connector client's (scm.HTTPClient) egress
+// policy to an explicit loopback allow-list for this test binary only: every
+// test in this package points a connector at an httptest.Server, which binds
+// to 127.0.0.1. Production callers get the strict default (see
+// internal/scm/httpclient.go); only this test binary's egress policy changes.
+func TestMain(m *testing.M) {
+	if err := scm.ConfigureEgress([]string{"127.0.0.1", "::1"}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/scm/bitbucket/connector.go
+++ b/backend/internal/scm/bitbucket/connector.go
@@ -280,7 +280,7 @@ func (c *BitbucketDCConnector) DownloadSourceArchive(ctx context.Context, creds 
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -329,7 +329,7 @@ func (c *BitbucketDCConnector) RegisterWebhook(ctx context.Context, creds *scm.A
 	c.setAuthHeaders(req, creds)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
 	}
@@ -361,7 +361,7 @@ func (c *BitbucketDCConnector) RemoveWebhook(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)
 	}
@@ -466,7 +466,7 @@ func (c *BitbucketDCConnector) doJSON(ctx context.Context, creds *scm.AccessToke
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return scm.WrapRemoteError(0, "request failed", err)
 	}

--- a/backend/internal/scm/bitbucket/egress_testmain_test.go
+++ b/backend/internal/scm/bitbucket/egress_testmain_test.go
@@ -1,0 +1,20 @@
+package bitbucket
+
+import (
+	"os"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// TestMain widens the shared connector client's (scm.HTTPClient) egress
+// policy to an explicit loopback allow-list for this test binary only: every
+// test in this package points a connector at an httptest.Server, which binds
+// to 127.0.0.1. Production callers get the strict default (see
+// internal/scm/httpclient.go); only this test binary's egress policy changes.
+func TestMain(m *testing.M) {
+	if err := scm.ConfigureEgress([]string{"127.0.0.1", "::1"}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -89,7 +89,7 @@ func (c *GitHubConnector) CompleteAuthorization(ctx context.Context, authCode st
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
 	}
@@ -161,7 +161,7 @@ func (c *GitHubConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
 	}
@@ -202,7 +202,7 @@ func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "search failed", err)
 	}
@@ -253,7 +253,7 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
 	}
@@ -306,7 +306,7 @@ func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
 	}
@@ -349,7 +349,7 @@ func (c *GitHubConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
 	}
@@ -391,7 +391,7 @@ func (c *GitHubConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
 	}
@@ -446,7 +446,7 @@ func (c *GitHubConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -483,7 +483,7 @@ func (c *GitHubConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 	req.Header.Set("Content-Type", "application/json")
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
@@ -514,7 +514,7 @@ func (c *GitHubConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessTo
 		return fmt.Errorf("github: create delete webhook request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)
@@ -624,7 +624,7 @@ func (c *GitHubConnector) fetchRepoList(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch repositories", err)
 	}

--- a/backend/internal/scm/github/egress_testmain_test.go
+++ b/backend/internal/scm/github/egress_testmain_test.go
@@ -1,0 +1,20 @@
+package github
+
+import (
+	"os"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// TestMain widens the shared connector client's (scm.HTTPClient) egress
+// policy to an explicit loopback allow-list for this test binary only: every
+// test in this package points a connector at an httptest.Server, which binds
+// to 127.0.0.1. Production callers get the strict default (see
+// internal/scm/httpclient.go); only this test binary's egress policy changes.
+func TestMain(m *testing.M) {
+	if err := scm.ConfigureEgress([]string{"127.0.0.1", "::1"}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -87,7 +87,7 @@ func (c *GitLabConnector) CompleteAuthorization(ctx context.Context, authCode st
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
 	}
@@ -139,7 +139,7 @@ func (c *GitLabConnector) RenewToken(ctx context.Context, refreshToken string) (
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to refresh token", err)
 	}
@@ -189,7 +189,7 @@ func (c *GitLabConnector) FetchRepositories(ctx context.Context, creds *scm.Acce
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)
 	}
@@ -228,7 +228,7 @@ func (c *GitLabConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch project", err)
 	}
@@ -269,7 +269,7 @@ func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "search failed", err)
 	}
@@ -316,7 +316,7 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
 	}
@@ -372,7 +372,7 @@ func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
 	}
@@ -422,7 +422,7 @@ func (c *GitLabConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
 	}
@@ -467,7 +467,7 @@ func (c *GitLabConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
 	}
@@ -522,7 +522,7 @@ func (c *GitLabConnector) DownloadSourceArchive(ctx context.Context, creds *scm.
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- URL is sourced from admin-controlled SCM provider or mirror configuration; non-admin users cannot influence these code paths
+	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to download archive", err)
 	}
@@ -556,7 +556,7 @@ func (c *GitLabConnector) RegisterWebhook(ctx context.Context, creds *scm.Access
 		return nil, fmt.Errorf("gitlab: create webhook request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return nil, scm.WrapRemoteError(0, "failed to create webhook", err)
@@ -588,7 +588,7 @@ func (c *GitLabConnector) RemoveWebhook(ctx context.Context, creds *scm.AccessTo
 		return fmt.Errorf("gitlab: create delete webhook request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- URL is sourced from admin-controlled SCM provider configuration; non-admin users cannot influence these code paths
+	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
 	resp, err := scm.HTTPClient.Do(req)
 	if err != nil {
 		return scm.WrapRemoteError(0, "failed to delete webhook", err)

--- a/backend/internal/scm/gitlab/egress_testmain_test.go
+++ b/backend/internal/scm/gitlab/egress_testmain_test.go
@@ -1,0 +1,20 @@
+package gitlab
+
+import (
+	"os"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// TestMain widens the shared connector client's (scm.HTTPClient) egress
+// policy to an explicit loopback allow-list for this test binary only: every
+// test in this package points a connector at an httptest.Server, which binds
+// to 127.0.0.1. Production callers get the strict default (see
+// internal/scm/httpclient.go); only this test binary's egress policy changes.
+func TestMain(m *testing.M) {
+	if err := scm.ConfigureEgress([]string{"127.0.0.1", "::1"}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/scm/httpclient.go
+++ b/backend/internal/scm/httpclient.go
@@ -5,16 +5,35 @@ package scm
 
 import (
 	"io"
-	"net/http"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// httpClientTimeout is the shared request timeout for all SCM connector calls.
+const httpClientTimeout = 30 * time.Second
 
 // HTTPClient is the shared HTTP client every SCM connector should use instead of
 // http.DefaultClient, which has a zero Timeout. Self-hosted/enterprise SCM instance
-// base URLs are admin-configurable, so a slow or hung instance could otherwise block
-// a request-handling goroutine indefinitely.
-var HTTPClient = &http.Client{
-	Timeout: 30 * time.Second,
+// base URLs are operator-configurable, so every request is routed through the
+// SSRF-safe egress client (internal/httpsafe): private/metadata targets are
+// refused at dial time (resolve-and-pin) and redirects are re-validated per hop.
+// The strict default policy applies until ConfigureEgress installs the
+// operator's allow-list at startup; tests that talk to local httptest servers
+// replace this client with one built from an explicit loopback allow-list.
+var HTTPClient = httpsafe.NewClient(httpClientTimeout, nil)
+
+// ConfigureEgress rebuilds the shared connector client with the
+// operator-configured egress allow-list (security.egress.allowlist). Call once
+// at startup before any connector traffic; entries may be hostnames, IPs, or
+// CIDR ranges.
+func ConfigureEgress(allowlist []string) error {
+	g, err := httpsafe.NewGuard(allowlist)
+	if err != nil {
+		return err
+	}
+	HTTPClient = httpsafe.NewClient(httpClientTimeout, g)
+	return nil
 }
 
 const (

--- a/backend/internal/services/pull_through.go
+++ b/backend/internal/services/pull_through.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 )
 
@@ -26,9 +27,14 @@ type PullThroughService struct {
 	orgRepo      *repositories.OrganizationRepository
 
 	// newUpstream is the factory used to build an UpstreamRegistryClient from a
-	// base URL.  It defaults to mirror.NewUpstreamRegistry; tests may override it
-	// via SetUpstreamFactory to inject a fake client without performing real HTTP.
+	// base URL.  It defaults to mirror.NewUpstreamRegistryWithGuard using this
+	// service's egress guard; tests may override it via SetUpstreamFactory to
+	// inject a fake client without performing real HTTP.
 	newUpstream func(baseURL string) mirror.UpstreamRegistryClient
+
+	// egressGuard widens the SSRF egress deny-list for upstream fetches
+	// (nil = strict). Set via SetEgressGuard.
+	egressGuard *httpsafe.Guard
 }
 
 // NewPullThroughService constructs a PullThroughService.
@@ -37,14 +43,22 @@ func NewPullThroughService(
 	mirrorRepo *repositories.MirrorRepository,
 	orgRepo *repositories.OrganizationRepository,
 ) *PullThroughService {
-	return &PullThroughService{
+	s := &PullThroughService{
 		providerRepo: providerRepo,
 		mirrorRepo:   mirrorRepo,
 		orgRepo:      orgRepo,
-		newUpstream: func(baseURL string) mirror.UpstreamRegistryClient {
-			return mirror.NewUpstreamRegistry(baseURL)
-		},
 	}
+	s.newUpstream = func(baseURL string) mirror.UpstreamRegistryClient {
+		return mirror.NewUpstreamRegistryWithGuard(baseURL, s.egressGuard)
+	}
+	return s
+}
+
+// SetEgressGuard installs the operator-configured egress guard
+// (security.egress.allowlist) used by the default upstream-client factory.
+// nil keeps the strict default policy.
+func (s *PullThroughService) SetEgressGuard(g *httpsafe.Guard) {
+	s.egressGuard = g
 }
 
 // SetUpstreamFactory replaces the upstream-client factory.  Intended for tests

--- a/backend/internal/services/pull_through_integration_test.go
+++ b/backend/internal/services/pull_through_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // ---------------------------------------------------------------------------
@@ -54,6 +55,10 @@ func newPullThroughEnv(t *testing.T) (
 	mirrorRepo := repositories.NewMirrorRepository(sqlx.NewDb(mirrorDB, "sqlmock"))
 
 	svc = NewPullThroughService(providerRepo, mirrorRepo, nil /* orgRepo: unused */)
+	// Tests point the service at an httptest.Server bound to 127.0.0.1; widen
+	// its egress policy with an explicit loopback allow-list (production keeps
+	// the strict default — see SetEgressGuard's doc comment).
+	svc.SetEgressGuard(httpsafe.MustGuard("127.0.0.1", "::1"))
 
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -476,7 +476,14 @@ failed to discover services at https://registry.terraform.io
 ```
 
 - Check outbound connectivity from the registry server to `registry.terraform.io:443`
-- If behind a proxy, set `HTTPS_PROXY` environment variable
+- `HTTPS_PROXY`/`HTTP_PROXY` are **not honored** by this or any other admin-configurable
+  outbound fetch (mirror sync, SCM connectors, the policy bundle, the OSV endpoint, SAML IdP
+  metadata, audit webhooks): they all share an SSRF-safe client that resolves and pins the
+  destination IP itself, and a forward proxy would let the real destination bypass that check
+  entirely. If the registry server needs to reach the public internet through a corporate
+  egress proxy, that must be handled at the network layer (e.g. a transparent proxy, or routing
+  the server's default route through the proxy), not via environment variables.
+- If the target is intentionally an internal/private address, add it to `security.egress.allowlist`
 - Verify the upstream URL is correct (default: `https://registry.terraform.io`)
 
 ### GPG Verification Failed


### PR DESCRIPTION
## Summary

Closes #556. Admin-configurable outbound HTTP clients (SCM webhook validation, mirror sync, etc.) had no protection against SSRF: a malicious or compromised config pointing at an internal address, cloud metadata endpoint, or via redirect to one, was followed with no restriction.

## Design

New shared `internal/httpsafe` package used by all admin-configurable outbound clients:

- **Resolve-and-pin dialing**: resolves the hostname, validates *every* returned IP against a deny-list, then dials the validated IP directly via a custom `DialContext` — closing the classic TOCTOU gap where DNS could resolve to something benign at check-time and something internal at connect-time (DNS rebinding).
- Scheme allow-list, explicit `security.egress.allowlist` escape hatch (default deny) for legitimate internal targets.
- `CheckRedirect` re-validates every hop against the same rules, not just the initial request.

## Review history

Two rounds of adversarial multi-agent review before being considered ready:

**Round 1** — 3 high confirmed and fixed (`ac47353`):
- `http.ProxyFromEnvironment` on the transport meant any `HTTPS_PROXY`/`HTTP_PROXY` env var set on the host could redirect all "validated" traffic through an attacker-controlled proxy, bypassing the resolve-and-pin logic entirely. Removed proxy support outright for this client.
- Header-only credential stripping on redirect missed the request body — a cross-origin redirect with a non-empty body (e.g. mid-OAuth-exchange) could leak it to an unintended host. Now refuses to follow any cross-origin redirect carrying a body.
- The same-origin check for redirect safety compared only host, ignoring scheme and port — an `https://good.example:443` → `http://good.example:8080` redirect would incorrectly be treated as same-origin.

**Round 2** — 1 high + 1 medium confirmed and fixed (`b5aa4f3`):
- Round 1's origin check was symmetric (any scheme change = cross-origin), which was actually a *regression*: a self-hosted SCM instance configured with `base_url=http://` (explicitly permitted) whose reverse proxy force-upgrades to `https` via a same-host redirect would have its OAuth token exchange (a POST with a body) incorrectly refused. Replaced with an asymmetric check — an http→https upgrade on the same host is safe to follow with credentials/body (strictly more secure hop); a downgrade or any host/port change is not.
- `docs/troubleshooting.md` still told operators to set `HTTPS_PROXY` to work around connectivity issues — no longer does anything since proxy support was removed in round 1. Corrected and pointed at `security.egress.allowlist` instead.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes, including SSRF/redirect regression tests for both rounds' findings