### PR TITLE
fix(gdpr): use published_by instead of nonexistent created_by column

### DIFF
--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -126,7 +126,7 @@ func (s *UserService) ExportUserData(ctx context.Context, userID string) (*UserD
 		SELECT DISTINCT m.id, m.namespace, m.name
 		FROM modules m
 		JOIN module_versions mv ON mv.module_id = m.id
-		WHERE mv.created_by = $1
+		WHERE mv.published_by = $1
 	`, userID)
 	if err == nil {
 		defer modRows.Close()
@@ -143,7 +143,7 @@ func (s *UserService) ExportUserData(ctx context.Context, userID string) (*UserD
 		SELECT DISTINCT p.id, p.namespace, p.type
 		FROM providers p
 		JOIN provider_versions pv ON pv.provider_id = p.id
-		WHERE pv.created_by = $1
+		WHERE pv.published_by = $1
 	`, userID)
 	if err == nil {
 		defer provRows.Close()


### PR DESCRIPTION
Closes #<!-- no local issue number; this fixes a bug surfaced by terraform-registry-frontend#580 -->

## Summary
`UserService.ExportUserData` (GDPR data export, Article 15/20) queries `module_versions` and `provider_versions` for records created by the exporting user, but referenced a `created_by` column that does not exist on either table -- only `published_by` does (see `internal/db/migrations/000001_initial_schema.up.sql`).

Both queries were wrapped in `if err == nil { ... }` guards, so the error was silently swallowed: the endpoint always returned `200` with `modules_created`/`providers_created` permanently empty for every user, while a real Postgres error (`column mv.created_by does not exist` / `column pv.created_by does not exist`) was logged on every single call to this endpoint.

This was surfaced by recurring Postgres errors in the terraform-registry-frontend E2E backend logs (sethbacon/terraform-registry-frontend#580).

Existing unit test coverage (`TestExportUserData_Success`) didn't catch this because it uses regex-based `sqlmock` query matching (`"SELECT DISTINCT .+ FROM modules"`) that doesn't validate real column names against an actual schema -- no test changes needed since the fix doesn't change the mock's expected pattern.

## Changelog
- fix: GDPR export now correctly finds modules/providers created by a user (`published_by` instead of nonexistent `created_by` column)

## Checklist

- [x] `go test ./...` passes
- [x] `go fmt ./...` and `go vet ./...` clean
- [x] No new `gosec` findings (2-line SQL column-name change only)
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge
