### PR TITLE
fix: TestExtractTarGz_PathTraversal asserted only err != nil

### DIFF
--- a/backend/internal/archiver/tarball_test.go
+++ b/backend/internal/archiver/tarball_test.go
@@ -129,6 +129,13 @@ func TestExtractTarGz_InvalidGzip(t *testing.T) {
 	}
 }
 
+// A shallow t.TempDir() plus a 3-level "../../../" escape can resolve all the
+// way to filesystem root, where the OS itself denies the write (non-root
+// can't create files there) -- asserting only err != nil can't tell that
+// apart from ExtractTarGz's own containment check actually firing, so a
+// broken/removed containment check could still pass this test by accident
+// (permission denial masking the missing guard). Assert the error is
+// specifically the containment check's own message.
 func TestExtractTarGz_PathTraversal(t *testing.T) {
 	// Build archive with a path traversal entry
 	var buf bytes.Buffer
@@ -146,8 +153,12 @@ func TestExtractTarGz_PathTraversal(t *testing.T) {
 	_ = gw.Close()
 
 	dest := t.TempDir()
-	if err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest); err == nil {
-		t.Error("expected path traversal error, got nil")
+	err := ExtractTarGz(bytes.NewReader(buf.Bytes()), dest)
+	if err == nil {
+		t.Fatal("expected path traversal error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid file path in archive") {
+		t.Errorf("error = %q, want it to mention the containment check's own rejection (not e.g. an OS permission error from an escape that happened to reach a restricted path)", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #599 (security test coverage expansion). This pre-existing test was flagged during adversarial review of that PR but left out of scope there since it's unrelated code to those findings.

`TestExtractTarGz_PathTraversal` sends a 3-level `"../../../evil.txt"` escape against a shallow `t.TempDir()`. That specific depth happens to resolve all the way to filesystem root (`/evil.txt`), where the OS itself denies the write (non-root can't create files at `/`) — so the test's bare `err == nil` check couldn't tell "`ExtractTarGz`'s own containment check fired" apart from "the OS happened to deny the write anyway." A broken or removed containment check could still pass this test by accident.

## Change

Assert the error specifically mentions the containment check's own `"invalid file path in archive"` message, rather than any error.

## Verification

Disabled the real containment check in `internal/archiver/tarball.go` and reran:
- Old assertion (`err == nil`): still passed — `permission denied` satisfies a bare non-nil check.
- New assertion (message match): correctly failed — `"create file /evil.txt: ... permission denied"` doesn't mention `"invalid file path in archive"`.

Reverted the production change afterward (`git diff` confirmed `tarball.go` is untouched).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` passes repo-wide
- [x] `golangci-lint run ./internal/archiver/...` (CI-pinned v2.12.2): 0 issues
- [x] Confirmed the new assertion actually catches the masking scenario the old one missed