### PR TITLE
feat(auth)!: adopt terraform-suite-identity v0.17.0 (email_verified, ClientSecretCiphertext, ScopeAdmin guard)

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -998,7 +998,7 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		role, wanted := desiredRole[orgName]
 		// rejectIfNotProvisionable refuses the automatic, IdP-driven role
 		// assignment when the resolved role_template carries auth.ScopeAdmin —
-		// see guardProvisionableRole's doc for the full rationale (#604).
+		// see guardProvisionableRole's doc for the full rationale (#173).
 		// Deliberately does NOT flip `wanted` to false: on rejection this must
 		// skip the assignment, not fall through to the revoke branch below and
 		// tear down an existing (possibly unrelated, legitimately-granted)

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -998,7 +998,7 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		role, wanted := desiredRole[orgName]
 		// rejectIfNotProvisionable refuses the automatic, IdP-driven role
 		// assignment when the resolved role_template carries auth.ScopeAdmin —
-		// see guardProvisionableRole's doc for the full rationale (#173).
+		// see guardProvisionableRole's doc for the full rationale (#604).
 		// Deliberately does NOT flip `wanted` to false: on rejection this must
 		// skip the assignment, not fall through to the revoke branch below and
 		// tear down an existing (possibly unrelated, legitimately-granted)

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -362,6 +362,13 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 		var err error
 		var oidcGroups []string // populated for OIDC logins when group_claim_name is configured
 		var emailVerified *bool
+		// oidcEmailVerified carries the IdP's email_verified signal (as returned by
+		// ExtractUserInfo) through to GetOrCreateUserByOIDC, which uses it to gate
+		// new email->identity bindings (see terraform-suite-identity's fix for
+		// audit #52). It is distinct from emailVerified/enforceEmailVerified above,
+		// which implements this repo's own RequireVerifiedEmail login-rejection
+		// policy from the raw claim.
+		var oidcEmailVerified bool
 
 		// Exchange code for tokens based on provider
 		switch sessionState.ProviderType {
@@ -398,12 +405,8 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 				return
 			}
 
-			// Extract user info. The library's own emailVerified return is
-			// discarded here in favor of the existing emailVerifiedClaim(idToken)
-			// helper below, which this repo's enforceEmailVerified/RequireVerifiedEmail
-			// gate already relies on -- reconciling the two is left to the other
-			// v0.17.0-adoption PR in this batch.
-			sub, email, name, _, err = oidcProv.ExtractUserInfo(idToken)
+			// Extract user info
+			sub, email, name, oidcEmailVerified, err = oidcProv.ExtractUserInfo(idToken)
 			if err != nil {
 				slog.Error("oidc: failed to extract user info from ID token", "error", err)
 				callbackError("user_info_failed", "Failed to extract user information from the ID token.")
@@ -449,9 +452,8 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 				return
 			}
 
-			// Extract user info (see the OIDC branch above re: the discarded
-			// library emailVerified return).
-			sub, email, name, _, err = h.azureADProvider.ExtractUserInfo(idToken)
+			// Extract user info
+			sub, email, name, oidcEmailVerified, err = h.azureADProvider.ExtractUserInfo(idToken)
 			if err != nil {
 				slog.Error("azuread: failed to extract user info from ID token", "error", err)
 				callbackError("user_info_failed", "Failed to extract user information from the ID token.")
@@ -481,10 +483,7 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			callbackError("email_bound", err.Error())
 			return
 		}
-		// emailVerified gates new email->identity bindings inside GetOrCreateUserByOIDC
-		// (linking a pre-provisioned account or creating a new one); a returning
-		// user matched by oidc_sub is unaffected regardless of this value.
-		user, err := h.userRepo.GetOrCreateUserByOIDC(ctx, sub, email, name, emailVerified != nil && *emailVerified)
+		user, err := h.userRepo.GetOrCreateUserByOIDC(ctx, sub, email, name, oidcEmailVerified)
 		if err != nil {
 			callbackError("user_creation_failed", "Failed to look up or create your account.")
 			return
@@ -997,13 +996,34 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		}
 
 		role, wanted := desiredRole[orgName]
+		// rejectIfNotProvisionable refuses the automatic, IdP-driven role
+		// assignment when the resolved role_template carries auth.ScopeAdmin —
+		// see guardProvisionableRole's doc for the full rationale (#604).
+		// Deliberately does NOT flip `wanted` to false: on rejection this must
+		// skip the assignment, not fall through to the revoke branch below and
+		// tear down an existing (possibly unrelated, legitimately-granted)
+		// membership.
+		rejectIfNotProvisionable := func() bool {
+			if guardErr := h.guardProvisionableRole(ctx, role); guardErr != nil {
+				slog.Warn(provider+" group mapping rejected: resolved role is not automatically provisionable by an IdP-driven mapping; a human admin must grant it explicitly",
+					"user_id", userID, "org", orgName, "role", role, "error", guardErr)
+				return true
+			}
+			return false
+		}
 		switch {
 		case wanted && isMember:
+			if rejectIfNotProvisionable() {
+				continue
+			}
 			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, role); err != nil {
 				return fmt.Errorf("update member role org=%s user=%s role=%s: %w", org.ID, userID, role, err)
 			}
 			slog.Info(provider+" group mapping applied", "user_id", userID, "org", orgName, "role", role)
 		case wanted && !isMember:
+			if rejectIfNotProvisionable() {
+				continue
+			}
 			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, role); err != nil {
 				return fmt.Errorf("add member org=%s user=%s role=%s: %w", org.ID, userID, role, err)
 			}
