### PR TITLE
test(security): expand security test coverage per issue #566 findings

### DIFF
--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -574,6 +574,36 @@ func TestServeFileHandler_DoubleSlashTraversal(t *testing.T) {
 	}
 }
 
+// TestServeFileHandler_URLEncodedTraversal documents how gin's wildcard param
+// interacts with the substring guard for percent-encoded traversal sequences.
+// gin (with the default UseRawPath: false) matches routes and populates
+// c.Param against req.URL.Path, which net/http's url.Parse has already
+// percent-decoded — so "%2e%2e%2f" reaches the handler as a literal "../"
+// well before the "strings.Contains(filePath, \"..\")" check runs. Each of
+// these encoded variants is expected to be rejected the same as the raw
+// ".." case, not to sneak past it.
+func TestServeFileHandler_URLEncodedTraversal(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"fully encoded slashes", "/v1/files/%2e%2e%2f%2e%2e%2fetc%2fpasswd"},
+		{"encoded dots literal slashes", "/v1/files/%2e%2e/%2e%2e/etc/passwd"},
+		{"encoded slashes literal dots", "/v1/files/..%2f..%2fetc%2fpasswd"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockStore{existsResult: true}
+			r := newServeRouter(t, store)
+
+			w := doGET(r, tt.path)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // UploadHandler test helpers
 // ---------------------------------------------------------------------------

--- a/backend/internal/archiver/tarball_test.go
+++ b/backend/internal/archiver/tarball_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,6 +181,79 @@ func TestExtractTarGz_ExceedsExtractionCap(t *testing.T) {
 	}
 }
 
+// Issue #566 finding [46]: TestExtractTarGz_ExceedsExtractionCap (above) only proves
+// a single oversized entry is rejected — that alone would also pass a naive per-entry
+// size check (e.g. "if header.Size > maxExtractBytes"). This test proves the cap is
+// tracked cumulatively across MANY entries that are each individually tiny relative to
+// the cap, closing the cumulative-sum-bypass gap.
+func TestExtractTarGz_ExceedsExtractionCap_CumulativeSmallEntries(t *testing.T) {
+	const entrySize = 1 << 20 // 1 MB per entry — 1% of the 100 MB cap, individually
+	const entryCount = 150    // 150 MB total, comfortably over the cap
+
+	chunk := bytes.Repeat([]byte("B"), entrySize)
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for i := 0; i < entryCount; i++ {
+		name := fmt.Sprintf("file-%03d.bin", i)
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(chunk))}); err != nil {
+			t.Fatalf("tar WriteHeader %s: %v", name, err)
+		}
+		if _, err := tw.Write(chunk); err != nil {
+			t.Fatalf("tar Write %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	dest := t.TempDir()
+	err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest)
+	if err == nil {
+		t.Fatal("expected extraction-size-limit error from cumulative small entries, got nil")
+	}
+	if !strings.Contains(err.Error(), "extraction size limit") {
+		t.Errorf("error = %q, want it to mention the extraction size limit", err.Error())
+	}
+
+	// Confirm extraction actually stopped partway through instead of writing all
+	// 150 MB to disk — a naive per-entry check would let every entry through since
+	// each is individually far under the cap.
+	var totalOnDisk int64
+	var fileCount int
+	walkErr := filepath.WalkDir(dest, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		fileCount++
+		totalOnDisk += info.Size()
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk dest: %v", walkErr)
+	}
+	if fileCount >= entryCount {
+		t.Errorf("expected extraction to stop before all %d entries were written, found %d files", entryCount, fileCount)
+	}
+	if totalOnDisk >= int64(entryCount)*int64(entrySize) {
+		t.Errorf("expected extraction to stop before writing all %d bytes to disk, found %d bytes", int64(entryCount)*int64(entrySize), totalOnDisk)
+	}
+	if totalOnDisk > maxExtractBytes+entrySize {
+		t.Errorf("extraction wrote %d bytes, more than one entry past the %d-byte cap", totalOnDisk, int64(maxExtractBytes))
+	}
+}
+
 // Issue #566 finding [46]: tar.TypeSymlink entries have no case in ExtractTarGz's
 // switch (no default), so they are silently no-op'd — assert that's actually true
 // and no symlink is ever created on disk, even one whose target would escape destDir.
@@ -211,6 +285,36 @@ func TestExtractTarGz_SymlinkEntryIgnored(t *testing.T) {
 	}
 }
 
