### PR TITLE
fix(notify): never silently fall back to plaintext on STARTTLS

### DIFF
--- a/backend/internal/notify/mailer.go
+++ b/backend/internal/notify/mailer.go
@@ -88,9 +88,10 @@ func sanitizeHeader(s string) string {
 }
 
 // sendMailTLS connects via implicit TLS (port 465 / SMTPS) and sends a message.
-// Use this when UseTLS=true and the port is 465; for port 587 STARTTLS,
-// smtp.SendMail handles the upgrade automatically — but we call this path for
-// both so the config is unambiguous: UseTLS=true always means an encrypted connection.
+// Use this when UseTLS=true and the port is 465; for port 587/25 STARTTLS,
+// falls back to sendMailStartTLS, which upgrades explicitly rather than
+// delegating to smtp.SendMail — so the config is unambiguous: UseTLS=true
+// always means an encrypted connection, never a silent plaintext fallback.
 // coverage:skip:integration-only — implicit-TLS dial plus a live SMTP protocol
 // exchange; cannot be meaningfully unit-tested without a real SMTP-over-TLS server
 // (the sibling Send is skipped for the same reason).
@@ -102,8 +103,7 @@ func sendMailTLS(addr, host string, auth smtp.Auth, from string, to []string, ms
 
 	conn, err := tls.Dial("tcp", addr, tlsConfig)
 	if err != nil {
-		// Fall back to STARTTLS via the standard smtp.SendMail path (port 587 pattern)
-		return smtp.SendMail(addr, auth, from, to, msg)
+		return sendMailStartTLS(addr, host, auth, from, to, msg)
 	}
 	defer conn.Close()
 
@@ -125,6 +125,56 @@ func sendMailTLS(addr, host string, auth smtp.Auth, from string, to []string, ms
 	for _, addr := range to {
 		if err := c.Rcpt(addr); err != nil {
 			return fmt.Errorf("smtp RCPT TO %s: %w", addr, err)
+		}
+	}
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("smtp write: %w", err)
+	}
+	return w.Close()
+}
+
+// sendMailStartTLS connects in plaintext, then upgrades via STARTTLS (the
+// standard submission-port pattern) before authenticating and sending. It
+// calls c.StartTLS directly instead of delegating to smtp.SendMail: SendMail
+// only upgrades when the server's EHLO response advertises the STARTTLS
+// extension, and otherwise silently continues in plaintext -- so a relay that
+// omits (or conditionally refuses) that advertisement would make a
+// UseTLS=true send quietly succeed unencrypted. Calling StartTLS explicitly
+// guarantees the upgrade is attempted and any failure (e.g. the relay
+// rejecting it) is surfaced as a real error rather than swallowed.
+// coverage:skip:integration-only — live SMTP protocol exchange (STARTTLS
+// handshake); cannot be meaningfully unit-tested without a real SMTP server.
+func sendMailStartTLS(addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	c, err := smtp.NewClient(conn, host)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("smtp new client: %w", err)
+	}
+	defer c.Quit() //nolint:errcheck
+
+	if err := c.StartTLS(&tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}); err != nil {
+		return fmt.Errorf("smtp starttls: %w", err)
+	}
+
+	if auth != nil {
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+	if err := c.Mail(from); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+	for _, rcpt := range to {
+		if err := c.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("smtp RCPT TO %s: %w", rcpt, err)
 		}
 	}
 	w, err := c.Data()

--- a/backend/internal/notify/mailer_test.go
+++ b/backend/internal/notify/mailer_test.go
@@ -241,3 +241,26 @@ func TestSendMailPlain_SendsAuthWhenConfigured(t *testing.T) {
 		t.Fatal("timed out waiting for fake SMTP server result")
 	}
 }
+
+// TestSendMailStartTLS_Rejected_ReturnsError is the regression test for the
+// bug this fix addresses: sendMailTLS's fallback previously delegated to
+// smtp.SendMail, which only attempts STARTTLS when the server's EHLO
+// advertises the extension and otherwise silently continues in plaintext --
+// so a relay whose STARTTLS command fails (this fake server always responds
+// "454 TLS not available", matching a live relay's
+// `454 4.3.3 TLS not available after start`) would previously result in a
+// silent plaintext "success" instead of a surfaced error. sendMailStartTLS
+// calls c.StartTLS directly, so the rejection must now propagate.
+func TestSendMailStartTLS_Rejected_ReturnsError(t *testing.T) {
+	addr, _ := fakeSMTPServer(t, true /* advertise STARTTLS */)
+	host, _, _ := net.SplitHostPort(addr)
+
+	err := sendMailStartTLS(addr, host, nil, "from@example.com", []string{"to@example.com"},
+		[]byte("Subject: hi\r\n\r\nbody\r\n"))
+	if err == nil {
+		t.Fatal("expected an error when the relay rejects STARTTLS, got nil (silent plaintext fallback)")
+	}
+	if !strings.Contains(err.Error(), "smtp starttls") {
+		t.Errorf("error = %q, want it to mention the starttls failure", err.Error())
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD041 -->
## Summary

`sendMailTLS`'s fallback (reached when the implicit-TLS dial fails,
which it always will for a submission port like 25/587) delegated to
`net/smtp.SendMail`. `SendMail` only attempts STARTTLS when the
server's EHLO response advertises the extension, and otherwise
**silently continues in plaintext** — with no way to opt out and no
error.

Confirmed live: with `UseTLS=true` against the same relay, TSM
correctly **failed** a test send (`smtp starttls: 454 "4.3.3 TLS not
available after start"`), while registry silently **"succeeded"**
over an unencrypted connection. This directly contradicted this
function's own doc comment ("UseTLS=true always means an encrypted
connection").

Adds `sendMailStartTLS`, which calls `c.StartTLS` directly (mirroring
the sibling `sendMailPlain`'s explicit-control pattern and TSM's own
transport) so a STARTTLS failure is always surfaced as a real error
instead of silently downgrading.

**Interim fix**: a shared `identity/mailer` package (this exact
transport logic, to eliminate the class of divergence that caused this
bug) is up for review at sethbacon/terraform-suite-identity#113. Once
merged and released, this package should switch to calling it instead
of maintaining its own copy.

## Changelog

- fix: never silently fall back to plaintext when a relay rejects STARTTLS with `UseTLS=true`

## Checklist

- [x] `go test ./...` passes
- [x] `go fmt ./...` and `go vet ./...` clean
- [ ] No new `gosec` findings
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Added `TestSendMailStartTLS_Rejected_ReturnsError`, which reproduces
the exact live failure (fake relay always rejects `STARTTLS` with `454
TLS not available`) and asserts the error now propagates.
