### PR TITLE
fix(security): fail-closed per-org API key ceilings and cross-org key-listing fix

### DIFF
--- a/backend/internal/api/admin/apikeys.go
+++ b/backend/internal/api/admin/apikeys.go
@@ -71,10 +71,12 @@ type CreateAPIKeyResponse struct {
 // ListAPIKeysHandler lists API keys for the authenticated user
 // GET /api/v1/apikeys
 // If organization_id is provided:
-//   - Users with api_keys:manage scope see all keys in that org
-//   - Otherwise, users only see their own keys in that org
+//   - Platform admins, and callers holding api_keys:manage IN THAT ORG, see all keys in the org
+//   - Otherwise, callers only see their own keys in that org
 //
-// If no organization_id: returns only the user's own keys across all orgs
+// If no organization_id:
+//   - Platform admins see all keys across all orgs
+//   - Otherwise, callers see only their own keys across all orgs
 func (h *APIKeyHandlers) ListAPIKeysHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Get user ID from context
@@ -97,27 +99,56 @@ func (h *APIKeyHandlers) ListAPIKeysHandler() gin.HandlerFunc {
 		// Get organization filter if provided
 		orgID := c.Query("organization_id")
 
-		// Check if user has api_keys:manage scope (allows viewing all keys in org)
+		// Platform admins (holders of the platform-wide "admin" wildcard) may view
+		// every key. For everyone else the "see all keys" decision must be derived
+		// from the caller's scopes IN THE TARGET ORGANIZATION, never from their
+		// login-time cross-org scope union (c.Get("scopes")). api_keys:manage is a
+		// per-org role-template scope, so trusting the global union would let a
+		// user_manager in org A enumerate every key's metadata (id, name,
+		// description, key_prefix, scopes, owner, expiry) in an unrelated org B --
+		// the same global-union-as-ceiling defect fixed for role assignment
+		// (role_ceiling.go) and key updates (UpdateAPIKeyHandler) in this batch
+		// (issue #648 class, CWE-266). Likewise, only platform admins may list keys
+		// across every org (ListAll); a per-org api_keys:manage holder must not.
 		scopesVal, _ := c.Get("scopes")
 		scopes, _ := scopesVal.([]string)
-		canManageAll := auth.HasScope(scopes, auth.ScopeAPIKeysManage) || auth.HasScope(scopes, auth.ScopeAdmin)
+		isPlatformAdmin := auth.HasScope(scopes, auth.ScopeAdmin)
+		// The global union is a superset of every per-org scope set, so a caller
+		// who lacks api_keys:manage here cannot hold it in ANY org -- skip the
+		// per-org lookup for them. A caller who DOES hold it globally might hold it
+		// only in a *different* org, so their management right is re-confirmed
+		// against the specific target org below before all keys are disclosed.
+		hasGlobalManage := isPlatformAdmin || auth.HasScope(scopes, auth.ScopeAPIKeysManage)
 
 		var keys []*models.APIKey
 		var err error
 
-		if orgID != "" {
-			if canManageAll {
-				// Users with api_keys:manage can see all keys in the organization
+		switch {
+		case orgID != "":
+			// Re-derive per-org whether the caller may manage all keys in THIS org.
+			canManageOrg := isPlatformAdmin
+			if !canManageOrg && hasGlobalManage {
+				orgScopes, scErr := h.orgRepo.GetUserScopesForOrg(c.Request.Context(), userID, orgID)
+				if scErr != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{
+						"error": "Failed to list API keys",
+					})
+					return
+				}
+				canManageOrg = auth.HasScope(orgScopes, auth.ScopeAPIKeysManage)
+			}
+			if canManageOrg {
+				// Caller manages keys in this org: see all keys in the org.
 				keys, err = h.apiKeyRepo.ListByOrganization(c.Request.Context(), orgID)
 			} else {
-				// Regular users only see their own keys in the organization
+				// Otherwise only the caller's own keys in the org.
 				keys, err = h.apiKeyRepo.ListByUserAndOrganization(c.Request.Context(), userID, orgID)
 			}
-		} else if canManageAll {
-			// Admins can see all keys across all organizations
+		case isPlatformAdmin:
+			// Only platform admins may enumerate keys across all organizations.
 			keys, err = h.apiKeyRepo.ListAll(c.Request.Context())
-		} else {
-			// Regular users only see their own keys across all organizations
+		default:
+			// Regular users only see their own keys across all organizations.
 			keys, err = h.apiKeyRepo.ListByUser(c.Request.Context(), userID)
 		}
 
@@ -566,31 +597,53 @@ func (h *APIKeyHandlers) UpdateAPIKeyHandler() gin.HandlerFunc {
 				return
 			}
 
-			if memberWithRole != nil && memberWithRole.RoleTemplateID != nil {
-				// Validate requested scopes are within user's allowed scopes for this org
-				userHasAdmin := false
-				for _, scope := range memberWithRole.RoleTemplateScopes {
-					if scope == "admin" {
-						userHasAdmin = true
-						break
-					}
+			// Fail closed exactly like CreateAPIKeyHandler: changing a key's scopes
+			// requires a current role in the key's organization. The previous code
+			// only enforced the ceiling when membership+role were present and
+			// otherwise applied req.Scopes verbatim, so a key owner who had been
+			// removed from the org (or had their role template cleared) could widen
+			// an org-bound key to "admin". The key survives removal — RemoveMember
+			// does not delete keys, and API-key auth sets scopes from the stored key
+			// without consulting the revocation watermark — so the owner could
+			// re-authenticate with the key and self-escalate to a platform-wide
+			// admin wildcard (issue #650, CWE-269). A null role template grants zero
+			// scopes and must be treated as such.
+			if memberWithRole == nil {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error": "You are not a member of this organization",
+				})
+				return
+			}
+			if memberWithRole.RoleTemplateID == nil {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error": "No role template assigned for this organization. Contact an administrator to assign a role.",
+				})
+				return
+			}
+
+			// Validate requested scopes are within user's allowed scopes for this org
+			userHasAdmin := false
+			for _, scope := range memberWithRole.RoleTemplateScopes {
+				if scope == "admin" {
+					userHasAdmin = true
+					break
+				}
+			}
+
+			if !userHasAdmin {
+				allowedScopeSet := make(map[string]bool)
+				for _, s := range memberWithRole.RoleTemplateScopes {
+					allowedScopeSet[s] = true
 				}
 
-				if !userHasAdmin {
-					allowedScopeSet := make(map[string]bool)
-					for _, s := range memberWithRole.RoleTemplateScopes {
-						allowedScopeSet[s] = true
-					}
-
-					for _, requestedScope := range req.Scopes {
-						if !allowedScopeSet[requestedScope] {
-							c.JSON(http.StatusForbidden, gin.H{
-								"error":          "Scope '" + requestedScope + "' exceeds your role permissions for this organization",
-								"allowed_scopes": memberWithRole.RoleTemplateScopes,
-								"role_template":  *memberWithRole.RoleTemplateName,
-							})
-							return
-						}
+				for _, requestedScope := range req.Scopes {
+					if !allowedScopeSet[requestedScope] {
+						c.JSON(http.StatusForbidden, gin.H{
+							"error":          "Scope '" + requestedScope + "' exceeds your role permissions for this organization",
+							"allowed_scopes": memberWithRole.RoleTemplateScopes,
+							"role_template":  *memberWithRole.RoleTemplateName,
+						})
+						return
 					}
 				}
 			}

--- a/backend/internal/api/admin/apikeys_test.go
+++ b/backend/internal/api/admin/apikeys_test.go
@@ -154,8 +154,24 @@ func TestListAPIKeys_OrgFilter_NoManageScope(t *testing.T) {
 	}
 }
 
+// A caller who holds api_keys:manage IN THE TARGET ORG may list all keys in
+// that org. The per-org role is re-derived via GetMemberWithRole, NOT trusted
+// from the login-time global scope union (issue #648 class, CWE-266). This is
+// the legitimate positive path.
 func TestListAPIKeys_OrgFilter_WithManageScope(t *testing.T) {
 	mock, r := newAPIKeyRouter(t, "user-1", []string{"api_keys:manage"})
+	roleID := "role-1"
+	roleName := "user-manager"
+	roleDisplay := "User Manager"
+	// GetUserScopesForOrg -> GetMemberWithRole: caller manages keys in org-1.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols).AddRow(
+			"org-1", "user-1", &roleID, time.Now(),
+			"Alice", "alice@example.com",
+			&roleName, &roleDisplay,
+			[]byte(`["api_keys:manage"]`),
+		))
+	// Manager sees all keys in the org.
 	mock.ExpectQuery("WHERE ak.organization_id").
 		WillReturnRows(sampleAKListRow())
 
