### PR TITLE
fix(ci): dependabot.yml used invalid schedule.interval "biweekly"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: gomod
     directory: /backend
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -36,7 +36,7 @@ updates:
   - package-ecosystem: docker
     directory: /backend
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -55,7 +55,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC
@@ -73,7 +73,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: biweekly
+      interval: weekly
       day: monday
       time: "09:00"
       timezone: UTC


### PR DESCRIPTION
## Summary

Dependabot's `schedule.interval` schema only accepts `daily, weekly, monthly, quarterly, semiannually, yearly, cron` — `biweekly` was never valid. All 4 entries in `.github/dependabot.yml` used it, so the whole file has been failing Dependabot's config-validation check (confirmed via its own error output on `main`). This isn't a required status check, so it went unnoticed — until PR #591 added a 4th entry (npm) that faithfully copied the same already-broken pattern from the other three, and the failure got surfaced while watching that PR's checks.

## Changes

Switched all 4 `interval: biweekly` → `interval: weekly` (closest supported cadence to the original intent; the existing `day`/`time`/`timezone` fields are already weekly-compatible, no other changes needed).

## Test plan

- [x] Valid YAML
- [x] Will confirm the `.github/dependabot.yml` check passes once this PR's checks run