### PR TITLE
docs(security): align security docs, threat model and compliance claims with the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains the backend API, database migrations, and deployment in
 - **User Management** — Comprehensive user administration
 - **Organization Membership** — Role-based team collaboration (viewer, publisher, devops, user_manager, auditor, admin)
 - **Configurable Modes** — Single-tenant or multi-tenant deployment
+- **Namespace Ownership** — Each module/provider namespace is bound to the organization that first published into it; mutations are checked against this claim to prevent cross-org namespace hijacking. Read-only `/api/v1/admin/namespaces` API for auditing current ownership (`organizations:read` scope).
 
 ### Module Source Control (SCM) Integration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,10 +3,17 @@
 
 ## Supported Versions
 
+We support the latest `3.x` minor/patch release. Earlier major versions do not
+receive security fixes; upgrade to the latest `3.x` release before reporting
+an issue against an older version.
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 3.x     | :white_check_mark: |
+| < 3.0   | :x:                |
+
+This table is refreshed as part of the release-please version-bump PR whenever
+the supported major version changes.
 
 ## Reporting a Vulnerability
 

--- a/backend/cmd/chaos-test/main.go
+++ b/backend/cmd/chaos-test/main.go
@@ -1,12 +1,15 @@
 // Package main implements a chaos/soak testing tool for the Terraform Registry.
 //
-// It injects controlled failures (Redis down, storage 5xx, DB connection storms)
-// while continuously exercising the API, then reports on error rates and recovery.
+// It drives sustained HTTP load against a running registry instance --
+// health-soak, api-soak, connection-storm, and large-payload scenarios --
+// then reports on error rates, latency, and recovery. It does not inject
+// failures into the registry's own dependencies (Redis, object storage,
+// PostgreSQL); it only exercises the API as an external client would.
 //
 // Usage:
 //
 //	go run ./cmd/chaos-test --target https://localhost:5000 --duration 1h --scenario all
-//	go run ./cmd/chaos-test --target https://localhost:5000 --duration 10m --scenario redis-down
+//	go run ./cmd/chaos-test --target https://localhost:5000 --duration 10m --scenario connection-storm
 package main
 
 import (

--- a/backend/docs/embed_test.go
+++ b/backend/docs/embed_test.go
@@ -1,0 +1,31 @@
+package docs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSwaggerJSONCoversNamespaceOwnershipAPI guards against issue #672's
+// documentation gap recurring: the namespace-ownership endpoints
+// (ListNamespaceClaimsHandler / GetNamespaceOwnershipHandler,
+// internal/api/admin/organizations.go) were registered in router_routes.go
+// with no Swagger annotations, so they were silently absent from the
+// generated spec and therefore invisible to cmd/api-test's swagger-coverage
+// report. This test fails if the annotations (or the generated spec) regress.
+func TestSwaggerJSONCoversNamespaceOwnershipAPI(t *testing.T) {
+	var spec struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(SwaggerJSON, &spec); err != nil {
+		t.Fatalf("failed to parse embedded swagger.json: %v", err)
+	}
+
+	for _, path := range []string{
+		"/api/v1/admin/namespaces",
+		"/api/v1/admin/namespaces/{namespace}",
+	} {
+		if _, ok := spec.Paths[path]; !ok {
+			t.Errorf("swagger.json is missing path %q; run `swag init -g cmd/server/main.go --outputTypes json` from backend/ after adding Swagger annotations", path)
+		}
+	}
+}

--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -2415,6 +2415,135 @@
                 }
             }
         },