@@ -164,6 +180,92 @@ func TestListAPIKeys_OrgFilter_WithManageScope(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Cross-org disclosure attack (issue #648 class, CWE-266): a caller who holds
+// api_keys:manage only in their LOGIN-TIME GLOBAL scope union (e.g. a
+// user_manager in some other org) queries an org they do NOT manage. The
+// handler must re-derive management rights per-org (GetUserScopesForOrg) and
+// fall back to the caller's OWN keys in that org — never ListByOrganization —
+// so no cross-org key metadata leaks. The previous code derived canManageAll
+// from c.Get("scopes") and listed every key in org-2.
+func TestListAPIKeys_OrgFilter_GlobalManageScope_NotInOrg_OwnKeysOnly(t *testing.T) {
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"api_keys:manage"})
+	// GetUserScopesForOrg -> GetMemberWithRole for org-2 returns no rows:
+	// the caller is not a member/manager of org-2.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols))
+	// Must fall back to the caller's OWN keys in org-2, not all keys.
+	mock.ExpectQuery("WHERE ak.user_id.*AND ak.organization_id").
+		WillReturnRows(sampleAKListRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/apikeys?organization_id=org-2", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Platform admins bypass the per-org lookup and may list all keys in any org.
+func TestListAPIKeys_OrgFilter_PlatformAdmin(t *testing.T) {
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"admin"})
+	// No GetMemberWithRole query: admin is exempt from the per-org lookup.
+	mock.ExpectQuery("WHERE ak.organization_id").
+		WillReturnRows(sampleAKListRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/apikeys?organization_id=org-2", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A DB error while re-deriving the caller's per-org scopes must fail closed (500),
+// not fall through to any listing.
+func TestListAPIKeys_OrgFilter_OrgScopeLookupDBError(t *testing.T) {
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"api_keys:manage"})
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/apikeys?organization_id=org-2", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Without an organization_id, a non-admin holding api_keys:manage only in the
+// global scope union must NOT list every key across all orgs (ListAll); they
+// see only their own keys. ListAll is reserved for platform admins.
+func TestListAPIKeys_NoOrg_GlobalManageScope_OwnKeysOnly(t *testing.T) {
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"api_keys:manage"})
+	mock.ExpectQuery("WHERE ak.user_id").
+		WillReturnRows(sampleAKListRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/apikeys", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }
 
@@ -775,5 +877,59 @@ func TestUpdateAPIKey_WithInvalidExpiresAt(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400: body=%s", w.Code, w.Body.String())
+	}
+}
+
+// Issue #650 (CWE-269): a key owner who is no longer a member of the key's
+// organization must not be able to widen the key's scopes. The key survives
+// removal (RemoveMember does not delete keys) and authenticates with its stored
+// scopes, so if the scope ceiling were skipped when membership is absent the
+// owner could self-escalate an org-bound key to "admin". UpdateAPIKeyHandler
+// must fail closed exactly like CreateAPIKeyHandler.
+func TestUpdateAPIKey_ScopeChange_NotMember_FailsClosed(t *testing.T) {
+	// The caller authenticates with the key's own (low) scopes, not admin.
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"modules:read"})
+	mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").WillReturnRows(sampleAKRow())
+	// GetMemberWithRole returns no rows -> caller is not a member of the org.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols))
+
+	body := `{"scopes":["admin"]}`
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/apikeys/key-1",
+		bytes.NewBufferString(body)))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (non-member must not widen key scopes): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A cleared role template (RoleTemplateID == nil) grants zero scopes and must be
+// treated as such: a scope change by a member whose role was cleared fails
+// closed rather than applying req.Scopes verbatim (issue #650).
+func TestUpdateAPIKey_ScopeChange_NullRole_FailsClosed(t *testing.T) {
+	mock, r := newAPIKeyRouter(t, "user-1", []string{"modules:read"})
+	mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").WillReturnRows(sampleAKRow())
+	// Member row exists but role_template_id is NULL (role cleared).
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols).AddRow(
+			"org-1", "user-1", nil, time.Now(),
+			"Alice", "alice@example.com",
+			nil, nil, []byte(`[]`),
+		))
+
+	body := `{"scopes":["modules:read"]}`
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/apikeys/key-1",
+		bytes.NewBufferString(body)))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (null role grants zero scopes): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -497,7 +497,7 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 		}
 
 		// Fetch user scopes to embed in JWT (avoids per-request DB lookup)
