### PR TITLE
fix(security): route remaining outbound HTTP clients through the httpsafe egress guard

### DIFF
--- a/backend/internal/api/admin/scanning_install.go
+++ b/backend/internal/api/admin/scanning_install.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
@@ -44,6 +45,13 @@ type ScanningInstallHandler struct {
 	updateJob    *jobs.ScannerUpdateJob
 	sbvRepo      *repositories.ScannerBinaryVersionRepository
 	approvalRepo *repositories.VersionApprovalRepository
+	egressGuard  *httpsafe.Guard
+}
+
+// SetEgressGuard installs the operator-configured egress guard threaded into
+// installer.Handle's InstallConfig (issue #676); nil is the strict default.
+func (h *ScanningInstallHandler) SetEgressGuard(g *httpsafe.Guard) {
+	h.egressGuard = g
 }
 
 // NewScanningInstallHandler constructs a ScanningInstallHandler.
@@ -86,7 +94,7 @@ func (h *ScanningInstallHandler) Install() gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
 		defer cancel()
 
-		ok, result, errMsg := installer.Handle(ctx, h.cfg.InstallDir, h.install, input.Tool, input.Version)
+		ok, result, errMsg := installer.Handle(ctx, h.cfg.InstallDir, h.egressGuard, h.install, input.Tool, input.Version)
 		if !ok {
 			if errMsg == "scanning.install_dir is not configured on the server" {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": errMsg})

--- a/backend/internal/api/admin/scanning_install_test.go
+++ b/backend/internal/api/admin/scanning_install_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
 
@@ -97,6 +98,35 @@ func TestInstallScannerHandler_InstallerSuccess(t *testing.T) {
 	}
 	if resp.Version != "0.52.2" {
 		t.Errorf("version = %q", resp.Version)
+	}
+}
+
+// TestInstallScannerHandler_ThreadsEgressGuard locks in that the admin install
+// endpoint passes the operator-configured egress guard through installer.Handle
+// into the InstallConfig the install func receives (issue #676's threading
+// requirement), rather than silently falling back to the strict nil-guard
+// default.
+func TestInstallScannerHandler_ThreadsEgressGuard(t *testing.T) {
+	cfg := &config.ScanningConfig{InstallDir: "/tmp/test"}
+	g := httpsafe.MustGuard("10.0.0.0/8")
+	var got *httpsafe.Guard
+	stub := func(ctx context.Context, c installer.InstallConfig, tool, version string) (*installer.Result, error) {
+		got = c.EgressGuard
+		return &installer.Result{BinaryPath: "/app/scanners/trivy", Version: "0.52.2"}, nil
+	}
+
+	h := NewScanningInstallHandler(cfg, stub, nil, nil, nil)
+	h.SetEgressGuard(g)
+	r := gin.New()
+	r.POST("/install", h.Install())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/install", jsonBodyAdmin(map[string]string{"tool": "trivy"}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if got != g {
+		t.Errorf("InstallConfig.EgressGuard = %v, want the guard set via SetEgressGuard", got)
 	}
 }
 