+// Issue #566 finding [46]: same gap as TestExtractTarGz_SymlinkEntryIgnored but for
+// tar.TypeLink (hardlink) entries — also has no case in ExtractTarGz's switch, so it
+// must be silently no-op'd rather than ever creating a link on disk.
+func TestExtractTarGz_HardlinkEntryIgnored(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "evil-hardlink",
+		Typeflag: tar.TypeLink,
+		Linkname: "../../../etc/passwd",
+		Mode:     0644,
+	}); err != nil {
+		t.Fatalf("tar WriteHeader: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest); err != nil {
+		t.Fatalf("ExtractTarGz should not error on a hardlink entry: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "evil-hardlink")); err == nil {
+		t.Error("hardlink entry should not have been created on disk")
+	}
+}
 
 func TestExtractTarGz_FileContents(t *testing.T) {
 	const tfContent = `variable "region" { default = "us-east-1" }`
@@ -227,6 +331,93 @@ func TestExtractTarGz_FileContents(t *testing.T) {
 	}
 	if string(got) != tfContent {
 		t.Errorf("file content = %q, want %q", got, tfContent)
+	}
+}
+
+// seedTarGzBytes builds a minimal valid tar.gz archive from name->content pairs, for
+// use as fuzz seed corpus. Fuzz seeds are registered outside of any *testing.T (via
+// *testing.F, in the body of the Fuzz function itself, before f.Fuzz is called), so
+// this mirrors buildTarGz above without requiring one; write errors are ignored since
+// they can't realistically occur against an in-memory bytes.Buffer.
+func seedTarGzBytes(files map[string]string) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range files {
+		_ = tw.WriteHeader(&tar.Header{Name: name, Mode: 0644, Size: int64(len(content))})
+		_, _ = tw.Write([]byte(content))
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	return buf.Bytes()
+}
+
+// Issue #566 finding [46]: FuzzExtractTarGz feeds arbitrary bytes through
+// ExtractTarGz and asserts it never panics and never writes anything outside
+// destDir, regardless of how malformed the input is. ExtractTarGz's own path
+// containment check (see the filepath.Rel logic in tarball.go) means a
+// well-behaved run either errors out before writing an escaping entry, or
+// succeeds having only ever written inside destDir — so containment is
+// verified here by walking destDir's *parent* after each run and failing if
+// anything landed outside destDir.
+func FuzzExtractTarGz(f *testing.F) {
+	f.Add(seedTarGzBytes(map[string]string{"main.tf": `resource "null_resource" "x" {}`}))
+	f.Add(seedTarGzBytes(map[string]string{"../../../evil.txt": "evil"}))
+	f.Add([]byte{})
+	f.Add([]byte("not a gzip stream at all"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		parent := t.TempDir()
+		dest := filepath.Join(parent, "extract")
+
+		// The return value is intentionally not asserted on: malformed input is
+		// expected to produce an error and that's fine. What matters is that
+		// ExtractTarGz never panics (a panic fails the fuzz run on its own) and
+		// never escapes destDir, whether it errors or not.
+		_ = ExtractTarGz(bytes.NewReader(data), dest)
+
+		// Walking a fixed ancestor (e.g. parent) only catches escapes that land
+		// exactly at that level -- a "../../../evil.txt" entry can climb past
+		// any fixed ancestor entirely and go undetected by a directory walk.
+		// Instead, independently re-parse the same input the way ExtractTarGz
+		// does and, for every entry, compute the exact naive (unsanitized)
+		// destination path; if that path resolves outside dest, assert nothing
+		// was actually written there -- this targets precisely where a
+		// malicious entry claims it wants to escape to, at any depth, without
+		// needing to bound how far up the filesystem to search.
+		for _, name := range tarEntryNames(data) {
+			wouldBePath := filepath.Clean(filepath.Join(dest, name))
+			rel, relErr := filepath.Rel(dest, wouldBePath)
+			escapes := relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+			if !escapes {
+				continue
+			}
+			if _, statErr := os.Lstat(wouldBePath); !os.IsNotExist(statErr) {
+				t.Fatalf("ExtractTarGz wrote outside destDir for entry %q: found at %s", name, wouldBePath)
+			}
+		}
+	})
+}
+
+// tarEntryNames re-parses a tar.gz byte stream the same way ExtractTarGz does
+// and returns every entry's raw (unsanitized) name, or nil if the stream
+// isn't a valid tar.gz -- used by FuzzExtractTarGz to independently determine
+// which paths a malicious archive targets, without trusting ExtractTarGz's
+// own accounting of what it wrote.
+func tarEntryNames(data []byte) []string {
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			return names
+		}
+		names = append(names, hdr.Name)
 	}
 }
 