-		scopes, err := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		scopes, err := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 		if err != nil {
 			scopes = []string{}
 		}
@@ -690,7 +690,7 @@ func (h *AuthHandlers) RefreshHandler() gin.HandlerFunc {
 		}
 
 		// Fetch fresh scopes to embed in the new JWT
-		scopes, err := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		scopes, err := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 		if err != nil {
 			scopes = []string{}
 		}
@@ -1249,7 +1249,7 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 		}
 
 		// Fetch user scopes to embed in JWT
-		scopes, scopeErr := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		scopes, scopeErr := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 		if scopeErr != nil {
 			scopes = []string{}
 		}
@@ -1394,7 +1394,7 @@ func (h *AuthHandlers) LDAPLoginHandler() gin.HandlerFunc {
 		}
 
 		// Fetch user scopes
-		scopes, err := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		scopes, err := h.orgRepo.GetUserCombinedScopes(ctx, user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 		if err != nil {
 			scopes = []string{}
 		}

--- a/backend/internal/api/admin/dev.go
+++ b/backend/internal/api/admin/dev.go
@@ -101,7 +101,7 @@ func (h *DevHandlers) ImpersonateUserHandler() gin.HandlerFunc {
 		}
 
 		// Fetch target user's scopes to embed in JWT
-		targetScopes, _ := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), targetUser.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		targetScopes, _ := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), targetUser.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 
 		// Generate a new JWT for the target user
 		token, err := auth.GenerateJWT(targetUser.ID, targetUser.Email, targetScopes, 24*time.Hour)
