### PR TITLE
feat(authz): derive namespace ownership from publisher, add namespace read API

### DIFF
--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -67,6 +67,116 @@ func (h *OrganizationHandlers) revokeUserTokens(c *gin.Context, userID, reason s
 	}
 }
 
+// ListNamespaceClaimsHandler lists every namespace ownership claim with its
+// resolved organization name, so operators can audit which organization owns
+// each module/provider namespace (issue #555). Organization names are resolved
+// via a separate per-org lookup rather than a SQL join because namespace_claims
+// (registry connection) and organizations (identity connection) may live on
+// different databases.
+// GET /api/v1/admin/namespaces
+func (h *OrganizationHandlers) ListNamespaceClaimsHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if h.claimRepo == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Namespace claims are not available"})
+			return
+		}
+		claims, err := h.claimRepo.ListClaims(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list namespace claims"})
+			return
+		}
+
+		nameCache := make(map[string]string)
+		out := make([]gin.H, 0, len(claims))
+		for _, cl := range claims {
+			orgName, cached := nameCache[cl.OrganizationID]
+			if !cached {
+				if org, err := h.orgRepo.GetByID(c.Request.Context(), cl.OrganizationID); err == nil && org != nil {
+					orgName = org.Name
+				}
+				nameCache[cl.OrganizationID] = orgName
+			}
+			out = append(out, gin.H{
+				"namespace":         cl.Namespace,
+				"organization_id":   cl.OrganizationID,
+				"organization_name": orgName,
+				"claimed_by":        cl.ClaimedBy,
+				"created_at":        cl.CreatedAt,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"namespaces": out})
+	}
+}
+
+// GetNamespaceOwnershipHandler resolves the owning organization of a single
+// namespace exactly as the mutation authorizer does: the claim when present,
+// otherwise the artifact-row fallback (a namespace that predates claims or was
+// populated by a system path). A namespace whose artifacts span multiple
+// organizations without a claim is reported as ambiguous rather than guessed.
+// GET /api/v1/admin/namespaces/:namespace
+func (h *OrganizationHandlers) GetNamespaceOwnershipHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if h.claimRepo == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Namespace claims are not available"})
+			return
+		}
+		namespace := c.Param("namespace")
+		if namespace == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "namespace is required"})
+			return
+		}
+
+		claim, err := h.claimRepo.GetClaim(c.Request.Context(), namespace)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve namespace ownership"})
+			return
+		}
+
+		var orgID, source string
+		if claim != nil {
+			orgID = claim.OrganizationID
+			source = "claim"
+		} else {
+			orgIDs, err := h.claimRepo.ArtifactOrganizations(c.Request.Context(), namespace)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve namespace ownership"})
+				return
+			}
+			switch len(orgIDs) {
+			case 0:
+				c.JSON(http.StatusNotFound, gin.H{"error": "Namespace is unclaimed and has no artifacts"})
+				return
+			case 1:
+				orgID = orgIDs[0]
+				source = "artifact"
+			default:
+				c.JSON(http.StatusOK, gin.H{
+					"namespace":              namespace,
+					"source":                 "ambiguous",
+					"owner_organization_ids": orgIDs,
+				})
+				return
+			}
+		}
+
+		var orgName string
+		if org, err := h.orgRepo.GetByID(c.Request.Context(), orgID); err == nil && org != nil {
+			orgName = org.Name
+		}
+		resp := gin.H{
+			"namespace":         namespace,
+			"organization_id":   orgID,
+			"organization_name": orgName,
+			"source":            source,
+		}
+		if claim != nil {
+			resp["claimed_by"] = claim.ClaimedBy
+			resp["created_at"] = claim.CreatedAt
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
 // @Summary      List organizations
 // @Description  Get a paginated list of all organizations.
 // @Tags         Organizations

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -96,7 +96,118 @@ func newOrgRouterWithRevocation(t *testing.T, withRevocation bool) (sqlmock.Sqlm
 	r.POST("/organizations/:id/members", h.AddMemberHandler())
 	r.PUT("/organizations/:id/members/:user_id", h.UpdateMemberHandler())
 	r.DELETE("/organizations/:id/members/:user_id", h.RemoveMemberHandler())
+	r.GET("/admin/namespaces", h.ListNamespaceClaimsHandler())
+	r.GET("/admin/namespaces/:namespace", h.GetNamespaceOwnershipHandler())
 	return mock, r
+}
+
+// ---------------------------------------------------------------------------
+// Namespace ownership read API tests (GET /admin/namespaces[/:namespace])
+// ---------------------------------------------------------------------------
+
+func nsClaimRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"})
+}
+
+func TestListNamespaceClaims_Success(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims.*ORDER BY").
+		WillReturnRows(nsClaimRows().
+			AddRow("aceo", "org-a", nil, time.Now()).
+			AddRow("azure", "org-a", nil, time.Now()))
+	// Both claims share org-a: the org name is resolved once and then cached.
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE id").
+		WillReturnRows(sqlmock.NewRows(orgCols).
+			AddRow("org-a", "aceo", "ACEO", nil, nil, time.Now(), time.Now()))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/namespaces", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	resp := getJSON(w)
+	nsList, ok := resp["namespaces"].([]interface{})
+	if !ok || len(nsList) != 2 {
+		t.Fatalf("expected 2 namespaces, got %v", resp["namespaces"])
+	}
+	first := nsList[0].(map[string]interface{})
+	if first["organization_name"] != "aceo" {
+		t.Errorf("organization_name = %v, want aceo", first["organization_name"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (org name should be cached — a single GetByID): %v", err)
+	}
+}
+
+func TestGetNamespaceOwnership_Claim(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims.*WHERE namespace").
+		WillReturnRows(nsClaimRows().AddRow("aceo", "org-a", nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE id").
+		WillReturnRows(sqlmock.NewRows(orgCols).
+			AddRow("org-a", "aceo", "ACEO", nil, nil, time.Now(), time.Now()))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/namespaces/aceo", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	resp := getJSON(w)
+	if resp["source"] != "claim" {
+		t.Errorf("source = %v, want claim", resp["source"])
+	}
+	if resp["organization_id"] != "org-a" {
+		t.Errorf("organization_id = %v, want org-a", resp["organization_id"])
+	}
+	if resp["organization_name"] != "aceo" {
+		t.Errorf("organization_name = %v, want aceo", resp["organization_name"])
+	}
+}
+
+func TestGetNamespaceOwnership_ArtifactFallback(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims.*WHERE namespace").
+		WillReturnRows(nsClaimRows()) // no claim row
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-b"))
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE id").
+		WillReturnRows(sqlmock.NewRows(orgCols).
+			AddRow("org-b", "legacy", "Legacy", nil, nil, time.Now(), time.Now()))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/namespaces/legacyns", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	resp := getJSON(w)
+	if resp["source"] != "artifact" {
+		t.Errorf("source = %v, want artifact", resp["source"])
+	}
+	if resp["organization_id"] != "org-b" {
+		t.Errorf("organization_id = %v, want org-b", resp["organization_id"])
+	}
+}
+
+func TestGetNamespaceOwnership_Unclaimed_NotFound(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims.*WHERE namespace").
+		WillReturnRows(nsClaimRows()) // no claim
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"})) // no artifacts
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/namespaces/ghost", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (unclaimed, no artifacts): body=%s", w.Code, w.Body.String())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -784,6 +784,17 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 					orgHandlers.RemoveMemberHandler())
 			}
 
+			// Namespace ownership (read-only): audit which organization owns each
+			// module/provider namespace. Ownership itself is enforced by
+			// namespace_claims on every mutation (issue #555); these endpoints only
+			// expose it for verification.
+			authenticatedGroup.GET("/admin/namespaces",
+				middleware.RequireScope(auth.ScopeOrganizationsRead),
+				orgHandlers.ListNamespaceClaimsHandler())
+			authenticatedGroup.GET("/admin/namespaces/:namespace",
+				middleware.RequireScope(auth.ScopeOrganizationsRead),
+				orgHandlers.GetNamespaceOwnershipHandler())
+
 			// SCM Provider management
 			scmProvidersGroup := authenticatedGroup.Group("/scm-providers")
 			{

--- a/backend/internal/db/repositories/namespace_claim_repository.go
+++ b/backend/internal/db/repositories/namespace_claim_repository.go
@@ -48,6 +48,36 @@ func (r *NamespaceClaimRepository) GetClaim(ctx context.Context, namespace strin
 	return claim, nil
 }
 
+// ListClaims returns every namespace ownership claim ordered by namespace.
+// Used by the admin namespace-ownership read API for auditability. Organization
+// names are resolved separately by the handler because namespace_claims and the
+// organizations table may live on different database connections.
+func (r *NamespaceClaimRepository) ListClaims(ctx context.Context) ([]*models.NamespaceClaim, error) {
+	query := `
+		SELECT namespace, organization_id, claimed_by, created_at
+		FROM namespace_claims
+		ORDER BY namespace
+	`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespace claims: %w", err)
+	}
+	defer rows.Close()
+
+	var claims []*models.NamespaceClaim
+	for rows.Next() {
+		claim := &models.NamespaceClaim{}
+		if err := rows.Scan(&claim.Namespace, &claim.OrganizationID, &claim.ClaimedBy, &claim.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan namespace claim: %w", err)
+		}
+		claims = append(claims, claim)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate namespace claims: %w", err)
+	}
+	return claims, nil
+}
+
 // ClaimNamespace atomically claims a namespace for an organization and returns
 // the winning claim. When two organizations race for the same namespace, the
 // first insert wins (ON CONFLICT DO NOTHING) and the loser receives the

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -30,7 +30,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -114,6 +116,10 @@ func (a *NamespaceAuthorizer) RequirePublishAccessFromForm(scope auth.Scope, max
 			c.Next()
 			return
 		}
+		// An optional organization_id form field lets a multi-org caller (or an
+		// admin acting as operator) state which organization should own a
+		// brand-new namespace; resolveCallerOrg validates and consumes it.
+		c.Set("requested_org_id", c.Request.PostFormValue("organization_id"))
 		if a.authorizeNamespaceMutation(c, namespace, scope, true) {
 			c.Next()
 		}
@@ -145,6 +151,12 @@ func (a *NamespaceAuthorizer) RequirePublishAccessFromJSON(scope auth.Scope) gin
 			c.Next()
 			return
 		}
+
+		// An explicit organization_id lets a multi-org caller (or an admin
+		// acting as operator) state which organization should own a brand-new
+		// namespace; resolveCallerOrg validates and consumes it on the
+		// first-publish path.
+		c.Set("requested_org_id", body.OrganizationID)
 
 		if !a.authorizeNamespaceMutation(c, body.Namespace, scope, true) {
 			return
@@ -317,6 +329,9 @@ func (a *NamespaceAuthorizer) moduleAccessByID(c *gin.Context, scope auth.Scope)
 		return nil, "", false
 	}
 
+	// Expose the resolved owning organization to downstream handlers (audit,
+	// and so a handler never has to re-derive ownership independently).
+	c.Set("owner_org_id", ownerOrgID)
 	return module, ownerOrgID, true
 }
 
