### PR TITLE
ci(trivy): patch base OS packages and ignore unfixed CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,9 @@ jobs:
           scan-type: fs
           scan-ref: backend/
           severity: HIGH,CRITICAL
+          # Only fail on vulnerabilities that have a fix available; un-actionable
+          # (no-fix-yet) CVEs shouldn't block CI.
+          ignore-unfixed: true
           exit-code: 1
           format: table
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,9 @@ jobs:
           scan-type: image
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           severity: HIGH,CRITICAL
+          # Only fail on vulnerabilities that have a fix available; un-actionable
+          # (no-fix-yet) CVEs shouldn't block a release.
+          ignore-unfixed: true
           exit-code: 1
           format: table
 
@@ -298,6 +301,9 @@ jobs:
           scan-type: image
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           severity: HIGH,CRITICAL
+          # Only fail on vulnerabilities that have a fix available; un-actionable
+          # (no-fix-yet) CVEs shouldn't block a release.
+          ignore-unfixed: true
           exit-code: 1
           format: table
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,8 +36,11 @@ RUN CLEAN_VERSION="${VERSION#v}" && \
 # Stage 2: Create minimal production image
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-# Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata
+# Apply the latest Alpine security patches on top of the digest-pinned base (the
+# pin freezes the package set, so a rebuild otherwise keeps shipping the base
+# layer's OS CVEs), then install runtime dependencies.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates tzdata
 
 # Create non-root user
 RUN addgroup -g 1000 registry && \

--- a/backend/Dockerfile.fips
+++ b/backend/Dockerfile.fips
@@ -38,7 +38,10 @@ RUN CLEAN_VERSION="${VERSION#v}" && \
 # Stage 2: Create minimal production image
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-RUN apk add --no-cache ca-certificates tzdata
+# Apply the latest Alpine security patches on top of the digest-pinned base (see
+# ./Dockerfile) before installing runtime dependencies.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates tzdata
 
 RUN addgroup -g 1000 registry && \
     adduser -D -u 1000 -G registry registry


### PR DESCRIPTION
## What

Defensive Trivy hardening for the backend image, matching the frontend fixes:

- **`apk upgrade --no-cache`** in the runtime stage of both `backend/Dockerfile` and `backend/Dockerfile.fips` — the base is pinned by digest (`alpine:3.24@sha256:...`), which freezes the package set, so a rebuild otherwise keeps shipping the base layer's OS CVEs.
- **`ignore-unfixed: true`** on all three Trivy steps (the two release image scans — regular + FIPS — and the CI filesystem scan) so a build is only blocked by CVEs that actually have a fix available; un-actionable (no-fix-yet) CVEs no longer gate a release.

## Context

Trivy blocks releases on HIGH/CRITICAL CVEs (`exit-code: 1`). The registry **frontend**'s v2.17.0 release just failed on `c-ares`/`curl`/`libexpat` HIGHs plus a baked-in TLS key. This backend image is **currently passing** — minimal alpine doesn't ship those nginx packages — so this is defensive hardening against the same class of failure, not an active fix.

`ignore-unfixed` affects only vulnerability findings, not secret/misconfig findings. No application code changes.