@@ -214,7 +214,7 @@ func (h *DevHandlers) DevLoginHandler() gin.HandlerFunc {
 			return
 		}
 
-		scopes, _ := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; narrow legitimate use per the deprecation notice
+		scopes, _ := h.orgRepo.GetUserCombinedScopes(c.Request.Context(), user.ID) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design via auth.GenerateJWT; flat cross-org scope union is intentional here — see the issue #652 disposition on auth.GenerateJWT (org-scoped tokens deferred; per-org membership is re-checked server-side on every org-scoped route)
 		token, err := auth.GenerateJWT(user.ID, user.Email, scopes, 24*time.Hour)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -193,9 +193,56 @@ func GetJWTSecret() string {
 // GenerateJWT creates a JWT for an authenticated user, delegating to the shared
 // identity TokenManager. Scopes are embedded so the auth middleware can
 // authorize without a database round-trip; a unique JTI is stamped for revocation.
+//
+// Issue #652 disposition — "Session JWTs embed a cross-organization union of
+// scopes with no org binding" (CWE-269), DEFERRED with the rationale below.
+//
+// This is the single canonical token-minting primitive for the registry, and it
+// deliberately calls the identity library's org-less TokenManager.Generate
+// (Deprecated in favor of GenerateForOrg) rather than issuing per-organization
+// tokens. Every session-issuing path (OIDC/SAML/LDAP/AzureAD callbacks, refresh,
+// and dev impersonation) routes through here with a FLAT scope union — the set
+// unioned across every organization the user belongs to
+// (store.OrganizationRepository.GetUserCombinedScopes) — so the resulting token
+// has an empty Claims.OrgID and a Claims.Scopes that does not record WHICH
+// organization granted a given scope. The identity library flags exactly this
+// flat-union Generate path as the cross-org privilege-escalation primitive
+// UNLESS the host independently re-checks per-organization membership on every
+// request.
+//
+// The registry's compensating control is precisely that per-request re-check:
+// authorization for an org-scoped resource never trusts Claims.Scopes alone, it
+// re-derives the caller's scopes IN THE TARGET ORGANIZATION server-side —
+//   - middleware.RequireOrgScopeForPathOrg for /organizations/:id* routes
+//     (orgRepo.GetUserScopesForOrg), closing GHSA-hc25-j576-cqm2;
+//   - middleware.NamespaceAuthorizer (namespace_claims ownership) for
+//     module/provider publish/mutate routes (issue #555);
+//   - in-handler orgRepo.GetUserScopesForOrg / GetMemberWithRole re-derivation
+//     for the role-assignment ceiling and API-key ceiling (issues #648/#650).
+//
+// The platform-wide "admin" wildcard is the one deliberate exception (superuser).
+//
+// Why DEFERRED rather than closed here: adopting org-scoped tokens
+// (TokenManager.GenerateForOrg + auth.HasScopeInOrg) is a suite-wide change that
+// must stamp an OrgID claim at every session-issuing path AND migrate every
+// consuming route to the per-org token check — the same org-scoped-token
+// migration already noted as "tracked separately" in RequireOrgScopeForPathOrg's
+// doc. It is out of scope for a surgical authz batch, and doing it piecemeal
+// would leave a mix of org-bound and flat tokens that is harder to reason about
+// than the uniform flat-token + per-org-re-check model in place today. Note the
+// compensating re-check is NOT yet universal: some org-scoped ADMIN resources
+// (SCM providers, mirror configs — org-scoped rows gated only on a coarse
+// scm:*/mirrors:* scope that a per-org role template such as "devops" grants)
+// still authorize from the flat union and are part of this deferred residual
+// (see the batch report / follow-up finding). This batch closes the concrete
+// paths (#648 org-creation auto-admin + role-ceiling, #650 API-key ceiling) by
+// which the flat token could be escalated all the way to the admin wildcard.
 func GenerateJWT(userID, email string, scopes []string, expiresIn time.Duration) (string, error) {
-	_ = GetJWTSecret()                                             // ensure the secret is validated and the TokenManager exists
-	return tokenManager.Generate(userID, email, scopes, expiresIn) //nolint:staticcheck // SA1019: registry issues suite-wide (not per-org) JWTs by design; this is the canonical call site, a deliberate suite-wide decision per the deprecation notice
+	_ = GetJWTSecret() // ensure the secret is validated and the TokenManager exists
+	// SA1019: TokenManager.Generate is deprecated in favor of GenerateForOrg;
+	// the registry issues suite-wide (org-less) JWTs by design — see the
+	// issue #652 disposition on this function.
+	return tokenManager.Generate(userID, email, scopes, expiresIn) //nolint:staticcheck // SA1019: deliberate org-less suite-wide token; issue #652 disposition documented on GenerateJWT
 }
 
 // ValidateJWT parses and validates a JWT via the shared identity TokenManager.

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -159,6 +159,47 @@ func TestGenerateAndValidateJWT(t *testing.T) {
 	})
 }
 
