### PR TITLE
feat(helm): support extra init containers on the backend pod

### DIFF
--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       serviceAccountName: {{ include "terraform-registry.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
+      {{- with .Values.backend.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: backend
           image: {{ include "terraform-registry.backendImage" . }}

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -58,6 +58,11 @@ backend:
   extraVolumeMounts: []
   # -- Additional volumes
   extraVolumes: []
+  # -- Additional init containers on the backend pod (e.g. to install a
+  #    private/enterprise CA bundle into the container's trust store before
+  #    the app starts, using extraVolumes/extraVolumeMounts to share the
+  #    result). Raw Kubernetes initContainer specs, passed through as-is.
+  extraInitContainers: []
 
 # -- Frontend configuration
 frontend:


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

Adds `backend.extraInitContainers` (raw Kubernetes initContainer specs,
passed through as-is) to the Helm chart, alongside the existing
`backend.extraVolumes` / `extraVolumeMounts` / `extraEnv` passthrough values.

Motivating use case: an operator needs the backend's outbound suite-sibling
discovery client (`internal/api/suite.go`, `terraform-suite-identity` v0.17.0+)
to trust a private/enterprise CA when the sibling's HTTPS certificate chains
to it -- e.g. an internal AKS deployment where the registry's sibling URL
must be `https://` (plaintext `http://` now fails closed) but the sibling's
enterprise cert isn't in the public CA bundle baked into the image.

This lets an operator's own values file wire up: a ConfigMap-mounted CA
bundle -> an init container that copies it into
`/usr/local/share/ca-certificates`, runs `update-ca-certificates`, and
writes the merged bundle to a shared `emptyDir` -> the main container
mounts that over `/etc/ssl/certs/ca-certificates.crt` (subPath). No CA
bytes or enterprise-specific logic are added to this chart -- everything
specific lives in the operator's private values file.

## Changelog

- feat: add `backend.extraInitContainers` to the Helm chart for injecting init containers (e.g. to trust a private CA) without baking secrets/certs into the public image

## Checklist

Chart-only change (no Go code touched).

- [ ] `go test ./...` passes
- [ ] `go fmt ./...` and `go vet ./...` clean
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Verified locally: `helm lint deployments/helm/` (same flags as CI) passes,
and `helm template ... --set backend.extraInitContainers[0].name=... --set
backend.extraInitContainers[0].image=...` renders the expected
`initContainers:` block.
