### PR TITLE
feat(release): publish the FIPS-140-3 Docker image variant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,115 @@ jobs:
           echo "  --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+  # ── Build + push FIPS-140-3 Docker image ─────────────────────────────────
+  # BoringCrypto-linked variant (backend/Dockerfile.fips) for FIPS-constrained
+  # environments. Mirrors the `docker` job above; only the Dockerfile and tag
+  # suffix differ.
+  docker-fips:
+    name: Publish FIPS Docker image
+    runs-on: ubuntu-latest
+    needs: ci
+    permissions:
+      contents: read
+      packages: write # required to push to ghcr.io
+      id-token: write # required for Sigstore OIDC (cosign keyless signing)
+      attestations: write # required for GitHub build provenance attestation
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (FIPS)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}-fips
+            type=semver,pattern={{major}}.{{minor}}-fips
+            type=semver,pattern={{major}}-fips
+            type=raw,value=fips,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: backend/
+          file: backend/Dockerfile.fips
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+
+      - name: Trivy image scan (published digest)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          format: table
+
+      - name: Generate SBOM for container image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: image-sbom-fips.spdx.json
+
+      - name: Upload container SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: container-sbom-fips
+          path: image-sbom-fips.spdx.json
+          retention-days: 90
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image with cosign (keyless)
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{
+          steps.build.outputs.digest }}"
+
+      - name: Attest build provenance (container)
+        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Print verification commands
+        run: |
+          echo "## Supply-chain verification (FIPS image)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Verify cosign signature" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "cosign verify \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-identity-regexp 'https://github\\.com/${{ github.repository_owner }}/terraform-registry-backend/' \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Verify build provenance" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "gh attestation verify \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
   # ── Publish the GitHub Release ────────────────────────────────────────────
   # release-please creates a DRAFT GitHub Release (with changelog) when the
   # release PR is merged (configured via "draft": true in
@@ -255,7 +364,7 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
-    needs: [goreleaser, docker]
+    needs: [goreleaser, docker, docker-fips]
     permissions:
       contents: write
     steps:
@@ -284,9 +393,17 @@ jobs:
           docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${TAG}
           \`\`\`
 
+          ## FIPS-140-3 Docker Image
+
+          BoringCrypto-linked variant for FIPS-constrained environments (see backend/Dockerfile.fips).
+
+          \`\`\`
+          docker pull ghcr.io/${GITHUB_REPOSITORY_OWNER}/terraform-registry-backend:${TAG#v}-fips
+          \`\`\`
+
           ## Supply-chain verification
 
-          Build provenance is attested via GitHub Artifact Attestations and the container image is signed with cosign (keyless, Sigstore).
+          Build provenance is attested via GitHub Artifact Attestations and both images are signed with cosign (keyless, Sigstore) — substitute the FIPS tag above to verify that image instead.
 
           \`\`\`bash
           # Verify binary provenance


### PR DESCRIPTION
## Summary
- `backend/Dockerfile.fips` (BoringCrypto-linked, `GOEXPERIMENT=boringcrypto`) has existed since the FIPS compliance work landed but was never actually built or published by any workflow — dormant, only buildable locally per its own header comment.
- Adds a `docker-fips` job mirroring the existing `docker` job exactly: metadata extraction, build+push, Trivy image scan (blocking on HIGH/CRITICAL), SBOM generation, cosign signing, and build-provenance attestation — tagged with a `-fips` suffix (e.g. `3.0.0-fips`, `3-fips`, `fips`).
- `publish-release` now waits on `docker-fips` too, and the GitHub Release notes document the FIPS pull command alongside the standard image.
- Found while auditing Trivy coverage across all repos that produce a Docker image — this repo already had exemplary Trivy setup, but the FIPS variant it ships was silently unpublished.

## Test plan
- [x] YAML validated (`yaml.safe_load` + `actionlint`).
- [x] Every action pinned to the exact same SHA as the sibling `docker` job (buildx, build-push-action, trivy-action, sbom-action, cosign-installer, attest-build-provenance).