--- a/backend/internal/api/admin/scanning_latest.go
+++ b/backend/internal/api/admin/scanning_latest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
@@ -35,7 +36,7 @@ type ScannerLatestResponse struct {
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Failed to resolve upstream release"
 // @Router       /api/v1/admin/scanning/latest [get]
-func GetScannerLatestHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
+func GetScannerLatestHandler(cfg *config.ScanningConfig, egressGuard *httpsafe.Guard) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tool := c.Query("tool")
 		if tool == "" {
@@ -50,7 +51,7 @@ func GetScannerLatestHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
-		latest, err := installer.CheckLatest(ctx, installer.InstallConfig{InstallDir: cfg.InstallDir}, tool)
+		latest, err := installer.CheckLatest(ctx, installer.InstallConfig{InstallDir: cfg.InstallDir, EgressGuard: egressGuard}, tool)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/backend/internal/api/admin/scanning_latest_test.go
+++ b/backend/internal/api/admin/scanning_latest_test.go
@@ -6,17 +6,26 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
+
+// scanningLatestLoopbackGuard allow-lists the httptest.Server addresses used
+// throughout this file (127.0.0.1) so tests exercise GetScannerLatestHandler's
+// installer.CheckLatest call (routed through httpsafe.NewClient via
+// installer.InstallConfig.EgressGuard, issue #676) without the strict default
+// egress policy rejecting the test server itself as an internal target.
+var scanningLatestLoopbackGuard = httpsafe.MustGuard("127.0.0.1")
 
 func TestGetScannerLatestHandler_UnsupportedTool(t *testing.T) {
 	cfg := &config.ScanningConfig{Tool: "trivy"}
 	r := gin.New()
-	r.GET("/latest", GetScannerLatestHandler(cfg))
+	r.GET("/latest", GetScannerLatestHandler(cfg, scanningLatestLoopbackGuard))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/latest?tool=snyk", nil)
@@ -32,7 +41,7 @@ func TestGetScannerLatestHandler_UpdateAvailable(t *testing.T) {
 	checksumsName := "trivy_0.60.0_checksums.txt"
 
 	mux := http.NewServeMux()
-	server := httptest.NewTLSServer(mux)
+	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
 	type ghAssetJSON struct {
@@ -67,16 +76,9 @@ func TestGetScannerLatestHandler_UpdateAvailable(t *testing.T) {
 	installer.Catalog["trivy"] = map[string]installer.AssetSpec{platform: spec}
 	t.Cleanup(func() { installer.Catalog["trivy"] = origCatalog })
 
-	// GetScannerLatestHandler has no HTTPClient injection point, so it uses
-	// http.DefaultTransport internally; point it at the httptest TLS server's
-	// certificate for the duration of this test.
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = server.Client().Transport
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
-
 	cfg := &config.ScanningConfig{Tool: "trivy", ExpectedVersion: "0.50.0"}
 	r := gin.New()
-	r.GET("/latest", GetScannerLatestHandler(cfg))
+	r.GET("/latest", GetScannerLatestHandler(cfg, scanningLatestLoopbackGuard))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/latest", nil)
@@ -103,7 +105,7 @@ func TestGetScannerLatestHandler_UpdateAvailable(t *testing.T) {
 
 func TestGetScannerLatestHandler_CheckLatestError(t *testing.T) {
 	mux := http.NewServeMux()
-	server := httptest.NewTLSServer(mux)
+	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
 	// No handler registered for /releases/latest -> the httptest server
@@ -121,13 +123,9 @@ func TestGetScannerLatestHandler_CheckLatestError(t *testing.T) {
 	installer.Catalog["trivy"] = map[string]installer.AssetSpec{platform: spec}
 	t.Cleanup(func() { installer.Catalog["trivy"] = origCatalog })
 
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = server.Client().Transport
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
-
 	cfg := &config.ScanningConfig{Tool: "trivy"}
 	r := gin.New()
-	r.GET("/latest", GetScannerLatestHandler(cfg))
+	r.GET("/latest", GetScannerLatestHandler(cfg, scanningLatestLoopbackGuard))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/latest", nil)
@@ -138,12 +136,56 @@ func TestGetScannerLatestHandler_CheckLatestError(t *testing.T) {
 	}
 }
 
+// TestGetScannerLatestHandler_StrictGuardRejectsLoopback is the negative
+// counterpart to TestGetScannerLatestHandler_CheckLatestError: it proves the
+// EgressGuard plumbed into installer.InstallConfig (issue #676) actually
+// blocks a loopback target under the strict default policy (nil guard),
+// rather than the handler silently reaching it. LatestReleaseAPI itself is
+// server-config-controlled in production, but the point of routing through
+// httpsafe is defense-in-depth against exactly this class of target.
+func TestGetScannerLatestHandler_StrictGuardRejectsLoopback(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"tag_name": "v0.60.0"})
+	})
+
+	spec := installer.AssetSpec{
+		LatestReleaseAPI: server.URL + "/releases/latest",
+		VersionedAPI:     server.URL + "/releases/tags/v%s",
+		AssetPattern:     regexp.MustCompile(`^trivy_[\d.]+_Linux-64bit\.tar\.gz$`),
+		ChecksumsPattern: regexp.MustCompile(`^trivy_[\d.]+_checksums\.txt$`),
+		BinaryInArchive:  "trivy",
+		ArchiveFormat:    "tar.gz",
+	}
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := installer.Catalog["trivy"]
+	installer.Catalog["trivy"] = map[string]installer.AssetSpec{platform: spec}
+	t.Cleanup(func() { installer.Catalog["trivy"] = origCatalog })
+
+	cfg := &config.ScanningConfig{Tool: "trivy"}
+	r := gin.New()
+	r.GET("/latest", GetScannerLatestHandler(cfg, nil)) // nil guard == strict default
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/latest", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (loopback target blocked), body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "blocked") {
+		t.Errorf("body = %s, want it to mention the egress guard blocking the target", w.Body.String())
+	}
+}
+
 func TestGetScannerLatestHandler_NoCurrentVersion(t *testing.T) {
 	archiveName := "trivy_0.60.0_Linux-64bit.tar.gz"
 	checksumsName := "trivy_0.60.0_checksums.txt"
 
 	mux := http.NewServeMux()
-	server := httptest.NewTLSServer(mux)
+	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
 	type ghAssetJSON struct {
@@ -177,16 +219,12 @@ func TestGetScannerLatestHandler_NoCurrentVersion(t *testing.T) {
 	installer.Catalog["trivy"] = map[string]installer.AssetSpec{platform: spec}
 	t.Cleanup(func() { installer.Catalog["trivy"] = origCatalog })
 
-	origTransport := http.DefaultTransport
-	http.DefaultTransport = server.Client().Transport
-	t.Cleanup(func() { http.DefaultTransport = origTransport })
-
 	// Enabled=false so the handler never attempts to resolve a live scanner
 	// binary/version, and ExpectedVersion is empty -> currentVersion stays ""
 	// -> UpdateAvailable is unconditionally true.
 	cfg := &config.ScanningConfig{Tool: "trivy", Enabled: false}
 	r := gin.New()
-	r.GET("/latest", GetScannerLatestHandler(cfg))
+	r.GET("/latest", GetScannerLatestHandler(cfg, scanningLatestLoopbackGuard))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/latest", nil)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -268,6 +268,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	sbvRepo := repositories.NewScannerBinaryVersionRepository(sqlxDB)
 	scannerApprovalRepo := repositories.NewVersionApprovalRepository(sqlxDB)
 	scannerUpdateJob := jobs.NewScannerUpdateJob(&cfg.Scanning, &cfg.Notifications, &cfg.CVE, sbvRepo, scannerApprovalRepo, oidcConfigRepo, moduleScannerJob, nil, nil)
+	scannerUpdateJob.SetEgressGuard(egressGuard)
 	jobRegistry.Register(scannerUpdateJob)
 
 	// Initialize the audit log cleanup job (no-op when retention_days=0)
@@ -416,8 +417,9 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	auditLogHandlers := admin.NewAuditLogHandlers(identityDB)
 
 	// Shared app-credential minter (Entra app / GitHub App) for providers opted
-	// into an app auth mode; scmRepo provides the token-cache store.
-	sharedMinter := appcreds.NewMinter(tokenCipher, scmRepo)
+	// into an app auth mode; scmRepo provides the token-cache store. Uses the
+	// shared egress guard for parity with the other SCM outbound paths (#676).
+	sharedMinter := appcreds.NewMinterWithGuard(tokenCipher, scmRepo, egressGuard)
 
 	// Initialize SCM publisher service (needed by scmLinkingHandler)
 	scmPublisher := services.NewSCMPublisher(scmRepo, moduleRepo, storageBackend, tokenCipher).
@@ -494,7 +496,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize setup wizard handlers
 	setupHandlers := setup.NewHandlers(
 		cfg, tokenCipher, oidcConfigRepo, storageConfigRepo, userRepo, orgRepo, authHandlers,
-	).WithScannerJob(moduleScannerJob)
+	).WithScannerJob(moduleScannerJob).WithEgressGuard(egressGuard)
 
 	// Initialize policy engine (no-op when disabled).
 	policyEngineCfg := policy.Config{
@@ -648,6 +650,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		statsHandlers:               statsHandlers,
 		scmWebhookHandler:           scmWebhookHandler,
 		approvalWebhookHandler:      approvalWebhookHandler,
+		egressGuard:                 egressGuard,
 	})
 
 	// Start every registered background job now that all wiring is complete.

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -37,6 +37,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
@@ -355,6 +356,7 @@ type apiV1RouteDeps struct {
 	statsHandlers               *admin.StatsHandler
 	scmWebhookHandler           *webhooks.SCMWebhookHandler
 	approvalWebhookHandler      *webhooks.ApprovalHandler
+	egressGuard                 *httpsafe.Guard
 }
 
 // registerAPIV1Routes wires the /api/v1, /scim/v2, and webhook route table
@@ -415,6 +417,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 	statsHandlers := d.statsHandlers
 	scmWebhookHandler := d.scmWebhookHandler
 	approvalWebhookHandler := d.approvalWebhookHandler
+	egressGuard := d.egressGuard
 
 	// Admin API endpoints
 	apiV1 := router.Group("/api/v1")
@@ -519,7 +522,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// auth-required so internal state/source names aren't exposed anonymously.
 			// Namespaced under /suite to avoid the /modules/:version wildcard.
 			authenticatedGroup.GET("/suite/modules/:namespace/:name/:system/consumers",
-				moduleConsumersHandler(func() *suite.DiscoveryClient { return suiteClient }, cfg))
+				moduleConsumersHandler(func() *suite.DiscoveryClient { return suiteClient }, cfg, egressGuard))
 
 			// Stats endpoints (require auth)
 			authenticatedGroup.GET("/admin/stats/dashboard", statsHandlers.GetDashboardStats)
@@ -627,6 +630,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScanByIDHandler(db))
 			installHandler := admin.NewScanningInstallHandler(&cfg.Scanning, nil, scannerUpdateJob, sbvRepo, scannerApprovalRepo)
+			installHandler.SetEgressGuard(egressGuard)
 			authenticatedGroup.POST("/admin/scanning/install",
 				middleware.RequireScope(auth.ScopeAdmin),
 				installHandler.Install())
@@ -635,7 +639,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				admin.TriggerScannerCheckHandler(scannerUpdateJob))
 			authenticatedGroup.GET("/admin/scanning/latest",
 				middleware.RequireScope(auth.ScopeScanningRead),
-				admin.GetScannerLatestHandler(&cfg.Scanning))
+				admin.GetScannerLatestHandler(&cfg.Scanning, egressGuard))
 			scanningAutoUpdateHandler := admin.NewScanningAutoUpdateHandler(&cfg.Scanning, oidcConfigRepo, scannerUpdateJob)
 			authenticatedGroup.PUT("/admin/scanning/auto-update",
 				middleware.RequireScope(auth.ScopeAdmin),

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
@@ -42,6 +43,7 @@ type Handlers struct {
 	authHandlers      *admin.AuthHandlers // to swap OIDC provider at runtime
 	installFunc       installer.InstallFunc
 	scannerJob        *jobs.ModuleScannerJob
+	egressGuard       *httpsafe.Guard
 }
 
 // WithScannerJob attaches the scanner job so that SaveScanningConfig can kick
@@ -49,6 +51,14 @@ type Handlers struct {
 // server restart.
 func (h *Handlers) WithScannerJob(job *jobs.ModuleScannerJob) *Handlers {
 	h.scannerJob = job
+	return h
+}
+
+// WithEgressGuard attaches the operator-configured egress guard so that
+// InstallScanner's installer.Handle call routes its downloads through the
+// shared httpsafe policy (issue #676); nil is the strict default.
+func (h *Handlers) WithEgressGuard(g *httpsafe.Guard) *Handlers {
+	h.egressGuard = g
 	return h
 }
 

--- a/backend/internal/api/setup/install.go
+++ b/backend/internal/api/setup/install.go
@@ -44,7 +44,7 @@ func (h *Handlers) InstallScanner(c *gin.Context) {
 		install = installer.Install
 	}
 
-	ok, result, errMsg := installer.Handle(ctx, h.cfg.Scanning.InstallDir, install, input.Tool, input.Version)
+	ok, result, errMsg := installer.Handle(ctx, h.cfg.Scanning.InstallDir, h.egressGuard, install, input.Tool, input.Version)
 	if !ok {
 		if errMsg == "scanning.install_dir is not configured on the server" {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": errMsg})

--- a/backend/internal/api/setup/install_test.go
+++ b/backend/internal/api/setup/install_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
 
@@ -154,6 +155,34 @@ func TestInstallScanner_Success_LatestVersion(t *testing.T) {
 	}
 	if resp.BinaryPath == "" {
 		t.Error("binary_path empty")
+	}
+}
+
+// TestInstallScanner_ThreadsEgressGuard locks in that the setup wizard's
+// install endpoint passes the operator-configured egress guard through
+// installer.Handle into the InstallConfig the install func receives (issue
+// #676's threading requirement), rather than silently falling back to the
+// strict nil-guard default.
+func TestInstallScanner_ThreadsEgressGuard(t *testing.T) {
+	env := newTestEnv(t)
+	env.h.cfg.Scanning.InstallDir = "/tmp/test"
+	g := httpsafe.MustGuard("10.0.0.0/8")
+	env.h.WithEgressGuard(g)
+
+	var got *httpsafe.Guard
+	env.h.installFunc = func(ctx context.Context, cfg installer.InstallConfig, tool, version string) (*installer.Result, error) {
+		got = cfg.EgressGuard
+		return &installer.Result{BinaryPath: "/app/scanners/trivy", Version: "0.52.2"}, nil
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/", jsonBody(map[string]string{"tool": "trivy"}))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	env.h.InstallScanner(c)
+	if got != g {
+		t.Errorf("InstallConfig.EgressGuard = %v, want the guard set via WithEgressGuard", got)
 	}
 }
 

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -13,7 +14,14 @@ import (
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
+
+// maxConsumersResponseBytes bounds the sibling's "/consumers" JSON response
+// body. The 2s Timeout on the client below bounds wall-clock time, not bytes;
+// without this cap a slow-trickle or oversized response would be fully
+// buffered in memory by json.Decode.
+const maxConsumersResponseBytes = 1 << 20 // 1 MB
 
 const suiteIssuer = "terraform-registry"
 
@@ -106,14 +114,19 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 // @Success      200  {object}  map[string]interface{}  "Consuming states (rows forwarded opaquely from the sibling) and total count"
 // @Failure      401  {object}  map[string]interface{}  "Authentication required"
 // @Router       /api/v1/suite/modules/{namespace}/{name}/{system}/consumers [get]
-func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config) gin.HandlerFunc {
+func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config, egressGuard *httpsafe.Guard) gin.HandlerFunc {
 	// hosts is THIS registry's set of canonical host identities the sibling
 	// matches "consumed by" on: its public host, its base/discovery host, and any
 	// operator-configured aliases (TFR_SERVER_HOST_ALIASES) for vanity-CNAME or
 	// port-asymmetry deployments. Canonicalized + de-duped so the join compares
 	// like-for-like against the host TSM captured from the module source address.
 	hosts := canonicalHostSet(cfg.Server.GetPublicURL(), cfg.Server.BaseURL, cfg.Server.HostAliases)
-	httpClient := &http.Client{Timeout: 2 * time.Second}
+	// Routed through the shared httpsafe egress guard like every other outbound
+	// client in this codebase: m.PublicURL is the sibling's self-advertised
+	// discovery field, not the operator-pinned SiblingURL, so it is untrusted
+	// input that must be resolve-and-pinned (and re-validated on redirect) the
+	// same as any other operator/upstream-influenced target (issue #653).
+	httpClient := httpsafe.NewClient(2*time.Second, egressGuard)
 
 	return func(c *gin.Context) {
 		empty := gin.H{"consumers": []any{}, "total": 0}
@@ -132,6 +145,16 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 		// host the outbound request below is permitted to reach.
 		siblingURL, err := url.Parse(m.PublicURL)
 		if err != nil || siblingURL.Host == "" {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		// m.PublicURL is the sibling's self-advertised manifest field, not the
+		// operator-pinned SiblingURL, so its scheme and target range are
+		// re-checked against the egress policy up front (the httpsafe client
+		// below re-validates at dial time regardless, but this fails fast with
+		// a clear reason instead of an opaque "sibling unreachable" empty
+		// result on the happy-path shape).
+		if err := egressGuard.ValidateURL(m.PublicURL); err != nil {
 			c.JSON(http.StatusOK, empty)
 			return
 		}
@@ -182,7 +205,7 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 			Consumers []json.RawMessage `json:"consumers"`
 			Total     int               `json:"total"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxConsumersResponseBytes)).Decode(&body); err != nil {
 			c.JSON(http.StatusOK, empty)
 			return
 		}

--- a/backend/internal/api/suite_consumers_test.go
+++ b/backend/internal/api/suite_consumers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,12 +14,20 @@ import (
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
-func mountConsumers(cfg *config.Config, dc *suite.DiscoveryClient) *gin.Engine {
+// loopbackGuard allow-lists the loopback addresses httptest.NewServer binds to
+// (127.0.0.1 / ::1) so the positive-path tests below can exercise a real
+// outbound round trip through the httpsafe-guarded client (issue #653)
+// without the strict default policy rejecting the test server itself as an
+// internal target.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
+
+func mountConsumers(cfg *config.Config, dc *suite.DiscoveryClient, guard *httpsafe.Guard) *gin.Engine {
 	r := gin.New()
 	r.GET("/api/v1/suite/modules/:namespace/:name/:system/consumers",
-		moduleConsumersHandler(func() *suite.DiscoveryClient { return dc }, cfg))
+		moduleConsumersHandler(func() *suite.DiscoveryClient { return dc }, cfg, guard))
 	return r
 }
 
@@ -57,7 +66,7 @@ func TestModuleConsumers_StandaloneReturnsEmpty(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Server.PublicURL = "https://registry.example.com"
 	cfg.Suite.SiblingToken = "tok"
-	code, out := getConsumers(mountConsumers(cfg, nil)) // no sibling
+	code, out := getConsumers(mountConsumers(cfg, nil, nil)) // no sibling
 	if code != http.StatusOK {
 		t.Fatalf("status = %d", code)
 	}
@@ -77,7 +86,7 @@ func TestModuleConsumers_NoTokenReturnsEmpty(t *testing.T) {
 
 	cfg := &config.Config{}
 	cfg.Server.PublicURL = "https://registry.example.com" // SiblingToken empty → inert
-	_, out := getConsumers(mountConsumers(cfg, dc))
+	_, out := getConsumers(mountConsumers(cfg, dc, loopbackGuard))
 	if c, _ := out["consumers"].([]any); len(c) != 0 {
 		t.Errorf("no sibling token must yield empty: %v", out)
 	}
@@ -106,7 +115,7 @@ func TestModuleConsumers_ProxiesActiveSibling(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Server.PublicURL = "https://registry.example.com"
 	cfg.Suite.SiblingToken = "s3cr3t"
-	code, out := getConsumers(mountConsumers(cfg, dc))
+	code, out := getConsumers(mountConsumers(cfg, dc, loopbackGuard))
 	if code != http.StatusOK {
 		t.Fatalf("status = %d", code)
 	}
@@ -151,7 +160,7 @@ func TestModuleConsumers_EmitsHostAliasSet(t *testing.T) {
 	cfg.Server.BaseURL = "http://registry.internal:8080"
 	cfg.Server.HostAliases = []string{"tf.example.com", "REGISTRY.example.com"} // alias + dup-of-public
 	cfg.Suite.SiblingToken = "s3cr3t"
-	if code, _ := getConsumers(mountConsumers(cfg, dc)); code != http.StatusOK {
+	if code, _ := getConsumers(mountConsumers(cfg, dc, loopbackGuard)); code != http.StatusOK {
 		t.Fatalf("status = %d", code)
 	}
 
@@ -182,8 +191,90 @@ func TestModuleConsumers_SiblingErrorReturnsEmpty(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Server.PublicURL = "https://registry.example.com"
 	cfg.Suite.SiblingToken = "s3cr3t"
-	_, out := getConsumers(mountConsumers(cfg, dc))
+	_, out := getConsumers(mountConsumers(cfg, dc, loopbackGuard))
 	if c, _ := out["consumers"].([]any); len(c) != 0 {
 		t.Errorf("sibling error must yield empty (graceful): %v", out)
+	}
+}
+
+// TestModuleConsumers_OversizedResponseIsCappedAndFails is the regression test
+// for issue #662: the sibling response is decoded through an io.LimitReader
+// capped at maxConsumersResponseBytes (1 MB), so a well-formed JSON document
+// whose encoded size exceeds that cap is truncated mid-document and fails to
+// decode, falling back to the graceful empty result -- it is never fully
+// buffered or forwarded. Without the io.LimitReader wrap (i.e. reverting
+// suite.go's decode to a bare resp.Body), this same oversized document would
+// decode successfully with all its rows and this test would fail.
+func TestModuleConsumers_OversizedResponseIsCappedAndFails(t *testing.T) {
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			w.Header().Set("Content-Type", "application/json")
+			// A single well-formed JSON document whose encoded size exceeds
+			// maxConsumersResponseBytes: the padding pushes total size past the
+			// cap, so io.LimitReader truncates mid-string before the closing
+			// quote/braces are ever read.
+			_, _ = io.WriteString(w, `{"consumers":[{"source_id":"s1","pad":"`)
+			_, _ = io.WriteString(w, strings.Repeat("x", maxConsumersResponseBytes+1024))
+			_, _ = io.WriteString(w, `"}],"total":1}`)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest) // discovery poll
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "s3cr3t"
+	code, out := getConsumers(mountConsumers(cfg, dc, loopbackGuard))
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if c, _ := out["consumers"].([]any); len(c) != 0 {
+		t.Errorf("oversized (cap-truncated) response must decode-fail to empty, got %d consumers", len(c))
+	}
+}
+
+// TestModuleConsumers_BlocksNonAllowlistedSiblingURL is the negative test for
+// issue #653: moduleConsumersHandler must not reach a sibling whose
+// self-advertised PublicURL (m.PublicURL, taken from the discovery manifest —
+// not the operator-pinned SiblingURL) is outside the operator's egress
+// allow-list, even though discovery itself already succeeded. A nil egress
+// guard is the strict default policy (no allow-list), so the loopback address
+// every httptest.Server in this file binds to stands in for the internal/
+// metadata host a compromised sibling or a MITM'd discovery response could
+// try to steer this credential-bearing request at.
+func TestModuleConsumers_BlocksNonAllowlistedSiblingURL(t *testing.T) {
+	var consumersHit bool
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			consumersHit = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"consumers": []map[string]any{{"source_id": "s1"}},
+				"total":     1,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest) // discovery poll
+	}))
+	defer srv.Close()
+	manifest.PublicURL = srv.URL
+	dc := activeClient(t, srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "s3cr3t"
+	code, out := getConsumers(mountConsumers(cfg, dc, nil)) // nil guard == strict default, no allow-list
+	if code != http.StatusOK {
+		t.Fatalf("status = %d", code)
+	}
+	if c, _ := out["consumers"].([]any); len(c) != 0 {
+		t.Errorf("non-allowlisted sibling target must yield empty: %v", out)
+	}
+	if consumersHit {
+		t.Error("the sibling's /consumers endpoint must never be reached when its advertised PublicURL is not egress-allowlisted")
 	}
 }

--- a/backend/internal/cve/osv/client.go
+++ b/backend/internal/cve/osv/client.go
@@ -29,6 +29,15 @@ const (
 	requestsPerSec  = 60
 )
 
+// maxOSVResponseBytes bounds the 200-response body read by QuerySingle/doBatch.
+// Every other outbound decode in this codebase (mirror/upstream.go,
+// mirror/github_releases.go, api/suite.go) wraps resp.Body in io.LimitReader
+// before decoding; these two capped only the non-200 error body (4096 bytes)
+// but decoded a 200 response with a bare, unbounded json.NewDecoder.Decode. A
+// batch of up to batchMaxSize queries can legitimately return many advisories,
+// so the cap is generous relative to the small error-body cap.
+const maxOSVResponseBytes = 20 << 20 // 20 MB
+
 // Client is a rate-limited HTTP client for the OSV.dev API.
 type Client struct {
 	endpoint   string
@@ -164,7 +173,7 @@ func (c *Client) QuerySingle(ctx context.Context, q Query) ([]Advisory, error) {
 	}
 
 	var result QueryResult
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxOSVResponseBytes)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode osv response: %w", err)
 	}
 	return result.Vulns, nil
@@ -195,7 +204,7 @@ func (c *Client) doBatch(ctx context.Context, queries []Query) ([]QueryResult, e
 	}
 
 	var br BatchResponse
-	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxOSVResponseBytes)).Decode(&br); err != nil {
 		return nil, fmt.Errorf("decode osv batch response: %w", err)
 	}
 	return br.Results, nil

--- a/backend/internal/cve/osv/client_test.go
+++ b/backend/internal/cve/osv/client_test.go
@@ -3,8 +3,10 @@ package osv
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -257,6 +259,49 @@ func TestQuerySingle_HTTPError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for HTTP 400, got nil")
+	}
+}
+
+// TestQuerySingle_OversizedResponseIsCapped is the regression test for the
+// #662 sibling in this client: the 200 response is decoded through an
+// io.LimitReader capped at maxOSVResponseBytes, so a well-formed JSON document
+// whose encoded size exceeds that cap is truncated mid-document and fails to
+// decode. Without the io.LimitReader wrap this same oversized document would
+// decode successfully and this test would fail.
+func TestQuerySingle_OversizedResponseIsCapped(t *testing.T) {
+	srv, client := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"vulns":[{"id":"GHSA-0001","summary":"pad`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxOSVResponseBytes+1024))
+		_, _ = io.WriteString(w, `"}]}`)
+	}))
+	_ = srv
+
+	_, err := client.QuerySingle(context.Background(), Query{
+		Package: Package{Ecosystem: "Go", Name: "example"}, Version: "1.0.0",
+	})
+	if err == nil {
+		t.Fatal("expected decode error for response exceeding maxOSVResponseBytes, got nil")
+	}
+}
+
+// TestDoBatch_OversizedResponseIsCapped is the regression test for the #662
+// sibling in doBatch's success-path decode (see
+// TestQuerySingle_OversizedResponseIsCapped for the cap-truncation rationale).
+func TestDoBatch_OversizedResponseIsCapped(t *testing.T) {
+	srv, client := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[{"vulns":[{"id":"GHSA-0001","summary":"pad`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxOSVResponseBytes+1024))
+		_, _ = io.WriteString(w, `"}]}]}`)
+	}))
+	_ = srv
+
+	_, err := client.doBatch(context.Background(), []Query{
+		{Package: Package{Ecosystem: "Go", Name: "foo"}, Version: "1.0.0"},
+	})
+	if err == nil {
+		t.Fatal("expected decode error for batch response exceeding maxOSVResponseBytes, got nil")
 	}
 }
 

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -1053,6 +1053,14 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 
 	log.Printf("Checksum verified for %s: %s", packageInfo.Filename, checksumHex)
 
+	// packageInfo.Filename comes straight from the upstream registry's package
+	// descriptor, unlike the other segments of this path (which are validated
+	// registry identifiers / platform values); reject path separators and '..'
+	// before it reaches the storage key (issue #677).
+	if err := validation.ValidateStorageFilename(packageInfo.Filename); err != nil {
+		return fmt.Errorf("unsafe filename from upstream package descriptor: %w", err)
+	}
+
 	// Store the binary
 	storagePath := fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s",
 		namespace, providerName, version, platform.OS, platform.Arch, packageInfo.Filename)

