### PR TITLE
feat(helm): wire suite coupling into the registry chart

### DIFF
--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -69,6 +69,15 @@ data:
   TFR_MULTI_TENANCY_ENABLED: {{ .Values.multiTenancy.enabled | quote }}
   TFR_MULTI_TENANCY_DEFAULT_ORGANIZATION: {{ .Values.multiTenancy.defaultOrganization | quote }}
 
+  # Suite coupling (optional; standalone by default — see docs/identity-schema.md).
+  # The shared service token (Consumed-by gate) lives in the Secret.
+  TFR_SUITE_SIBLING_URL: {{ .Values.suite.siblingUrl | quote }}
+  TFR_SUITE_ROLE_SEED_OWNER: {{ .Values.suite.roleSeedOwner | quote }}
+  TFR_SUITE_IDENTITY_SHARED_STORE: {{ .Values.suite.identitySharedStore | quote }}
+  {{- if .Values.suite.trustedIssuers }}
+  TFR_SUITE_TRUSTED_ISSUERS: {{ join "," .Values.suite.trustedIssuers | quote }}
+  {{- end }}
+
   # Security (TLS terminated at Ingress)
   TFR_SECURITY_TLS_ENABLED: "false"
   TFR_SECURITY_RATE_LIMITING_ENABLED: {{ .Values.security.rateLimiting.enabled | quote }}

--- a/deployments/helm/templates/secret.yaml
+++ b/deployments/helm/templates/secret.yaml
@@ -31,4 +31,9 @@ stringData:
   {{- if and .Values.auth.azureAd.enabled .Values.auth.azureAd.clientSecret }}
   TFR_AUTH_AZURE_AD_CLIENT_SECRET: {{ .Values.auth.azureAd.clientSecret | quote }}
   {{- end }}
+  {{- if .Values.suite.siblingToken }}
+  # Shared suite service token gating the cross-app "Consumed by" read; must
+  # equal the sibling TSM's TSM_SUITE_SERVICE_TOKEN. Empty disables the feature.
+  TFR_SUITE_SIBLING_TOKEN: {{ .Values.suite.siblingToken | quote }}
+  {{- end }}
 {{- end }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -210,6 +210,29 @@ security:
     #   allowedOrigins: ["https://registry.example.com"]
     allowedOrigins: []
 
+# -- Suite coupling with the Terraform State Manager. Standalone by default.
+# A COUPLED deployment (sharing one identity database and/or JWT secret) MUST
+# set roleSeedOwner to exactly one owner ("registry" or "tsm") across both
+# apps to avoid clobbering each other's shared role scopes. See
+# docs/identity-schema.md if also cutting over to the shared identity DB schema.
+suite:
+  # -- Sibling TSM's public origin (its /suite/manifest is polled). Empty = standalone.
+  siblingUrl: ""
+  # -- Role-template seeder / identity owner: self | registry | tsm.
+  roleSeedOwner: "self"
+  # -- Set true only when both apps share one identity database + IdP (enables seamless SSO).
+  identitySharedStore: false
+  # -- Shared service token sent (X-Suite-Service-Token) when this app proxies a
+  # cross-app "Consumed by" read to the sibling TSM. Empty disables the proxy.
+  # Must equal the sibling's TSM_SUITE_SERVICE_TOKEN. Ignored if
+  # security.existingSecret is set (add TFR_SUITE_SIBLING_TOKEN there instead).
+  siblingToken: ""
+  # -- Additional trusted JWT issuers, for a coupled suite deployment sharing
+  # security.jwtSecret with sibling apps. Empty (default) means only this app's
+  # own tokens validate — the standalone-safe default. Example:
+  #   trustedIssuers: ["terraform-state-manager"]
+  trustedIssuers: []
+
 # -- Redis configuration (optional, enables HA features)
 # When redis.host is set, rate limiting uses distributed GCRA in Redis and
 # OIDC session state is stored in Redis -- both required for correct behavior


### PR DESCRIPTION
## Summary
- Closes #615: this chart had zero wiring for the suite-coupling feature (siblingUrl, roleSeedOwner, identitySharedStore, siblingToken, trustedIssuers), while terraform-state-manager-backend's chart already has full first-class support for its side of the same feature.
- Adds a `suite:` values block and wires it into `configmap.yaml`/`secret.yaml`, mirroring TSM's pattern exactly (same key names/shape) with one addition: `trustedIssuers`, which has no TSM equivalent since this app's `SuiteConfig` uniquely supports configurable trusted JWT issuers (`TFR_SUITE_TRUSTED_ISSUERS`).
- Standalone deployments are unaffected — all new values default to empty/false/self, rendering the same as before (verified below).

## Test plan
- [x] `helm lint` clean (pre-existing INFO-level "missing required value" messages are unrelated to this change — they're for `security.jwtSecret`/`encryptionKey`/`externalDatabase.password`, expected when those aren't set).
- [x] `helm template` with suite values unset renders no `TFR_SUITE_TRUSTED_ISSUERS`/`TFR_SUITE_SIBLING_TOKEN` lines (correctly empty/standalone).
- [x] `helm template` with suite values set (siblingUrl, roleSeedOwner=registry, identitySharedStore=true, siblingToken, trustedIssuers=[terraform-state-manager]) renders all fields correctly, including the comma-joined `trustedIssuers` list.
- [x] `kubeconform` validates all 15 rendered resources clean in both cases.