### PR TITLE
fix(notifications): never serialize recipients as null

### DIFF
--- a/backend/internal/api/admin/notifications.go
+++ b/backend/internal/api/admin/notifications.go
@@ -136,6 +136,15 @@ func NewNotificationsHandler(
 
 // toResponse builds the redacted response shape shared by GetConfig and PutConfig.
 func (h *NotificationsHandler) toResponse(passwordConfigured bool) NotificationsConfigResponse {
+	// A nil slice marshals to JSON `null`, not `[]` -- the frontend calls
+	// .join() on this field unconditionally, so a null response throws
+	// "Cannot read properties of null (reading 'join')" and crashes the
+	// admin Notifications page. Normalize to an empty slice so the field is
+	// always a real (possibly empty) JSON array.
+	recipients := h.cfg.Recipients
+	if recipients == nil {
+		recipients = []string{}
+	}
 	return NotificationsConfigResponse{
 		Enabled: h.cfg.Enabled,
 		SMTP: NotificationsSMTPResponse{
@@ -145,7 +154,7 @@ func (h *NotificationsHandler) toResponse(passwordConfigured bool) Notifications
 			From:     h.cfg.SMTP.From,
 			UseTLS:   h.cfg.SMTP.UseTLS,
 		},
-		Recipients:                     h.cfg.Recipients,
+		Recipients:                     recipients,
 		Events:                         NotificationEventsJSON(h.cfg.Events),
 		APIKeyExpiryWarningDays:        h.cfg.APIKeyExpiryWarningDays,
 		APIKeyExpiryCheckIntervalHours: h.cfg.APIKeyExpiryCheckIntervalHours,

--- a/backend/internal/api/admin/notifications_test.go
+++ b/backend/internal/api/admin/notifications_test.go
@@ -164,6 +164,39 @@ func TestNotificationsHandler_GetConfig_NoPassword(t *testing.T) {
 	}
 }
 
+// TestNotificationsHandler_GetConfig_RecipientsNeverNull guards against a
+// regression that crashed the admin Notifications page: a nil
+// config.Recipients slice marshals to JSON `null`, and the frontend calls
+// .join() on it unconditionally, throwing "Cannot read properties of null
+// (reading 'join')". A zero-value config.NotificationsConfig{} (as returned
+// when nothing has ever been persisted) must still serialize recipients as
+// an empty array, never null.
+func TestNotificationsHandler_GetConfig_RecipientsNeverNull(t *testing.T) {
+	h, _, mock := newNotificationsHandler(t)
+	mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow(nil))
+
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.GET("/notifications/config", h.GetConfig)
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/notifications/config", nil))
+
+	if strings.Contains(w.Body.String(), `"recipients":null`) {
+		t.Fatalf("recipients must never serialize as null, got body=%s", w.Body.String())
+	}
+
+	var resp NotificationsConfigResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Recipients == nil {
+		t.Error("resp.Recipients should be an empty (non-nil) slice, not nil")
+	}
+	if len(resp.Recipients) != 0 {
+		t.Errorf("resp.Recipients = %v, want empty", resp.Recipients)
+	}
+}
+
 func TestNotificationsHandler_GetConfig_PasswordConfiguredFromDB(t *testing.T) {
 	h, _, mock := newNotificationsHandler(t)
 	dbRow := `{"enabled":true,"smtp":{"host":"smtp.example.com","port":587,"from":"a@example.com","smtp_password_encrypted":"cipher"}}`


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

`GET /api/v1/admin/notifications/config` returned `"recipients":null`
whenever `config.Recipients` had never been set (a nil Go slice
marshals to JSON `null`, not `[]`). The admin frontend calls
`config.recipients.join(', ')` unconditionally, so a fresh/never-
configured deployment crashed the entire Notifications page with:

```text
TypeError: Cannot read properties of null (reading 'join')
```

Confirmed live on the UAT registry (a freshly (re)deployed backend with
no persisted SMTP config yet -- "Something went wrong" on
`/admin/notifications`).

Normalizes `toResponse`'s `Recipients` to an empty slice when nil, so
the field always serializes as a real (possibly empty) JSON array.
Frontend fix (defensive `config.recipients ?? []`) lands separately in
`terraform-registry-frontend`.

## Changelog

- fix: never serialize notifications config `recipients` as `null`, only as a (possibly empty) array

## Checklist

- [x] `go test ./...` passes
- [x] `go fmt ./...` and `go vet ./...` clean
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Added `TestNotificationsHandler_GetConfig_RecipientsNeverNull`, which
asserts the raw response body never contains `"recipients":null`.