--- a/backend/internal/jobs/mirror_sync_test.go
+++ b/backend/internal/jobs/mirror_sync_test.go
@@ -2,13 +2,17 @@ package jobs
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
 
 // ---------------------------------------------------------------------------
@@ -480,5 +484,132 @@ func TestMirrorSyncJob_Stop_DirectStop(t *testing.T) {
 		// OK — Start returned after Stop()
 	case <-time.After(3 * time.Second):
 		t.Error("Start did not return after Stop()")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncPlatformBinary — upstream-controlled filename validation (issue #677)
+// ---------------------------------------------------------------------------
+
+// fakeUpstreamClient is a minimal mirror.UpstreamRegistryClient stub whose
+// GetProviderPackage/DownloadFileStream responses are set per test, per the
+// dependency-injection contract documented on the interface itself.
+type fakeUpstreamClient struct {
+	pkg    *mirror.ProviderPackageResponse
+	pkgErr error
+	binary string // DownloadFileStream body content
+	dlErr  error
+}
+
+func (f *fakeUpstreamClient) DiscoverServices(_ context.Context) (*mirror.ServiceDiscoveryResponse, error) {
+	return nil, nil
+}
+func (f *fakeUpstreamClient) ListProviderVersions(_ context.Context, _, _ string) ([]mirror.ProviderVersion, error) {
+	return nil, nil
+}
+func (f *fakeUpstreamClient) GetProviderPackage(_ context.Context, _, _, _, _, _ string) (*mirror.ProviderPackageResponse, error) {
+	return f.pkg, f.pkgErr
+}
+func (f *fakeUpstreamClient) DownloadFile(_ context.Context, _ string) ([]byte, error) {
+	return []byte(f.binary), f.dlErr
+}
+func (f *fakeUpstreamClient) DownloadFileStream(_ context.Context, _ string) (*mirror.DownloadStream, error) {
+	if f.dlErr != nil {
+		return nil, f.dlErr
+	}
+	return &mirror.DownloadStream{Body: io.NopCloser(strings.NewReader(f.binary)), ContentLength: int64(len(f.binary))}, nil
+}
+func (f *fakeUpstreamClient) GetProviderDocIndexByVersion(_ context.Context, _, _, _ string) ([]mirror.ProviderDocEntry, error) {
+	return nil, nil
+}
+func (f *fakeUpstreamClient) GetProviderDocContent(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+var _ mirror.UpstreamRegistryClient = (*fakeUpstreamClient)(nil)
+
+// TestSyncPlatformBinary_RejectsUnsafeUpstreamFilename is the negative test for
+// issue #677: an upstream package descriptor reporting a path-traversal
+// filename must be rejected before it reaches the storage key. The job's
+// storageBackend/providerRepo are left nil — the validation error must be
+// returned before either is touched, so a regression here would panic (nil
+// storageBackend.Upload) rather than silently succeed.
+func TestSyncPlatformBinary_RejectsUnsafeUpstreamFilename(t *testing.T) {
+	job := NewMirrorSyncJob(nil, nil, nil, nil, nil, "")
+	upstream := &fakeUpstreamClient{
+		pkg: &mirror.ProviderPackageResponse{
+			Filename:    "../../etc/passwd",
+			DownloadURL: "https://upstream.example.com/download",
+		},
+		binary: "fake-binary-content",
+	}
+	versionRecord := &models.ProviderVersion{ID: "v1"}
+
+	err := job.syncPlatformBinary(context.Background(), upstream, versionRecord,
+		"hashicorp", "aws", "5.0.0", mirror.ProviderPlatform{OS: "linux", Arch: "amd64"}, nil)
+	if err == nil {
+		t.Fatal("expected error for path-traversal filename from upstream package descriptor")
+	}
+	if !strings.Contains(err.Error(), "unsafe filename") {
+		t.Errorf("error = %q, want it to mention the unsafe filename check", err.Error())
+	}
+}
+
+// fakeUploadStorage is a minimal storage.Storage stub recording the path
+// passed to Upload, for the positive-path test below.
+type fakeUploadStorage struct {
+	uploadedPath string
+}
+
+func (s *fakeUploadStorage) Upload(_ context.Context, path string, _ io.Reader, size int64) (*storage.UploadResult, error) {
+	s.uploadedPath = path
+	return &storage.UploadResult{Path: path, Size: size}, nil
+}
+func (s *fakeUploadStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	return nil, nil
+}
+func (s *fakeUploadStorage) Delete(_ context.Context, _ string) error { return nil }
+func (s *fakeUploadStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return "", nil
+}
+func (s *fakeUploadStorage) Exists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (s *fakeUploadStorage) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
+	return nil, nil
+}
+
+var _ storage.Storage = (*fakeUploadStorage)(nil)
+
+// TestSyncPlatformBinary_AcceptsWellFormedFilename is the positive-path
+// companion: a normal upstream filename must still pass the new validation
+// check and reach the storage backend, at the same storage path as before
+// this fix.
+func TestSyncPlatformBinary_AcceptsWellFormedFilename(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("platform-1"))
+
+	job := NewMirrorSyncJob(nil, repositories.NewProviderRepository(db), nil, nil, &fakeUploadStorage{}, "local")
+	upstream := &fakeUpstreamClient{
+		pkg: &mirror.ProviderPackageResponse{
+			Filename:    "terraform-provider-aws_5.0.0_linux_amd64.zip",
+			DownloadURL: "https://upstream.example.com/download",
+		},
+		binary: "fake-binary-content",
+	}
+	versionRecord := &models.ProviderVersion{ID: "v1"}
+
+	err = job.syncPlatformBinary(context.Background(), upstream, versionRecord,
+		"hashicorp", "aws", "5.0.0", mirror.ProviderPlatform{OS: "linux", Arch: "amd64"}, nil)
+	if err != nil {
+		t.Fatalf("syncPlatformBinary: %v", err)
+	}
+	gotStorage := job.storageBackend.(*fakeUploadStorage)
+	wantPath := "providers/hashicorp/aws/5.0.0/linux/amd64/terraform-provider-aws_5.0.0_linux_amd64.zip"
+	if gotStorage.uploadedPath != wantPath {
+		t.Errorf("uploaded path = %q, want %q", gotStorage.uploadedPath, wantPath)
 	}
 }

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -23,6 +23,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
@@ -50,6 +51,12 @@ type ScannerUpdateJob struct {
 	manualCh chan struct{}
 	mu       sync.Mutex
 	started  bool
+	// egressGuard is threaded into every installer.InstallConfig this job builds
+	// so the installer's default HTTP client (GitHub API + browser_download_url
+	// asset fetches) is routed through the shared httpsafe resolve-and-pin guard
+	// rather than a bare http.Client (issue #676's defect class). Set via
+	// SetEgressGuard; nil is the strict default policy.
+	egressGuard *httpsafe.Guard
 }
 
 // NewScannerUpdateJob constructs a ScannerUpdateJob. check and download default to
@@ -96,6 +103,12 @@ func (j *ScannerUpdateJob) Name() string { return "scanner-update" }
 // Teams/email), in addition to the direct recipients email. Call before Start.
 func (j *ScannerUpdateJob) SetNotifier(n *notify.Notifier) {
 	j.notifier = n
+}
+
+// SetEgressGuard wires the shared egress guard into every installer.InstallConfig
+// this job builds (issue #676). Call before Start.
+func (j *ScannerUpdateJob) SetEgressGuard(g *httpsafe.Guard) {
+	j.egressGuard = g
 }
 
 // Start begins the background update-check loop. It runs an initial check (plus
@@ -190,7 +203,7 @@ func (j *ScannerUpdateJob) runCheck(ctx context.Context) {
 		return
 	}
 
-	latest, err := j.check(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir}, tool)
+	latest, err := j.check(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir, EgressGuard: j.egressGuard}, tool)
 	if err != nil {
 		log.Printf("[scanner-update] failed to check latest version for %s: %v", tool, err)
 		return
@@ -210,7 +223,7 @@ func (j *ScannerUpdateJob) runCheck(ctx context.Context) {
 		return
 	}
 
-	res, err := j.download(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir, SignatureMode: j.scanCfg.SignatureVerification}, tool, latest.LatestVersion)
+	res, err := j.download(ctx, installer.InstallConfig{InstallDir: j.scanCfg.InstallDir, SignatureMode: j.scanCfg.SignatureVerification, EgressGuard: j.egressGuard}, tool, latest.LatestVersion)
 	if err != nil {
 		log.Printf("[scanner-update] failed to download %s %s: %v", tool, latest.LatestVersion, err)
 		failed := &models.ScannerBinaryVersion{

--- a/backend/internal/jobs/scanner_update_job_test.go
+++ b/backend/internal/jobs/scanner_update_job_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // newTestScannerUpdateJob builds a ScannerUpdateJob with only scanCfg populated,
@@ -29,6 +30,22 @@ func newTestScannerUpdateJob(scanCfg *config.ScanningConfig) *ScannerUpdateJob {
 		nil, // check (defaults to installer.CheckLatest, unused here)
 		nil, // download (defaults to installer.DownloadVerified, unused here)
 	)
+}
+
+// TestScannerUpdateJob_SetEgressGuard locks in that SetEgressGuard (issue #676)
+// actually populates the field runCheck threads into every
+// installer.InstallConfig it builds; runCheck itself needs a live Postgres
+// (sbvRepo) so isn't exercised here — see the file doc comment.
+func TestScannerUpdateJob_SetEgressGuard(t *testing.T) {
+	j := newTestScannerUpdateJob(&config.ScanningConfig{})
+	if j.egressGuard != nil {
+		t.Fatalf("egressGuard = %v, want nil before SetEgressGuard", j.egressGuard)
+	}
+	g := httpsafe.MustGuard("10.0.0.0/8")
+	j.SetEgressGuard(g)
+	if j.egressGuard != g {
+		t.Error("SetEgressGuard did not set the egressGuard field")
+	}
 }
 
 func TestSupersededDirsToRemove(t *testing.T) {

--- a/backend/internal/jobs/terraform_mirror_attestation_test.go
+++ b/backend/internal/jobs/terraform_mirror_attestation_test.go
@@ -26,7 +26,7 @@ func TestAttestationVerifierForConfig_FlagOff_NoAttempt(t *testing.T) {
 		UpstreamURL:             "https://github.com/open-policy-agent/opa",
 		VerifyGitHubAttestation: false,
 	}
-	if v := attestationVerifierForConfig(cfg); v != nil {
+	if v := attestationVerifierForConfig(cfg, nil); v != nil {
 		t.Errorf("expected nil verifier when flag is off, got %v", v)
 	}
 }
@@ -37,7 +37,7 @@ func TestAttestationVerifierForConfig_NonGitHubUpstream_NoAttempt(t *testing.T) 
 		UpstreamURL:             "https://releases.hashicorp.com",
 		VerifyGitHubAttestation: true,
 	}
-	if v := attestationVerifierForConfig(cfg); v != nil {
+	if v := attestationVerifierForConfig(cfg, nil); v != nil {
 		t.Errorf("expected nil verifier for non-GitHub upstream even with flag on, got %v", v)
 	}
 }
@@ -48,7 +48,7 @@ func TestAttestationVerifierForConfig_FlagOn_GitHubUpstream_Attempted(t *testing
 		UpstreamURL:             "https://github.com/open-policy-agent/opa",
 		VerifyGitHubAttestation: true,
 	}
-	v := attestationVerifierForConfig(cfg)
+	v := attestationVerifierForConfig(cfg, nil)
 	if v == nil {
 		t.Fatal("expected non-nil verifier when flag is on and upstream is GitHub-hosted")
 	}
@@ -62,7 +62,7 @@ func TestAttestationVerifierForConfig_InvalidUpstream_NoAttempt(t *testing.T) {
 		UpstreamURL:             "https://github.com/",
 		VerifyGitHubAttestation: true,
 	}
-	if v := attestationVerifierForConfig(cfg); v != nil {
+	if v := attestationVerifierForConfig(cfg, nil); v != nil {
 		t.Errorf("expected nil verifier for unparseable GitHub URL, got %v", v)
 	}
 }

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -549,7 +549,7 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 	// platform — the pinned identity is the same for every binary in this
 	// config). nil when the flag is off or the upstream isn't GitHub-hosted,
 	// in which case syncOnePlatform skips attestation entirely.
-	attestVerifier := attestationVerifierForConfig(cfg)
+	attestVerifier := attestationVerifierForConfig(cfg, j.egressGuard)
 
 	platformOK := 0
 	platformFail := 0
@@ -716,6 +716,15 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 
 	if _, seekErr := tmpFile.Seek(0, io.SeekStart); seekErr != nil {
 		errStr := fmt.Sprintf("failed to seek temp file: %v", seekErr)
+		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, sha256Verified, sumsGPGVerified, attestationVerified, &errStr)
+		return false
+	}
+
+	// p.Filename comes straight from the upstream releases index (same defect
+	// class as the provider mirror's packageInfo.Filename, issue #677): reject
+	// path separators and '..' before it reaches the storage key.
+	if err := validation.ValidateStorageFilename(p.Filename); err != nil {
+		errStr := fmt.Sprintf("unsafe filename from upstream releases index: %v", err)
 		_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "failed", nil, nil, sha256Verified, sumsGPGVerified, attestationVerified, &errStr)
 		return false
 	}
