### PR TITLE
fix(deps): bump Go 1.26.4 -> 1.26.5 to close two stdlib CVEs

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-registry/terraform-registry
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.63.1


### PR DESCRIPTION
## Summary
Closes #620, #621 (auto-filed by the OSV-Scanner / govulncheck weekly scans).

Three findings from the scan:
- **GO-2026-5856** (crypto/tls Encrypted Client Hello privacy leak) — confirmed **reachable** by govulncheck via LDAP StartTLS, the HTTP server, the SMTP mailer, and the Azure DevOps connector. Fixed in go1.26.5.
- **GO-2026-4970** / CVE-2026-39822 (`os.Root` sandbox escape via trailing-slash symlink) — not reachable from our code today, but fixed by the same bump.
- **GO-2026-5932** (`golang.org/x/crypto/openpgp`: unmaintained, no fixed version exists anywhere) — **not fixed by this PR**. It's a transitive dependency of `sigstore/rekor/pkg/pki/pgp` (we're already on the latest `sigstore-go` v1.2.2 / `rekor` v1.5.3 — no newer version drops it), and govulncheck confirms it's not reachable from our own code. Tracked as an accepted risk pending an upstream fix from sigstore/rekor; nothing on our side can resolve it right now.

The Docker images (`backend/Dockerfile`, `Dockerfile.fips`) were already pinned to `golang:1.26.5-alpine` from earlier work — only `go.mod`'s `go` directive (which drives CI's toolchain via `setup-backend`'s `go-version-file`) was still behind, so CI itself was building/testing against the vulnerable 1.26.4.

## Test plan
- [x] `govulncheck ./...` locally: 0 vulnerabilities in code, 0 in imported packages (down from 1 reachable + 1 unreachable stdlib finding) — only the untouched, unfixable x/crypto/openpgp finding remains, correctly reported as "in modules you require" (not called).
- [x] `go mod tidy` — clean diff, no other dependency drift.
- [x] Full verification gate: build, vet, gofmt, golangci-lint (0 issues), full test suite `-race` (stable across two independent runs), filtered coverage 80.0% (floor 80%), gosec vs baseline (0 new findings).