+        "/api/v1/admin/namespaces": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "List every namespace ownership claim with its resolved organization name, so operators can audit which organization owns each module/provider namespace.",
+                "tags": [
+                    "Organizations"
+                ],
+                "summary": "List namespace ownership claims",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.ListNamespaceClaimsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/namespaces/{namespace}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Resolve the owning organization of a single namespace exactly as the mutation authorizer does: the claim when present, otherwise the artifact-row fallback. A namespace whose artifacts span multiple organizations without a claim is reported as ambiguous rather than guessed.",
+                "tags": [
+                    "Organizations"
+                ],
+                "summary": "Get namespace ownership",
+                "parameters": [
+                    {
+                        "description": "Namespace name",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.NamespaceOwnershipResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "namespace is required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Namespace is unclaimed and has no artifacts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/notifications/channels": {
             "get": {
                 "security": [
@@ -16973,6 +17102,17 @@
                     }
                 }
             },
+            "admin.ListNamespaceClaimsResponse": {
+                "type": "object",
+                "properties": {
+                    "namespaces": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/admin.NamespaceClaimItem"
+                        }
+                    }
+                }
+            },
             "admin.ListOrganizationsResponse": {
                 "type": "object",
                 "properties": {
@@ -17246,6 +17386,55 @@
                         "type": "string"
                     },
                     "version": {
+                        "type": "string"
+                    }
+                }
+            },
+            "admin.NamespaceClaimItem": {
+                "type": "object",
+                "properties": {
+                    "claimed_by": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "organization_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "admin.NamespaceOwnershipResponse": {
+                "type": "object",
+                "properties": {
+                    "claimed_by": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "organization_name": {
+                        "type": "string"
+                    },
+                    "owner_organization_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source": {
                         "type": "string"
                     }
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1906,6 +1906,107 @@
                 }
             }
         },
+        "/api/v1/admin/namespaces": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "List every namespace ownership claim with its resolved organization name, so operators can audit which organization owns each module/provider namespace.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Organizations"
+                ],
+                "summary": "List namespace ownership claims",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ListNamespaceClaimsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/namespaces/{namespace}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Resolve the owning organization of a single namespace exactly as the mutation authorizer does: the claim when present, otherwise the artifact-row fallback. A namespace whose artifacts span multiple organizations without a claim is reported as ambiguous rather than guessed.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Organizations"
+                ],
+                "summary": "Get namespace ownership",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace name",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.NamespaceOwnershipResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "namespace is required",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Namespace is unclaimed and has no artifacts",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/notifications/channels": {
             "get": {
                 "security": [
@@ -13818,6 +13919,17 @@
                 }
             }
         },