@@ -947,7 +956,7 @@ func (j *TerraformMirrorSyncJob) backfillAttestation(
 	cfg *models.TerraformMirrorConfig,
 	filteredVersions []mirror.TerraformVersionInfo,
 ) error {
-	verifier := attestationVerifierForConfig(cfg)
+	verifier := attestationVerifierForConfig(cfg, j.egressGuard)
 	if verifier == nil {
 		return nil
 	}
@@ -1151,11 +1160,15 @@ type attestationVerifier interface {
 // or the upstream is not GitHub-hosted (the attestation API is GitHub-only —
 // releases.hashicorp.com and releases.opentofu.org have no equivalent), in
 // which case callers skip attestation entirely and stay checksum-only.
-func attestationVerifierForConfig(cfg *models.TerraformMirrorConfig) attestationVerifier {
+//
+// egress is threaded through to the verifier's HTTP client (same operator-
+// configured guard as newReleasesClient above), for parity with the rest of
+// this sync job's outbound calls (issue #676's Minter fix, same defect class).
+func attestationVerifierForConfig(cfg *models.TerraformMirrorConfig, egress *httpsafe.Guard) attestationVerifier {
 	if !cfg.VerifyGitHubAttestation || !mirror.IsGitHubReleasesURL(cfg.UpstreamURL) {
 		return nil
 	}
-	v, err := mirror.NewGitHubAttestationVerifier(cfg.UpstreamURL)
+	v, err := mirror.NewGitHubAttestationVerifierWithGuard(cfg.UpstreamURL, egress)
 	if err != nil {
 		log.Printf("[terraform-mirror] cannot build GitHub attestation verifier for %s: %v", cfg.UpstreamURL, err)
 		return nil

--- a/backend/internal/jobs/terraform_mirror_sync_test.go
+++ b/backend/internal/jobs/terraform_mirror_sync_test.go
@@ -4,13 +4,17 @@ package jobs
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
 )
 
 // newTestTerraformSyncJob returns a job with nil dependencies — sufficient for
@@ -124,5 +128,85 @@ func TestTerraformMirrorSyncJob_StartContextCancel(t *testing.T) {
 		// OK — Start returned after context cancellation
 	case <-time.After(3 * time.Second):
 		t.Error("Start did not return after context cancellation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncOnePlatform — upstream-controlled filename validation (issue #677)
+// ---------------------------------------------------------------------------
+
+// fakeReleasesClient is a minimal terraformReleasesClient stub; only
+// DownloadBinaryStream is exercised by syncOnePlatform.
+type fakeReleasesClient struct {
+	binary string
+}
+
+func (f *fakeReleasesClient) ListVersions(_ context.Context) ([]mirror.TerraformVersionInfo, error) {
+	return nil, nil
+}
+func (f *fakeReleasesClient) FetchSHASums(_ context.Context, _ string) (map[string]string, []byte, error) {
+	return nil, nil, nil
+}
+func (f *fakeReleasesClient) FetchSHASumsSignature(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+func (f *fakeReleasesClient) DownloadBinaryStream(_ context.Context, _ string) (io.ReadCloser, int64, error) {
+	return io.NopCloser(strings.NewReader(f.binary)), int64(len(f.binary)), nil
+}
+
+var _ terraformReleasesClient = (*fakeReleasesClient)(nil)
+
+// TestSyncOnePlatform_RejectsUnsafeUpstreamFilename is the negative test for
+// issue #677: an upstream releases-index entry reporting a path-traversal
+// filename must be rejected before it reaches the storage key.
+func TestSyncOnePlatform_RejectsUnsafeUpstreamFilename(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectExec("UPDATE terraform_version_platforms").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	job := NewTerraformMirrorSyncJob(repo, nil, "local")
+	client := &fakeReleasesClient{binary: "fake-binary-content"}
+	p := models.TerraformVersionPlatform{ID: uuid.New(), OS: "linux", Arch: "amd64", Filename: "../../etc/passwd"}
+
+	ok := job.syncOnePlatform(context.Background(), client, "1.7.0", p, nil, false, nil)
+	if ok {
+		t.Fatal("expected syncOnePlatform to fail for a path-traversal filename from the upstream releases index")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestSyncOnePlatform_AcceptsWellFormedFilename is the positive-path
+// companion: a normal upstream filename must still pass the new validation
+// check and reach the storage backend at the expected storage path.
+func TestSyncOnePlatform_AcceptsWellFormedFilename(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectExec("UPDATE terraform_version_platforms").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	fakeStorage := &fakeUploadStorage{}
+	job := NewTerraformMirrorSyncJob(repo, fakeStorage, "local")
+	client := &fakeReleasesClient{binary: "fake-binary-content"}
+	p := models.TerraformVersionPlatform{ID: uuid.New(), OS: "linux", Arch: "amd64", Filename: "terraform_1.7.0_linux_amd64.zip"}
+
+	ok := job.syncOnePlatform(context.Background(), client, "1.7.0", p, nil, false, nil)
+	if !ok {
+		t.Fatal("expected syncOnePlatform to succeed for a well-formed upstream filename")
+	}
+	wantPath := "terraform-binaries/1.7.0/linux/amd64/terraform_1.7.0_linux_amd64.zip"
+	if fakeStorage.uploadedPath != wantPath {
+		t.Errorf("uploaded path = %q, want %q", fakeStorage.uploadedPath, wantPath)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
 	}
 }

--- a/backend/internal/mirror/attestation.go
+++ b/backend/internal/mirror/attestation.go
@@ -56,6 +56,8 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/util"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // GitHubActionsOIDCIssuer is the only OIDC issuer accepted for GitHub Artifact
@@ -129,10 +131,14 @@ var attestationTrustRootAggregateTimeout = attestationTrustRootFetchTimeout
 var fetchTrustRoot = func() (*root.TrustedRoot, error) {
 	// Each individual HTTP round trip is bounded by this client; the
 	// aggregate deadline across the whole (possibly multi-request) fetch is
-	// separately enforced by fetchTrustRootBounded.
+	// separately enforced by fetchTrustRootBounded. Routed through the shared
+	// httpsafe egress guard for parity with every other outbound client in
+	// this package (sibling of issue #676's Minter fix): the CDN host is
+	// fixed and public so a nil guard (strict default) is correct here, but a
+	// bare http.Client is still the wrong default to reach for.
 	f := fetcher.NewDefaultFetcher()
 	f.SetHTTPUserAgent(util.ConstructUserAgent())
-	f.SetHTTPClient(&http.Client{Timeout: attestationTrustRootFetchTimeout})
+	f.SetHTTPClient(httpsafe.NewClient(attestationTrustRootFetchTimeout, nil))
 
 	// DisableLocalCache lets the TUF client work on a read-only root
 	// filesystem (e.g. Kubernetes readOnlyRootFilesystem: true), matching
@@ -240,8 +246,20 @@ type GitHubAttestationVerifier struct {
 }
 
 // NewGitHubAttestationVerifier builds a verifier for the repository referenced
-// by a GitHub upstream URL (same URL formats ParseGitHubOwnerRepo accepts).
+// by a GitHub upstream URL (same URL formats ParseGitHubOwnerRepo accepts),
+// using the strict (no allow-list) egress policy. Equivalent to
+// NewGitHubAttestationVerifierWithGuard(upstreamURL, nil).
 func NewGitHubAttestationVerifier(upstreamURL string) (*GitHubAttestationVerifier, error) {
+	return NewGitHubAttestationVerifierWithGuard(upstreamURL, nil)
+}
+
+// NewGitHubAttestationVerifierWithGuard is NewGitHubAttestationVerifier with an
+// egress guard, for parity with the other outbound paths in this package
+// (UpstreamRegistry, releases clients): the attestation fetch carries a
+// credential (the GITHUB_TOKEN bearer token, when set) to a fixed public host,
+// so it is routed through the shared httpsafe resolve-and-pin client rather
+// than a bare http.Client (sibling of issue #676's Minter fix).
+func NewGitHubAttestationVerifierWithGuard(upstreamURL string, egress *httpsafe.Guard) (*GitHubAttestationVerifier, error) {
 	owner, repo, err := ParseGitHubOwnerRepo(upstreamURL)
 	if err != nil {
 		return nil, err
@@ -249,7 +267,7 @@ func NewGitHubAttestationVerifier(upstreamURL string) (*GitHubAttestationVerifie
 	return &GitHubAttestationVerifier{
 		Owner:      owner,
 		Repo:       repo,
-		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		HTTPClient: httpsafe.NewClient(30*time.Second, egress),
 		APIToken:   os.Getenv("GITHUB_TOKEN"),
 		APIBaseURL: "https://api.github.com",
 

--- a/backend/internal/mirror/attestation_test.go
+++ b/backend/internal/mirror/attestation_test.go
@@ -337,6 +337,35 @@ func TestNewGitHubAttestationVerifier_InvalidURL(t *testing.T) {
 	}
 }
 
+// TestNewGitHubAttestationVerifierWithGuard_RejectsLoopbackTarget exercises
+// the egress guard wired into NewGitHubAttestationVerifier/WithGuard (sibling
+// of issue #676's Minter fix): APIBaseURL defaults to the fixed public
+// api.github.com host, but the client itself must still fail closed against
+// an internal/loopback target rather than silently dialing it, so a future
+// misconfiguration (or test regression) can't turn this into a live SSRF
+// primitive. A nil guard is the strict default policy, and port 1 is closed,
+// so this fails before any TCP connect is attempted.
+func TestNewGitHubAttestationVerifierWithGuard_RejectsLoopbackTarget(t *testing.T) {
+	vs, _ := ca.NewVirtualSigstore()
+	v, err := NewGitHubAttestationVerifierWithGuard("https://github.com/"+testOwner+"/"+testRepo, nil) // nil guard == strict default
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v.APIBaseURL = "http://127.0.0.1:1" // nothing listens here
+	v.trustedMaterial = func() (root.TrustedMaterial, error) { return vs, nil }
+
+	err = v.VerifyBinaryAttestation(context.Background(), validDigest)
+	if !errors.Is(err, ErrAttestationUnavailable) {
+		t.Fatalf("expected ErrAttestationUnavailable, got %v", err)
+	}
+	// Assert on the guard's own wording, not just "any error": port 1 is
+	// closed, so a bare connection-refused error would also satisfy this
+	// without proving the egress guard is what blocked the request.
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target", err.Error())
+	}
+}
+
 func TestVerifyBinaryAttestation_TrustRootUnavailable(t *testing.T) {
 	called := false
 	v := &GitHubAttestationVerifier{

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -234,7 +234,7 @@ func (c *GitHubReleasesClient) fetchReleasesPage(ctx context.Context, page int) 
 	}
 
 	var releases []gitHubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&releases); err != nil {
 		return nil, fmt.Errorf("failed to decode GitHub releases response: %w", err)
 	}
 	return releases, nil
@@ -520,7 +520,10 @@ func (c *GitHubReleasesClient) fetchReleaseByTag(ctx context.Context, tag string
 	}
 
 	var rel gitHubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+	// maxUpstreamResponseBytes (defined in upstream.go, shared across this
+	// package's outbound clients) bounds this decode the same way it already
+	// bounds fetchReleasesPage above.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&rel); err != nil {
 		return gitHubRelease{}, err
 	}
 	return rel, nil

--- a/backend/internal/mirror/github_releases_test.go
+++ b/backend/internal/mirror/github_releases_test.go
@@ -547,6 +547,29 @@ func TestGitHubListVersions_Success(t *testing.T) {
 	}
 }
 
+// TestGitHubListVersions_OversizedResponseIsCapped is the regression test for
+// the #662 sibling in fetchReleasesPage's decode: the response is decoded
+// through an io.LimitReader capped at maxUpstreamResponseBytes (shared with
+// mirror/upstream.go), so a well-formed JSON array whose encoded size exceeds
+// that cap is truncated mid-document and fails to decode. Without the
+// io.LimitReader wrap this same oversized document would decode successfully
+// and this test would fail.
+func TestGitHubListVersions_OversizedResponseIsCapped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"tag_name":"v1.0.0","draft":false,"assets":[{"name":"pad","browser_download_url":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+		_, _ = io.WriteString(w, `"}]}]`)
+	}))
+	defer ts.Close()
+
+	client := newTestGitHubClient(ts, "opentofu", "opentofu", "opentofu")
+	_, err := client.ListVersions(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error for releases page exceeding maxUpstreamResponseBytes, got nil")
+	}
+}
+
 func TestGitHubListVersions_SkipDraftReleases(t *testing.T) {
 	draft := sampleReleaseJSON("v1.10.0-alpha1", "opentofu")
 	draft.Draft = true
@@ -696,6 +719,26 @@ func TestGitHubFetchSHASums_NotFound(t *testing.T) {
 	_, _, err := client.FetchSHASums(context.Background(), "1.9.0")
 	if err == nil {
 		t.Fatal("expected error when no SHA256SUMS asset found, got nil")
+	}
+}
+
+// TestFetchReleaseByTag_OversizedResponseIsCapped is the regression test for
+// the #662 sibling in fetchReleaseByTag's decode (see
+// TestGitHubListVersions_OversizedResponseIsCapped for the cap-truncation
+// rationale).
+func TestFetchReleaseByTag_OversizedResponseIsCapped(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"tag_name":"v1.9.0","draft":false,"assets":[{"name":"pad","browser_download_url":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+		_, _ = io.WriteString(w, `"}]}`)
+	}))
+	defer ts.Close()
+
+	client := newTestGitHubClient(ts, "opentofu", "opentofu", "opentofu")
+	_, err := client.fetchReleaseByTag(context.Background(), "v1.9.0")
+	if err == nil {
+		t.Fatal("expected decode error for release response exceeding maxUpstreamResponseBytes, got nil")
 	}
 }
 

--- a/backend/internal/mirror/terraform_releases.go
+++ b/backend/internal/mirror/terraform_releases.go
@@ -27,6 +27,12 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
+// maxTerraformIndexBytes bounds the releases index.json stream decoded by
+// ListVersions. The index is typically ~10 MB (see the package doc comment);
+// this cap is generous relative to that so legitimate growth over time isn't
+// affected, while still bounding an adversarial/oversized upstream response.
+const maxTerraformIndexBytes = 64 << 20 // 64 MB
+
 // HashiCorpReleasesGPGKey is the ASCII-armored public GPG key used by
 // HashiCorp to sign release artifact SHA256SUMS files.
 // Source: https://www.hashicorp.com/security / https://keybase.io/hashicorp
@@ -302,8 +308,14 @@ func (c *TerraformReleasesClient) ListVersions(ctx context.Context) ([]Terraform
 	}
 
 	// Stream-decode: read the top-level {"versions":{...}} manually to avoid
-	// holding the full ~10 MB document in memory before processing.
-	dec := json.NewDecoder(resp.Body)
+	// holding the full ~10 MB document in memory before processing. The stream
+	// itself is still capped at maxTerraformIndexBytes: without it, a
+	// compromised/malicious upstream (or a MITM) could serve an oversized or
+	// slow-trickle index.json and grow the decoded versions slice unboundedly
+	// in memory (CWE-400), the same defect class as the other read/decode
+	// sites in this file (FetchSHASums, FetchSHASumsSignature) and in the
+	// sibling upstream.go/github_releases.go files this batch fixed.
+	dec := json.NewDecoder(io.LimitReader(resp.Body, maxTerraformIndexBytes))
 
 	// Opening '{'
 	if _, err := dec.Token(); err != nil {

--- a/backend/internal/mirror/terraform_releases_test.go
+++ b/backend/internal/mirror/terraform_releases_test.go
@@ -194,6 +194,27 @@ func TestListVersions_MalformedJSON(t *testing.T) {
 	}
 }
 
+// TestListVersions_OversizedIndexIsCapped is the regression test for the #662
+// sibling in ListVersions' stream decode: resp.Body is wrapped in an
+// io.LimitReader capped at maxTerraformIndexBytes, so a well-formed index.json
+// whose encoded size exceeds that cap is truncated mid-document and fails to
+// decode instead of being buffered unbounded. Without the io.LimitReader wrap
+// this oversized-but-well-formed document would decode successfully and this
+// test would fail.
+func TestListVersions_OversizedIndexIsCapped(t *testing.T) {
+	_, c := newReleasesClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"versions":{"1.0.0":{"version":"1.0.0","shasums":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxTerraformIndexBytes+1024))
+		_, _ = io.WriteString(w, `"}}}`)
+	})
+
+	_, err := c.ListVersions(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error for index.json exceeding maxTerraformIndexBytes, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // FetchSHASums
 // ---------------------------------------------------------------------------

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -44,6 +44,14 @@ const maxUpstreamResponseBytes = 10 << 20 // 10 MB
 // error messages, matching the cap already used by DownloadFileStream's error path.
 const maxUpstreamErrorBodyBytes = 4096
 
+// maxDownloadFileBytes bounds DownloadFile/downloadFileOnce, used to fetch the
+// SHASUMS and detached-signature files (small text, not the provider binaries
+// themselves — those go through the streaming DownloadFileStream instead).
+// Without this cap the unbounded io.ReadAll would fully buffer an oversized or
+// slow-trickle response from the httpsafe-guarded but still upstream-controlled
+// server in memory (CWE-400), the same defect class fixed elsewhere in this file.
+const maxDownloadFileBytes = 10 << 20 // 10 MB
+
 // NewUpstreamRegistry creates a new upstream registry client with the strict
 // egress policy (no allow-list). Both clients are SSRF-safe: the configured
 // base URL and every upstream-returned URL (download_url, shasums_url,
@@ -296,7 +304,7 @@ func (u *UpstreamRegistry) downloadFileOnce(ctx context.Context, fileURL string)
 		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxDownloadFileBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read download content: %w", err)
 	}
@@ -441,12 +449,12 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 		return "", fmt.Errorf("failed to fetch v2 provider: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		resp.Body.Close()
 		return "", fmt.Errorf("v2 provider lookup failed with status %d: %s", resp.StatusCode, string(body))
 	}
 	var provResp providerV2Response
-	decodeErr := json.NewDecoder(resp.Body).Decode(&provResp)
+	decodeErr := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&provResp)
 	resp.Body.Close()
 	if decodeErr != nil {
 		return "", fmt.Errorf("failed to decode v2 provider response: %w", decodeErr)
@@ -476,12 +484,12 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 			return "", fmt.Errorf("failed to fetch v2 provider-versions (page %d): %w", versionPage, err)
 		}
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 			resp.Body.Close()
 			return "", fmt.Errorf("v2 provider-versions request failed with status %d: %s", resp.StatusCode, string(body))
 		}
 		var versionsResp providerVersionListV2
-		decodeErr = json.NewDecoder(resp.Body).Decode(&versionsResp)
+		decodeErr = json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&versionsResp)
 		resp.Body.Close()
 		if decodeErr != nil {
 			return "", fmt.Errorf("failed to decode v2 provider-versions response (page %d): %w", versionPage, decodeErr)
@@ -535,13 +543,13 @@ func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, nam
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 			resp.Body.Close()
 			return nil, fmt.Errorf("v2 provider doc index request failed with status %d: %s", resp.StatusCode, string(body))
 		}
 
 		var page providerDocListV2
-		decodeErr := json.NewDecoder(resp.Body).Decode(&page)
+		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&page)
 		resp.Body.Close()
 		if decodeErr != nil {
 			return nil, fmt.Errorf("failed to decode v2 provider doc index response (page %d): %w", pageNum, decodeErr)
@@ -595,12 +603,12 @@ func (u *UpstreamRegistry) GetProviderDocContent(ctx context.Context, upstreamDo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxUpstreamErrorBodyBytes))
 		return "", fmt.Errorf("provider doc content request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var v2Resp providerDocContentV2
-	if err := json.NewDecoder(resp.Body).Decode(&v2Resp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&v2Resp); err != nil {
 		return "", fmt.Errorf("failed to decode v2 provider doc response: %w", err)
 	}
 

--- a/backend/internal/mirror/upstream.go
+++ b/backend/internal/mirror/upstream.go
@@ -455,7 +455,7 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 	}
 	var provResp providerV2Response
 	decodeErr := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&provResp)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if decodeErr != nil {
 		return "", fmt.Errorf("failed to decode v2 provider response: %w", decodeErr)
 	}
@@ -490,7 +490,7 @@ func (u *UpstreamRegistry) resolveProviderVersionID(ctx context.Context, namespa
 		}
 		var versionsResp providerVersionListV2
 		decodeErr = json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&versionsResp)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if decodeErr != nil {
 			return "", fmt.Errorf("failed to decode v2 provider-versions response (page %d): %w", versionPage, decodeErr)
 		}
@@ -550,7 +550,7 @@ func (u *UpstreamRegistry) GetProviderDocIndexByVersion(ctx context.Context, nam
 
 		var page providerDocListV2
 		decodeErr := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamResponseBytes)).Decode(&page)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if decodeErr != nil {
 			return nil, fmt.Errorf("failed to decode v2 provider doc index response (page %d): %w", pageNum, decodeErr)
 		}