--- a/backend/internal/auth/saml/provider_test.go
+++ b/backend/internal/auth/saml/provider_test.go
@@ -1,6 +1,7 @@
 package saml
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/crewjam/saml"
@@ -230,6 +231,27 @@ func TestFetchIdPMetadata_RequiresHTTPS(t *testing.T) {
 	_, err := fetchIdPMetadata("http://insecure.example.com/metadata", nil)
 	if err == nil {
 		t.Fatal("expected error for non-HTTPS metadata URL")
+	}
+}
+
+// fetchIdPMetadata routes the fetch through httpsafe.NewClient (dial-time
+// resolve-and-pin), not an upfront ValidateURL call, so the SSRF guard here
+// is only exercised by actually attempting the request. A nil egress guard
+// is the strict default policy (no allow-list entries), so a loopback
+// target must be rejected before any TCP connection is attempted -- nothing
+// needs to be listening on the target port for this to fail closed.
+func TestFetchIdPMetadata_RejectsLoopbackTarget(t *testing.T) {
+	_, err := fetchIdPMetadata("https://127.0.0.1:1/metadata", nil)
+	if err == nil {
+		t.Fatal("expected error for loopback metadata URL target")
+	}
+	// Assert on the SSRF guard's own wording, not just "any error": port 1
+	// is closed, so a connection-refused error would also satisfy a bare
+	// err != nil check without proving the egress guard is what blocked
+	// this -- if the guard ever regressed, "connection refused" would
+	// silently keep this test green.
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target (not e.g. a bare connection error)", err.Error())
 	}
 }
 

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -86,6 +86,44 @@ func TestValidateRegistryURL(t *testing.T) {
 	}
 }
 