@@ -1211,10 +1231,12 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Get or create user (reuse the OIDC path — sub is unique per IdP). The
-		// email is treated as verified: it comes from a signed SAML assertion the
-		// SP has already cryptographically validated, unlike a self-asserted OIDC
-		// claim.
+		// Get or create user (reuse the OIDC path — sub is unique per IdP).
+		// emailVerified=true: the email comes from a signed SAML assertion the IdP
+		// itself vouches for (validated above by ValidateResponse), not a value the
+		// end user self-asserts — the same trust level GetOrCreateUserByOIDC's
+		// emailVerified gate is designed to require before trusting a new
+		// email->identity binding.
 		user, err := h.userRepo.GetOrCreateUserByOIDC(ctx, sub, userInfo.Email, userInfo.Name, true)
 		if err != nil {
 			callbackError("user_creation_failed", "Failed to look up or create your account.")
@@ -1355,9 +1377,11 @@ func (h *AuthHandlers) LDAPLoginHandler() gin.HandlerFunc {
 			return
 		}
 
-		// The email is treated as verified: it comes from the LDAP directory entry
-		// of a principal who just proved control of the account via a successful
-		// bind, unlike a self-asserted OIDC claim.
+		// emailVerified=true: the email is an attribute read directly off the
+		// directory entry the user just bound-authenticated against (not a
+		// self-asserted claim), the same administratively-controlled trust level
+		// GetOrCreateUserByOIDC's emailVerified gate is designed to require before
+		// trusting a new email->identity binding.
 		user, err := h.userRepo.GetOrCreateUserByOIDC(ctx, sub, userInfo.Email, userInfo.Name, true)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to look up or create your account"})

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -897,6 +897,16 @@ func TestCallbackHandler_ErrorRedirectsToFrontend(t *testing.T) {
 var authOrgCols = []string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}
 var authMemberCols = []string{"organization_id", "user_id", "role_template_id", "created_at"}
 
+// expectRoleScopesLookup queues the guardProvisionableRole scopes lookup that
+// now runs before every "wanted" (add/update) branch of reconcileGroupMemberships.
+// scopes is marshaled to the JSON array the real `scopes` column holds.
+func expectRoleScopesLookup(mock sqlmock.Sqlmock, roleName string, scopes []string) {
+	scopesJSON, _ := json.Marshal(scopes)
+	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE name").
+		WithArgs(roleName).
+		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow(scopesJSON))
+}
+
 func TestApplyGroupMappings_MatchingGroup_AddMember(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
@@ -916,6 +926,9 @@ func TestApplyGroupMappings_MatchingGroup_AddMember(t *testing.T) {
 	// CheckMembership → GetMember → not found (no rows)
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols))
+
+	// guardProvisionableRole → scopes lookup (non-admin, so the write proceeds)
+	expectRoleScopesLookup(mock, "editor", []string{"modules:read", "modules:write"})
 
 	// AddMemberWithParams → lookup role template
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
@@ -944,8 +957,11 @@ func TestApplyGroupMappings_MatchingGroup_UpdateMember(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// Role is a non-admin role template deliberately: this test is about the
+	// UPDATE-member mechanics, not the ScopeAdmin guard (see
+	// TestReconcile_ResolvedRoleCarriesScopeAdmin_UpdatePath_Rejected for that).
 	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
-		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "admins", Organization: "acme", Role: "editor"},
 	}
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
@@ -961,10 +977,13 @@ func TestApplyGroupMappings_MatchingGroup_UpdateMember(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
 			AddRow("org-1", "user-1", &roleID, time.Now()))
 
+	// guardProvisionableRole → scopes lookup (non-admin, so the write proceeds)
+	expectRoleScopesLookup(mock, "editor", []string{"modules:read", "modules:write"})
+
 	// UpdateMemberRole → lookup role template
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
-		WithArgs("admin").
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-admin"))
+		WithArgs("editor").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-editor"))
 
 	// UpdateMemberRoleTemplate → UPDATE
 	mock.ExpectExec("UPDATE organization_members.*SET role_template_id").
@@ -1654,8 +1673,11 @@ func expectNotMember(mock sqlmock.Sqlmock) {
 		WillReturnRows(sqlmock.NewRows(authMemberCols))
 }
 
-// expectAddMember queues the role-template lookup + INSERT done by AddMemberWithParams.
+// expectAddMember queues the guardProvisionableRole scopes lookup (non-admin,
+// so the guard passes) followed by the role-template lookup + INSERT done by
+// AddMemberWithParams.
 func expectAddMember(mock sqlmock.Sqlmock, roleName, roleID string) {
+	expectRoleScopesLookup(mock, roleName, []string{"placeholder:scope"})
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 		WithArgs(roleName).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(roleID))
@@ -1663,8 +1685,11 @@ func expectAddMember(mock sqlmock.Sqlmock, roleName, roleID string) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
 
-// expectUpdateMember queues the role-template lookup + UPDATE done by UpdateMemberRole.
+// expectUpdateMember queues the guardProvisionableRole scopes lookup (non-admin,
+// so the guard passes) followed by the role-template lookup + UPDATE done by
+// UpdateMemberRole.
 func expectUpdateMember(mock sqlmock.Sqlmock, roleName, roleID string) {
+	expectRoleScopesLookup(mock, roleName, []string{"placeholder:scope"})
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 		WithArgs(roleName).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(roleID))
@@ -1736,14 +1761,16 @@ func TestReconcile_KeepsGroup_PreservesMembership(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// Role is a non-admin role template deliberately: this test is about
+	// preserving membership across logins, not the ScopeAdmin guard.
 	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
-		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "admins", Organization: "acme", Role: "editor"},
 	}
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
 	expectOrgByName(mock, "acme", "org-acme")