--- a/backend/internal/mirror/upstream_test.go
+++ b/backend/internal/mirror/upstream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -298,6 +299,28 @@ func TestDownloadFile_Error(t *testing.T) {
 	}
 }
 
+// TestDownloadFile_OversizedResponseCapped locks in the maxDownloadFileBytes
+// cap added to downloadFileOnce (sibling of the #662 CWE-400 fixes elsewhere
+// in this file): DownloadFile is used for SHASUMS/signature files, which are
+// small text, so an oversized response must not be buffered unbounded.
+func TestDownloadFile_OversizedResponseCapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, strings.Repeat("x", maxDownloadFileBytes+1024))
+	}))
+	defer srv.Close()
+
+	u := NewUpstreamRegistryWithGuard("http://example.com", loopbackGuard)
+	u.DownloadClient = u.HTTPClient
+
+	data, err := u.DownloadFile(context.Background(), srv.URL+"/SHA256SUMS")
+	if err != nil {
+		t.Fatalf("DownloadFile error: %v", err)
+	}
+	if len(data) != maxDownloadFileBytes {
+		t.Errorf("len(data) = %d, want exactly maxDownloadFileBytes (%d) — response should be truncated at the cap, not buffered unbounded", len(data), maxDownloadFileBytes)
+	}
+}
+
 func TestDownloadFile_ContextCancelled(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -434,6 +457,57 @@ func TestResolveProviderVersionID_Pagination(t *testing.T) {
 	}
 }
 