+// ValidateRegistryURL delegates the actual SSRF classification to
+// egress.ValidateURL (internal/httpsafe). These cases lock in that an
+// admin-configured upstream_registry_url pointing at a loopback, RFC 1918,
+// or link-local/cloud-metadata target is rejected under the strict default
+// policy (nil egress == no allow-list entries, not "no enforcement" -- see
+// httpsafe.Guard.HostExempt's nil receiver handling). Literal IPs are used
+// so classification happens synchronously with no DNS dependency.
+func TestValidateRegistryURL_RejectsSSRFTargets(t *testing.T) {
+	tests := []string{
+		"http://127.0.0.1",
+		"http://127.0.0.1:8080",
+		"http://[::1]",
+		"http://169.254.169.254", // cloud metadata endpoint (AWS/GCP/Azure)
+		"http://10.0.0.5",        // RFC 1918
+		"http://172.16.0.1",      // RFC 1918
+		"http://192.168.1.1",     // RFC 1918
+		"http://[fc00::1]",       // IPv6 unique local (RFC 1918 equivalent)
+		"http://[fe80::1]",       // IPv6 link-local
+		"http://0.0.0.0",         // unspecified
+	}
+	for _, u := range tests {
+		if err := ValidateRegistryURL(u, nil); err == nil {
+			t.Errorf("ValidateRegistryURL(%q) = nil, want a rejection error", u)
+		}
+	}
+}
+
+// An explicit egress allow-list entry for an otherwise-blocked target must
+// still be honored through ValidateRegistryURL -- confirms the SSRF guard's
+// escape hatch (security.egress.allowlist) actually reaches this call site
+// and isn't silently bypassed by ValidateRegistryURL's own scheme/host checks.
+func TestValidateRegistryURL_AllowlistedPrivateTargetPasses(t *testing.T) {
+	guard := httpsafe.MustGuard("10.0.0.5")
+	if err := ValidateRegistryURL("http://10.0.0.5", guard); err != nil {
+		t.Errorf("ValidateRegistryURL with an allow-listed target = %v, want nil", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DiscoverServices
 // ---------------------------------------------------------------------------

--- a/backend/internal/policy/bundle_loader_test.go
+++ b/backend/internal/policy/bundle_loader_test.go
@@ -24,6 +24,26 @@ func TestFetchBundle_RequiresHTTPS(t *testing.T) {
 	}
 }
 
+// fetchBundle routes the request through httpsafe.NewClient (dial-time
+// resolve-and-pin), not an upfront ValidateURL call, so the SSRF guard is
+// only exercised by actually attempting the request. A nil egress guard is
+// the strict default policy (no allow-list entries), so a loopback target
+// must be rejected before any TCP connection is attempted.
+func TestFetchBundle_RejectsLoopbackTarget(t *testing.T) {
+	_, err := fetchBundle(context.Background(), "https://127.0.0.1:1/bundle.tar.gz", "", nil)
+	if err == nil {
+		t.Fatal("expected error for loopback bundle_url target")
+	}
+	// Assert on the SSRF guard's own wording, not just "any error": port 1
+	// is closed, so a connection-refused error would also satisfy a bare
+	// err != nil check without proving the egress guard is what blocked
+	// this -- if the guard ever regressed, "connection refused" would
+	// silently keep this test green.
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target (not e.g. a bare connection error)", err.Error())
+	}
+}
+
 func TestFetchBundle_HTTPAllowedWhenHostAllowlisted(t *testing.T) {
 	bundleData, err := buildBundle(map[string]string{"deny.rego": denyNamespaceRego})
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #566 (7 findings from the 2026-07-09 blind security audit, turning the recent fixes into regression-proof guarantees).

**Findings [45] (per-package coverage gate) and [51] (coverage:skip governance) were already resolved** by prior commit `22cfddf` (#580) — verified against current code, no action needed. Finding [49] (LDAP `InsecureSkipVerify`) and most of finding [47] (path-traversal payload tests) were also already covered by that same commit.

## What's actually new in this PR

- **[47]**: added `TestServeFileHandler_URLEncodedTraversal` — confirms the traversal guard sees already-decoded paths (Gin's `UseRawPath` is never set), so URL-encoded payloads collapse to the same literal `..` case already covered; a narrow but real regression pin against a future routing-config change.
- **[48]**: the SSRF *fix* itself (`egress.ValidateURL` / `httpsafe.Guard`) was already completed by #556 earlier this session. Added the rejection tests it never had: `TestValidateRegistryURL_RejectsSSRFTargets` (loopback, RFC 1918, 169.254.169.254, IPv6 link-local/ULA, unspecified) + `TestValidateRegistryURL_AllowlistedPrivateTargetPasses` for the mirror package; `TestFetchIdPMetadata_RejectsLoopbackTarget` for SAML; `TestFetchBundle_RejectsLoopbackTarget` for the policy bundle loader. (SCM `InstanceBaseURL` has no separate validate-at-save-time function to test the same way — its protection is structural, via the shared dial-time-guarded HTTP client already covered at the `internal/httpsafe` layer.)
- **[46]**: added `TestExtractTarGz_ExceedsExtractionCap_CumulativeSmallEntries` (proves the 100MB cap is tracked cumulatively across many small entries, not just caught by a per-entry check), `TestExtractTarGz_HardlinkEntryIgnored` (companion to the existing symlink test), and `FuzzExtractTarGz` piping arbitrary bytes through the real extraction path into a temp dir.

## Adversarial review

Every new test was verified to be load-bearing (not just "no error occurred"), not merely reviewed by eye:

- The SSRF-rejection tests and the archive-cap/hardlink tests were confirmed to fail when their corresponding production guard was temporarily neutralized, then production code was restored to its exact original state (`git diff` empty) with no residual changes.
- Two real gaps were found during that pass and fixed:
  - `TestFetchIdPMetadata_RejectsLoopbackTarget` / `TestFetchBundle_RejectsLoopbackTarget` initially asserted only `err != nil` — a plain "connection refused" from a merely-closed port would also satisfy that, unable to distinguish "the SSRF guard blocked this" from "nothing was listening anyway." Strengthened both to assert the error text specifically mentions the guard's own "blocked" wording.
  - `FuzzExtractTarGz`'s containment check originally walked a fixed ancestor directory, which only detects an escape landing exactly one level above the extraction target — a deeper escape (e.g. the fuzz corpus's own `../../../evil.txt` seed) climbs past that ancestor entirely and goes undetected. Replaced with a check that independently re-parses the same input's tar entries and, for each one, computes its exact naive (unsanitized) destination path, asserting nothing was written there when that path resolves outside the destination — this targets precisely where a malicious entry claims it wants to escape to, at any depth. Reproduced the exact blind spot (confirmed the old check missed the 3-level escape) and confirmed the new check catches it, before restoring the neutralized production code.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes repo-wide
- [x] `golangci-lint run` (CI-pinned v2.12.2) on all touched packages: 0 issues
- [x] `go test -fuzz=FuzzExtractTarGz -fuzztime=15s`: ~92k executions, no crashes
- [x] Every load-bearing claim above was empirically reproduced, not assumed