+        "admin.ListNamespaceClaimsResponse": {
+            "type": "object",
+            "properties": {
+                "namespaces": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.NamespaceClaimItem"
+                    }
+                }
+            }
+        },
         "admin.ListOrganizationsResponse": {
             "type": "object",
             "properties": {
@@ -14091,6 +14203,55 @@
                     "type": "string"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.NamespaceClaimItem": {
+            "type": "object",
+            "properties": {
+                "claimed_by": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "admin.NamespaceOwnershipResponse": {
+            "type": "object",
+            "properties": {
+                "claimed_by": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "owner_organization_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -67,6 +67,15 @@ func (h *OrganizationHandlers) revokeUserTokens(c *gin.Context, userID, reason s
 	}
 }
 
+// @Summary      List namespace ownership claims
+// @Description  List every namespace ownership claim with its resolved organization name, so operators can audit which organization owns each module/provider namespace.
+// @Tags         Organizations
+// @Security     Bearer
+// @Produce      json
+// @Success      200  {object}  admin.ListNamespaceClaimsResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/namespaces [get]
 // ListNamespaceClaimsHandler lists every namespace ownership claim with its
 // resolved organization name, so operators can audit which organization owns
 // each module/provider namespace (issue #555). Organization names are resolved
@@ -108,6 +117,18 @@ func (h *OrganizationHandlers) ListNamespaceClaimsHandler() gin.HandlerFunc {
 	}
 }
 
+// @Summary      Get namespace ownership
+// @Description  Resolve the owning organization of a single namespace exactly as the mutation authorizer does: the claim when present, otherwise the artifact-row fallback. A namespace whose artifacts span multiple organizations without a claim is reported as ambiguous rather than guessed.
+// @Tags         Organizations
+// @Security     Bearer
+// @Produce      json
+// @Param        namespace  path  string  true  "Namespace name"
+// @Success      200  {object}  admin.NamespaceOwnershipResponse
+// @Failure      400  {object}  map[string]interface{}  "namespace is required"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      404  {object}  map[string]interface{}  "Namespace is unclaimed and has no artifacts"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/namespaces/{namespace} [get]
 // GetNamespaceOwnershipHandler resolves the owning organization of a single
 // namespace exactly as the mutation authorizer does: the claim when present,
 // otherwise the artifact-row fallback (a namespace that predates claims or was

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -314,6 +314,34 @@ type ListMirroredProvidersResponse struct {
 	Providers []MirroredProviderSummary `json:"providers"`
 }
 
+// NamespaceClaimItem describes one namespace ownership claim in the
+// ListNamespaceClaimsResponse.
+type NamespaceClaimItem struct {
+	Namespace        string    `json:"namespace"`
+	OrganizationID   string    `json:"organization_id"`
+	OrganizationName string    `json:"organization_name"`
+	ClaimedBy        string    `json:"claimed_by"`
+	CreatedAt        time.Time `json:"created_at"`
+}
+
+// ListNamespaceClaimsResponse is returned by GET /api/v1/admin/namespaces.
+type ListNamespaceClaimsResponse struct {
+	Namespaces []NamespaceClaimItem `json:"namespaces"`
+}
+
+// NamespaceOwnershipResponse is returned by GET /api/v1/admin/namespaces/{namespace}.
+// ClaimedBy and CreatedAt are only present when Source is "claim"; OwnerOrganizationIDs
+// is only present when Source is "ambiguous".
+type NamespaceOwnershipResponse struct {
+	Namespace            string     `json:"namespace"`
+	Source               string     `json:"source"`
+	OrganizationID       string     `json:"organization_id,omitempty"`
+	OrganizationName     string     `json:"organization_name,omitempty"`
+	ClaimedBy            string     `json:"claimed_by,omitempty"`
+	CreatedAt            *time.Time `json:"created_at,omitempty"`
+	OwnerOrganizationIDs []string   `json:"owner_organization_ids,omitempty"`
+}
+
 // AuditLogResponse represents a single audit log entry in list or get responses.
 type AuditLogResponse struct {
 	ID             string                 `json:"id"`

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1307,6 +1307,16 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid logging level: %s (must be debug, info, warn, or error)", c.Logging.Level)
 	}
 
+	// Validate binary mirror auth mode. "" (unset) and "none" both mean no
+	// access control; any other unrecognized value used to be silently
+	// treated the same as "none" by BinaryMirrorAuthMiddleware (fail open on
+	// typo) -- reject it here instead so a misconfigured value stops startup
+	// rather than silently disabling access control.
+	validBinaryMirrorAuth := map[string]bool{"": true, "none": true, "allowlist": true, "mtls": true}
+	if !validBinaryMirrorAuth[c.BinaryMirror.Auth] {
+		return fmt.Errorf("invalid binary_mirror.auth: %s (must be none, allowlist, or mtls)", c.BinaryMirror.Auth)
+	}
+
 	if c.Scanning.Enabled {
 		if c.Scanning.BinaryPath == "" {
 			return fmt.Errorf("scanning.binary_path is required when scanning.enabled=true")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -427,6 +427,38 @@ func TestValidate(t *testing.T) {
 			t.Errorf("Validate() unexpected error when policy disabled: %v", err)
 		}
 	})
+
+	// -------------------------------------------------------------------
+	// binary_mirror.auth (issue #673: unrecognized values used to fail
+	// open by silently behaving like "none")
+	// -------------------------------------------------------------------
+
+	t.Run("binary_mirror auth unset defaults to none", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.BinaryMirror.Auth = ""
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for unset binary_mirror.auth: %v", err)
+		}
+	})
+
+	for _, mode := range []string{"none", "allowlist", "mtls"} {
+		mode := mode
+		t.Run("binary_mirror auth "+mode+" accepted", func(t *testing.T) {
+			cfg := minimalValidConfig()
+			cfg.BinaryMirror.Auth = mode
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("Validate() unexpected error for binary_mirror.auth %q: %v", mode, err)
+			}
+		})
+	}
+
+	t.Run("binary_mirror auth typo rejected instead of silently failing open", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.BinaryMirror.Auth = "allowlst" // typo for "allowlist"
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for misspelled binary_mirror.auth, got nil")
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/middleware/binary_mirror_auth.go
+++ b/backend/internal/middleware/binary_mirror_auth.go
@@ -17,8 +17,11 @@ import (
 //   - "mtls"      — requires a verified TLS client certificate on the connection; requests
 //     without one receive 403.
 //
-// Any unrecognised Auth value is treated as "none" to avoid accidentally locking out
-// operators who upgrade with a misconfigured value.
+// Any unrecognised Auth value is treated as "none" here as a defense-in-depth
+// default for callers that construct BinaryMirrorConfig directly (e.g. tests).
+// The normal config-loading path (config.Config.Validate) now rejects an
+// unrecognised binary_mirror.auth value at startup instead of silently
+// falling back to "none", so a typo can no longer reach this middleware.
 func BinaryMirrorAuthMiddleware(cfg config.BinaryMirrorConfig) gin.HandlerFunc {
 	switch cfg.Auth {
 	case "allowlist":

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -104,6 +104,7 @@ These endpoints implement the HashiCorp protocols that `terraform init` and `ter
 | Provider Upload | `POST /api/v1/providers` | `providers:write` |
 | Users | `/api/v1/admin/users` | `admin:users` |
 | Organizations | `/api/v1/admin/organizations` | `admin:organizations` |
+| Namespace Ownership (read-only) | `/api/v1/admin/namespaces` | `organizations:read` |
 | API Keys | `/api/v1/apikeys` | `admin:apikeys` |
 | RBAC / Role Templates | `/api/v1/admin/roles` | `admin:roles` |
 | Mirror Configuration | `/api/v1/admin/mirrors` | `mirrors:manage` |

--- a/docs/compliance/iso27001-mapping.md
+++ b/docs/compliance/iso27001-mapping.md
@@ -5,7 +5,7 @@ This document maps ISO 27001:2022 Annex A controls to Terraform Registry
 features, configurations, and evidence sources. It supports organizations
 seeking ISO 27001 certification that include the registry in their ISMS scope.
 
-**Last updated:** 2026-06-17
+**Last updated:** 2026-07-24
 **Applicable version:** 1.0.0+
 
 ---
@@ -71,7 +71,7 @@ application with no physical infrastructure requirements.
 | A.8.26  | Application security requirements       | Input validation, parameterized queries, CSRF protection          | Validation package, middleware                     |
 | A.8.27  | Secure system architecture              | Architecture documentation, ADRs                                  | `docs/architecture.md`, `docs/adr/`                |
 | A.8.28  | Secure coding                           | gosec static analysis, linting, code review                       | CI workflows, CODEOWNERS                           |
-| A.8.29  | Security testing                        | Unit tests, integration tests, E2E tests, fuzz tests (planned)    | Test suites, CI workflows                          |
+| A.8.29  | Security testing                        | Unit tests, integration tests, E2E tests, fuzz tests               | Test suites; nightly fuzz workflow `.github/workflows/fuzz.yml` runs `backend/internal/analyzer/analyzer_fuzz_test.go` and `backend/internal/scm/*/connector_fuzz_test.go`; `backend/internal/archiver/tarball_test.go` also defines a fuzz target but is exercised only as a seed-corpus regression test via `go test`, not in the fuzz.yml matrix |
 | A.8.31  | Separation of environments              | Separate compose files for dev/test/prod; env var config          | `deployments/docker-compose*.yml`                  |
 | A.8.32  | Change management                       | Git-based PR workflow, required reviews, CI gates                 | Branch protection, CI                              |
 | A.8.33  | Test information                        | Test fixtures use synthetic data only                             | Test files                                         |
@@ -86,6 +86,16 @@ Controls marked N/A are not applicable because:
 - **A.6.1 (Screening):** Organizational HR responsibility, not application-level.
 - **A.7.x (Physical controls):** Application runs in cloud/container environments; physical security is the provider's responsibility.
 - **A.8.1 (Endpoint devices):** Server-side application; end-user device management is organizational responsibility.
+
+---
+
+## Review Schedule
+
+This mapping is reviewed on the same cadence as
+[docs/threat-model.md](../threat-model.md) §8 (on every major version release,
+when new authentication mechanisms or data stores/external integrations are
+introduced, and at least annually), so control mappings do not lag the
+codebase's actual test/CI maturity.
 
 ---
 

--- a/docs/compliance/soc2-mapping.md
+++ b/docs/compliance/soc2-mapping.md
@@ -5,7 +5,7 @@ This document maps SOC 2 Trust Service Criteria to Terraform Registry features,
 configurations, and evidence sources. It is intended to assist compliance teams
 during SOC 2 Type II audits.
 
-**Last updated:** 2026-04-20
+**Last updated:** 2026-07-24
 **Applicable version:** 0.10.0+
 
 ---
@@ -123,6 +123,16 @@ during SOC 2 Type II audits.
 | P4.1     | Use limitation        | PII used only for auth/audit; not shared externally  | Audit shipper config (self-hosted destinations only) |
 | P6.1     | Data subject access   | User data export endpoint                            | `/admin/users/:id/export`                            |
 | P8.1     | Data quality          | IdP-sourced attributes; SCIM sync keeps data current | SCIM provisioning                                    |
+
+---
+
+## Review Schedule
+
+This mapping is reviewed on the same cadence as
+[docs/threat-model.md](../threat-model.md) §8 (on every major version release,
+when new authentication mechanisms or data stores/external integrations are
+introduced, and at least annually), so control mappings do not lag the
+codebase's actual test/CI maturity.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -952,6 +952,11 @@ binary_mirror:
 When `auth=allowlist`, the client IP is resolved using the same `trusted_proxies` rules
 described in the Server section.
 
+> **Unrecognized values are rejected at startup.** `binary_mirror.auth` must be
+> one of `none`, `allowlist`, or `mtls` (or left unset, which behaves like
+> `none`); any other value fails config validation instead of starting the
+> server, so a typo can no longer silently disable access control.
+
 ---
 
 ## Policy Engine (OPA / Rego)

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,8 +1,8 @@
 <!-- markdownlint-disable MD013 MD060 -->
 # Threat Model — Terraform Registry
 
-**Document version:** 1.0
-**Last updated:** 2026-04-20
+**Document version:** 1.1
+**Last updated:** 2026-07-24
 **Methodology:** STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
 
 ---
@@ -69,6 +69,7 @@ Terraform modules and providers. It comprises:
 | **TB-5** | Backend → Redis: password-authenticated, optionally TLS-encrypted.                                |
 | **TB-6** | Backend → External IdP: OIDC/SAML/LDAP over TLS.                                                  |
 | **TB-7** | Backend → Scanner binary: local process invocation with constrained arguments.                    |
+| **TB-8** | Backend → Sibling Suite app (TSM): shared-secret-authenticated (`X-Suite-Service-Token`) outbound calls for audit federation and the "Consumed by" proxy; opt-in JWT issuer-trust widening via `TFR_SUITE_TRUSTED_ISSUERS`. Only active when `TFR_SUITE_SIBLING_URL` is configured. See [Suite Audit Federation](suite-audit-federation.md). |
 
 ## 4. Assets
 
@@ -82,6 +83,7 @@ Terraform modules and providers. It comprises:
 | Audit logs               | High        | Compliance evidence; must be tamper-resistant         |
 | User PII                 | Medium      | Email addresses, usernames, IdP identifiers           |
 | Scanner findings         | High        | Vulnerability data about hosted modules               |
+| Suite sibling service token | Critical | Shared secret (`TFR_SUITE_SIBLING_TOKEN`) authenticating outbound audit federation and "Consumed by" reads to the sibling Suite app |
 
 ## 5. STRIDE Analysis
 
@@ -94,6 +96,7 @@ Terraform modules and providers. It comprises:
 | S-3 | Attacker performs LDAP injection to bypass auth            | Backend LDAP connector | Parameterized LDAP queries with input escaping; bind DN validation                                                               | ✅ Implemented |
 | S-4 | Attacker hijacks session via XSS                           | Frontend               | httpOnly + Secure + SameSite=Lax cookies (Lax, not Strict, is required so the cookie survives the OIDC top-level redirect); CSP with nonces; no inline scripts | ✅ Implemented |
 | S-5 | DNS spoofing redirects IdP callbacks                       | Backend OIDC           | Strict redirect_uri validation; state parameter CSRF protection                                                                  | ✅ Implemented |
+| S-6 | Compromised/malicious sibling widens accepted JWT issuers, letting tokens it mints be trusted here | Backend JWT / Suite config (TB-8) | `TFR_SUITE_TRUSTED_ISSUERS` is an explicit operator opt-in allow-list, not derived automatically from suite discovery; only meaningful when `TFR_JWT_SECRET` is deliberately shared with the sibling | ⚙️ Operator-configured |
 
 ### 5.2 Tampering (T)
 
@@ -124,6 +127,8 @@ Terraform modules and providers. It comprises:
 | I-4 | Verbose error messages reveal internal topology  | Backend     | Production mode uses generic error messages; stack traces only in debug level; Swagger UI disabled by default in production  | ✅ Implemented |
 | I-5 | Scanner findings exposed to non-admin users      | Backend API | Scanner endpoints require `admin` or `scanning:read` scope                                                                   | ✅ Implemented |
 | I-6 | User PII enumeration via API                     | Backend API | User list endpoints require admin scope; user lookup by ID only (no email enumeration); rate limiting                        | ✅ Implemented |
+| I-7 | Leaked `TFR_SUITE_SIBLING_TOKEN` lets an attacker call the sibling's federated audit ingest and "Consumed by" consumers endpoint as this app (TB-8) | Suite federation (`suite.go`, audit webhook shipper) | Per-deployment shared secret injected via env/secret, never logged; the sibling gates its own endpoints on the header value | ⚙️ Operator-configured |
+| I-8 | Outbound "Consumed by" proxy call in `suite.go` (TB-8) uses a plain `http.Client` rather than the centralized `httpsafe` resolve-and-pin SSRF guard used for other operator-configured URLs (e.g. `policy.bundle_url`) | Backend suite proxy | Destination host is structurally fixed to the discovery-advertised sibling `PublicURL` (built via `net/url`, not string concatenation); user/module input is confined to query parameters | ⚠️ Partial — not yet routed through `httpsafe` |
 
 ### 5.5 Denial of Service (D)
 
@@ -145,6 +150,7 @@ Terraform modules and providers. It comprises:
 | E-3 | Container escape leads to host compromise            | Deployment   | Non-root container user; read-only root filesystem; dropped capabilities; seccomp/AppArmor profiles recommended in deployment docs       | ⚙️ Operator-configured |
 | E-4 | SQL injection leads to privilege escalation          | Backend      | Parameterized queries; DB user has minimum required grants (no SUPERUSER); separate migration user for DDL                               | ✅ Implemented |
 | E-5 | Path traversal in module/provider archive extraction | Backend      | Archive extraction validates paths; rejects entries with `..` components; temp directory isolation                                       | ✅ Implemented |
+| E-6 | Attacker with `modules:write`/`providers:write` publishes into or overwrites another organization's namespace (namespace hijacking, CWE-639) | Backend namespace authz | `namespace_claims` binds each namespace to the organization that first published into it; every module/provider mutation route checks the caller's organization against the claim (`internal/middleware/namespace_authz.go`); a namespace whose artifacts span multiple orgs without a claim is denied as ambiguous rather than guessed; read-only `/api/v1/admin/namespaces` API exposes current ownership for audit | ✅ Implemented |
 
 > **Status legend:** ✅ Implemented = enforced by the application; ⚠️ Partial =
 > partially enforced; ⚙️ Operator-configured = the application ships safe defaults


### PR DESCRIPTION
Closes #670
Closes #671
Closes #672
Closes #673
Closes #691
Closes #692

Batch `i-docs` from the 2026-07-22 blind security audit:

- **#691** — SECURITY.md's "Supported Versions" table no longer implies the current release is unsupported.
- **#692** — compliance mappings updated to reflect actual test/CI maturity and release cadence.
- **#671** — threat model gains trust-boundary/asset/STRIDE coverage for the Suite/sibling-app federation surface.
- **#672** — the 3.5.0 namespace-ownership API gets the documentation CONTRIBUTING.md requires.
- **#673** — Binary Mirror Access Control docs now state the fail-open-on-typo behavior.
- **#670** — the chaos-test tool's documented fault-injection scenarios are reconciled with the implementation.

Verification: 3-reviewer adversarial panel consensus; `gofmt` clean, `go build ./...` and the affected package tests (admin, docs, all cmd/*) green on the rebased branch.