+// TestResolveProviderVersionID_OversizedProviderLookupIsCapped is the
+// regression test for the #662 sibling in this file's v2 provider lookup: the
+// response is decoded through an io.LimitReader capped at
+// maxUpstreamResponseBytes (10 MB, matching the v1 functions above), so a
+// well-formed JSON document whose encoded size exceeds that cap is truncated
+// mid-document and fails to decode. Without the io.LimitReader wrap this same
+// oversized document would decode successfully and this test would fail.
+func TestResolveProviderVersionID_OversizedProviderLookupIsCapped(t *testing.T) {
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":{"id":"100","pad":"`)
+			_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+			_, _ = io.WriteString(w, `"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	_, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "5.0.0")
+	if err == nil {
+		t.Fatal("expected decode error for provider lookup response exceeding maxUpstreamResponseBytes, got nil")
+	}
+}
+
+// TestResolveProviderVersionID_OversizedVersionsPageIsCapped is the
+// regression test for the #662 sibling in this file's v2 provider-versions
+// page decode (see TestResolveProviderVersionID_OversizedProviderLookupIsCapped
+// for the cap-truncation rationale).
+func TestResolveProviderVersionID_OversizedVersionsPageIsCapped(t *testing.T) {
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "100"}})
+		case "/v2/providers/100/provider-versions":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"id":"1","attributes":{"version":"pad`)
+			_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+			_, _ = io.WriteString(w, `"}}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	_, err := u.resolveProviderVersionID(context.Background(), "hashicorp", "aws", "5.0.0")
+	if err == nil {
+		t.Fatal("expected decode error for provider-versions page exceeding maxUpstreamResponseBytes, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetProviderDocIndexByVersion
 // ---------------------------------------------------------------------------
@@ -559,6 +633,35 @@ func TestGetProviderDocIndexByVersion_Empty(t *testing.T) {
 	}
 }
 
+// TestGetProviderDocIndexByVersion_OversizedPageIsCapped is the regression
+// test for the #662 sibling in this function's provider-docs page decode (see
+// TestResolveProviderVersionID_OversizedProviderLookupIsCapped for the
+// cap-truncation rationale).
+func TestGetProviderDocIndexByVersion_OversizedPageIsCapped(t *testing.T) {
+	_, u := newTestRegistry(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/providers/hashicorp/aws":
+			json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "5000"}})
+		case "/v2/providers/5000/provider-versions":
+			json.NewEncoder(w).Encode(makeVersionListPage([]providerVersionEntryV2{
+				makeVersionEntry("999", "5.0.0"),
+			}, nil))
+		case "/v2/provider-docs":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"id":"1","attributes":{"title":"pad`)
+			_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+			_, _ = io.WriteString(w, `"}}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	_, err := u.GetProviderDocIndexByVersion(context.Background(), "hashicorp", "aws", "5.0.0")
+	if err == nil {
+		t.Fatal("expected decode error for provider-docs page exceeding maxUpstreamResponseBytes, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // GetProviderDocContent
 // ---------------------------------------------------------------------------
@@ -628,6 +731,24 @@ func TestGetProviderDocContent_InvalidJSON(t *testing.T) {
 	_, err := u.GetProviderDocContent(context.Background(), "12345")
 	if err == nil {
 		t.Error("expected error for invalid JSON")
+	}
+}
+
+// TestGetProviderDocContent_OversizedResponseIsCapped is the regression test
+// for the #662 sibling in this function's decode (see
+// TestResolveProviderVersionID_OversizedProviderLookupIsCapped for the
+// cap-truncation rationale).
+func TestGetProviderDocContent_OversizedResponseIsCapped(t *testing.T) {
+	_, u := newTestRegistry(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"attributes":{"content":"pad`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxUpstreamResponseBytes+1024))
+		_, _ = io.WriteString(w, `"}}}`)
+	})
+
+	_, err := u.GetProviderDocContent(context.Background(), "12345")
+	if err == nil {
+		t.Fatal("expected decode error for doc content response exceeding maxUpstreamResponseBytes, got nil")
 	}
 }
 

--- a/backend/internal/scanner/installer/installer.go
+++ b/backend/internal/scanner/installer/installer.go
@@ -23,16 +23,18 @@ import (
 	"time"
 
 	goversion "github.com/hashicorp/go-version"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
 // Size caps to prevent zip-bomb / decompression-bomb DoS.
 const (
-	maxArchiveSize   = 500 << 20 // 500 MB
-	maxFileSize      = 200 << 20 // 200 MB per extracted file
-	maxChecksumsSize = 8 << 10   // 8 KB
-	maxSigBundleSize = 1 << 20   // 1 MB; a sigstore bundle (cert chain + inclusion proof) is a few KB-15KB
+	maxArchiveSize     = 500 << 20 // 500 MB
+	maxFileSize        = 200 << 20 // 200 MB per extracted file
+	maxChecksumsSize   = 8 << 10   // 8 KB
+	maxSigBundleSize   = 1 << 20   // 1 MB; a sigstore bundle (cert chain + inclusion proof) is a few KB-15KB
+	maxReleaseJSONSize = 1 << 20   // 1 MB; a GitHub release with a large asset list is well under this
 )
 
 // InstallConfig holds parameters for an Install call.
@@ -41,8 +43,16 @@ type InstallConfig struct {
 	InstallDir string
 	// Timeout caps the entire operation; default 5 minutes if zero.
 	Timeout time.Duration
-	// HTTPClient is optional; default is http.Client{Timeout: 5m}.
+	// HTTPClient is optional; default is an httpsafe-guarded client (see
+	// EgressGuard) with a Timeout of 5m.
 	HTTPClient *http.Client
+	// EgressGuard is used to build the default HTTPClient when one isn't
+	// supplied: the GitHub API and browser_download_url asset URLs this package
+	// dials are upstream (GitHub)-supplied, so the default client is routed
+	// through the shared httpsafe resolve-and-pin egress guard rather than a
+	// bare http.Client (issue #676's defect class). A nil guard is the strict
+	// default policy. Ignored when HTTPClient is set explicitly.
+	EgressGuard *httpsafe.Guard
 	// SignatureMode controls the optional cryptographic signature check (on top of
 	// the mandatory SHA256 checksum): "off" skips it, "warn" verifies and records
 	// the result but never blocks, "enforce" fails the install on a definitive
@@ -106,7 +116,7 @@ func Install(ctx context.Context, cfg InstallConfig, tool, pinnedVersion string)
 	}
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: cfg.Timeout}
+		client = httpsafe.NewClient(cfg.Timeout, cfg.EgressGuard)
 	}
 
 	// 1. Verify install dir is writable.
@@ -421,7 +431,7 @@ func CheckLatest(ctx context.Context, cfg InstallConfig, tool string) (*LatestIn
 	}
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: cfg.Timeout}
+		client = httpsafe.NewClient(cfg.Timeout, cfg.EgressGuard)
 	}
 
 	spec, ok := Lookup(tool, runtime.GOOS, runtime.GOARCH)
@@ -469,7 +479,7 @@ func DownloadVerified(ctx context.Context, cfg InstallConfig, tool, pinnedVersio
 	}
 	client := cfg.HTTPClient
 	if client == nil {
-		client = &http.Client{Timeout: cfg.Timeout}
+		client = httpsafe.NewClient(cfg.Timeout, cfg.EgressGuard)
 	}
 
 	if err := ensureWritableDir(cfg.InstallDir); err != nil {
@@ -562,8 +572,12 @@ func resolveRelease(ctx context.Context, client *http.Client, spec AssetSpec, pi
 		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
 	}
 
+	// The non-200 error body above is capped at 1024 bytes, but this success-path
+	// decode was unbounded (the exact "capped-error/uncapped-success" pattern
+	// fixed in cve/osv/client.go for the same #662 defect class): an oversized
+	// or slow-trickle 200 response would otherwise be fully buffered in memory.
 	var release ghRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxReleaseJSONSize)).Decode(&release); err != nil {
 		return nil, fmt.Errorf("decode release JSON: %w", err)
 	}
 	return &release, nil
