### PR TITLE
test(notifications): restore 80% coverage gate for delivery channels

### DIFF
--- a/backend/internal/api/admin/notification_channels_test.go
+++ b/backend/internal/api/admin/notification_channels_test.go
@@ -1,0 +1,319 @@
+package admin
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+	"github.com/terraform-registry/terraform-registry/internal/notify"
+)
+
+var adminChannelCols = []string{
+	"id", "name", "type", "encrypted_target", "events", "enabled",
+	"last_status", "last_error", "last_sent_at", "created_at", "updated_at",
+}
+
+func adminChannelRow(id uuid.UUID, enc string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows(adminChannelCols).AddRow(
+		id, "ops", "webhook", enc, []byte(`["cve_detected"]`), true,
+		nil, nil, nil, now, now)
+}
+
+// newChannelHandlers builds the handlers over a sqlmock-backed repository and a
+// real token cipher. guard is the egress guard used for create/update target
+// validation (pass nil to skip the egress check in a test).
+func newChannelHandlers(t *testing.T, guard *httpsafe.Guard) (*NotificationChannelHandlers, sqlmock.Sqlmock, *crypto.TokenCipher) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewNotificationChannelRepository(db)
+	tc, err := crypto.NewTokenCipher(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	notifier := notify.NewNotifier(repo, nil, tc, httpsafe.MustGuard("127.0.0.1"))
+	return NewNotificationChannelHandlers(repo, notifier, tc, guard), mock, tc
+}
+
+func channelTestCtx(method, body string, params gin.Params) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, "/", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = params
+	return c, w
+}
+
+func TestNotificationChannelRequest_Validate(t *testing.T) {
+	strict := httpsafe.MustGuard() // strict default policy
+
+	cases := []struct {
+		name    string
+		req     notificationChannelRequest
+		guard   *httpsafe.Guard
+		wantErr bool
+	}{
+		{"bad type", notificationChannelRequest{Type: "sms"}, nil, true},
+		{"unknown event", notificationChannelRequest{Type: "webhook", Events: []string{"nope"}}, nil, true},
+		{"email valid", notificationChannelRequest{Type: "email", Target: "ops@example.com"}, nil, false},
+		{"email invalid", notificationChannelRequest{Type: "email", Target: "not-an-email"}, nil, true},
+		{"url valid, nil guard", notificationChannelRequest{Type: "webhook", Target: "https://hooks.example.com/x"}, nil, false},
+		{"url bad scheme", notificationChannelRequest{Type: "webhook", Target: "ftp://host/y"}, nil, true},
+		{"url no host", notificationChannelRequest{Type: "webhook", Target: "https://"}, nil, true},
+		{"guard blocks metadata", notificationChannelRequest{Type: "webhook", Target: "http://169.254.169.254/latest"}, strict, true},
+		{"empty target ok", notificationChannelRequest{Type: "slack"}, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.validate(tc.guard)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validate() err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNotificationChannelRequest_Events(t *testing.T) {
+	if got := (&notificationChannelRequest{}).events(); got == nil || len(got) != 0 {
+		t.Errorf("events() on nil = %v, want empty non-nil slice", got)
+	}
+	if got := (&notificationChannelRequest{Events: []string{"cve_detected"}}).events(); len(got) != 1 {
+		t.Errorf("events() = %v, want 1 entry", got)
+	}
+}
+
+func TestListChannels(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	mock.ExpectQuery("FROM notification_channels ORDER BY").WillReturnRows(adminChannelRow(uuid.New(), "ENC"))
+	c, w := channelTestCtx(http.MethodGet, "", nil)
+	h.ListChannels(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestListChannels_Error(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	mock.ExpectQuery("FROM notification_channels ORDER BY").WillReturnError(errors.New("boom"))
+	c, w := channelTestCtx(http.MethodGet, "", nil)
+	h.ListChannels(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestCreateChannel(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	mock.ExpectQuery("INSERT INTO notification_channels").WillReturnRows(adminChannelRow(uuid.New(), "ENC"))
+	body := `{"name":"ops","type":"webhook","target":"https://hooks.example.com/x","events":["cve_detected"]}`
+	c, w := channelTestCtx(http.MethodPost, body, nil)
+	h.CreateChannel(c)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateChannel_BadJSON(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPost, `{bad`, nil)
+	h.CreateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestCreateChannel_InvalidType(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPost, `{"name":"x","type":"sms","target":"y"}`, nil)
+	h.CreateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestCreateChannel_MissingTarget(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPost, `{"name":"x","type":"webhook"}`, nil)
+	h.CreateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestCreateChannel_RepoError(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	mock.ExpectQuery("INSERT INTO notification_channels").WillReturnError(errors.New("boom"))
+	body := `{"name":"ops","type":"webhook","target":"https://hooks.example.com/x"}`
+	c, w := channelTestCtx(http.MethodPost, body, nil)
+	h.CreateChannel(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestUpdateChannel(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnRows(adminChannelRow(id, "ENC"))
+	body := `{"name":"ops","type":"webhook","target":"https://hooks.example.com/x"}`
+	c, w := channelTestCtx(http.MethodPut, body, gin.Params{{Key: "id", Value: id.String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannel_KeepTarget(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnRows(adminChannelRow(id, "ENC"))
+	// No target => the encrypt step is skipped and the existing target kept.
+	body := `{"name":"ops","type":"webhook"}`
+	c, w := channelTestCtx(http.MethodPut, body, gin.Params{{Key: "id", Value: id.String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateChannel_InvalidID(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPut, `{"name":"x","type":"webhook"}`, gin.Params{{Key: "id", Value: "not-a-uuid"}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestUpdateChannel_BadJSON(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPut, `{bad`, gin.Params{{Key: "id", Value: uuid.New().String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestUpdateChannel_ValidateFail(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPut, `{"name":"x","type":"sms"}`, gin.Params{{Key: "id", Value: uuid.New().String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestUpdateChannel_RepoError(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnError(errors.New("boom"))
+	body := `{"name":"ops","type":"webhook","target":"https://hooks.example.com/x"}`
+	c, w := channelTestCtx(http.MethodPut, body, gin.Params{{Key: "id", Value: id.String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestUpdateChannel_NotFound(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnError(sql.ErrNoRows)
+	body := `{"name":"ops","type":"webhook","target":"https://hooks.example.com/x"}`
+	c, w := channelTestCtx(http.MethodPut, body, gin.Params{{Key: "id", Value: id.String()}})
+	h.UpdateChannel(c)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestDeleteChannel(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+	c, _ := channelTestCtx(http.MethodDelete, "", gin.Params{{Key: "id", Value: id.String()}})
+	h.DeleteChannel(c)
+	// DeleteChannel replies 204 with no body; c.Status() buffers the code on the
+	// gin writer without flushing it to the recorder, so assert on the writer.
+	if c.Writer.Status() != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", c.Writer.Status(), http.StatusNoContent)
+	}
+}
+
+func TestDeleteChannel_InvalidID(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodDelete, "", gin.Params{{Key: "id", Value: "bad"}})
+	h.DeleteChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestDeleteChannel_RepoError(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectExec("DELETE FROM notification_channels").WillReturnError(errors.New("boom"))
+	c, w := channelTestCtx(http.MethodDelete, "", gin.Params{{Key: "id", Value: id.String()}})
+	h.DeleteChannel(c)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestTestChannel_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h, mock, tc := newChannelHandlers(t, nil)
+	enc, err := tc.Seal(srv.URL)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	id := uuid.New()
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnRows(adminChannelRow(id, enc))
+	mock.ExpectExec("UPDATE notification_channels SET last_status").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	c, w := channelTestCtx(http.MethodPost, "", gin.Params{{Key: "id", Value: id.String()}})
+	h.TestChannel(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTestChannel_InvalidID(t *testing.T) {
+	h, _, _ := newChannelHandlers(t, nil)
+	c, w := channelTestCtx(http.MethodPost, "", gin.Params{{Key: "id", Value: "bad"}})
+	h.TestChannel(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d", w.Code)
+	}
+}
+
+func TestTestChannel_NotFound(t *testing.T) {
+	h, mock, _ := newChannelHandlers(t, nil)
+	id := uuid.New()
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnError(sql.ErrNoRows)
+	c, w := channelTestCtx(http.MethodPost, "", gin.Params{{Key: "id", Value: id.String()}})
+	h.TestChannel(c)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code = %d", w.Code)
+	}
+}

--- a/backend/internal/db/repositories/notification_channel_repository_test.go
+++ b/backend/internal/db/repositories/notification_channel_repository_test.go
@@ -1,0 +1,254 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+func newNotificationChannelRepo(t *testing.T) (*NotificationChannelRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewNotificationChannelRepository(db), mock
+}
+
+var notificationChannelTestCols = []string{
+	"id", "name", "type", "encrypted_target", "events", "enabled",
+	"last_status", "last_error", "last_sent_at", "created_at", "updated_at",
+}
+
+// fullChannelRow populates every nullable column and a non-empty events array,
+// exercising the JSON unmarshal and the Valid branches of scanNotificationChannel.
+func fullChannelRow(id uuid.UUID, enc string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows(notificationChannelTestCols).AddRow(
+		id, "ops-webhook", "webhook", enc, []byte(`["cve_detected"]`), true,
+		"sent", "prior failure", now, now, now)
+}
+
+// minimalChannelRow uses NULL status/error/sent_at and NULL events, exercising
+// the empty-events and nil-NullX branches of scanNotificationChannel.
+func minimalChannelRow(id uuid.UUID, enc string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows(notificationChannelTestCols).AddRow(
+		id, "ops-mail", "email", enc, nil, true,
+		nil, nil, nil, now, now)
+}
+
+func TestNotificationChannelRepo_Create(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("INSERT INTO notification_channels").
+		WillReturnRows(fullChannelRow(id, "ENC"))
+
+	ch := &models.NotificationChannel{Name: "ops-webhook", Type: "webhook", EncryptedTarget: "ENC", Events: []string{"cve_detected"}, Enabled: true}
+	saved, err := repo.Create(context.Background(), ch)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if saved.ID != id {
+		t.Errorf("ID = %v, want %v", saved.ID, id)
+	}
+	if saved.EncryptedTarget != "" {
+		t.Error("Create must redact EncryptedTarget in the returned channel")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNotificationChannelRepo_Create_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("INSERT INTO notification_channels").WillReturnError(errDB)
+	if _, err := repo.Create(context.Background(), &models.NotificationChannel{Events: []string{}}); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_List(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("FROM notification_channels ORDER BY created_at DESC").
+		WillReturnRows(fullChannelRow(id, "ENC"))
+	list, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	if list[0].EncryptedTarget != "" {
+		t.Error("List must redact EncryptedTarget")
+	}
+	if list[0].LastStatus == nil || *list[0].LastStatus != "sent" {
+		t.Error("expected LastStatus 'sent'")
+	}
+}
+
+func TestNotificationChannelRepo_List_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("FROM notification_channels ORDER BY").WillReturnError(errDB)
+	if _, err := repo.List(context.Background()); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_GetByID(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("FROM notification_channels WHERE id").
+		WillReturnRows(minimalChannelRow(id, "ENC"))
+	ch, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if ch == nil || ch.ID != id {
+		t.Fatalf("GetByID returned %+v", ch)
+	}
+	if len(ch.Events) != 0 {
+		t.Errorf("expected empty events, got %v", ch.Events)
+	}
+	if ch.EncryptedTarget != "ENC" {
+		t.Error("GetByID must return the encrypted target for decryption")
+	}
+}
+
+func TestNotificationChannelRepo_GetByID_NotFound(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnError(sql.ErrNoRows)
+	ch, err := repo.GetByID(context.Background(), uuid.New())
+	if err != nil || ch != nil {
+		t.Errorf("GetByID(no rows) = (%v, %v), want (nil, nil)", ch, err)
+	}
+}
+
+func TestNotificationChannelRepo_GetByID_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnError(errDB)
+	if _, err := repo.GetByID(context.Background(), uuid.New()); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_GetByID_BadEventsJSON(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	now := time.Now()
+	rows := sqlmock.NewRows(notificationChannelTestCols).AddRow(
+		id, "x", "webhook", "ENC", []byte("{not-json"), true,
+		nil, nil, nil, now, now)
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnRows(rows)
+	if _, err := repo.GetByID(context.Background(), id); err == nil {
+		t.Error("expected JSON unmarshal error")
+	}
+}
+
+func TestNotificationChannelRepo_Update(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").
+		WillReturnRows(fullChannelRow(id, "ENC"))
+	updated, err := repo.Update(context.Background(), id, "ops", "webhook", []string{"cve_detected"}, true, "NEWENC")
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated == nil || updated.EncryptedTarget != "" {
+		t.Error("Update must return a redacted channel")
+	}
+}
+
+func TestNotificationChannelRepo_Update_KeepTarget(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("UPDATE notification_channels").
+		WillReturnRows(minimalChannelRow(id, "ENC"))
+	// Empty encryptedTarget => COALESCE keeps the existing one.
+	if _, err := repo.Update(context.Background(), id, "ops", "email", nil, false, ""); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+func TestNotificationChannelRepo_Update_NotFound(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnError(sql.ErrNoRows)
+	ch, err := repo.Update(context.Background(), uuid.New(), "n", "webhook", nil, true, "E")
+	if err != nil || ch != nil {
+		t.Errorf("Update(no rows) = (%v, %v), want (nil, nil)", ch, err)
+	}
+}
+
+func TestNotificationChannelRepo_Update_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("UPDATE notification_channels").WillReturnError(errDB)
+	if _, err := repo.Update(context.Background(), uuid.New(), "n", "webhook", nil, true, "E"); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_Delete(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectExec("DELETE FROM notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := repo.Delete(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestNotificationChannelRepo_Delete_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectExec("DELETE FROM notification_channels").WillReturnError(errDB)
+	if err := repo.Delete(context.Background(), uuid.New()); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_ListEnabledForEvent(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	id := uuid.New()
+	mock.ExpectQuery("WHERE enabled").WillReturnRows(fullChannelRow(id, "ENC"))
+	list, err := repo.ListEnabledForEvent(context.Background(), "cve_detected")
+	if err != nil {
+		t.Fatalf("ListEnabledForEvent: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	// The encrypted target must be retained here (it is needed to send).
+	if list[0].EncryptedTarget != "ENC" {
+		t.Error("ListEnabledForEvent must retain the encrypted target")
+	}
+}
+
+func TestNotificationChannelRepo_ListEnabledForEvent_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectQuery("WHERE enabled").WillReturnError(errDB)
+	if _, err := repo.ListEnabledForEvent(context.Background(), "cve_detected"); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestNotificationChannelRepo_RecordDelivery(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectExec("UPDATE notification_channels SET last_status").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	if err := repo.RecordDelivery(context.Background(), uuid.New(), "sent", "", time.Now()); err != nil {
+		t.Fatalf("RecordDelivery: %v", err)
+	}
+}
+
+func TestNotificationChannelRepo_RecordDelivery_DBError(t *testing.T) {
+	repo, mock := newNotificationChannelRepo(t)
+	mock.ExpectExec("UPDATE notification_channels SET last_status").WillReturnError(errDB)
+	if err := repo.RecordDelivery(context.Background(), uuid.New(), "failed", "boom", time.Now()); err == nil {
+		t.Error("expected error")
+	}
+}

--- a/backend/internal/notify/mailer.go
+++ b/backend/internal/notify/mailer.go
@@ -91,6 +91,9 @@ func sanitizeHeader(s string) string {
 // Use this when UseTLS=true and the port is 465; for port 587 STARTTLS,
 // smtp.SendMail handles the upgrade automatically — but we call this path for
 // both so the config is unambiguous: UseTLS=true always means an encrypted connection.
+// coverage:skip:integration-only — implicit-TLS dial plus a live SMTP protocol
+// exchange; cannot be meaningfully unit-tested without a real SMTP-over-TLS server
+// (the sibling Send is skipped for the same reason).
 func sendMailTLS(addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
 	tlsConfig := &tls.Config{
 		ServerName: host,

--- a/backend/internal/notify/notifier_delivery_test.go
+++ b/backend/internal/notify/notifier_delivery_test.go
@@ -1,0 +1,240 @@
+package notify
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+)
+
+var notifyChannelCols = []string{
+	"id", "name", "type", "encrypted_target", "events", "enabled",
+	"last_status", "last_error", "last_sent_at", "created_at", "updated_at",
+}
+
+// newTestNotifier builds a Notifier over a sqlmock-backed channel repository, a
+// real token cipher, and an egress guard that allow-lists loopback so an
+// httptest server (127.0.0.1) is a reachable channel target.
+func newTestNotifier(t *testing.T) (*Notifier, sqlmock.Sqlmock, *crypto.TokenCipher) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewNotificationChannelRepository(db)
+	tc, err := crypto.NewTokenCipher(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return NewNotifier(repo, nil, tc, httpsafe.MustGuard("127.0.0.1")), mock, tc
+}
+
+func webhookChannelRow(id uuid.UUID, enc string) *sqlmock.Rows {
+	now := time.Now()
+	return sqlmock.NewRows(notifyChannelCols).AddRow(
+		id, "ops", "webhook", enc, []byte(`["cve_detected"]`), true,
+		nil, nil, nil, now, now)
+}
+
+func TestNotifier_NilIsNoOp(t *testing.T) {
+	var n *Notifier
+	n.Notify(context.Background(), Event{Type: EventCVEDetected}) // must not panic
+	if err := n.SendTest(context.Background(), uuid.New()); err == nil {
+		t.Error("SendTest on a nil Notifier should return an error")
+	}
+}
+
+func TestParseRecipients(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"single", "ops@example.com", 1, false},
+		{"multiple with spaces", "a@example.com, b@example.com ", 2, false},
+		{"skips blanks", "a@example.com,,", 1, false},
+		{"empty", "", 0, true},
+		{"only blanks", " , ", 0, true},
+		{"invalid", "not-an-email", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseRecipients(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseRecipients(%q) err = %v, wantErr %v", tc.in, err, tc.wantErr)
+			}
+			if err == nil && len(got) != tc.want {
+				t.Errorf("ParseRecipients(%q) = %d recipients, want %d", tc.in, len(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestTeamsPayload(t *testing.T) {
+	p := teamsPayload("Title", "Body")
+	if p["type"] != "message" {
+		t.Errorf("type = %v, want message", p["type"])
+	}
+	if _, ok := p["attachments"]; !ok {
+		t.Error("teams payload missing attachments")
+	}
+}
+
+func TestNotifier_send(t *testing.T) {
+	n, _, _ := newTestNotifier(t)
+	for _, typ := range []string{"webhook", "slack", "teams"} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		if err := n.send(context.Background(), typ, srv.URL, "Title", "Message"); err != nil {
+			t.Errorf("send(%s): unexpected error %v", typ, err)
+		}
+		srv.Close()
+	}
+}
+
+func TestNotifier_send_Non2xx(t *testing.T) {
+	n, _, _ := newTestNotifier(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	if err := n.send(context.Background(), "webhook", srv.URL, "t", "m"); err == nil {
+		t.Error("expected an error for a non-2xx destination response")
+	}
+}
+
+func TestNotifier_send_TransportErrorRedacted(t *testing.T) {
+	n, _, _ := newTestNotifier(t)
+	// Loopback is allow-listed by the test guard, so the request is attempted
+	// and fails to connect (port 1). The error must not embed the target URL.
+	target := "http://127.0.0.1:1/secret-webhook-token"
+	err := n.send(context.Background(), "webhook", target, "t", "m")
+	if err == nil {
+		t.Fatal("expected a connection error")
+	}
+	if got := err.Error(); contains(got, "secret-webhook-token") {
+		t.Errorf("send error leaked the target URL: %q", got)
+	}
+}
+
+func TestNotifier_decryptTarget(t *testing.T) {
+	n, _, tc := newTestNotifier(t)
+	enc, err := tc.Seal("https://hooks.example.com/x")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	got, err := n.decryptTarget(&models.NotificationChannel{EncryptedTarget: enc})
+	if err != nil || got != "https://hooks.example.com/x" {
+		t.Fatalf("decryptTarget = (%q, %v)", got, err)
+	}
+	if _, err := n.decryptTarget(&models.NotificationChannel{EncryptedTarget: ""}); err == nil {
+		t.Error("decryptTarget with no target should error")
+	}
+	if _, err := n.decryptTarget(&models.NotificationChannel{EncryptedTarget: "not-valid-ciphertext"}); err == nil {
+		t.Error("decryptTarget with a bad ciphertext should error")
+	}
+}
+
+func TestNotifier_sendEmail_InvalidRecipients(t *testing.T) {
+	n, _, _ := newTestNotifier(t)
+	// ParseRecipients fails before the (nil) mailer is touched.
+	if err := n.sendEmail("not-an-email", "t", "m"); err == nil {
+		t.Error("sendEmail with an invalid recipient should error")
+	}
+}
+
+func TestNotifier_Notify_DeliversToChannel(t *testing.T) {
+	hit := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case hit <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, mock, tc := newTestNotifier(t)
+	enc, err := tc.Seal(srv.URL)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	mock.ExpectQuery("WHERE enabled").WillReturnRows(webhookChannelRow(uuid.New(), enc))
+	mock.ExpectExec("UPDATE notification_channels SET last_status").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	n.Notify(context.Background(), Event{Type: EventCVEDetected, Title: "t", Message: "m"})
+	select {
+	case <-hit:
+	default:
+		t.Error("expected the webhook endpoint to receive the notification")
+	}
+}
+
+func TestNotifier_Notify_RepoError(t *testing.T) {
+	n, mock, _ := newTestNotifier(t)
+	mock.ExpectQuery("WHERE enabled").WillReturnError(sql.ErrConnDone)
+	// A repository failure is logged, not panicked or propagated.
+	n.Notify(context.Background(), Event{Type: EventCVEDetected})
+}
+
+func TestNotifier_Notify_DecryptError(t *testing.T) {
+	n, mock, _ := newTestNotifier(t)
+	// An undecryptable target makes delivery fail; the failure must be recorded
+	// (exercises deliver's error path and record's "failed" branch).
+	mock.ExpectQuery("WHERE enabled").WillReturnRows(webhookChannelRow(uuid.New(), "not-decryptable"))
+	mock.ExpectExec("UPDATE notification_channels SET last_status").WillReturnResult(sqlmock.NewResult(0, 1))
+	n.Notify(context.Background(), Event{Type: EventCVEDetected, Title: "t", Message: "m"})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNotifier_SendTest_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, mock, tc := newTestNotifier(t)
+	enc, err := tc.Seal(srv.URL)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	id := uuid.New()
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnRows(webhookChannelRow(id, enc))
+	mock.ExpectExec("UPDATE notification_channels SET last_status").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := n.SendTest(context.Background(), id); err != nil {
+		t.Fatalf("SendTest: %v", err)
+	}
+}
+
+func TestNotifier_SendTest_NotFound(t *testing.T) {
+	n, mock, _ := newTestNotifier(t)
+	mock.ExpectQuery("FROM notification_channels WHERE id").WillReturnError(sql.ErrNoRows)
+	if err := n.SendTest(context.Background(), uuid.New()); err == nil {
+		t.Error("SendTest for a missing channel should return an error")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Restores the unit-test coverage gate (80% filtered floor) that the 3.2.0 release PR (#626) is failing.

The notification delivery-channel feature from #625 (channel repository, admin CRUD handlers, and the `Notifier` fan-out) merged with almost no unit tests, dropping filtered coverage from ~80% to **78.7%** and failing the release CI gate.

## Changes

Unit tests only (no production behavior change):

- **`internal/db/repositories`** — sqlmock tests for every `NotificationChannel` DAO method (create / list / get / update / delete / list-enabled-for-event / record-delivery) and the row scanner, including not-found and DB-error paths. Package coverage: 86.9% → 90.1%.
- **`internal/notify`** — the delivery path end-to-end over a sqlmock-backed repo and an `httptest` server whose loopback address is allow-listed on the egress guard: `Notify`, `SendTest`, `send` (webhook / Slack / Teams payloads), `decryptTarget`, `ParseRecipients`, `teamsPayload`, the non-2xx and transport-error (URL-redaction) branches, and the `record` "failed" path.
- **`internal/api/admin`** — handler tests for list / create / update / delete / test plus the request `validate()` matrix (bad type, unknown event, email vs URL target, egress-guard rejection).
- **`internal/notify/mailer.go`** — marks the integration-only `sendMailTLS` with `coverage:skip:integration-only`, matching its sibling `Send`: it performs an implicit-TLS dial and a live SMTP protocol exchange and cannot be meaningfully unit-tested.

## Result

Filtered coverage: **78.7% → 80.2%**. Full suite passes; `internal/db/repositories` stays above its 85% per-package floor.

## Context

Root cause of the missed gate: #625 was squash-merged with a `[skip ci]` directive (from a swagger-regen commit) in the squash body, which suppressed all workflows on the merge — so neither CI nor Release Please ran, and the coverage regression wasn't caught until the release PR was cut manually.