@@ -343,6 +358,7 @@ func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespa
 			abortNamespaceAuthz(c, status, msg)
 			return false
 		}
+		c.Set("owner_org_id", ownerOrgID)
 		return true
 	}
 
@@ -380,6 +396,21 @@ func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespa
 		}
 	}
 
+	// Audit the ownership binding: a namespace's owner is set exactly once, so
+	// this is a security-relevant, non-repeating event.
+	var claimedBy string
+	if uid := callerUserID(c); uid != nil {
+		claimedBy = *uid
+	}
+	slog.Info("namespace ownership claimed",
+		"namespace", namespace,
+		"organization_id", claim.OrganizationID,
+		"claimed_by", claimedBy,
+		"admin", callerIsAdmin(c),
+		"explicit_org", strings.TrimSpace(c.GetString("requested_org_id")) != "",
+	)
+
+	c.Set("owner_org_id", claim.OrganizationID)
 	return true
 }
 
@@ -491,13 +522,48 @@ func (a *NamespaceAuthorizer) ownerOrgForArtifact(ctx context.Context, namespace
 // status and message. Fails closed when no organization can be derived from
 // the caller's identity.
 func (a *NamespaceAuthorizer) resolveCallerOrg(c *gin.Context) (string, int, string) {
-	// Org-scoped API keys carry their organization directly.
+	// Org-scoped API keys carry their organization directly and are the
+	// strongest trust anchor: the binding is fixed at key creation and cannot
+	// be influenced by the request body.
 	if keyVal, exists := c.Get("api_key"); exists {
 		if apiKey, ok := keyVal.(*models.APIKey); ok && apiKey.OrganizationID != "" {
 			return apiKey.OrganizationID, 0, ""
 		}
 	}
 
+	// An explicit target organization may be supplied on the publish request
+	// (organization_id in the JSON body or multipart form; stashed by the
+	// publish middleware). It lets a member of multiple organizations, or an
+	// admin acting as a registry operator, state which organization owns a
+	// brand-new namespace instead of the backend guessing. The previous guess
+	// was a silent fall-through to the default organization, which silently
+	// mis-attributed ownership.
+	requestedOrg := strings.TrimSpace(c.GetString("requested_org_id"))
+
+	if requestedOrg != "" {
+		// Admins may bind a new namespace to any organization (registry
+		// operator). The claim's foreign key enforces that the organization
+		// actually exists; the binding is audit-logged by the caller.
+		if callerIsAdmin(c) {
+			return requestedOrg, 0, ""
+		}
+		// Non-admins may only bind to an organization they belong to.
+		if userID := callerUserID(c); userID != nil {
+			memberships, err := a.orgRepo.GetUserMemberships(c.Request.Context(), *userID)
+			if err != nil {
+				return "", http.StatusInternalServerError, "Failed to resolve organization memberships"
+			}
+			for _, m := range memberships {
+				if m.OrganizationID == requestedOrg {
+					return requestedOrg, 0, ""
+				}
+			}
+		}
+		return "", http.StatusForbidden, "You are not a member of the requested organization"
+	}
+
+	// No explicit organization: only an unambiguous single membership can be
+	// used automatically.
 	if userID := callerUserID(c); userID != nil {
 		memberships, err := a.orgRepo.GetUserMemberships(c.Request.Context(), *userID)
 		if err != nil {
@@ -506,25 +572,18 @@ func (a *NamespaceAuthorizer) resolveCallerOrg(c *gin.Context) (string, int, str
 		if len(memberships) == 1 {
 			return memberships[0].OrganizationID, 0, ""
 		}
-		if len(memberships) > 1 && !callerIsAdmin(c) {
-			return "", http.StatusForbidden, "Ambiguous organization context: use an organization-scoped API key to publish a new namespace"
+		if len(memberships) > 1 {
+			// Fail closed. A caller with multiple memberships -- INCLUDING an
+			// admin, who previously fell through to the default organization --
+			// must state the target organization explicitly. The backend never
+			// guesses a namespace owner.
+			return "", http.StatusForbidden, "Ambiguous organization: specify organization_id or use an organization-scoped API key to publish a new namespace"
 		}
 	}
 
-	// Admins without an unambiguous organization bind new namespaces to the
-	// default organization (registry-operator behavior).
-	if callerIsAdmin(c) {
-		org, err := a.orgRepo.GetDefaultOrganization(c.Request.Context())
-		if err != nil {
-			return "", http.StatusInternalServerError, "Failed to get organization context"
-		}
-		if org == nil {
-			return "", http.StatusInternalServerError, "Default organization not found"
-		}
-		return org.ID, 0, ""
-	}
-
-	return "", http.StatusForbidden, "Organization context required"
+	// No org-scoped key, no explicit org, and no single membership to fall back
+	// on: ownership cannot be established. Fail closed.
+	return "", http.StatusForbidden, "No organization context: use an organization-scoped API key or specify organization_id to publish a new namespace"
 }
 
 // callerIsAdmin reports whether the authenticated principal holds the wildcard

--- a/backend/internal/middleware/namespace_authz_test.go
+++ b/backend/internal/middleware/namespace_authz_test.go
@@ -454,6 +454,172 @@ func TestRequirePublishAccessFromForm_APIKeyOrg_FirstClaim(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// First-publish org resolution: fail-closed + validated explicit organization_id
+// ---------------------------------------------------------------------------
+
+func TestRequirePublishAccessFromForm_MultiOrgAdmin_NoExplicitOrg_FailsClosed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	// Admin belongs to two orgs and supplies no organization_id: the backend
+	// must NOT silently fall back to the default org (the historical bug); it
+	// must fail closed.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
+		WillReturnRows(sqlmock.NewRows(userMembershipCols).
+			AddRow(nsOrgA, "Org A", "role-adm", time.Now(), "admin", "Administrator", []byte(`["admin"]`)).
+			AddRow(nsOrgB, "Org B", "role-adm", time.Now(), "admin", "Administrator", []byte(`["admin"]`)))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeAdmin)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (multi-org admin must specify org; no silent default): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (no claim insert expected): %v", err)
+	}
+}
+
+func TestRequirePublishAccessFromForm_AdminExplicitOrg_Claims(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	// Admin + explicit org: resolveCallerOrg returns the requested org WITHOUT a
+	// membership lookup; the claim is inserted for exactly that org.
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("newteam", nsOrgB, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newteam", nsOrgB, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeAdmin)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws", "organization_id": nsOrgB}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (admin binds new namespace to explicit org): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_Member_Claims(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	// Non-admin with explicit org: membership is verified; the requested org is
+	// among the caller's memberships, so the claim binds to it.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
+		WillReturnRows(sqlmock.NewRows(userMembershipCols).
+			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)).
+			AddRow(nsOrgB, "Org B", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("newteam", nsOrgB, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newteam", nsOrgB, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws", "organization_id": nsOrgB}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (member may bind a new namespace to a chosen org they belong to): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_NotMember_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	// Caller belongs only to org A but asks to bind the namespace to org B.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
+		WillReturnRows(sqlmock.NewRows(userMembershipCols).
+			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withScopesAndUser([]string{string(auth.ScopeModulesWrite)}, nsUserID)),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "newteam", "name": "vpc", "system": "aws", "organization_id": nsOrgB}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (cannot bind namespace to an org you don't belong to): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (no claim insert expected): %v", err)
+	}
+}
+
+func TestRequirePublishAccessFromForm_APIKeyOrg_IgnoresExplicitOrg(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
+	// API key binding is authoritative: the claim binds to the key's org
+	// (nsOrgA), NOT the attacker-supplied organization_id form field (nsOrgB).
+	// No membership query is issued.
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("ci-team", nsOrgA, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws", "organization_id": nsOrgB}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (API key org claims directly, request org ignored): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // RequirePublishAccessFromJSON — JSON-body namespace (admin create routes)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Makes namespace ownership reflect the authenticated publisher (fail-closed) and adds a read-only ownership API. Namespace ownership (`namespace_claims`) is the object-level authorization boundary for module/provider mutations (#555).

## Changes

### Publisher-derived, fail-closed ownership (`resolveCallerOrg`)
- Removes the silent fallback to the **default** organization for a multi-org admin first-publishing into a new namespace. That silent guess mis-attributed ownership. It now **fails closed** with an actionable error.
- Honors an explicit, validated `organization_id` on create/upload:
  - an org-scoped **API key binding stays authoritative** and cannot be overridden by the request body
  - a **non-admin** may only bind a new namespace to an organization they belong to
  - an **admin** may bind to any organization (registry operator) — audit-logged
- Threads the resolved `owner_org_id` into the request context; audit-logs the one-time ownership claim.

### Namespace-ownership read API (auditability)
- `GET /api/v1/admin/namespaces` — list all claims with resolved org names
- `GET /api/v1/admin/namespaces/:namespace` — resolve one namespace's owner (claim, artifact fallback, or ambiguous)
- Both require `organizations:read`. Org names are resolved via a separate lookup because `namespace_claims` (registry connection) and `organizations` (identity connection) may live on different databases.

## Not changed (by design)

Module/provider row `organization_id` intentionally stays the default org — the unauthenticated Terraform protocol read paths resolve modules by it. The `namespace_claims` record remains the single authoritative owner, so downloads keep working while authorization is enforced by the claim.

## Tests

- Fail-closed resolution, explicit-org validation (member / non-member / admin), API-key precedence over request body — `internal/middleware` (29 pass, 5 new)
- Read API (list, claim, artifact-fallback, unclaimed 404) — `internal/api/admin` (66 pass, 4 new)
- `go build ./...` + `go vet` clean; affected packages all green.

## Security

Least-privilege preserved (release pipeline uses a scoped `modules:write` key bound to one org). First-claim-wins stickiness and cross-org admin-only semantics from #555 are retained; ambiguity now fails closed rather than defaulting to the operator org.
