### PR TITLE
fix(helm): apply backend.extraInitContainers to scanner-worker too

### DIFF
--- a/deployments/helm/templates/scanner-worker-deployment.yaml
+++ b/deployments/helm/templates/scanner-worker-deployment.yaml
@@ -36,6 +36,10 @@ spec:
       serviceAccountName: {{ include "terraform-registry.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.backend.podSecurityContext | nindent 8 }}
+      {{- with .Values.backend.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: scanner-worker
           image: {{ include "terraform-registry.backendImage" . }}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

The scanner-worker Deployment already shares `backend.extraVolumes` /
`extraVolumeMounts` with the main backend Deployment (so workers inherit
the same storage/database credentials), but was missing the matching
`backend.extraInitContainers` passthrough added in #629.

An operator using `extraInitContainers` + `extraVolumes` to populate a
shared volume (e.g. merging a private CA into `/etc/ssl/certs` via an
init container, as `terraform-registry-aks` now does) got the volume
**mount** on scanner-worker without the init container that populates
it -- an empty `emptyDir` subPath-mounted over an existing file crashes
the container at the OCI runtime level:

```text
OCI runtime create failed: ... error mounting ".../ca-bundle/..." to
rootfs at "/etc/ssl/certs/ca-certificates.crt": create mountpoint
...: not a directory
```

Confirmed live: this crash-looped scanner-worker pods and left the
backend's `helm upgrade` stuck in `pending-upgrade` (`--wait` never
completed) despite the main backend/frontend Deployments succeeding.
Fixed forward on the live UAT cluster with a direct `kubectl patch`
while this proper chart fix goes through review.

Adds the same `{{- with .Values.backend.extraInitContainers }}` block
to `scanner-worker-deployment.yaml` as the main Deployment already has.

## Changelog

- fix: apply `backend.extraInitContainers` to the scanner-worker Deployment too, matching its existing `extraVolumes`/`extraVolumeMounts` passthrough

## Checklist

Chart-only change (no Go code touched).

- [ ] `go test ./...` passes
- [ ] `go fmt ./...` and `go vet ./...` clean
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Verified locally: `helm lint` (with `scanning.enabled=true
scannerWorker.enabled=true`) passes, and `helm template` with a test
`backend.extraInitContainers` value renders the `initContainers:` block
on both the backend and scanner-worker Deployments.