-	expectIsMember(mock, "org-acme", "user-1", "rt-admin")
-	expectUpdateMember(mock, "admin", "rt-admin")
+	expectIsMember(mock, "org-acme", "user-1", "rt-editor")
+	expectUpdateMember(mock, "editor", "rt-editor")
 
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
 	if err != nil {
@@ -1817,7 +1844,14 @@ func TestReconcile_DefaultRole_FirstLoginAdds(t *testing.T) {
 
 	expectOrgByName(mock, "default", "org-default")
 	expectNotMember(mock)
-	expectAddMember(mock, "viewer", "rt-viewer")
+	// default_role is a static, admin-configured fallback (not an IdP-driven
+	// group mapping), so guardProvisionableRole does not run here — no scopes
+	// lookup is expected, unlike expectAddMember's use elsewhere in this file.
+	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+		WithArgs("viewer").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-viewer"))
+	mock.ExpectExec("INSERT INTO organization_members").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"whatever"})
 	if err != nil {
@@ -1869,16 +1903,18 @@ func TestReconcile_MultipleGroupsSameOrg_Deterministic(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// Roles are both non-admin role templates deliberately: this test is about
+	// deterministic mapping-order precedence, not the ScopeAdmin guard.
 	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
-		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "admins", Organization: "acme", Role: "owner"},
 		{Group: "devs", Organization: "acme", Role: "editor"},
 	}
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
-	// User has BOTH groups. First config mapping (admins → admin) must win.
+	// User has BOTH groups. First config mapping (admins → owner) must win.
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	expectAddMember(mock, "admin", "rt-admin")
+	expectAddMember(mock, "owner", "rt-owner")
 
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"devs", "admins"})
 	if err != nil {
@@ -1895,8 +1931,10 @@ func TestReconcile_MultipleManagedOrgs_MixedActions(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// acme's role is a non-admin role template deliberately: this test is about
+	// reconciling multiple orgs in one login, not the ScopeAdmin guard.
 	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
-		{Group: "admins", Organization: "acme", Role: "admin"},
+		{Group: "admins", Organization: "acme", Role: "editor"},
 		{Group: "ops", Organization: "platform", Role: "operator"},
 	}
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
@@ -1904,7 +1942,7 @@ func TestReconcile_MultipleManagedOrgs_MixedActions(t *testing.T) {
 	// acme: has group → add member.
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	expectAddMember(mock, "admin", "rt-admin")
+	expectAddMember(mock, "editor", "rt-editor")
 	// platform: no group, currently a member → revoke.
 	expectOrgByName(mock, "platform", "org-platform")
 	expectIsMember(mock, "org-platform", "user-1", "rt-operator")
@@ -1937,6 +1975,103 @@ func TestReconcile_RevokeError_Surfaced(t *testing.T) {
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"not-admins"})
 	if err == nil {
 		t.Error("expected error from RemoveMember failure, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// reconcileGroupMemberships — ScopeAdmin guard (issue #604, defense-in-depth
+// adoption of terraform-suite-identity's ValidateProvisionableScopes). An
+// IdP-driven group mapping that resolves to a role_template carrying
+// auth.ScopeAdmin must be refused automatically, not silently granted.
+// ---------------------------------------------------------------------------
+
+// New member add is REJECTED when the resolved role_template's scopes carry
+// ScopeAdmin: no INSERT is issued, no error is returned (the login itself
+// still succeeds — only the automatic grant is refused and logged).
+func TestReconcile_ResolvedRoleCarriesScopeAdmin_AddPath_Rejected(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	// guardProvisionableRole's scopes lookup returns the grant-all wildcard —
+	// AddMemberWithParams (and its own "SELECT id FROM role_templates" lookup)
+	// must NEVER be reached.
+	expectRoleScopesLookup(mock, "admin", []string{"admin"})
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (no INSERT/role-template lookup should have been issued): %v", err)
+	}
+}
+
+// Existing member's role UPDATE is REJECTED the same way: the membership is
+// left untouched (not upgraded, and — importantly — not revoked either).
+func TestReconcile_ResolvedRoleCarriesScopeAdmin_UpdatePath_Rejected(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "admin"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-editor")
+	expectRoleScopesLookup(mock, "admin", []string{"admin"})
+	// No UPDATE (or the revoke DELETE) must follow.
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (no UPDATE/DELETE should have been issued): %v", err)
+	}
+}
+
+// A role_template whose scopes are a normal, non-admin set proceeds exactly as
+// before (already covered by the success-path tests above); this test only
+// pins down the "role name doesn't exist" edge case: guardProvisionableRole
+// must defer to AddMemberWithParams's own lookup error rather than swallowing
+// or duplicating it.
+func TestReconcile_GuardProvisionableRole_UnknownRoleTemplate_DefersToRealLookup(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "ghost-role"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectNotMember(mock)
+	// guardProvisionableRole's own scopes lookup finds no such role template.
+	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE name").
+		WithArgs("ghost-role").
+		WillReturnRows(sqlmock.NewRows([]string{"scopes"}))
+	// AddMemberWithParams's lookup is reached and fails with its own clear error.
+	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+		WithArgs("ghost-role").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err == nil {
+		t.Fatal("expected error from AddMemberWithParams' role template lookup, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }
 
@@ -1979,8 +2114,10 @@ func TestApplySAMLGroupMappings_KeepsGroup_Upserts(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// Role is a non-admin role template deliberately: this test is about the
+	// upsert mechanics, not the ScopeAdmin guard.
 	cfg.Auth.SAML.GroupMappings = []config.SAMLGroupMapping{
-		{Group: "saml-admins", Organization: "acme", Role: "admin"},
+		{Group: "saml-admins", Organization: "acme", Role: "editor"},
 	}
 	h := &AuthHandlers{
 		cfg:        cfg,
@@ -1991,7 +2128,7 @@ func TestApplySAMLGroupMappings_KeepsGroup_Upserts(t *testing.T) {
 
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	expectAddMember(mock, "admin", "rt-admin")
+	expectAddMember(mock, "editor", "rt-editor")
 
 	err := h.applySAMLGroupMappings(context.Background(), "user-1", []string{"saml-admins"})
 	if err != nil {
@@ -2125,14 +2262,16 @@ func TestApplyLDAPGroupMappings_CaseInsensitiveDN_Matches(t *testing.T) {
 
 	cfg := &config.Config{}
 	// Configured DN uses lowercase; the user presents a mixed/upper-case DN.
+	// Role is a non-admin role template deliberately: this test is about
+	// case-insensitive DN matching, not the ScopeAdmin guard.
 	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
-		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "editor"},
 	}
 	h := newLDAPHandler(db, cfg)
 
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	expectAddMember(mock, "admin", "rt-admin")
+	expectAddMember(mock, "editor", "rt-editor")
 
 	err := h.applyLDAPGroupMappings(context.Background(), "user-1",
 		[]string{"CN=Admins,OU=Groups,DC=Example,DC=Com"})
@@ -2232,16 +2371,18 @@ func TestApplyLDAPGroupMappings_MultipleDNsSameOrg_Deterministic(t *testing.T) {
 	defer db.Close()
 
 	cfg := &config.Config{}
+	// Roles are both non-admin role templates deliberately: this test is about
+	// deterministic mapping-order precedence, not the ScopeAdmin guard.
 	cfg.Auth.LDAP.GroupMappings = []config.LDAPGroupMapping{
-		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "admin"},
+		{GroupDN: "cn=admins,ou=groups,dc=example,dc=com", Organization: "acme", Role: "owner"},
 		{GroupDN: "cn=devs,ou=groups,dc=example,dc=com", Organization: "acme", Role: "editor"},
 	}
 	h := newLDAPHandler(db, cfg)
 
-	// User has BOTH DNs. First config mapping (admins → admin) must win.
+	// User has BOTH DNs. First config mapping (admins → owner) must win.
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	expectAddMember(mock, "admin", "rt-admin")
+	expectAddMember(mock, "owner", "rt-owner")
 
 	err := h.applyLDAPGroupMappings(context.Background(), "user-1", []string{
 		"cn=devs,ou=groups,dc=example,dc=com",

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -1979,7 +1979,7 @@ func TestReconcile_RevokeError_Surfaced(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// reconcileGroupMemberships — ScopeAdmin guard (issue #173, defense-in-depth
+// reconcileGroupMemberships — ScopeAdmin guard (issue #604, defense-in-depth
 // adoption of terraform-suite-identity's ValidateProvisionableScopes). An
 // IdP-driven group mapping that resolves to a role_template carrying
 // auth.ScopeAdmin must be refused automatically, not silently granted.

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -1979,7 +1979,7 @@ func TestReconcile_RevokeError_Surfaced(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// reconcileGroupMemberships — ScopeAdmin guard (issue #604, defense-in-depth
+// reconcileGroupMemberships — ScopeAdmin guard (issue #173, defense-in-depth
 // adoption of terraform-suite-identity's ValidateProvisionableScopes). An
 // IdP-driven group mapping that resolves to a role_template carrying
 // auth.ScopeAdmin must be refused automatically, not silently granted.

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -28,7 +28,7 @@ import (
 // carrying ScopeAdmin once a mapping names one — this guards against that
 // changing in the future (e.g. a lower-privileged, org-scoped mapping-writer
 // API), per terraform-suite-identity's ValidateProvisionableScopes doc and
-// this repo's issue #173.
+// this repo's issue #604.
 //
 // A role_template name that does not resolve to a row returns nil (no error):
 // the caller's own UpdateMemberRole/AddMemberWithParams performs the

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -1,0 +1,55 @@
+// group_mapping_guard.go guards reconcileGroupMemberships against an
+// IdP-driven group mapping resolving to a role_template that carries
+// auth.ScopeAdmin, the grant-all wildcard scope.
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+// guardProvisionableRole rejects a group mapping's resolved role_template when
+// its scopes carry auth.ScopeAdmin ("admin"). Call this in reconcileGroupMemberships
+// immediately before trusting a mapped Role for an automatic, IdP-driven
+// membership write (UpdateMemberRole / AddMemberWithParams) — never on a role
+// read back for an already-trusted, direct admin action (e.g. the manual
+// "make this user an admin" endpoints in organizations.go/setup/handlers.go,
+// which intentionally grant "admin" and must not be affected by this guard).
+//
+// This is defense-in-depth, not a fix for an active exploit: the group-mapping
+// CONFIG that names a Role is itself only reachable by a caller who already
+// holds ScopeAdmin (see internal/api/router.go's oidcAdminGroup gate), so an
+// unprivileged actor cannot plant Role: "admin" in a mapping today. But nothing
+// in reconcileGroupMemberships itself refuses to auto-apply a role_template
+// carrying ScopeAdmin once a mapping names one — this guards against that
+// changing in the future (e.g. a lower-privileged, org-scoped mapping-writer
+// API), per terraform-suite-identity's ValidateProvisionableScopes doc and
+// this repo's issue #604.
+//
+// A role_template name that does not resolve to a row returns nil (no error):
+// the caller's own UpdateMemberRole/AddMemberWithParams performs the
+// authoritative name lookup immediately afterward and surfaces a clear
+// "role template not found" error there, so this guard does not need to
+// duplicate that failure mode. Any other lookup/parse failure is returned
+// (fails closed) — a transient DB error here should not silently let an
+// unverified role's scopes through.
+func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) error {
+	var scopesJSON []byte
+	err := h.db.QueryRowContext(ctx,
+		`SELECT scopes FROM role_templates WHERE name = $1`, roleTemplateName).Scan(&scopesJSON)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("look up role template %q scopes: %w", roleTemplateName, err)
+	}
+	var scopes []string
+	if err := json.Unmarshal(scopesJSON, &scopes); err != nil {
+		return fmt.Errorf("parse role template %q scopes: %w", roleTemplateName, err)
+	}
+	return auth.ValidateProvisionableScopes(scopes)
+}

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -28,7 +28,7 @@ import (
 // carrying ScopeAdmin once a mapping names one — this guards against that
 // changing in the future (e.g. a lower-privileged, org-scoped mapping-writer
 // API), per terraform-suite-identity's ValidateProvisionableScopes doc and
-// this repo's issue #604.
+// this repo's issue #173.
 //
 // A role_template name that does not resolve to a row returns nil (no error):
 // the caller's own UpdateMemberRole/AddMemberWithParams performs the

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -244,10 +244,14 @@ func (h *Handlers) SaveOIDCConfig(c *gin.Context) {
 		name = "default"
 	}
 
-	// Create the new OIDC config. CreateOIDCConfig deactivates any existing
-	// configs and inserts the new one atomically (single transaction) when
-	// IsActive is true, enforcing the single-active-config invariant without
-	// the race window a separate deactivate-then-create pair would have.
+	// Create the new OIDC config. As of terraform-suite-identity v0.17.0,
+	// CreateOIDCConfig itself wraps the insert in a deactivate-all-then-
+	// activate-one transaction whenever IsActive is true (the same transaction
+	// ActivateOIDCConfig uses), so the single-active-config invariant is
+	// enforced atomically at write time. The previously-separate explicit
+	// DeactivateAllOIDCConfigs call is no longer needed here — keeping it would
+	// just reintroduce the transient "zero active configs" window between two
+	// non-atomic calls that this transaction is designed to close.
 	now := time.Now()
 	oidcCfg := &models.OIDCConfig{
 		ID:                     uuid.New(),

--- a/backend/internal/api/setup/handlers_test.go
+++ b/backend/internal/api/setup/handlers_test.go
@@ -407,7 +407,10 @@ func TestSaveOIDCConfig_DeactivateError(t *testing.T) {
 		"redirect_url":  "https://app/callback",
 	})
 
-	// Deactivate-others (within CreateOIDCConfig's transaction) fails.
+	// terraform-suite-identity v0.17.0+: CreateOIDCConfig(IsActive: true) wraps
+	// the deactivate-all step in its own transaction (see handlers.go's
+	// SaveOIDCConfig comment) — a failure there rolls back and surfaces as a
+	// CreateOIDCConfig error, same as an INSERT failure below.
 	env.oidcMock.ExpectBegin()
 	env.oidcMock.ExpectExec("UPDATE oidc_config SET is_active = false").
 		WillReturnError(errDB)
@@ -418,6 +421,9 @@ func TestSaveOIDCConfig_DeactivateError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if err := env.oidcMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }
 
@@ -448,6 +454,9 @@ func TestSaveOIDCConfig_CreateError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	if err := env.oidcMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
 }
 
 func TestSaveOIDCConfig_Success(t *testing.T) {
@@ -464,8 +473,10 @@ func TestSaveOIDCConfig_Success(t *testing.T) {
 		"redirect_url":  "https://app/callback",
 	})
 
-	// CreateOIDCConfig deactivates existing configs and inserts the new one
-	// atomically in a single transaction (single-active-config invariant).
+	// CreateOIDCConfig(IsActive: true) wraps deactivate-all + insert in one
+	// transaction (terraform-suite-identity v0.17.0+; see handlers.go's
+	// SaveOIDCConfig comment) — no separate, non-transactional deactivate call
+	// precedes it.
 	env.oidcMock.ExpectBegin()
 	env.oidcMock.ExpectExec("UPDATE oidc_config SET is_active = false").
 		WillReturnResult(sqlmock.NewResult(0, 0))
@@ -481,6 +492,9 @@ func TestSaveOIDCConfig_Success(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+	if err := env.oidcMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 
 	resp := getJSON(w)

--- a/backend/internal/api/suite_test.go
+++ b/backend/internal/api/suite_test.go
@@ -184,6 +184,18 @@ func TestStartSuiteDiscovery_NilWhenNoSiblingURL(t *testing.T) {
 	}
 }
 
+// TestStartSuiteDiscovery_NilOnPlaintextSiblingURL verifies startSuiteDiscovery
+// degrades to standalone (nil, logged) rather than panicking or starting an
+// insecure client, now that suite.NewDiscoveryClient fails closed on a
+// plaintext "http://" sibling URL (terraform-suite-identity v0.17.0+).
+func TestStartSuiteDiscovery_NilOnPlaintextSiblingURL(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Suite.SiblingURL = "http://tfstate.internal.example.com"
+	if dc := startSuiteDiscovery(cfg); dc != nil {
+		t.Error("expected nil when SiblingURL uses plaintext HTTP")
+	}
+}
+
 func TestUIConfigHandler_ForwardsIdentityBlock(t *testing.T) {
 	sibling := suite.Manifest{
 		SchemaVersion: suite.SchemaVersionV1,

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -115,15 +115,25 @@ func ValidateJWTSecret() error {
 		// current secret — in a coupled suite deployment sharing TFR_JWT_SECRET
 		// with a sibling app (per ADR 012), that sibling's tokens (or a token
 		// crafted with a spoofed iss) would be silently accepted here (issue #559
-		// finding [0]). This does not add audience enforcement (the shared
-		// TokenManager has no audience support yet); that half of the finding
-		// requires a change to the terraform-suite-identity library itself.
+		// finding [0]).
 		//
 		// This is the default, standalone-safe set (own issuer only). A coupled
 		// suite deployment extends it via SetTrustedIssuers (suite.trusted_issuers
 		// / TFR_SUITE_TRUSTED_ISSUERS), called once at startup after this
 		// function; see cmd/server/main.go.
 		tokenManager.SetAllowedIssuers([]string{jwtIssuer})
+		// Stamp/require this app's own identity as the audience (issue #559
+		// finding [0], completed via #608). An issuer pin alone still lets a
+		// trusted sibling's token through unchanged; SetAudience closes that gap
+		// by additionally requiring a token — even one from a trusted sibling
+		// issuer — to have been minted FOR this app specifically. Audience
+		// support (SetAudience/NewCoupledTokenManager) is new in
+		// terraform-suite-identity v0.17.0; before that bump this half of the
+		// finding could not be closed without a library change. Safe to enable
+		// unconditionally: Validate only enforces the check once set, so a
+		// standalone (non-coupled) deployment is unaffected beyond every token
+		// now also carrying/requiring its own aud claim.
+		tokenManager.SetAudience(jwtIssuer)
 	})
 
 	return jwtSecretErr

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -345,8 +345,13 @@ func TestSetTrustedIssuers(t *testing.T) {
 
 	// A token signed with the SAME secret but a different issuer — simulating
 	// a sibling app in a coupled suite deployment sharing TFR_JWT_SECRET
-	// (ADR 012).
+	// (ADR 012). The sibling also stamps this app's own identity as the
+	// audience, as terraform-suite-identity's coupled-suite guidance directs a
+	// well-behaved sibling to do when minting a token meant to be honored here
+	// — see TestValidateJWT_AudienceEnforced below for the cases where it does
+	// not (or audiences it for itself instead).
 	siblingTM := identityauth.NewTokenManager(secret, "terraform-state-manager")
+	siblingTM.SetAudience(jwtIssuer)
 	siblingToken, err := siblingTM.Generate("user-1", "user1@example.com", nil, time.Hour)
 	if err != nil {
 		t.Fatalf("sibling Generate: %v", err)
@@ -417,6 +422,79 @@ func TestSetTrustedIssuers(t *testing.T) {
 		// The real (non-blank) entry alongside it must still work.
 		if _, err := ValidateJWT(siblingToken); err != nil {
 			t.Errorf("legitimate sibling issuer should still be trusted: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Audience enforcement (issue #559 finding [0], completed via #608)
+// ---------------------------------------------------------------------------
+
+// TestValidateJWT_AudienceEnforced confirms ValidateJWTSecret now also stamps
+// and requires this app's own audience, closing the half of #559 finding [0]
+// that SetAllowedIssuers alone left open: a trusted sibling issuer is no
+// longer sufficient on its own — the token must also have been minted FOR
+// this app.
+func TestValidateJWT_AudienceEnforced(t *testing.T) {
+	resetJWTSecret()
+	secret := "test-jwt-secret-that-is-32-chars-!"
+	t.Setenv("TFR_JWT_SECRET", secret)
+	if err := ValidateJWTSecret(); err != nil {
+		t.Fatalf("ValidateJWTSecret: %v", err)
+	}
+	t.Cleanup(func() { SetTrustedIssuers(nil) })
+	SetTrustedIssuers([]string{"terraform-state-manager"})
+	t.Cleanup(func() { SetTrustedIssuers(nil) })
+
+	t.Run("own token carries own audience and validates", func(t *testing.T) {
+		token, err := GenerateJWT("user-1", "user1@example.com", nil, time.Hour)
+		if err != nil {
+			t.Fatalf("GenerateJWT: %v", err)
+		}
+		if _, err := ValidateJWT(token); err != nil {
+			t.Errorf("own token with own audience should validate: %v", err)
+		}
+	})
+
+	t.Run("trusted issuer but no audience claim is rejected", func(t *testing.T) {
+		// The sibling's issuer is trusted (see SetTrustedIssuers above), but this
+		// token never had an audience stamped — simulating a sibling that has not
+		// (yet) adopted SetAudience. Trusting the issuer must not be enough on
+		// its own.
+		siblingTM := identityauth.NewTokenManager(secret, "terraform-state-manager")
+		token, err := siblingTM.Generate("attacker-or-unaware-sibling", "x@example.com", []string{"admin"}, time.Hour)
+		if err != nil {
+			t.Fatalf("sibling Generate: %v", err)
+		}
+		if _, err := ValidateJWT(token); err == nil {
+			t.Error("a trusted-issuer token with no audience claim must be rejected once this app requires an audience")
+		}
+	})
+
+	t.Run("trusted issuer but wrong audience is rejected", func(t *testing.T) {
+		// The sibling stamps ITS OWN identity as the audience (i.e. mints a
+		// normal token for its own use), not this app's — this must not validate
+		// here even though the issuer is trusted and the secret matches.
+		siblingTM := identityauth.NewTokenManager(secret, "terraform-state-manager")
+		siblingTM.SetAudience("terraform-state-manager")
+		token, err := siblingTM.Generate("user-1", "user1@example.com", nil, time.Hour)
+		if err != nil {
+			t.Fatalf("sibling Generate: %v", err)
+		}
+		if _, err := ValidateJWT(token); err == nil {
+			t.Error("a trusted-issuer token audienced for a different app must be rejected")
+		}
+	})
+
+	t.Run("trusted issuer and correct audience validates", func(t *testing.T) {
+		siblingTM := identityauth.NewTokenManager(secret, "terraform-state-manager")
+		siblingTM.SetAudience(jwtIssuer)
+		token, err := siblingTM.Generate("user-1", "user1@example.com", nil, time.Hour)
+		if err != nil {
+			t.Fatalf("sibling Generate: %v", err)
+		}
+		if _, err := ValidateJWT(token); err != nil {
+			t.Errorf("a trusted-issuer token correctly audienced for this app should validate: %v", err)
 		}
 	})
 }

--- a/backend/internal/auth/scopes.go
+++ b/backend/internal/auth/scopes.go
@@ -159,3 +159,18 @@ func ValidateScopeString(scope string) error {
 	}
 	return nil
 }
+
+// ValidateProvisionableScopes rejects ScopeAdmin ("admin") from a scope list,
+// naming it specifically, and returns nil otherwise. Call this when mapping
+// externally-influenced data (an OIDC/SAML/LDAP IdP group claim, a SCIM
+// attribute, or any other value a lower-trust source contributes) onto a
+// scope/role list, BEFORE that list is trusted or persisted — never on scopes
+// read back from an already-trusted, admin-seeded role_template, where
+// carrying ScopeAdmin is expected and legitimate.
+//
+// Thin wrapper over identityauth.ValidateProvisionableScopes, matching this
+// file's existing pattern of re-exporting the shared identity module's
+// scope-checking helpers.
+func ValidateProvisionableScopes(scopes []string) error {
+	return identityauth.ValidateProvisionableScopes(scopes)
+}

--- a/backend/internal/auth/scopes_test.go
+++ b/backend/internal/auth/scopes_test.go
@@ -152,6 +152,28 @@ func TestValidateScopeString(t *testing.T) {
 	}
 }
 
+func TestValidateProvisionableScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		scopes  []string
+		wantErr bool
+	}{
+		{"empty list", []string{}, false},
+		{"non-admin scopes", []string{"modules:read", "providers:write"}, false},
+		{"admin alone", []string{"admin"}, true},
+		{"admin among others", []string{"modules:read", "admin"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProvisionableScopes(tt.scopes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProvisionableScopes(%v) error = %v, wantErr %v", tt.scopes, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGetDefaultScopes(t *testing.T) {
 	scopes := GetDefaultScopes()
 	if len(scopes) == 0 {

--- a/backend/internal/db/repositories/oidc_config_repository_test.go
+++ b/backend/internal/db/repositories/oidc_config_repository_test.go
@@ -604,11 +604,16 @@ func TestCreateOIDCConfig_Success(t *testing.T) {
 // TestCreateOIDCConfig_ActiveSuccess covers the IsActive=true path: the
 // identity store enforces the single-active-config invariant by wrapping the
 // deactivate-others + insert steps in one transaction.
+//
+// terraform-suite-identity v0.17.0+: creating an already-active config wraps
+// the insert in the same deactivate-all-then-activate-one transaction
+// ActivateOIDCConfig uses, so the single-active-config invariant is
+// enforced at write time (see CreateOIDCConfig's doc comment).
 func TestCreateOIDCConfig_ActiveSuccess(t *testing.T) {
 	repo, mock := newOIDCConfigRepo(t)
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE oidc_config SET is_active = false").
-		WillReturnResult(sqlmock.NewResult(0, 1))
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("INSERT INTO oidc_config").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
@@ -628,6 +633,39 @@ func TestCreateOIDCConfig_ActiveSuccess(t *testing.T) {
 	err := repo.CreateOIDCConfig(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestCreateOIDCConfig_Inactive_PlainInsert covers the !IsActive path, which
+// remains a plain, untransacted insert (behavior unchanged from before
+// v0.17.0) — added alongside the now-transactional active-config test above so
+// both CreateOIDCConfig code paths have explicit coverage.
+func TestCreateOIDCConfig_Inactive_PlainInsert(t *testing.T) {
+	repo, mock := newOIDCConfigRepo(t)
+	mock.ExpectExec("INSERT INTO oidc_config").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	cfg := &models.OIDCConfig{
+		ID:           uuid.New(),
+		Name:         "test",
+		ProviderType: "generic_oidc",
+		IssuerURL:    "https://issuer.example.com",
+		ClientID:     "client-id",
+		RedirectURL:  "https://app.example.com/callback",
+		IsActive:     false,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	err := repo.CreateOIDCConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Bumps `github.com/sethbacon/terraform-suite-identity` to `v0.17.0` and adopts every call-site change the release requires. This bundles three issues into one PR because they all touch the same dependency bump — landing them separately would guarantee `go.mod`/`go.sum` merge conflicts between the PRs.

## What changed

### #606 — `email_verified` plumbing (breaking)
`oidc.Provider.ExtractUserInfo` gained a 5th return value (`emailVerified bool`), and `store.UserRepository.GetOrCreateUserByOIDC`/`GetOrCreateUserFromOIDC` gained a required `emailVerified bool` parameter. Fixed every call site:

- `internal/auth/azuread/provider.go` — wrapper signature updated, forwards the identity library's value.
- `internal/api/admin/auth.go` (OIDC + Azure AD login in `CallbackHandler`) — the real IdP `email_verified` claim is captured from `ExtractUserInfo` and forwarded into `GetOrCreateUserByOIDC`.
- `internal/api/admin/auth.go` (SAML ACS handler, LDAP login handler) — pass `true`. Neither protocol carries an OIDC `email_verified` claim; SAML's email comes from a signed assertion the IdP itself vouches for, and LDAP's comes from a directory attribute the user just bound-authenticated against — both are the IdP-controlled trust level the gate is designed to require, not a self-asserted value.
- `internal/api/scim/handlers.go` — pass `true` with a comment: SCIM provisioning already trusts the calling IdP's directory sync out of band, so there's no lower-trust signal to check against.

This is safe: the new parameter only tightens `GetOrCreateUserFromOIDC`'s behavior (refusing to establish a *new* email→identity binding — a fresh account or linking a pre-provisioned one — when the email isn't verified). Returning users matched by `oidc_sub` are unaffected. Real OIDC/Azure AD logins now forward the actual claim; SAML/LDAP/SCIM correctly assert `true` since none of those paths has a lower-trust, self-asserted email to distrust.

### #607 — `ClientSecretEncrypted` → `ClientSecretCiphertext` (mechanical)
Renamed at the two call sites backed by the identity library's aliased `OIDCConfig` type: `internal/api/router_startup.go` (`tokenCipher.Open(...)`) and `internal/api/setup/handlers.go` (struct literal). `internal/scm/types.go`'s own, unrelated `ClientSecretEncrypted` field (a separate SCM-provider struct) is untouched, per the issue's own explicit callout. No behavior change — this repo already encrypts the secret itself via `tokenCipher.Seal`/`.Open`.

### #604 — ScopeAdmin guard on IdP-driven group→role mappings (partial, per its own scope)
Wired `auth.ValidateProvisionableScopes` (new in v0.17.0) into `reconcileGroupMemberships`, the single choke point shared by `applyGroupMappings` (OIDC), `applySAMLGroupMappings`, and `applyLDAPGroupMappings`. Added `internal/api/admin/group_mapping_guard.go`: right before an IdP-driven mapping's resolved role is trusted (`UpdateMemberRole`/`AddMemberWithParams`), the role_template's scopes are looked up and checked; if they carry the `admin` wildcard, the automatic assignment is refused (logged) and the existing membership — if any — is left untouched (deliberately does **not** fall through to the revoke branch, since that would tear down an unrelated, legitimately-granted membership).

As #604 documents, this is defense-in-depth, not a fix for an active exploit: the mapping config that names a `Role` already requires `ScopeAdmin` to write today (`internal/api/router.go`'s `oidcAdminGroup` gate). This closes the path in advance for if that gate is ever loosened (e.g. a lower-privileged, org-scoped mapping-writer API). The cross-org privilege escalation item on the #609 checklist was already fixed separately (#611, merged to `main` ahead of this branch) and isn't part of this PR.

### #608 — `SetAudience` (cross-app JWT replay protection, completes #559 finding [0])
An earlier fix wired up `SetAllowedIssuers` (`internal/auth/jwt.go`) to pin JWT validation to this app's own issuer, but explicitly deferred the audience half of the finding, since the shared `TokenManager` had no audience support prior to `v0.17.0`. Now that this PR bumps to `v0.17.0` (which adds `SetAudience`/`NewCoupledTokenManager`), that blocker is gone, so `ValidateJWTSecret` now also calls `tokenManager.SetAudience(jwtIssuer)` right alongside the issuer pin — this app's own identity, matching the library's coupled-suite guidance. An issuer pin alone still lets a *trusted* sibling's token through unchanged; the audience check additionally requires the token to have been minted for this app specifically, closing the cross-app replay gap in a deployment sharing `TFR_JWT_SECRET` (ADR 012). Safe to enable unconditionally — `Validate` only enforces the check once an audience is set, so this is backward compatible for standalone (non-coupled) deployments, at the cost of every token now also carrying/requiring its own `aud` claim (a one-time, expected re-login for any session token minted before this deploys, since none of those carry an `aud` claim yet).

New `TestValidateJWT_AudienceEnforced` covers: an own-minted token still validates; a trusted-issuer token with no audience claim is rejected; one audienced for a different app is rejected; one correctly audienced for this app validates. `TestSetTrustedIssuers`' sibling-token fixture was updated to carry the correct audience so it continues to exercise the issuer-trust path in isolation rather than incidentally tripping the new audience check.

**Behavior change to flag:** an IdP group mapping that resolves to a role_template carrying `ScopeAdmin` (e.g. a mapping literally configured with `Role: "admin"`) will no longer be auto-applied on login. It's refused and logged instead; a human admin must grant it explicitly via the direct admin API. Existing tests that used `Role: "admin"` as incidental sample data (not testing this guard) were renamed to a neutral role; new tests (`TestReconcile_ResolvedRoleCarriesScopeAdmin_*`) cover the guard itself.

### Other fallout from the bump (beyond the three issues above)
A clean build/test/lint on v0.17.0 is the point of this PR, so these are fixed too:

- **`suite.NewDiscoveryClient` fail-closed signature** (identity v0.17.0, also the subject of open issue #605): it now returns `(*DiscoveryClient, error)` and fails closed on a plaintext `http://` sibling URL (protects the unauthenticated manifest fetch from tampering). `startSuiteDiscovery` now logs and degrades to standalone instead of erroring; tests against `httptest`'s plaintext loopback servers moved to the new `NewInsecureDiscoveryClient` (the documented, sanctioned use case for that constructor). Added a test confirming `startSuiteDiscovery` returns `nil` for a plaintext sibling URL. This incidentally resolves #605 too.
- **`oidc.Provider.GetAuthURL` deprecated** in favor of `BeginAuth` (nonce+PKCE) — newly flagged by `golangci-lint`'s staticcheck (SA1019). Migrating is a real behavior change to the callback verification path (state persistence, PKCE verifier plumbing), so it's intentionally out of scope here; suppressed with a justified `//nolint:staticcheck` at the two production call sites and three tests that intentionally exercise the deprecated method, matching this repo's existing convention (see `internal/storage/gcs/gcs.go`).
- **`CreateOIDCConfig` now wraps an active config's insert in its own transaction** (deactivate-all-then-insert, mirroring `ActivateOIDCConfig`) when `IsActive: true`. Removed the now-redundant, separately-called `DeactivateAllOIDCConfigs` in `SaveOIDCConfig` — keeping it would only reintroduce the transient "zero active configs" window between two non-atomic calls that the library's new transaction is designed to close. Updated the affected repository/handler tests to mock the transaction (`ExpectBegin`/`ExpectCommit`/`ExpectRollback`) instead of two separate calls.
- **`AddMemberWithParams`/`UpdateMemberRole`'s role-template-by-name lookup now fails closed**: an unresolvable role name returns a clear "role template not found" error instead of silently inserting a `NULL` role_template_id. Updated the one test (`TestAddMemberWithParams_TemplateNotFound`) that asserted the old silent-fallback behavior.

## Verification gate (all green)

| Step | Result |
|---|---|
| `go mod tidy && git diff --exit-code go.mod go.sum` | Diff is exactly the intended v0.17.0 bump (+ transitive `golang.org/x/net`); re-running `tidy` a second time produces zero further changes |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `golangci-lint run ./...` (v2.12.2, pinned) | 0 issues |
| `go test ./...` | all packages pass |
| `gosec` (v2.26.1, pinned) vs `gosec-baseline.json` via `scripts/gosec-compare.py` | 18 active findings, matches baseline exactly — 0 new, 0 resolved |

Added/updated tests: `internal/auth/azuread/provider_delegation_test.go`, `internal/auth/oidc/provider_test.go`, `internal/auth/scopes_test.go` (`TestValidateProvisionableScopes`), `internal/auth/jwt_test.go` (`TestValidateJWT_AudienceEnforced`), `internal/api/admin/auth_test.go` (ScopeAdmin-guard tests + renamed incidental `"admin"` sample roles), `internal/api/suite_test.go`/`suite_consumers_test.go`, `internal/api/setup/handlers_test.go`, `internal/db/models/oidc_config_test.go`, `internal/db/repositories/oidc_config_repository_test.go`, `internal/db/repositories/organization_repository_test.go`.

## For the maintainer

Once this merges, **#609** (final: pin to v0.17.0) can be closed — this PR *is* that pin plus its required call-site updates (the cross-org item on its checklist was already closed separately by #611). Not closing it myself per the task instructions.

Closes #606, #607, #608, and (partially, per its own scope) #604.

---

**Update:** an adversarial review of this PR's first version flagged that it bumped to v0.17.0 (which is exactly the release that added `SetAudience`/`NewCoupledTokenManager`) while leaving `SetAudience` itself uncalled and issue #608 open — the code comment justifying that gap ("the shared TokenManager has no audience support yet") was consequently stale/incorrect as of this very bump. Fixed in the latest commit; see the `#608` section above and the verification gate, both re-run clean after the fix.