+// TestGenerateJWT_IsGlobalOrgLessToken pins the issue #652 disposition
+// (session JWTs embed a cross-organization scope union with no org binding).
+// The registry's canonical session token is DELIBERATELY global/org-less: the
+// minted token carries the caller's flat scope union verbatim and an EMPTY
+// OrgID, so nothing in the token records which organization granted a scope.
+// This is exactly why authorization for org-scoped resources must re-derive
+// per-org membership server-side (RequireOrgScopeForPathOrg, the namespace
+// authorizer, and the #648/#650 in-handler ceilings) rather than trusting
+// Claims.Scopes. Should a future change begin binding tokens to an organization
+// (TokenManager.GenerateForOrg), OrgID would become non-empty and trip this
+// test — a signal that the deferred org-scoped-token migration has begun and the
+// per-org enforcement layer must be revisited in tandem.
+func TestGenerateJWT_IsGlobalOrgLessToken(t *testing.T) {
+	resetJWTSecret()
+	t.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars-!")
+
+	// A flat union deliberately mixing scopes a user might hold in DIFFERENT
+	// organizations (e.g. modules:read in org A, organizations:write + scm:manage
+	// in org B) — the shape GetUserCombinedScopes produces.
+	unionScopes := []string{"modules:read", "organizations:write", "scm:manage"}
+	token, err := GenerateJWT("user-1", "u@example.com", unionScopes, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT() error: %v", err)
+	}
+	claims, err := ValidateJWT(token)
+	if err != nil {
+		t.Fatalf("ValidateJWT() error: %v", err)
+	}
+	if claims.OrgID != "" {
+		t.Errorf("claims.OrgID = %q, want empty: registry issues org-less suite-wide tokens by design (issue #652); a non-empty OrgID means org-scoped tokens are being introduced and per-org enforcement must be re-audited", claims.OrgID)
+	}
+	if len(claims.Scopes) != len(unionScopes) {
+		t.Fatalf("claims.Scopes = %v, want the flat union %v embedded verbatim", claims.Scopes, unionScopes)
+	}
+	for i, s := range unionScopes {
+		if claims.Scopes[i] != s {
+			t.Errorf("claims.Scopes[%d] = %q, want %q", i, claims.Scopes[i], s)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // trimSecretBytes
 // ---------------------------------------------------------------------------

--- a/backend/internal/db/repositories/organization_repository.go
+++ b/backend/internal/db/repositories/organization_repository.go
@@ -37,16 +37,29 @@ func CascadeOrganizationRename(ctx context.Context, db *sql.DB, orgID, oldName, 
 		}
 	}()
 
+	// Match module/provider rows by namespace alone, NOT by organization_id.
+	// Artifact rows are stamped with the DEFAULT organization at publish time,
+	// not the namespace's true owner (issue #555), so an `organization_id = orgID`
+	// predicate matches nothing whenever a NON-default organization is renamed --
+	// silently leaving that organization's artifacts pinned to the old namespace
+	// while the organization row and its namespace_claims move to the new name,
+	// orphaning them from the unauthenticated protocol read path (which resolves
+	// modules/providers by namespace). A namespace is a globally-unique ownership
+	// identity (namespace_claims.namespace is the PRIMARY KEY) and this cascade is
+	// triggered precisely by renaming the organization that owns it, so matching
+	// on the old namespace string alone is both correct and complete. The
+	// namespace_claims row below is matched by organization_id because claims —
+	// unlike artifact rows — do carry the true owning organization.
 	if _, err = tx.ExecContext(ctx,
-		`UPDATE modules SET namespace = $1, updated_at = NOW() WHERE organization_id = $2 AND namespace = $3`,
-		newName, orgID, oldName,
+		`UPDATE modules SET namespace = $1, updated_at = NOW() WHERE namespace = $2`,
+		newName, oldName,
 	); err != nil {
 		return fmt.Errorf("cascade rename to modules: %w", err)
 	}
 
 	if _, err = tx.ExecContext(ctx,
-		`UPDATE providers SET namespace = $1, updated_at = NOW() WHERE organization_id = $2 AND namespace = $3`,
-		newName, orgID, oldName,
+		`UPDATE providers SET namespace = $1, updated_at = NOW() WHERE namespace = $2`,
+		newName, oldName,
 	); err != nil {
 		return fmt.Errorf("cascade rename to providers: %w", err)
 	}

--- a/backend/internal/db/repositories/organization_repository_test.go
+++ b/backend/internal/db/repositories/organization_repository_test.go
@@ -78,6 +78,42 @@ func TestCascadeOrganizationRename_Success(t *testing.T) {
 	}
 }
 
+// Issue #555 (regression): the module/provider namespace cascade must match rows
+// by namespace ALONE, not by organization_id. Artifact rows are stamped with the
+// default organization at publish time, not the namespace's true owner, so an
+// `organization_id = orgID` predicate silently skips a renamed non-default org's
+// artifacts -- leaving them pinned to the old namespace while the organization
+// row and namespace_claims move, orphaning them from the read path. This asserts
+// the modules/providers UPDATEs carry exactly (newName, oldName) and no org_id,
+// while the namespace_claims UPDATE (whose rows DO carry the true org) still
+// scopes by organization_id.
+func TestCascadeOrganizationRename_MatchesArtifactsByNamespaceOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE modules SET namespace").
+		WithArgs("new", "old").
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectExec("UPDATE providers SET namespace").
+		WithArgs("new", "old").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").
+		WithArgs("new", "org-1", "old").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err != nil {
+		t.Fatalf("CascadeOrganizationRename: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
 func TestCascadeOrganizationRename_ModulesError(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
Closes #650
Part of #555 (regression item: cascade rename now matches artifacts by namespace only)

Batch `a-authz-org-binding` from the 2026-07-22 blind security audit. Follow-up to #697 — this branch is rebased onto it and inherits its `organizations:create`/`org_owner` design unchanged.

- **#650** — `UpdateAPIKeyHandler` now fails closed on the per-org scope ceiling: absent membership or a null role template returns 403 instead of permitting scope widening.
- **Panel-discovered sibling (no filed issue)** — `ListAPIKeysHandler` disclosed cross-org API key metadata to any holder of a global `api_keys:manage` scope; per-org re-derivation via `GetUserScopesForOrg` now gates it, `ListAll` is platform-admin only, lookups fail closed.
- **#652** — documented deferral (not closed by this PR): session JWTs remain org-less pending a `terraform-suite-identity` change; a pinning test and doc block record the constraint.
- **#555 regression** — organization cascade-rename matches modules/providers by namespace alone (namespace is a global PK).

Verification: 3-reviewer adversarial panel consensus (3/3), plus an independent post-rebase correctness review (approve, 0 blocking) that re-ran the affected packages and verified the vendored identity semantics. Full `go test ./...` green.

Merge order: merge this before the `b-secrets-log-hygiene` PR (both touch `internal/auth/jwt.go`; the other branch will be rebased after this lands).