@@ -764,7 +778,9 @@ func randHex(n int) string {
 
 // Handle is a shared helper for both setup and admin install handlers.
 // It runs the install logic and returns a JSON-friendly response map.
-func Handle(ctx context.Context, installDir string, install InstallFunc, tool, version string) (success bool, result *Result, errMsg string) {
+// guard is threaded into the InstallConfig so the default HTTP client honours
+// the operator-configured egress allow-list; nil is the strict default policy.
+func Handle(ctx context.Context, installDir string, guard *httpsafe.Guard, install InstallFunc, tool, version string) (success bool, result *Result, errMsg string) {
 	if !Supports(tool) {
 		return false, nil, fmt.Sprintf(
 			"auto-install is not available for %q — install it manually and enter the binary path below. Supported: %v",
@@ -781,8 +797,9 @@ func Handle(ctx context.Context, installDir string, install InstallFunc, tool, v
 	}
 
 	r, err := install(ctx, InstallConfig{
-		InstallDir: installDir,
-		Timeout:    5 * time.Minute,
+		InstallDir:  installDir,
+		Timeout:     5 * time.Minute,
+		EgressGuard: guard,
 	}, tool, version)
 	if err != nil {
 		return false, nil, err.Error()

--- a/backend/internal/scanner/installer/installer_test.go
+++ b/backend/internal/scanner/installer/installer_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
 // ---------------------------------------------------------------------------
@@ -183,6 +185,82 @@ func mustCompile(t *testing.T, pattern string) *regexp.Regexp {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+// newDefaultClientReleaseServer starts a plain (non-TLS) httptest server
+// serving a minimal GitHub release for "trivy" and returns a patched
+// AssetSpec, for tests of the cfg.HTTPClient == nil fallback (issue #676):
+// unlike setupTestServer/setupTestServerFull, callers here must NOT set
+// InstallConfig.HTTPClient, so the default httpsafe.NewClient(cfg.Timeout,
+// cfg.EgressGuard) path in Install/CheckLatest/DownloadVerified actually runs.
+// Plain HTTP avoids the self-signed-cert problem that httpsafe.NewClient's
+// transport (which does not consult http.DefaultTransport) would otherwise hit.
+func newDefaultClientReleaseServer(t *testing.T) (*httptest.Server, AssetSpec) {
+	t.Helper()
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	archiveName := "trivy_1.2.3_Linux-64bit.tar.gz"
+	checksumsName := "trivy_1.2.3_checksums.txt"
+	release := ghRelease{TagName: "v1.2.3", Assets: []ghAsset{
+		{Name: archiveName, BrowserDownloadURL: server.URL + "/assets/" + archiveName},
+		{Name: checksumsName, BrowserDownloadURL: server.URL + "/assets/" + checksumsName},
+	}}
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(release)
+	})
+
+	spec := AssetSpec{
+		LatestReleaseAPI: server.URL + "/releases/latest",
+		VersionedAPI:     server.URL + "/releases/tags/v%s",
+		AssetPattern:     mustCompile(t, `^`+regexp_escape(archiveName)+`$`),
+		ChecksumsPattern: mustCompile(t, `^`+regexp_escape(checksumsName)+`$`),
+		BinaryInArchive:  "trivy",
+		ArchiveFormat:    "tar.gz",
+	}
+	return server, spec
+}
+
+// TestCheckLatest_DefaultClient_AllowlistedLoopbackSucceeds is the positive
+// counterpart of TestCheckLatest_DefaultClient_StrictPolicyBlocksLoopback: an
+// EgressGuard that allow-lists the test server's loopback address lets the
+// default (cfg.HTTPClient == nil) client reach it (issue #676).
+func TestCheckLatest_DefaultClient_AllowlistedLoopbackSucceeds(t *testing.T) {
+	_, spec := newDefaultClientReleaseServer(t)
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	info, err := CheckLatest(context.Background(), InstallConfig{EgressGuard: httpsafe.MustGuard("127.0.0.1")}, "trivy")
+	if err != nil {
+		t.Fatalf("CheckLatest: %v", err)
+	}
+	if info.LatestVersion != "1.2.3" {
+		t.Errorf("LatestVersion = %q, want 1.2.3", info.LatestVersion)
+	}
+}
+
+// TestCheckLatest_DefaultClient_StrictPolicyBlocksLoopback proves the
+// cfg.HTTPClient == nil fallback in CheckLatest is actually routed through the
+// httpsafe egress guard (issue #676) rather than a bare http.Client: without an
+// allow-listed guard, the strict default policy rejects the loopback target the
+// httptest server binds to.
+func TestCheckLatest_DefaultClient_StrictPolicyBlocksLoopback(t *testing.T) {
+	_, spec := newDefaultClientReleaseServer(t)
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	_, err := CheckLatest(context.Background(), InstallConfig{}, "trivy") // nil HTTPClient, nil EgressGuard
+	if err == nil {
+		t.Fatal("expected error for loopback target under the strict default egress policy, got nil")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target", err.Error())
+	}
+}
 
 func TestInstall_Trivy_Latest_Success(t *testing.T) {
 	archiveName := "trivy_0.52.2_Linux-64bit.tar.gz"
@@ -743,7 +821,7 @@ func TestSupportedTools(t *testing.T) {
 }
 
 func TestHandle_UnsupportedTool(t *testing.T) {
-	ok, _, msg := Handle(context.Background(), "/tmp", nil, "snyk", "")
+	ok, _, msg := Handle(context.Background(), "/tmp", nil, nil, "snyk", "")
 	if ok {
 		t.Error("expected failure")
 	}
@@ -753,7 +831,7 @@ func TestHandle_UnsupportedTool(t *testing.T) {
 }
 
 func TestHandle_EmptyInstallDir(t *testing.T) {
-	ok, _, msg := Handle(context.Background(), "", nil, "trivy", "")
+	ok, _, msg := Handle(context.Background(), "", nil, nil, "trivy", "")
 	if ok {
 		t.Error("expected failure")
 	}
@@ -772,7 +850,7 @@ func TestHandle_Success(t *testing.T) {
 		}, nil
 	}
 
-	ok, result, msg := Handle(context.Background(), "/app/scanners", InstallFunc(stub), "trivy", "")
+	ok, result, msg := Handle(context.Background(), "/app/scanners", nil, InstallFunc(stub), "trivy", "")
 	if !ok {
 		t.Fatalf("expected success, got error: %s", msg)
 	}
@@ -786,12 +864,34 @@ func TestHandle_InstallerError(t *testing.T) {
 		return nil, ErrChecksumMismatch
 	}
 
-	ok, _, msg := Handle(context.Background(), "/app/scanners", InstallFunc(stub), "trivy", "")
+	ok, _, msg := Handle(context.Background(), "/app/scanners", nil, InstallFunc(stub), "trivy", "")
 	if ok {
 		t.Error("expected failure")
 	}
 	if !strings.Contains(msg, "checksum") {
 		t.Errorf("message should mention checksum: %s", msg)
+	}
+}
+
+// TestHandle_ThreadsEgressGuard locks in that Handle passes its guard into the
+// InstallConfig it builds, so the setup/admin install handlers (which call
+// Install only through Handle) get the operator-configured egress policy
+// rather than silently falling back to the strict nil-guard default (issue
+// #676's threading requirement).
+func TestHandle_ThreadsEgressGuard(t *testing.T) {
+	g := httpsafe.MustGuard("10.0.0.0/8")
+	var got *httpsafe.Guard
+	stub := func(ctx context.Context, cfg InstallConfig, tool, version string) (*Result, error) {
+		got = cfg.EgressGuard
+		return &Result{BinaryPath: "/app/scanners/trivy", Version: "0.52.2"}, nil
+	}
+
+	ok, _, msg := Handle(context.Background(), "/app/scanners", g, InstallFunc(stub), "trivy", "")
+	if !ok {
+		t.Fatalf("expected success, got error: %s", msg)
+	}
+	if got != g {
+		t.Errorf("InstallConfig.EgressGuard = %v, want the guard passed to Handle", got)
 	}
 }
 
@@ -827,6 +927,43 @@ func TestCheckLatest_ReturnsLatestVersionAndURLs(t *testing.T) {
 	}
 	if info.SignatureSupported {
 		t.Error("SignatureSupported should be false when spec.Signature.Type is unset")
+	}
+}
+
+// TestCheckLatest_OversizedReleaseJSONIsCapped is the regression test for the
+// resolveRelease fix (mirroring the cve/osv/client.go pattern for the same
+// #662 defect class): the success-path decode is wrapped in an io.LimitReader
+// capped at maxReleaseJSONSize, so a well-formed release JSON whose encoded
+// size exceeds that cap is truncated mid-document and fails to decode instead
+// of being buffered unbounded.
+func TestCheckLatest_OversizedReleaseJSONIsCapped(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"tag_name":"v1.2.3","assets":[{"name":"pad","browser_download_url":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", maxReleaseJSONSize+1024))
+		_, _ = io.WriteString(w, `"}]}`)
+	})
+
+	spec := AssetSpec{
+		LatestReleaseAPI: server.URL + "/releases/latest",
+		VersionedAPI:     server.URL + "/releases/tags/v%s",
+		AssetPattern:     mustCompile(t, `^trivy_[\d.]+_Linux-64bit\.tar\.gz$`),
+		ChecksumsPattern: mustCompile(t, `^trivy_[\d.]+_checksums\.txt$`),
+		BinaryInArchive:  "trivy",
+		ArchiveFormat:    "tar.gz",
+	}
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	origCatalog := Catalog["trivy"]
+	Catalog["trivy"] = map[string]AssetSpec{platform: spec}
+	t.Cleanup(func() { Catalog["trivy"] = origCatalog })
+
+	_, err := CheckLatest(context.Background(), InstallConfig{HTTPClient: server.Client()}, "trivy")
+	if err == nil {
+		t.Fatal("expected decode error for release JSON exceeding maxReleaseJSONSize, got nil")
 	}
 }
 

--- a/backend/internal/scm/appcreds/minter.go
+++ b/backend/internal/scm/appcreds/minter.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 )
 
@@ -59,12 +60,24 @@ type Minter struct {
 	githubAPIBaseURL  string
 }
 
-// NewMinter builds a Minter using the production identity-provider endpoints.
+// NewMinter builds a Minter using the production identity-provider endpoints
+// and the strict (no allow-list) egress policy. Equivalent to
+// NewMinterWithGuard(cipher, store, nil).
 func NewMinter(cipher *crypto.TokenCipher, store ProviderTokenStore) *Minter {
+	return NewMinterWithGuard(cipher, store, nil)
+}
+
+// NewMinterWithGuard is NewMinter with an egress guard, for parity with the
+// other SCM outbound paths (scm.HTTPClient): the token-exchange requests carry
+// a credential (the RS256 app JWT or a client assertion), so they are routed
+// through the shared httpsafe resolve-and-pin client rather than a bare
+// http.Client, even though entraLoginBaseURL/githubAPIBaseURL are currently
+// fixed to public hosts (issue #676).
+func NewMinterWithGuard(cipher *crypto.TokenCipher, store ProviderTokenStore, egress *httpsafe.Guard) *Minter {
 	return &Minter{
 		cipher:            cipher,
 		store:             store,
-		httpClient:        &http.Client{Timeout: 30 * time.Second},
+		httpClient:        httpsafe.NewClient(30*time.Second, egress),
 		now:               time.Now,
 		refreshMargin:     tokenRefreshMargin,
 		entraLoginBaseURL: "https://login.microsoftonline.com",

--- a/backend/internal/scm/appcreds/minter_test.go
+++ b/backend/internal/scm/appcreds/minter_test.go
@@ -16,8 +16,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 )
+
+// loopbackGuard allow-lists the loopback addresses httptest.NewServer binds to
+// (127.0.0.1 / ::1) so the positive-path tests below can exercise a real HTTP
+// round trip through the httpsafe-guarded client (issue #676) without the
+// strict default policy rejecting the test server itself as an internal
+// target.
+var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
 // fakeStore is an in-memory ProviderTokenStore for tests.
 type fakeStore struct {
@@ -86,7 +94,7 @@ func TestMintProviderToken_EntraApp(t *testing.T) {
 
 	cipher := testCipher(t)
 	store := &fakeStore{}
-	m := NewMinter(cipher, store)
+	m := NewMinterWithGuard(cipher, store, loopbackGuard)
 	m.entraLoginBaseURL = srv.URL
 
 	secret, _ := cipher.Seal("the-secret")
@@ -126,7 +134,7 @@ func TestMintProviderToken_EntraApp_ErrorStatus(t *testing.T) {
 	defer srv.Close()
 
 	cipher := testCipher(t)
-	m := NewMinter(cipher, &fakeStore{})
+	m := NewMinterWithGuard(cipher, &fakeStore{}, loopbackGuard)
 	m.entraLoginBaseURL = srv.URL
 
 	secret, _ := cipher.Seal("bad")
@@ -139,6 +147,38 @@ func TestMintProviderToken_EntraApp_ErrorStatus(t *testing.T) {
 	}
 	if _, err := m.MintProviderToken(context.Background(), p); err == nil {
 		t.Fatal("expected error on 401 from Entra")
+	}
+}
+
+// TestMintProviderToken_EntraApp_RejectsLoopbackTarget exercises the egress
+// guard wired in NewMinter/NewMinterWithGuard (issue #676): entraLoginBaseURL
+// is hard-coded in production, but the client itself must still fail closed
+// against an internal/loopback target rather than silently dialing it, so a
+// future misconfiguration (or test regression) can't turn this into a live
+// SSRF primitive. A nil guard is the strict default policy, and port 1 is
+// closed, so no listener is needed for this to fail before any TCP connect.
+func TestMintProviderToken_EntraApp_RejectsLoopbackTarget(t *testing.T) {
+	cipher := testCipher(t)
+	m := NewMinter(cipher, &fakeStore{}) // nil guard == strict default
+	m.entraLoginBaseURL = "https://127.0.0.1:1"
+
+	secret, _ := cipher.Seal("s")
+	p := &scm.SCMProvider{
+		ID:                    uuid.New(),
+		AuthMode:              scm.AuthModeEntraApp,
+		TenantID:              strptr("t"),
+		ClientID:              "c",
+		ClientSecretEncrypted: secret,
+	}
+	_, err := m.MintProviderToken(context.Background(), p)
+	if err == nil {
+		t.Fatal("expected error for loopback entraLoginBaseURL target")
+	}
+	// Assert on the guard's own wording, not just "any error": port 1 is
+	// closed, so a bare connection-refused error would also satisfy err != nil
+	// without proving the egress guard is what blocked this.
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target", err.Error())
 	}
 }
 
@@ -164,7 +204,7 @@ func TestMintProviderToken_GitHubApp(t *testing.T) {
 
 	cipher := testCipher(t)
 	store := &fakeStore{}
-	m := NewMinter(cipher, store)
+	m := NewMinterWithGuard(cipher, store, loopbackGuard)
 	m.githubAPIBaseURL = srv.URL
 
 	encKey, _ := cipher.Seal(keyPEM)
@@ -189,6 +229,33 @@ func TestMintProviderToken_GitHubApp(t *testing.T) {
 	}
 	if len(store.upserts) != 1 {
 		t.Errorf("upserts = %d, want 1", len(store.upserts))
+	}
+}
+
+// TestMintProviderToken_GitHubApp_RejectsLoopbackTarget is the GitHub-App
+// counterpart of TestMintProviderToken_EntraApp_RejectsLoopbackTarget: the
+// installation-token exchange must fail closed against a loopback
+// githubAPIBaseURL rather than dialing it (issue #676).
+func TestMintProviderToken_GitHubApp_RejectsLoopbackTarget(t *testing.T) {
+	cipher := testCipher(t)
+	m := NewMinter(cipher, &fakeStore{}) // nil guard == strict default
+	m.githubAPIBaseURL = "https://127.0.0.1:1"
+
+	encKey, _ := cipher.Seal(generateTestKeyPEM(t))
+	p := &scm.SCMProvider{
+		ID:                     uuid.New(),
+		ProviderType:           scm.ProviderGitHub,
+		AuthMode:               scm.AuthModeGitHubApp,
+		GitHubAppID:            strptr("12345"),
+		GitHubInstallationID:   strptr("67890"),
+		EncryptedAppPrivateKey: &encKey,
+	}
+	_, err := m.MintProviderToken(context.Background(), p)
+	if err == nil {
+		t.Fatal("expected error for loopback githubAPIBaseURL target")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error = %q, want it to mention the egress guard blocking the target", err.Error())
 	}
 }
 
@@ -255,7 +322,7 @@ func TestMintProviderToken_CacheExpiredRemints(t *testing.T) {
 		TokenType:            "Bearer",
 		ExpiresAt:            &past,
 	}}
-	m := NewMinter(cipher, store)
+	m := NewMinterWithGuard(cipher, store, loopbackGuard)
 	m.entraLoginBaseURL = srv.URL
 
 	secret, _ := cipher.Seal("s")

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -32,6 +32,14 @@ const (
 	// maxExtractBytes caps the total uncompressed size of any single archive entry
 	// during zip→tar.gz conversion to prevent decompression bomb attacks.
 	maxExtractBytes = 500 << 20 // 500 MB
+	// maxArchiveDownloadBytes caps the raw (compressed) zip response read into
+	// memory before conversion. Unlike the other SCM connectors (github/gitlab/
+	// bitbucket), which stream resp.Body straight back to the caller, Azure
+	// DevOps only supports zip and zip.NewReader requires an io.ReaderAt, so the
+	// response must be fully buffered here — but that buffering must still be
+	// size-capped (CWE-400), matching the cap already applied to each extracted
+	// entry below.
+	maxArchiveDownloadBytes = 500 << 20 // 500 MB
 )
 
 // AzureDevOpsConnector implements scm.Connector for Azure DevOps using Microsoft Entra ID OAuth
@@ -515,11 +523,19 @@ func (c *AzureDevOpsConnector) DownloadSourceArchive(ctx context.Context, creds 
 		return nil, scm.WrapRemoteError(resp.StatusCode, fmt.Sprintf("failed to download archive: %s", string(body)), nil)
 	}
 
-	// Read the entire zip response into memory so we can use zip.NewReader (which needs io.ReaderAt).
-	zipData, err := io.ReadAll(resp.Body)
+	// Read the entire zip response into memory so we can use zip.NewReader (which
+	// needs io.ReaderAt). Capped at maxArchiveDownloadBytes to bound memory use
+	// against an oversized or slow-trickle response (CWE-400); +1 lets us detect
+	// and report the overflow with a clear error rather than silently truncating
+	// into a corrupt zip that would otherwise fail with an opaque "not a valid
+	// zip file" error.
+	zipData, err := io.ReadAll(io.LimitReader(resp.Body, maxArchiveDownloadBytes+1))
 	_ = resp.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read zip response: %w", err)
+	}
+	if int64(len(zipData)) > maxArchiveDownloadBytes {
+		return nil, fmt.Errorf("archive exceeds size cap (%d bytes)", maxArchiveDownloadBytes)
 	}
 
 	// Convert zip → tar.gz in memory and return a ReadCloser.

--- a/backend/internal/scm/azuredevops/connector_test.go
+++ b/backend/internal/scm/azuredevops/connector_test.go
@@ -360,6 +360,26 @@ func TestDownloadSourceArchive_Success(t *testing.T) {
 	}
 }
 
+// TestDownloadSourceArchive_OversizedResponseCapped locks in the
+// maxArchiveDownloadBytes cap on the raw zip response read in
+// DownloadSourceArchive (same CWE-400 defect class as #662): unlike the other
+// SCM connectors, Azure DevOps must fully buffer the response (zip.NewReader
+// needs io.ReaderAt), so that buffering must itself be size-capped rather than
+// unbounded.
+func TestDownloadSourceArchive_OversizedResponseCapped(t *testing.T) {
+	_, c := newTestConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(bytes.Repeat([]byte("x"), maxArchiveDownloadBytes+1024))
+	})
+
+	_, err := c.DownloadSourceArchive(context.Background(), creds(), "proj", "repo", "v1.0", scm.ArchiveZipball)
+	if err == nil {
+		t.Fatal("expected error for archive response exceeding maxArchiveDownloadBytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds size cap") {
+		t.Errorf("error = %q, want it to mention the size cap", err.Error())
+	}
+}
+
 // ---------------------------------------------------------------------------
 // SearchRepositories (filters in-memory from FetchRepositories)
 // ---------------------------------------------------------------------------

--- a/backend/internal/validation/filename.go
+++ b/backend/internal/validation/filename.go
@@ -1,0 +1,28 @@
+// filename.go validates upstream-supplied filenames before they are used as a
+// storage-key path component, rejecting path separators and traversal
+// sequences so an untrusted filename cannot inject extra path segments into
+// an object-storage key.
+package validation
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateStorageFilename returns an error if name is not safe to use as the
+// final path component of an object-storage key: it must be non-empty and
+// free of path separators ('/', '\') and '..' traversal sequences. Intended
+// for filenames sourced from untrusted/upstream data (e.g. an upstream
+// registry's package descriptor) rather than caller-constructed names.
+func ValidateStorageFilename(name string) error {
+	if name == "" {
+		return fmt.Errorf("filename cannot be empty")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("filename %q must not contain path separators", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("filename %q must not contain '..'", name)
+	}
+	return nil
+}

--- a/backend/internal/validation/filename_test.go
+++ b/backend/internal/validation/filename_test.go
@@ -1,0 +1,34 @@
+package validation
+
+import "testing"
+
+func TestValidateStorageFilename(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid: realistic upstream package filenames.
+		{"typical provider zip", "terraform-provider-aws_5.0.0_linux_amd64.zip", false},
+		{"typical binary zip", "terraform_1.7.0_linux_amd64.zip", false},
+		{"dot in version", "terraform-provider-aws_5.0.0-beta.1_linux_amd64.zip", false},
+
+		// Invalid: path traversal / injection attempts from an upstream descriptor.
+		{"empty string", "", true},
+		{"forward slash", "../../etc/passwd", true},
+		{"single parent ref", "..", true},
+		{"embedded parent ref", "foo/../bar.zip", true},
+		{"leading slash", "/etc/passwd", true},
+		{"backslash", `..\..\windows\system32`, true},
+		{"dot-dot suffix no separator", "foo..bar.zip", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateStorageFilename(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateStorageFilename(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #653
Closes #662
Closes #676
Closes #677

## Summary

Batch `c-egress-ssrf` from the 2026-07-22 blind security audit: eliminates the last outbound HTTP paths that bypassed `internal/httpsafe`'s resolve-and-pin egress guard, and bounds the remaining unbounded response reads.

- **#653 — suite consumers proxy**: `moduleConsumersHandler` sent the sibling service token via a bespoke `http.Client` to a sibling-advertised (`m.PublicURL`) target. Now routed through `httpsafe.NewClient(egressGuard)` with the guard threaded from the router.
- **#662 — suite consumers proxy unbounded decode**: the proxy's JSON decode now reads through an `io.LimitReader` cap, matching every other outbound decode in the codebase.
- **#676 — SCM app-token Minter**: `NewMinter`'s bare `http.Client` (GitHub App / Entra token exchanges carrying credentials) replaced with an httpsafe-guarded client.
- **#677 — mirror sync storage-key filename**: upstream-supplied `packageInfo.Filename` is now validated via the new `internal/validation/filename.go` before entering the storage key.
- **Scanner installer (same defect class as #653/#676, no audit issue filed)**: `Install`/`CheckLatest`/`DownloadVerified` built bare `http.Client`s for GitHub-API- and release-asset URLs (`browser_download_url` is upstream-controlled). `InstallConfig` gains an `EgressGuard` field; the default client is now `httpsafe.NewClient(cfg.Timeout, cfg.EgressGuard)` at all three call sites, and the guard is threaded from every caller: `ScannerUpdateJob` (new `SetEgressGuard`), `GetScannerLatestHandler`, and `installer.Handle` -> setup-wizard + admin install handlers. `resolveRelease`'s success-path decode also gains a 1 MB cap (same capped-error/uncapped-success pattern fixed in `cve/osv/client.go`).
- Consistency caps/guard threading in `mirror/attestation.go`, `mirror/github_releases.go`, `mirror/terraform_releases.go`, `mirror/upstream.go`, `cve/osv/client.go`, and `scm/azuredevops/connector.go`.

Existing HTTPS-only checks, size caps, and path-traversal protections are untouched (additive only). TDD throughout: each fix carries a negative test (loopback/internal target rejected under the strict nil-guard default) and a positive test (allow-listed loopback reachable), following the Minter-fix pattern.

## Changelog

- fix: route the suite consumers proxy, SCM app-token minter, and scanner installer downloads through the shared httpsafe egress guard; bound proxy and release-metadata response reads; validate mirrored provider filenames before storage-key use

## Checklist

- [x] `go test ./...` passes
- [x] `go fmt ./...` and `go vet ./...` clean (pre-existing `internal/auth/jwt.go` gofmt drift exists on `main` and is untouched here)
- [x] No new `gosec` findings (verified by JSON diff against `main`: identical finding set, line-shifted only)
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge