### PR TITLE
fix(security): alertable rate-limit backend errors, DB query timeouts, panic-safe goroutines, audit shipper wiring

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -316,9 +316,11 @@ func serve(cfg *config.Config) error {
 		// Run against the identity database (defaults to the app DB). Identity
 		// migrations are schema-qualified (identity.*), so a plain connection
 		// suffices; a dedicated connection lets identity live in a separate database
-		// (TFR_IDENTITY_DATABASE_*) without coupling to the app pool.
+		// (TFR_IDENTITY_DATABASE_*) without coupling to the app pool. Uses
+		// GetMigrationDSN() (not GetDSN()) so identity_database.statement_timeout_secs
+		// cannot cancel a long-running migration mid-run.
 		identityMigrateDB, mErr := db.Connect(
-			cfg.IdentityDatabase.GetDSN(),
+			cfg.IdentityDatabase.GetMigrationDSN(),
 			cfg.IdentityDatabase.MaxConnections, cfg.IdentityDatabase.MinIdleConnections,
 		)
 		if mErr != nil {
@@ -332,11 +334,24 @@ func serve(cfg *config.Config) error {
 		log.Println("Identity schema migrations completed successfully")
 	}
 
-	// Run migrations automatically on startup
+	// Run migrations automatically on startup, against a separate short-lived
+	// connection built from GetMigrationDSN() rather than the request-serving
+	// `database` pool: database.statement_timeout_secs defaults to 30s to
+	// protect request-serving queries (issue #664), but this codebase's own
+	// migration history includes full-table backfills (e.g.
+	// migrations/000020_search_indexes.up.sql,
+	// 000031_backfill_scanner_name.up.sql) that can legitimately run longer
+	// than that on a production-sized table.
 	log.Println("Running database migrations...")
-	if err := db.RunMigrations(database, "up"); err != nil {
+	migrateDB, mErr := db.Connect(cfg.Database.GetMigrationDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if mErr != nil {
+		return fmt.Errorf("failed to connect for migrations: %w", mErr)
+	}
+	if err := db.RunMigrations(migrateDB, "up"); err != nil {
+		_ = migrateDB.Close()
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
+	_ = migrateDB.Close()
 	log.Println("Database migrations completed successfully")
 
 	// Get migration version
@@ -505,7 +520,15 @@ func serve(cfg *config.Config) error {
 		TLSConfig:         serverTLSConfig,
 	}
 
-	// Start server in a goroutine
+	// Start server in a goroutine. A listener failure (bind failure, or an
+	// accept-loop failure such as fd exhaustion after the server has been
+	// running) is sent over listenErrCh instead of calling log.Fatalf here
+	// (issue #686): log.Fatalf calls os.Exit(1) directly from this goroutine,
+	// which would terminate the process immediately without running serve()'s
+	// deferred database.Close() or bgServices.Shutdown() below — worst-case
+	// exactly during a resource-exhaustion incident. Sending the error back to
+	// the main goroutine instead lets the normal shutdown path run.
+	listenErrCh := make(chan error, 1)
 	go func() {
 		log.Printf("Starting server on %s", cfg.Server.GetAddress())  // #nosec G706 -- config values from trusted config file/env, not user input
 		log.Printf("Base URL: %s", cfg.Server.BaseURL)                // #nosec G706 -- config values from trusted config file/env, not user input
@@ -522,30 +545,50 @@ func serve(cfg *config.Config) error {
 		}
 
 		if err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Failed to start server: %v", err)
+			listenErrCh <- err
 		}
 	}()
 
-	// Wait for interrupt signal
+	// Wait for either an interrupt signal or the listener goroutine reporting
+	// a startup/accept-loop failure.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
 
-	log.Println("Shutting down server...")
+	listenErr := waitForShutdownOrListenError(quit, listenErrCh)
 
 	// Graceful shutdown with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := server.Shutdown(ctx); err != nil {
+	if err := server.Shutdown(ctx); err != nil && listenErr == nil {
 		return fmt.Errorf("server forced to shutdown: %w", err)
 	}
 
 	// Stop background jobs and rate limiter goroutines
 	bgServices.Shutdown()
 
+	if listenErr != nil {
+		return fmt.Errorf("failed to start server: %w", listenErr)
+	}
+
 	log.Println("Server stopped gracefully")
 	return nil
+}
+
+// waitForShutdownOrListenError blocks until either quit receives a shutdown
+// signal or listenErrCh delivers a listener startup/accept-loop failure
+// (issue #686), and returns the listener error, if any. Extracted from serve()
+// so the channel-selection logic itself — the fix for #686 — is unit
+// testable: serve() as a whole requires a live DB connection and is not.
+func waitForShutdownOrListenError(quit <-chan os.Signal, listenErrCh <-chan error) error {
+	select {
+	case <-quit:
+		log.Println("Shutting down server...")
+		return nil
+	case listenErr := <-listenErrCh:
+		log.Printf("Server listener failed: %v", listenErr)
+		return listenErr
+	}
 }
 
 // handleSetupToken checks if the initial setup wizard needs a setup token and
@@ -773,8 +816,10 @@ func identitySchemaName() string {
 }
 
 func runMigrations(cfg *config.Config, direction string) error {
-	// Connect to database
-	database, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	// Connect to database. Uses GetMigrationDSN() (not GetDSN()) so
+	// database.statement_timeout_secs cannot cancel a long-running migration
+	// mid-run — see the identical comment in serve() for the full rationale.
+	database, err := db.Connect(cfg.Database.GetMigrationDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
@@ -215,5 +217,60 @@ func TestHandleSetupToken_PendingFeature_RearmWhenExplicitlyAllowed(t *testing.T
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet sqlmock expectations (should mint a token when rearm is allowed): %v", err)
+	}
+}
+
+// TestWaitForShutdownOrListenError_QuitSignal and
+// TestWaitForShutdownOrListenError_ListenerError are regression tests for
+// issue #686: a listener startup/accept-loop failure (bind failure, or fd
+// exhaustion after the server has been running) used to call log.Fatalf
+// directly inside the listener goroutine, which calls os.Exit(1) and skips
+// serve()'s deferred database.Close() and bgServices.Shutdown(). The fix
+// sends the error over a channel back to the main goroutine instead, so the
+// normal shutdown path always runs. These tests assert the channel-selection
+// logic that fix depends on: a listener error must be returned (not
+// discarded, not treated the same as a clean quit signal), and a normal quit
+// signal must still return nil.
+func TestWaitForShutdownOrListenError_QuitSignal(t *testing.T) {
+	quit := make(chan os.Signal, 1)
+	listenErrCh := make(chan error, 1)
+
+	quit <- os.Interrupt
+
+	err := waitForShutdownOrListenError(quit, listenErrCh)
+	if err != nil {
+		t.Errorf("waitForShutdownOrListenError() = %v, want nil for a normal quit signal", err)
+	}
+}
+
+func TestWaitForShutdownOrListenError_ListenerError(t *testing.T) {
+	quit := make(chan os.Signal, 1)
+	listenErrCh := make(chan error, 1)
+
+	wantErr := errors.New("listen tcp :8080: bind: address already in use")
+	listenErrCh <- wantErr
+
+	err := waitForShutdownOrListenError(quit, listenErrCh)
+	if err != wantErr {
+		t.Errorf("waitForShutdownOrListenError() = %v, want %v", err, wantErr)
+	}
+}
+
+func TestWaitForShutdownOrListenError_ListenerErrorWinsWhenBothReady(t *testing.T) {
+	// If both channels have a pending value, either is a legal select outcome
+	// in general, but this test only sends to listenErrCh so there is no
+	// ambiguity — it guards against a future edit reordering the select cases
+	// in a way that stops checking listenErrCh at all.
+	quit := make(chan os.Signal, 1)
+	listenErrCh := make(chan error, 1)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		listenErrCh <- errors.New("accept loop failure")
+	}()
+
+	err := waitForShutdownOrListenError(quit, listenErrCh)
+	if err == nil {
+		t.Error("waitForShutdownOrListenError() = nil, want the delayed listener error")
 	}
 }

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -59,6 +59,8 @@ database:
   password: ${DATABASE_PASSWORD}
   ssl_mode: prefer
   max_connections: 25
+  # statement_timeout_secs: 30            # cancel queries running longer than this; 0 disables (default 30)
+  # idle_in_transaction_timeout_secs: 30  # cancel sessions idle inside an open transaction; 0 disables (default 30)
 
 storage:
   default_backend: local  # Options: azure, s3, local

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -143,6 +143,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/dsig v1.3.0 // indirect

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // RBACHandlers handles RBAC-related API endpoints
@@ -106,7 +107,7 @@ func (h *RBACHandlers) notifyApprovalPending(approval *models.MirrorApprovalRequ
 		target, approval.Reason,
 	)
 
-	go func() {
+	safego.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
@@ -125,7 +126,7 @@ func (h *RBACHandlers) notifyApprovalPending(approval *models.MirrorApprovalRequ
 		if err := h.mailer.Send(recipients, subject, body); err != nil {
 			slog.Warn("failed to send approval-pending notification email", "error", err)
 		}
-	}()
+	})
 }
 
 // ============================================================================

--- a/backend/internal/api/admin/scanning_auto_update.go
+++ b/backend/internal/api/admin/scanning_auto_update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // scanningAutoUpdateInput is the PUT /api/v1/admin/scanning/auto-update request body.
@@ -133,7 +134,7 @@ func (h *ScanningAutoUpdateHandler) Put(c *gin.Context) {
 	// discarded (issue #565 finding [40]).
 	if h.updateJob != nil {
 		_ = h.updateJob.Stop()
-		go func() { _ = h.updateJob.Start(context.Background()) }()
+		safego.Go(func() { _ = h.updateJob.Start(context.Background()) })
 	}
 
 	c.JSON(http.StatusOK, ScanningAutoUpdateResponse{

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/services"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
@@ -317,11 +318,11 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 				for _, platform := range platforms {
 					if platform.OS == clientOS && platform.Arch == clientArch {
 						platformID := platform.ID
-						go func() {
+						safego.Go(func() {
 							if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
 								slog.Error("failed to increment download count for mirror provider", "error", err)
 							}
-						}()
+						})
 						telemetry.ProviderDownloadsTotal.WithLabelValues(namespace, providerType, clientOS, clientArch).Inc()
 						break
 					}
@@ -337,7 +338,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			action := "GET " + middleware.RedactSensitivePath(c.Request.URL.Path)
 			ip := c.ClientIP()
 			versionIDForAudit := providerVersion.ID
-			go func() {
+			safego.Go(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
@@ -348,7 +349,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 				}); err != nil {
 					slog.Error("failed to write audit log for mirror platform index", "error", err, "action", action)
 				}
-			}()
+			})
 		}
 
 		// Use c.Data with plain "application/json" (no charset) to satisfy the

--- a/backend/internal/api/modules/download.go
+++ b/backend/internal/api/modules/download.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -113,12 +114,12 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 
 		// Increment download counter asynchronously (don't block the response)
 		versionID := moduleVersion.ID
-		go func() {
+		safego.Go(func() {
 			// Use background context to avoid cancellation when request completes
 			if err := moduleRepo.IncrementDownloadCount(context.Background(), versionID); err != nil {
 				slog.Warn("failed to increment module download count", "version_id", versionID, "error", err)
 			}
-		}()
+		})
 
 		// Increment Prometheus download counter
 		telemetry.ModuleDownloadsTotal.WithLabelValues(namespace, system).Inc()
@@ -143,7 +144,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 					orgIDStr = &s
 				}
 			}
-			go func() {
+			safego.Go(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
@@ -156,7 +157,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 				}); err != nil {
 					slog.Error("failed to write audit log for module download", "error", err, "action", action)
 				}
-			}()
+			})
 		}
 
 		// Return 204 No Content with X-Terraform-Get header

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/services"
@@ -511,11 +512,11 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": connErr.Error()})
 			return
 		}
-		go func() {
+		safego.Go(func() {
 			if syncErr := h.publisher.TriggerManualSync(context.Background(), link, connector, token); syncErr != nil {
 				slog.Warn("manual sync failed", "module_id", moduleID, "error", syncErr)
 			}
-		}()
+		})
 		c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
 		return
 	}
@@ -616,7 +617,7 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 	// Trigger async sync in background using a new context
 	// (c.Request.Context() would be canceled when the HTTP response is sent)
 	slog.Debug("starting async sync", "module_id", moduleID, "owner", link.RepositoryOwner, "repo", link.RepositoryName)
-	go func() {
+	safego.Go(func() {
 		slog.Debug("running sync in goroutine", "module_id", moduleID)
 		if err := h.publisher.TriggerManualSync(context.Background(), link, connector, token); err != nil {
 			// Log error but don't fail the request
@@ -624,7 +625,7 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 		} else {
 			slog.Debug("manual sync completed successfully", "module_id", moduleID)
 		}
-	}()
+	})
 
 	c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
 }

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
@@ -129,7 +130,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		// Track provider downloads: path is providers/{namespace}/{type}/{version}/{os}/{arch}/{file}
 		if providerRepo != nil {
 			if ns, pt, ver, osName, arch, ok := parseProviderFilePath(filePath); ok {
-				go trackProviderDownload(providerRepo, orgRepo, ns, pt, ver, osName, arch)
+				safego.Go(func() { trackProviderDownload(providerRepo, orgRepo, ns, pt, ver, osName, arch) })
 				telemetry.ProviderDownloadsTotal.WithLabelValues(ns, pt, osName, arch).Inc()
 			}
 		}
@@ -146,7 +147,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			// use rather than logging the raw path (issue #678 sibling).
 			action := "GET " + middleware.RedactSensitivePath(c.Request.URL.Path)
 			ip := c.ClientIP()
-			go func() {
+			safego.Go(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
@@ -156,7 +157,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 				}); err != nil {
 					slog.Error("failed to write audit log for file download", "error", err, "action", action)
 				}
-			}()
+			})
 		}
 
 		// Set response headers

--- a/backend/internal/api/modules/upload.go
+++ b/backend/internal/api/modules/upload.go
@@ -18,6 +18,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
 	"github.com/terraform-registry/terraform-registry/internal/policy"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -375,7 +376,7 @@ func notifyModulePublished(mailer *notify.Mailer, notifier *notify.Notifier, cfg
 		namespace, name, system, version,
 	)
 
-	go func() {
+	safego.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
@@ -395,5 +396,5 @@ func notifyModulePublished(mailer *notify.Mailer, notifier *notify.Notifier, cfg
 		if err := mailer.Send(recipients, subject, body); err != nil {
 			slog.Warn("failed to send module-published notification email", "error", err)
 		}
-	}()
+	})
 }

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -188,12 +189,12 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 
 		// Increment download counter asynchronously (don't block the response)
 		platformID := platform.ID
-		go func() {
+		safego.Go(func() {
 			// Use background context to avoid cancellation when request completes
 			if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
 				slog.Warn("failed to increment provider download count", "platform_id", platformID, "error", err)
 			}
-		}()
+		})
 
 		// Increment Prometheus download counter
 		telemetry.ProviderDownloadsTotal.WithLabelValues(namespace, providerType, os, arch).Inc()
@@ -218,7 +219,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 					orgIDStr = &s
 				}
 			}
-			go func() {
+			safego.Go(func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 				if err := auditRepo.CreateAuditLog(ctx, &models.AuditLog{
@@ -231,7 +232,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 				}); err != nil {
 					slog.Error("failed to write audit log for provider download", "error", err, "action", action)
 				}
-			}()
+			})
 		}
 
 		// Format response per Terraform Provider Registry Protocol spec

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -36,6 +36,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/api/setup"
 	terraform_binaries "github.com/terraform-registry/terraform-registry/internal/api/terraform_binaries"
 	"github.com/terraform-registry/terraform-registry/internal/api/webhooks"
+	"github.com/terraform-registry/terraform-registry/internal/audit"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/auth/mtls"
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -74,6 +75,11 @@ type BackgroundServices struct {
 	jobs               *jobs.Registry
 	rateLimiters       []middleware.RateLimiterBackend
 	principalOverrides *middleware.PrincipalOverrideLimiters
+	// auditShipper is non-nil only when cfg.Audit.Shippers configured at least
+	// one active shipper (issue #659). Closed on shutdown so a batching
+	// WebhookShipper flushes its remaining entries and a FileShipper closes
+	// its file handle, rather than being abandoned mid-process-exit.
+	auditShipper audit.Shipper
 }
 
 // Shutdown stops all background goroutines. It should be called after the HTTP
@@ -91,6 +97,11 @@ func (bg *BackgroundServices) Shutdown() {
 	}
 	if bg.principalOverrides != nil {
 		_ = bg.principalOverrides.Close()
+	}
+	if bg.auditShipper != nil {
+		if err := bg.auditShipper.Close(); err != nil {
+			slog.Error("failed to close audit shipper", "error", err)
+		}
 	}
 	slog.Info("all background services stopped")
 }
@@ -135,6 +146,24 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	}
 	if err := scm.ConfigureEgress(cfg.Security.Egress.Allowlist); err != nil {
 		log.Fatalf("failed to configure SCM connector egress policy: %v", err)
+	}
+
+	// Construct the real audit external-shipping subsystem from cfg.Audit so
+	// AuditMiddlewareWithShipper below is no longer wired up with hardcoded
+	// nils (issue #659): previously audit.NewMultiShipperWithGuard's
+	// WebhookShipper/SyslogShipper/FileShipper were fully implemented but
+	// unreachable dead code, and cfg.Audit.LogReadOperations/LogFailedRequests
+	// were silently ignored regardless of what an operator configured.
+	auditShipperMS, err := audit.NewMultiShipperFromConfig(cfg.Audit.Shippers, egressGuard)
+	if err != nil {
+		log.Fatalf("invalid audit.shippers config: %v", err)
+	}
+	var auditShipper audit.Shipper
+	if auditShipperMS.Len() > 0 {
+		auditShipper = auditShipperMS
+		slog.Info("audit external shipping active", "shippers", auditShipperMS.Len())
+	} else if len(cfg.Audit.Shippers) > 0 {
+		slog.Warn("audit.shippers is configured but no shipper is active (all disabled, or unsupported on this platform); external audit shipping is a no-op")
 	}
 
 	// Initialize storage backend
@@ -626,6 +655,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		moduleAdminHandlers:         moduleAdminHandlers,
 		providerAdminHandlers:       providerAdminHandlers,
 		auditRepo:                   auditRepo,
+		auditShipper:                auditShipper,
 		nsAuthz:                     nsAuthz,
 		scanRepo:                    scanRepo,
 		moduleDocsRepo:              moduleDocsRepo,
@@ -673,6 +703,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		jobs:               jobRegistry,
 		rateLimiters:       collectRateLimiterBackends(authRateLimiter, generalRateLimiter, uploadRateLimiter, orgRateLimiter),
 		principalOverrides: principalOverrides,
+		auditShipper:       auditShipper,
 	}
 
 	return router, bg

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -33,6 +33,7 @@ import (
 	terraform_binaries "github.com/terraform-registry/terraform-registry/internal/api/terraform_binaries"
 	"github.com/terraform-registry/terraform-registry/internal/api/uitheme"
 	"github.com/terraform-registry/terraform-registry/internal/api/webhooks"
+	"github.com/terraform-registry/terraform-registry/internal/audit"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
@@ -322,6 +323,7 @@ type apiV1RouteDeps struct {
 	moduleAdminHandlers         *admin.ModuleAdminHandlers
 	providerAdminHandlers       *admin.ProviderAdminHandlers
 	auditRepo                   *repositories.AuditRepository
+	auditShipper                audit.Shipper
 	nsAuthz                     *middleware.NamespaceAuthorizer
 	scanRepo                    *repositories.ModuleScanRepository
 	moduleDocsRepo              *repositories.ModuleDocsRepository
@@ -359,6 +361,27 @@ type apiV1RouteDeps struct {
 	egressGuard                 *httpsafe.Guard
 }
 
+// registerAuthenticatedGroupMiddleware wires the middleware stack applied to
+// every authenticated API v1 route: auth, CSRF, per-principal and
+// per-organization rate limiting, and audit logging. Extracted into its own
+// function (rather than inlined in registerAPIV1Routes, which is
+// coverage:skip:integration-only and requires the full handler dependency
+// graph to construct) specifically so this wiring — in particular, passing
+// the real auditShipper and &cfg.Audit into AuditMiddlewareWithShipper rather
+// than the pre-#659 hardcoded nils — has a direct regression test
+// (TestRegisterAuthenticatedGroupMiddleware_AuditShipsToRealShipper).
+func registerAuthenticatedGroupMiddleware(authenticatedGroup *gin.RouterGroup, d *apiV1RouteDeps) {
+	authenticatedGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo))
+	authenticatedGroup.Use(middleware.CSRFMiddleware(d.cfg)) // double-submit cookie CSRF protection + browser-origin Bearer allowlist
+	authenticatedGroup.Use(middleware.PrincipalRateLimitMiddleware(d.generalRateLimiter, d.principalOverrides))
+	authenticatedGroup.Use(middleware.OrgRateLimitMiddleware(d.generalRateLimiter, d.orgRateLimiter))
+	// Audit all authenticated actions. Ships to any configured external
+	// destinations and honors cfg.Audit.LogReadOperations/LogFailedRequests
+	// (issue #659 — previously always AuditMiddleware(auditRepo), which
+	// hardcodes shipper=nil and auditCfg=nil).
+	authenticatedGroup.Use(middleware.AuditMiddlewareWithShipper(d.auditRepo, d.auditShipper, &d.cfg.Audit))
+}
+
 // registerAPIV1Routes wires the /api/v1, /scim/v2, and webhook route table
 // onto router.
 // coverage:skip:integration-only — registers the /api/v1, /scim/v2, and webhook route table; tested via E2E
@@ -372,8 +395,6 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 	authRateLimiter := d.authRateLimiter
 	generalRateLimiter := d.generalRateLimiter
 	uploadRateLimiter := d.uploadRateLimiter
-	orgRateLimiter := d.orgRateLimiter
-	principalOverrides := d.principalOverrides
 	authHandlers := d.authHandlers
 	userRepo := d.userRepo
 	apiKeyRepo := d.apiKeyRepo
@@ -507,11 +528,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 
 		// Authenticated-only endpoints
 		authenticatedGroup := apiV1.Group("")
-		authenticatedGroup.Use(middleware.AuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
-		authenticatedGroup.Use(middleware.CSRFMiddleware(cfg)) // double-submit cookie CSRF protection + browser-origin Bearer allowlist
-		authenticatedGroup.Use(middleware.PrincipalRateLimitMiddleware(generalRateLimiter, principalOverrides))
-		authenticatedGroup.Use(middleware.OrgRateLimitMiddleware(generalRateLimiter, orgRateLimiter))
-		authenticatedGroup.Use(middleware.AuditMiddleware(auditRepo)) // Audit all authenticated actions
+		registerAuthenticatedGroupMiddleware(authenticatedGroup, d)
 		{
 			// Auth endpoints (require auth)
 			authenticatedGroup.POST("/auth/refresh", authHandlers.RefreshHandler())

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -15,7 +15,10 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/audit"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
@@ -522,5 +525,98 @@ func TestAllowLowEntropyEncryptionKey(t *testing.T) {
 				t.Errorf("allowLowEntropyEncryptionKey() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// registerAuthenticatedGroupMiddleware — regression test for issue #659.
+//
+// router_routes.go:511 (pre-fix) wired the authenticated route group with
+// middleware.AuditMiddleware(auditRepo), which hardcodes shipper=nil and
+// auditCfg=nil, making external audit shipping and the
+// LogReadOperations/LogFailedRequests config flags permanently unreachable in
+// production. This test drives a real request through the actual wiring
+// function the router uses (not just AuditMiddlewareWithShipper in
+// isolation) and asserts the configured shipper is actually invoked — it
+// fails if router_routes.go ever reverts to the old hardcoded-nil call.
+// ---------------------------------------------------------------------------
+
+// spyShipper is a minimal audit.Shipper that records shipped entries.
+type spyShipper struct {
+	shipped chan *audit.LogEntry
+}
+
+func (s *spyShipper) Ship(_ context.Context, entry *audit.LogEntry) error {
+	s.shipped <- entry
+	return nil
+}
+
+func (s *spyShipper) Close() error { return nil }
+
+func TestRegisterAuthenticatedGroupMiddleware_AuditShipsToRealShipper(t *testing.T) {
+	// GenerateJWT/ValidateJWT lazily initialize a shared, process-wide
+	// TokenManager (sync.Once) that requires TFR_JWT_SECRET outside dev mode.
+	t.Setenv("TFR_JWT_SECRET", "test-jwt-secret-for-router-wiring-test-32ch!!")
+
+	userDB, userMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (user): %v", err)
+	}
+	defer userDB.Close()
+
+	userRepo := repositories.NewUserRepository(userDB)
+
+	userCols := []string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(userCols).
+			AddRow("user-1", "test@example.com", "Test User", nil, time.Now(), time.Now()))
+
+	shipper := &spyShipper{shipped: make(chan *audit.LogEntry, 1)}
+
+	d := &apiV1RouteDeps{
+		cfg: &config.Config{
+			Audit: config.AuditConfig{LogReadOperations: true},
+		},
+		userRepo: userRepo,
+		// orgRepo, apiKeyRepo, tokenRepo, userTokenRevocationRepo: nil is safe —
+		// the JWT auth path uses scopes embedded in the token claims and skips
+		// revocation checks when the repos are nil (see AuthMiddleware).
+		auditRepo:    nil, // nil is safe: AuditMiddlewareWithShipper skips the DB write when nil
+		auditShipper: shipper,
+	}
+
+	router := gin.New()
+	apiV1 := router.Group("")
+	authenticatedGroup := apiV1.Group("")
+	registerAuthenticatedGroupMiddleware(authenticatedGroup, d)
+	authenticatedGroup.GET("/dummy", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	token, err := auth.GenerateJWT("user-1", "test@example.com", nil, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/dummy", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (request must pass auth to reach the audit middleware)", w.Code)
+	}
+
+	select {
+	case entry := <-shipper.shipped:
+		if entry.Action != "GET /dummy" {
+			t.Errorf("shipped entry action = %q, want %q", entry.Action, "GET /dummy")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("audit shipper.Ship was never called: the real auditShipper/cfg.Audit did not reach " +
+			"AuditMiddlewareWithShipper (regression for issue #659 — router wiring reverted to the " +
+			"hardcoded-nil middleware.AuditMiddleware(auditRepo))")
+	}
+
+	if err := userMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled user-mock expectations: %v", err)
 	}
 }

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -804,11 +805,11 @@ func (h *Handlers) SaveScanningConfig(c *gin.Context) {
 	// If scanning was just enabled at runtime, kick off the scanner job so that
 	// pending scans are processed immediately without a server restart.
 	if input.Enabled && h.scannerJob != nil {
-		go func() {
+		safego.Go(func() {
 			if err := h.scannerJob.Start(context.Background()); err != nil {
 				slog.Warn("setup: scanner job failed to start after config save", "error", err)
 			}
-		}()
+		})
 	}
 
 	c.JSON(http.StatusOK, SaveScanningConfigResponse{

--- a/backend/internal/api/terraform_binaries/binaries.go
+++ b/backend/internal/api/terraform_binaries/binaries.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -330,11 +331,11 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 
 	// Increment Prometheus download counter and persist to DB (non-blocking).
 	telemetry.TerraformBinaryDownloadsTotal.WithLabelValues(versionStr, osStr, archStr).Inc()
-	go func() {
+	safego.Go(func() {
 		if err := h.repo.IncrementDownloadCount(context.Background(), platform.ID); err != nil {
 			log.Printf("[terraform-binaries] download count increment failed for platform %s: %v", platform.ID, err)
 		}
-	}()
+	})
 
 	// Audit log the download event asynchronously
 	if h.auditRepo != nil {
@@ -356,7 +357,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 				orgIDStr = &s
 			}
 		}
-		go func() {
+		safego.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			if err := h.auditRepo.CreateAuditLog(ctx, &models.AuditLog{
@@ -369,7 +370,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 			}); err != nil {
 				slog.Error("failed to write audit log for binary download", "error", err, "action", action)
 			}
-		}()
+		})
 	}
 
 	c.JSON(http.StatusOK, models.TerraformBinaryDownloadResponse{

--- a/backend/internal/audit/shipper.go
+++ b/backend/internal/audit/shipper.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
@@ -154,6 +155,46 @@ func NewMultiShipperWithGuard(configs []ShipperConfig, egress *httpsafe.Guard) (
 	return ms, nil
 }
 
+// NewMultiShipperFromConfig builds a MultiShipper from the operator-facing
+// config.AuditShipperConfig list (internal/config), translating each entry to
+// this package's own ShipperConfig/WebhookConfig/SyslogConfig/FileConfig
+// types. egress widens the SSRF deny-list applied to webhook shippers exactly
+// as NewMultiShipperWithGuard (issue #659: this is what lets
+// cfg.Audit.Shippers actually reach a real Shipper at startup instead of
+// being wired up with hardcoded nils).
+func NewMultiShipperFromConfig(cfgs []config.AuditShipperConfig, egress *httpsafe.Guard) (*MultiShipper, error) {
+	converted := make([]ShipperConfig, 0, len(cfgs))
+	for _, c := range cfgs {
+		sc := ShipperConfig{Enabled: c.Enabled, Type: c.Type}
+		if c.Syslog != nil {
+			sc.Syslog = &SyslogConfig{
+				Network:  c.Syslog.Network,
+				Address:  c.Syslog.Address,
+				Tag:      c.Syslog.Tag,
+				Facility: c.Syslog.Facility,
+			}
+		}
+		if c.Webhook != nil {
+			sc.Webhook = &WebhookConfig{
+				URL:           c.Webhook.URL,
+				Headers:       c.Webhook.Headers,
+				Timeout:       time.Duration(c.Webhook.TimeoutSecs) * time.Second,
+				BatchSize:     c.Webhook.BatchSize,
+				FlushInterval: time.Duration(c.Webhook.FlushInterval) * time.Second,
+			}
+		}
+		if c.File != nil {
+			sc.File = &FileConfig{
+				Path:       c.File.Path,
+				MaxSizeMB:  c.File.MaxSizeMB,
+				MaxBackups: c.File.MaxBackups,
+			}
+		}
+		converted = append(converted, sc)
+	}
+	return NewMultiShipperWithGuard(converted, egress)
+}
+
 // Ship sends an entry to all configured shippers
 func (ms *MultiShipper) Ship(ctx context.Context, entry *LogEntry) error {
 	ms.mu.RLock()
@@ -168,6 +209,16 @@ func (ms *MultiShipper) Ship(ctx context.Context, entry *LogEntry) error {
 		}
 	}
 	return lastErr
+}
+
+// Len returns the number of active (enabled and successfully constructed)
+// shippers, so a caller can warn when shippers were configured in YAML but
+// none ended up active (e.g. all individually disabled, or a syslog entry
+// skipped as unsupported on this platform).
+func (ms *MultiShipper) Len() int {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return len(ms.shippers)
 }
 
 // Close closes all shippers
@@ -187,6 +238,7 @@ func (ms *MultiShipper) Close() error {
 // WebhookShipper ships audit logs to a webhook
 type WebhookShipper struct {
 	cfg       *WebhookConfig
+	timeout   time.Duration // defaulted copy of cfg.Timeout; see NewWebhookShipperWithGuard
 	client    *http.Client
 	batchCh   chan *LogEntry
 	batch     []*LogEntry
@@ -213,6 +265,7 @@ func NewWebhookShipperWithGuard(cfg *WebhookConfig, egress *httpsafe.Guard) (*We
 
 	ws := &WebhookShipper{
 		cfg:     cfg,
+		timeout: timeout,
 		client:  httpsafe.NewClient(timeout, egress),
 		batchCh: make(chan *LogEntry, 1000),
 		batch:   make([]*LogEntry, 0),
@@ -277,7 +330,7 @@ func (ws *WebhookShipper) flushBatch() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), ws.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ws.timeout)
 	defer cancel()
 
 	if err := ws.sendRequest(ctx, data); err != nil {

--- a/backend/internal/audit/shipper_test.go
+++ b/backend/internal/audit/shipper_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/audit"
+	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
@@ -115,6 +116,106 @@ func TestMultiShipper_ContinuesAfterShipperError(t *testing.T) {
 	}
 	if srv2Count != 1 {
 		t.Errorf("second shipper received %d calls, want 1", srv2Count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewMultiShipperFromConfig — issue #659: cfg.Audit.Shippers must actually
+// reach a real audit.Shipper instead of being wired up with hardcoded nils.
+// ---------------------------------------------------------------------------
+
+func TestNewMultiShipperFromConfig_Empty(t *testing.T) {
+	ms, err := audit.NewMultiShipperFromConfig(nil, nil)
+	if err != nil {
+		t.Fatalf("NewMultiShipperFromConfig(nil) error: %v", err)
+	}
+	if ms.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", ms.Len())
+	}
+}
+
+func TestNewMultiShipperFromConfig_DisabledEntrySkipped(t *testing.T) {
+	cfgs := []config.AuditShipperConfig{
+		{Enabled: false, Type: "webhook", Webhook: &config.AuditWebhookConfig{URL: "http://example.com"}},
+	}
+	ms, err := audit.NewMultiShipperFromConfig(cfgs, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ms.Len() != 0 {
+		t.Errorf("Len() = %d, want 0 (disabled entry should not become an active shipper)", ms.Len())
+	}
+}
+
+func TestNewMultiShipperFromConfig_WebhookDeliversEntry(t *testing.T) {
+	var received bytes.Buffer
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Auth-Token")
+		received.ReadFrom(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfgs := []config.AuditShipperConfig{
+		{
+			Enabled: true,
+			Type:    "webhook",
+			Webhook: &config.AuditWebhookConfig{
+				URL:         srv.URL,
+				Headers:     map[string]string{"X-Auth-Token": "secret"},
+				TimeoutSecs: 5,
+			},
+		},
+	}
+	ms, err := audit.NewMultiShipperFromConfig(cfgs, loopbackGuard)
+	if err != nil {
+		t.Fatalf("NewMultiShipperFromConfig error: %v", err)
+	}
+	if ms.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", ms.Len())
+	}
+	defer ms.Close()
+
+	if err := ms.Ship(context.Background(), &audit.LogEntry{Action: "config.test"}); err != nil {
+		t.Fatalf("Ship() error: %v", err)
+	}
+
+	var decoded audit.LogEntry
+	if err := json.Unmarshal(received.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Action != "config.test" {
+		t.Errorf("Action = %q, want config.test", decoded.Action)
+	}
+	if gotHeader != "secret" {
+		t.Errorf("X-Auth-Token = %q, want secret (config.AuditWebhookConfig.Headers not translated)", gotHeader)
+	}
+}
+
+func TestNewMultiShipperFromConfig_FileShipper(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.log")
+	cfgs := []config.AuditShipperConfig{
+		{Enabled: true, Type: "file", File: &config.AuditFileConfig{Path: path}},
+	}
+	ms, err := audit.NewMultiShipperFromConfig(cfgs, nil)
+	if err != nil {
+		t.Fatalf("NewMultiShipperFromConfig error: %v", err)
+	}
+	if ms.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", ms.Len())
+	}
+	defer ms.Close()
+
+	if err := ms.Ship(context.Background(), &audit.LogEntry{Action: "file.config.test"}); err != nil {
+		t.Fatalf("Ship() error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Contains(data, []byte("file.config.test")) {
+		t.Errorf("log file does not contain shipped entry: %s", data)
 	}
 }
 
@@ -344,6 +445,47 @@ func TestWebhookShipper_BatchFlushOnInterval(t *testing.T) {
 		// success — interval flush worked
 	case <-time.After(3 * time.Second):
 		t.Error("timed out waiting for interval flush")
+	}
+}
+
+// TestWebhookShipper_BatchFlushZeroTimeout reproduces issue #660: the
+// constructor defaults a local `timeout` to 10s only to build the http.Client,
+// but flushBatch used to derive its per-request context straight from
+// ws.cfg.Timeout, which stays the zero value the operator left unset.
+// context.WithTimeout(parent, 0) yields an already-expired deadline, so every
+// batched send failed immediately with "context deadline exceeded" even
+// though the caller left Timeout unset expecting the same 10s default the
+// underlying http.Client got. Batching with Timeout left unset (0) must still
+// successfully deliver.
+func TestWebhookShipper_BatchFlushZeroTimeout(t *testing.T) {
+	done := make(chan struct{}, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		done <- struct{}{}
+	}))
+	defer srv.Close()
+
+	ws, err := audit.NewWebhookShipperWithGuard(&audit.WebhookConfig{
+		URL:           srv.URL,
+		Timeout:       0, // left unset — must not yield an already-expired context
+		BatchSize:     1, // triggers an immediate flush on the first entry
+		FlushInterval: 5 * time.Second,
+	}, loopbackGuard)
+	if err != nil {
+		t.Fatalf("NewWebhookShipper error: %v", err)
+	}
+	defer ws.Close()
+
+	if err := ws.Ship(context.Background(), &audit.LogEntry{Action: "zero-timeout-batch"}); err != nil {
+		t.Fatalf("Ship(1) error: %v", err)
+	}
+
+	select {
+	case <-done:
+		// success — the batch was delivered despite Timeout being unset
+	case <-time.After(3 * time.Second):
+		t.Error("timed out waiting for batch flush with Timeout=0; flushBatch is likely deriving an already-expired context from the zero cfg.Timeout instead of the defaulted value")
 	}
 }
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -347,6 +347,15 @@ type DatabaseConfig struct {
 	SSLMode            string `mapstructure:"ssl_mode"`
 	MaxConnections     int    `mapstructure:"max_connections"`
 	MinIdleConnections int    `mapstructure:"min_idle_connections"`
+	// StatementTimeoutSecs bounds how long a single query may run before
+	// Postgres cancels it, so a stuck or lock-contended query cannot hold a
+	// pooled connection indefinitely and exhaust MaxConnections (issue #664,
+	// CWE-400). 0 disables the timeout.
+	StatementTimeoutSecs int `mapstructure:"statement_timeout_secs"`
+	// IdleInTransactionTimeoutSecs bounds how long a session may sit idle
+	// inside an open transaction before Postgres cancels it. 0 disables the
+	// timeout.
+	IdleInTransactionTimeoutSecs int `mapstructure:"idle_in_transaction_timeout_secs"`
 }
 
 // StorageConfig holds storage backend configuration
@@ -808,6 +817,8 @@ func bindEnvVars(v *viper.Viper) error {
 		"database.ssl_mode",
 		"database.max_connections",
 		"database.min_idle_connections",
+		"database.statement_timeout_secs",
+		"database.idle_in_transaction_timeout_secs",
 		"identity_database.host",
 		"identity_database.port",
 		"identity_database.name",
@@ -816,6 +827,8 @@ func bindEnvVars(v *viper.Viper) error {
 		"identity_database.ssl_mode",
 		"identity_database.max_connections",
 		"identity_database.min_idle_connections",
+		"identity_database.statement_timeout_secs",
+		"identity_database.idle_in_transaction_timeout_secs",
 
 		// Server
 		"server.host",
@@ -1065,6 +1078,11 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.ssl_mode", "require")
 	v.SetDefault("database.max_connections", 25)
 	v.SetDefault("database.min_idle_connections", 5)
+	// Conservative defaults so a stuck or lock-contended query cannot hold a
+	// pooled connection indefinitely (issue #664, CWE-400). Set to 0 to
+	// disable, e.g. if a one-off migration needs more headroom.
+	v.SetDefault("database.statement_timeout_secs", 30)
+	v.SetDefault("database.idle_in_transaction_timeout_secs", 30)
 
 	// Identity database — empty defaults so each field falls back to the app
 	// database (above) unless TFR_IDENTITY_DATABASE_* overrides it.
@@ -1076,6 +1094,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("identity_database.ssl_mode", "")
 	v.SetDefault("identity_database.max_connections", 0)
 	v.SetDefault("identity_database.min_idle_connections", 0)
+	v.SetDefault("identity_database.statement_timeout_secs", 0)
+	v.SetDefault("identity_database.idle_in_transaction_timeout_secs", 0)
 
 	// Storage defaults
 	v.SetDefault("storage.default_backend", "local")
@@ -1362,12 +1382,60 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// GetDSN returns the PostgreSQL connection string
-func (c *DatabaseConfig) GetDSN() string {
+// baseDSN returns the "host=... sslmode=..." connection-parameter portion of
+// the DSN shared by GetDSN, GetDSNWithSearchPath, and GetMigrationDSN.
+func (c *DatabaseConfig) baseDSN() string {
 	return fmt.Sprintf(
 		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
 		c.Host, c.Port, c.User, c.Password, c.Name, c.SSLMode,
 	)
+}
+
+// dsnOptions returns the libpq "-c key=value ..." options clause applied to
+// every registry database connection. StatementTimeoutSecs and
+// IdleInTransactionTimeoutSecs bound how long a single query (or an
+// idle-in-transaction session) may hold a connection out of the pool, so a
+// stuck or lock-contended query cannot exhaust the small, fixed-size
+// connection pool (issue #664, CWE-400); either can be left at 0 to disable.
+// extra appends further "-c key=value" clauses (e.g. search_path). Returns ""
+// if there is nothing to set.
+func (c *DatabaseConfig) dsnOptions(extra ...string) string {
+	opts := make([]string, 0, len(extra)+2)
+	if c.StatementTimeoutSecs > 0 {
+		opts = append(opts, fmt.Sprintf("-c statement_timeout=%ds", c.StatementTimeoutSecs))
+	}
+	if c.IdleInTransactionTimeoutSecs > 0 {
+		opts = append(opts, fmt.Sprintf("-c idle_in_transaction_session_timeout=%ds", c.IdleInTransactionTimeoutSecs))
+	}
+	for _, e := range extra {
+		opts = append(opts, "-c "+e)
+	}
+	return strings.Join(opts, " ")
+}
+
+// migrationDsnOptions is like dsnOptions but never sets statement_timeout.
+// Schema migrations run on a separate, short-lived connection (see
+// GetMigrationDSN) specifically so a full-table backfill or index build
+// (e.g. migrations/000020_search_indexes.up.sql,
+// 000031_backfill_scanner_name.up.sql) cannot be cancelled mid-run by the
+// operator's statement_timeout_secs, which is sized for request-serving
+// queries and would otherwise fail server startup outright. idle_in_transaction
+// is still applied since migrations execute statements without idling.
+func (c *DatabaseConfig) migrationDsnOptions() string {
+	opts := make([]string, 0, 1)
+	if c.IdleInTransactionTimeoutSecs > 0 {
+		opts = append(opts, fmt.Sprintf("-c idle_in_transaction_session_timeout=%ds", c.IdleInTransactionTimeoutSecs))
+	}
+	return strings.Join(opts, " ")
+}
+
+// GetDSN returns the PostgreSQL connection string
+func (c *DatabaseConfig) GetDSN() string {
+	base := c.baseDSN()
+	if opts := c.dsnOptions(); opts != "" {
+		base += fmt.Sprintf(" options='%s'", opts)
+	}
+	return base
 }
 
 // GetDSNWithSearchPath returns the DSN with the connection's search_path set, so
@@ -1375,7 +1443,18 @@ func (c *DatabaseConfig) GetDSN() string {
 // route identity data access at the dedicated identity schema while feature
 // tables fall back to public.
 func (c *DatabaseConfig) GetDSNWithSearchPath(searchPath string) string {
-	return c.GetDSN() + fmt.Sprintf(" options='-c search_path=%s'", searchPath)
+	return c.baseDSN() + fmt.Sprintf(" options='%s'", c.dsnOptions("search_path="+searchPath))
+}
+
+// GetMigrationDSN returns the DSN for the dedicated, short-lived connection
+// used to run schema migrations. It is identical to GetDSN() except
+// statement_timeout is never applied (see migrationDsnOptions).
+func (c *DatabaseConfig) GetMigrationDSN() string {
+	base := c.baseDSN()
+	if opts := c.migrationDsnOptions(); opts != "" {
+		base += fmt.Sprintf(" options='%s'", opts)
+	}
+	return base
 }
 
 // resolveIdentityDatabase fills any unset IdentityDatabase field from the primary
@@ -1407,6 +1486,12 @@ func (c *Config) resolveIdentityDatabase() {
 	}
 	if id.MinIdleConnections == 0 {
 		id.MinIdleConnections = c.Database.MinIdleConnections
+	}
+	if id.StatementTimeoutSecs == 0 {
+		id.StatementTimeoutSecs = c.Database.StatementTimeoutSecs
+	}
+	if id.IdleInTransactionTimeoutSecs == 0 {
+		id.IdleInTransactionTimeoutSecs = c.Database.IdleInTransactionTimeoutSecs
 	}
 }
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -77,6 +77,136 @@ func TestGetDSNWithSearchPath(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// DatabaseConfig.GetDSN — statement_timeout / idle_in_transaction_session_timeout
+// (issue #664: no bound on a stuck/lock-contended query holding a pooled
+// connection).
+// ---------------------------------------------------------------------------
+
+func TestGetDSN_StatementTimeoutSet(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+		StatementTimeoutSecs: 30,
+	}
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=require options='-c statement_timeout=30s'"
+	if got := cfg.GetDSN(); got != want {
+		t.Errorf("GetDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestGetDSN_BothTimeoutsSet(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+		StatementTimeoutSecs:         30,
+		IdleInTransactionTimeoutSecs: 45,
+	}
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=require" +
+		" options='-c statement_timeout=30s -c idle_in_transaction_session_timeout=45s'"
+	if got := cfg.GetDSN(); got != want {
+		t.Errorf("GetDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestGetDSN_TimeoutZeroDisabled(t *testing.T) {
+	// 0 (the Go zero value, and what existing tests/callers construct without
+	// setting the field) must produce exactly the pre-#664 DSN with no
+	// options clause at all — no regression for configs that don't set it.
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+	}
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=require"
+	if got := cfg.GetDSN(); got != want {
+		t.Errorf("GetDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveIdentityDatabase_InheritsTimeouts(t *testing.T) {
+	cfg := &Config{
+		Database: DatabaseConfig{
+			Host: "primary", StatementTimeoutSecs: 30, IdleInTransactionTimeoutSecs: 30,
+		},
+	}
+	cfg.resolveIdentityDatabase()
+	if cfg.IdentityDatabase.StatementTimeoutSecs != 30 {
+		t.Errorf("IdentityDatabase.StatementTimeoutSecs = %d, want 30 (inherited from Database)", cfg.IdentityDatabase.StatementTimeoutSecs)
+	}
+	if cfg.IdentityDatabase.IdleInTransactionTimeoutSecs != 30 {
+		t.Errorf("IdentityDatabase.IdleInTransactionTimeoutSecs = %d, want 30 (inherited from Database)", cfg.IdentityDatabase.IdleInTransactionTimeoutSecs)
+	}
+}
+
+func TestResolveIdentityDatabase_ExplicitTimeoutNotOverridden(t *testing.T) {
+	cfg := &Config{
+		Database:         DatabaseConfig{Host: "primary", StatementTimeoutSecs: 30},
+		IdentityDatabase: DatabaseConfig{StatementTimeoutSecs: 90},
+	}
+	cfg.resolveIdentityDatabase()
+	if cfg.IdentityDatabase.StatementTimeoutSecs != 90 {
+		t.Errorf("IdentityDatabase.StatementTimeoutSecs = %d, want 90 (explicit value preserved)", cfg.IdentityDatabase.StatementTimeoutSecs)
+	}
+}
+
+func TestGetDSNWithSearchPath_CombinesWithTimeouts(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "disable",
+		StatementTimeoutSecs: 30,
+	}
+	got := cfg.GetDSNWithSearchPath("identity,public")
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=disable" +
+		" options='-c statement_timeout=30s -c search_path=identity,public'"
+	if got != want {
+		t.Errorf("GetDSNWithSearchPath() = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DatabaseConfig.GetMigrationDSN — regression coverage for the migration
+// connection excluding statement_timeout (default 30s, issue #664) so a
+// full-table backfill migration (e.g. migrations/000020_search_indexes.up.sql,
+// 000031_backfill_scanner_name.up.sql) cannot be cancelled mid-run and fail
+// server startup.
+// ---------------------------------------------------------------------------
+
+func TestGetMigrationDSN_OmitsStatementTimeout(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+		StatementTimeoutSecs: 30,
+	}
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=require"
+	if got := cfg.GetMigrationDSN(); got != want {
+		t.Errorf("GetMigrationDSN() = %q, want %q (statement_timeout must not appear)", got, want)
+	}
+}
+
+func TestGetMigrationDSN_KeepsIdleInTransactionTimeout(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+		StatementTimeoutSecs:         30,
+		IdleInTransactionTimeoutSecs: 45,
+	}
+	want := "host=localhost port=5432 user=registry password=secret dbname=terraform_registry sslmode=require" +
+		" options='-c idle_in_transaction_session_timeout=45s'"
+	if got := cfg.GetMigrationDSN(); got != want {
+		t.Errorf("GetMigrationDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestGetMigrationDSN_NoTimeoutsSetMatchesGetDSN(t *testing.T) {
+	cfg := DatabaseConfig{
+		Host: "localhost", Port: 5432, User: "registry",
+		Password: "secret", Name: "terraform_registry", SSLMode: "require",
+	}
+	if got, want := cfg.GetMigrationDSN(), cfg.GetDSN(); got != want {
+		t.Errorf("GetMigrationDSN() = %q, want %q (should match GetDSN() when no timeouts are set)", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // ServerConfig.GetAddress
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -1170,7 +1170,8 @@ func (j *MirrorSyncJob) TriggerManualSync(ctx context.Context, mirrorID uuid.UUI
 
 	// Use a background context for the sync operation since the HTTP request
 	// context will be cancelled when the response is sent
-	go j.syncMirror(context.Background(), *config) // #nosec G118 -- request context cancels when response is sent; background context is required for async sync
+	configCopy := *config
+	safego.Go(func() { j.syncMirror(context.Background(), configCopy) }) // #nosec G118 -- request context cancels when response is sent; background context is required for async sync
 
 	return nil
 }

--- a/backend/internal/jobs/scanner_update_job.go
+++ b/backend/internal/jobs/scanner_update_job.go
@@ -26,6 +26,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scanner/installer"
 )
 
@@ -384,11 +385,11 @@ func (j *ScannerUpdateJob) Activate(ctx context.Context, v *models.ScannerBinary
 		// must outlive the caller's ctx — which, via the admin install+activate handler,
 		// is the HTTP request context and would cancel the job the moment the request
 		// returns. context.Background() is therefore intentional here, not a leak.
-		go func() { // #nosec G118 -- long-lived daemon restart must not inherit the request-scoped caller ctx
+		safego.Go(func() { // #nosec G118 -- long-lived daemon restart must not inherit the request-scoped caller ctx
 			if err := j.scannerJob.Start(context.Background()); err != nil {
 				log.Printf("[scanner-update] scanner job failed to restart after activation: %v", err)
 			}
-		}()
+		})
 	}
 
 	if err := j.sbvRepo.MarkActive(ctx, v.ID); err != nil {

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -117,6 +117,63 @@ func TestAuditMiddleware_FailedWriteSkippedWhenLogFailedRequestsFalse(t *testing
 	}
 }
 
+func TestAuditMiddleware_ZeroValueConfigBehavesLikeNilConfig(t *testing.T) {
+	// Regression for issue #659: router.go now always passes a non-nil
+	// &cfg.Audit into AuditMiddlewareWithShipper (previously always nil). An
+	// unconfigured "audit:" YAML section zero-values to &config.AuditConfig{}
+	// (LogReadOperations=false, LogFailedRequests=false), which must behave
+	// identically to the old default (auditCfg == nil): reads and failed
+	// requests skipped, successful writes still shipped.
+	cfg := &config.AuditConfig{}
+
+	t.Run("GET skipped", func(t *testing.T) {
+		cs := newCaptureShipper(1)
+		r := gin.New()
+		r.Use(AuditMiddlewareWithShipper(nil, cs, cfg))
+		r.GET("/modules/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/modules/test", nil)
+		r.ServeHTTP(w, req)
+
+		select {
+		case <-cs.ch:
+			t.Error("shipper called for GET with zero-value config, want no shipping (same as nil config)")
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+
+	t.Run("failed POST skipped", func(t *testing.T) {
+		cs := newCaptureShipper(1)
+		r := gin.New()
+		r.Use(AuditMiddlewareWithShipper(nil, cs, cfg))
+		r.POST("/modules/test", func(c *gin.Context) { c.Status(http.StatusBadRequest) })
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/modules/test", nil)
+		r.ServeHTTP(w, req)
+
+		select {
+		case <-cs.ch:
+			t.Error("shipper called for failed POST with zero-value config, want no shipping (same as nil config)")
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+
+	t.Run("successful POST shipped", func(t *testing.T) {
+		cs := newCaptureShipper(1)
+		r := gin.New()
+		r.Use(AuditMiddlewareWithShipper(nil, cs, cfg))
+		r.POST("/modules/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/modules/test", nil)
+		r.ServeHTTP(w, req)
+
+		cs.waitForEntry(t, 500*time.Millisecond)
+	})
+}
+
 // ---------------------------------------------------------------------------
 // AuditMiddlewareWithShipper — shipping path
 // ---------------------------------------------------------------------------

--- a/backend/internal/middleware/quota.go
+++ b/backend/internal/middleware/quota.go
@@ -33,6 +33,18 @@ var (
 		},
 		[]string{"org", "resource"},
 	)
+
+	// quotaBackendErrors is incremented each time a quota check fails (DB
+	// error) and the middleware fails open, allowing the request through
+	// unchecked (sibling of issue #661's rate-limiter fail-open metric —
+	// same "fail open on backend error with no alerting" defect signature).
+	quotaBackendErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "registry_quota_backend_errors_total",
+			Help: "Total number of requests allowed through unchecked because a quota check failed (fail-open), by organization and resource type.",
+		},
+		[]string{"org", "resource"},
+	)
 )
 
 // QuotaChecker provides quota lookup and enforcement.
@@ -57,6 +69,7 @@ func (qc *QuotaChecker) CheckPublishQuota() gin.HandlerFunc {
 		exceeded, resetTime, err := qc.isPublishQuotaExceeded(c.Request.Context(), orgID)
 		if err != nil {
 			// On error, allow the request (fail open for availability)
+			quotaBackendErrors.WithLabelValues(orgID, "publishes").Inc()
 			c.Next()
 			return
 		}
@@ -88,6 +101,8 @@ func (qc *QuotaChecker) CheckDownloadQuota() gin.HandlerFunc {
 
 		exceeded, resetTime, err := qc.isDownloadQuotaExceeded(c.Request.Context(), orgID)
 		if err != nil {
+			// On error, allow the request (fail open for availability)
+			quotaBackendErrors.WithLabelValues(orgID, "downloads").Inc()
 			c.Next()
 			return
 		}

--- a/backend/internal/middleware/quota_test.go
+++ b/backend/internal/middleware/quota_test.go
@@ -8,6 +8,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestNewQuotaChecker(t *testing.T) {
@@ -103,6 +104,8 @@ func TestCheckPublishQuota_DBError_FailOpen(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").WillReturnError(sqlmock.ErrCancelled)
 
+	before := testutil.ToFloat64(quotaBackendErrors.WithLabelValues("org-1", "publishes"))
+
 	qc := NewQuotaChecker(db)
 	r := quotaRouter(qc, "publish")
 
@@ -112,6 +115,12 @@ func TestCheckPublishQuota_DBError_FailOpen(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open on DB error)", w.Code)
+	}
+	// Sibling of issue #661: a fail-open quota check must be alertable, not
+	// just a silent pass-through.
+	after := testutil.ToFloat64(quotaBackendErrors.WithLabelValues("org-1", "publishes"))
+	if after != before+1 {
+		t.Errorf("quotaBackendErrors{org-1,publishes} = %v, want %v", after, before+1)
 	}
 }
 
@@ -177,6 +186,8 @@ func TestCheckDownloadQuota_DBError_FailOpen(t *testing.T) {
 
 	mock.ExpectQuery("SELECT").WillReturnError(sqlmock.ErrCancelled)
 
+	before := testutil.ToFloat64(quotaBackendErrors.WithLabelValues("org-1", "downloads"))
+
 	qc := NewQuotaChecker(db)
 	r := quotaRouter(qc, "download")
 
@@ -186,6 +197,10 @@ func TestCheckDownloadQuota_DBError_FailOpen(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200 (fail open)", w.Code)
+	}
+	after := testutil.ToFloat64(quotaBackendErrors.WithLabelValues("org-1", "downloads"))
+	if after != before+1 {
+		t.Errorf("quotaBackendErrors{org-1,downloads} = %v, want %v", after, before+1)
 	}
 }
 

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -224,6 +224,7 @@ func RateLimitMiddleware(backend RateLimiterBackend) gin.HandlerFunc {
 		allowed, remaining, err := backend.Allow(c.Request.Context(), principal)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "rate_limit_bucket", principal)
+			telemetry.RateLimitBackendErrorsTotal.WithLabelValues(tierFromPrincipal(principal), keyTypeFromPrincipal(principal)).Inc()
 			c.Next()
 			return
 		}
@@ -264,6 +265,7 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 		allowed, remaining, err := individual.Allow(c.Request.Context(), principal)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "rate_limit_bucket", principal)
+			telemetry.RateLimitBackendErrorsTotal.WithLabelValues("individual", keyTypeFromPrincipal(principal)).Inc()
 			c.Next()
 			return
 		}
@@ -288,6 +290,7 @@ func OrgRateLimitMiddleware(individual RateLimiterBackend, orgBackend RateLimite
 					orgAllowed, orgRemaining, orgErr := orgBackend.Allow(c.Request.Context(), orgKey)
 					if orgErr != nil {
 						slog.Warn("org rate limiter backend error, allowing request", "error", orgErr, "org_key", orgKey)
+						telemetry.RateLimitBackendErrorsTotal.WithLabelValues("organization", "org").Inc()
 					} else if !orgAllowed {
 						c.Header("X-RateLimit-Remaining", strconv.Itoa(orgRemaining))
 						c.Header("Retry-After", "60")
@@ -368,6 +371,7 @@ func PrincipalRateLimitMiddleware(defaultBackend RateLimiterBackend, overrides *
 		allowed, remaining, err := backend.Allow(c.Request.Context(), principal)
 		if err != nil {
 			slog.Warn("rate limiter backend error, allowing request", "error", err, "rate_limit_bucket", principal)
+			telemetry.RateLimitBackendErrorsTotal.WithLabelValues("principal", keyTypeFromPrincipal(principal)).Inc()
 			c.Next()
 			return
 		}

--- a/backend/internal/middleware/ratelimit_test.go
+++ b/backend/internal/middleware/ratelimit_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -9,7 +10,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
 // ---------------------------------------------------------------------------
@@ -651,5 +654,118 @@ func TestPrincipalRateLimitMiddleware_NilDefault(t *testing.T) {
 	// Should pass through when default is nil
 	if w.Code == http.StatusTooManyRequests {
 		t.Error("should pass through when default backend is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backend-error fail-open path (issue #661): a rate limiter backend error
+// (e.g. a Redis outage) must still let the request through — that behavior is
+// intentional for availability — but must now also be alertable via
+// telemetry.RateLimitBackendErrorsTotal instead of only a log line.
+// ---------------------------------------------------------------------------
+
+// erroringRateLimiterBackend always fails, simulating a backend outage (e.g.
+// Redis unreachable).
+type erroringRateLimiterBackend struct{}
+
+func (erroringRateLimiterBackend) Allow(_ context.Context, _ string) (bool, int, error) {
+	return false, 0, errors.New("simulated backend outage")
+}
+func (erroringRateLimiterBackend) RemainingTokens(_ context.Context, _ string) (int, error) {
+	return 0, errors.New("simulated backend outage")
+}
+func (erroringRateLimiterBackend) Close() error { return nil }
+
+func TestRateLimitMiddleware_BackendError_FailsOpenAndIncrementsMetric(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	before := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("individual", "ip"))
+
+	r := gin.New()
+	r.Use(RateLimitMiddleware(erroringRateLimiterBackend{}))
+	r.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.9.1:1234"
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (backend error must fail open)", w.Code)
+	}
+	after := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("individual", "ip"))
+	if after != before+1 {
+		t.Errorf("RateLimitBackendErrorsTotal{individual,ip} = %v, want %v", after, before+1)
+	}
+}
+
+func TestOrgRateLimitMiddleware_IndividualBackendError_FailsOpenAndIncrementsMetric(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	before := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("individual", "ip"))
+
+	r := gin.New()
+	r.Use(OrgRateLimitMiddleware(erroringRateLimiterBackend{}, nil))
+	r.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.9.2:1234"
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (backend error must fail open)", w.Code)
+	}
+	after := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("individual", "ip"))
+	if after != before+1 {
+		t.Errorf("RateLimitBackendErrorsTotal{individual,ip} = %v, want %v", after, before+1)
+	}
+}
+
+func TestOrgRateLimitMiddleware_OrgBackendError_FailsOpenAndIncrementsMetric(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	individual := newTestLimiter(600, 10)
+	defer individual.Stop()
+
+	before := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("organization", "org"))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("organization_id", "org-with-broken-backend")
+		c.Next()
+	})
+	r.Use(OrgRateLimitMiddleware(individual, erroringRateLimiterBackend{}))
+	r.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.9.3:1234"
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (org backend error must fail open)", w.Code)
+	}
+	after := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("organization", "org"))
+	if after != before+1 {
+		t.Errorf("RateLimitBackendErrorsTotal{organization,org} = %v, want %v", after, before+1)
+	}
+}
+
+func TestPrincipalRateLimitMiddleware_BackendError_FailsOpenAndIncrementsMetric(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	before := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("principal", "user"))
+
+	mw := PrincipalRateLimitMiddleware(erroringRateLimiterBackend{}, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest("GET", "/test", nil)
+	c.Set("user_id", "some-user")
+	mw(c)
+
+	if w.Code != http.StatusOK && w.Code != 0 {
+		t.Errorf("status = %d, want 200/unset (backend error must fail open)", w.Code)
+	}
+	after := testutil.ToFloat64(telemetry.RateLimitBackendErrorsTotal.WithLabelValues("principal", "user"))
+	if after != before+1 {
+		t.Errorf("RateLimitBackendErrorsTotal{principal,user} = %v, want %v", after, before+1)
 	}
 }

--- a/backend/internal/mirror/attestation.go
+++ b/backend/internal/mirror/attestation.go
@@ -55,6 +55,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/tuf"
 	"github.com/sigstore/sigstore-go/pkg/util"
 	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
@@ -182,10 +183,10 @@ func fetchTrustRootBounded() (*root.TrustedRoot, error) {
 	// fake do, and go test -race catches exactly that race otherwise).
 	fetch := fetchTrustRoot
 	ch := make(chan fetchTrustRootResult, 1)
-	go func() {
+	safego.Go(func() {
 		r, err := fetch()
 		ch <- fetchTrustRootResult{r, err}
-	}()
+	})
 
 	select {
 	case res := <-ch:

--- a/backend/internal/safego/adoption_sweep_test.go
+++ b/backend/internal/safego/adoption_sweep_test.go
@@ -1,0 +1,128 @@
+package safego_test
+
+// adoption_sweep_test.go is a lint-style regression test for issue #562
+// ("internal/safego's panic-recovering goroutine launcher is adopted in only
+// 7 files; numerous request-triggered fire-and-forget goroutines use raw `go
+// func()` with no recovery"). It statically walks the request/webhook/admin
+// packages swept to adopt safego.Go and fails if a new bare `go` statement is
+// introduced there without either wrapping its function in safego.Go or
+// having its own local `defer recover()` (e.g. a goroutine that must set an
+// error variable on panic instead of just logging it — see
+// internal/services/storage_migration.go's upload-pipe goroutine).
+//
+// This intentionally does NOT cover every goroutine in the codebase: several
+// packages start long-lived background daemons once at process/component
+// startup (cleanup tickers, file watchers, discovery pollers) rather than
+// per request, which is a different — and separately tracked — concern than
+// the "numerous request-triggered fire-and-forget goroutines" this finding
+// describes.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sweptDirs are the packages containing request/webhook/admin-triggered
+// fire-and-forget goroutines converted to safego.Go for issue #562. Adding a
+// new raw `go` statement here should be caught by this test.
+var sweptDirs = []string{
+	"../api/admin",
+	"../api/mirror",
+	"../api/modules",
+	"../api/providers",
+	"../api/setup",
+	"../api/terraform_binaries",
+	"../mirror",
+	"../services",
+	"../jobs",
+}
+
+func TestNoUnrecoveredGoroutinesInSweptPackages(t *testing.T) {
+	fset := token.NewFileSet()
+
+	// Parsed per-file rather than with parser.ParseDir, which is deprecated as
+	// of Go 1.25 (SA1019) for not honouring build tags. This sweep only needs
+	// each non-test .go file's AST, so a plain directory read avoids both the
+	// deprecation and a dependency on golang.org/x/tools/go/packages.
+	for _, dir := range sweptDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			filename := filepath.Join(dir, name)
+			file, err := parser.ParseFile(fset, filename, nil, 0)
+			if err != nil {
+				t.Fatalf("failed to parse %s: %v", filename, err)
+			}
+			{
+				ast.Inspect(file, func(n ast.Node) bool {
+					goStmt, ok := n.(*ast.GoStmt)
+					if !ok {
+						return true
+					}
+					if isSafegoGoCall(goStmt.Call) || hasLocalRecover(goStmt.Call) {
+						return true
+					}
+					pos := fset.Position(goStmt.Pos())
+					t.Errorf(
+						"%s:%d: raw `go` statement without safego.Go or a local recover() — "+
+							"wrap the function body in safego.Go(...) (see internal/safego), or "+
+							"add a local `defer func() { recover() }()` if the goroutine must react "+
+							"to the panic itself (e.g. set an error variable)",
+						filepath.Base(filename), pos.Line,
+					)
+					return true
+				})
+			}
+		}
+	}
+}
+
+// isSafegoGoCall reports whether call is safego.Go(...).
+func isSafegoGoCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return pkgIdent.Name == "safego" && sel.Sel.Name == "Go"
+}
+
+// hasLocalRecover reports whether call is a function literal invocation whose
+// body contains its own `recover()` call, guarding against an unrecovered
+// panic even without going through safego.Go.
+func hasLocalRecover(call *ast.CallExpr) bool {
+	lit, ok := call.Fun.(*ast.FuncLit)
+	if !ok {
+		return false
+	}
+	found := false
+	ast.Inspect(lit.Body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := callExpr.Fun.(*ast.Ident); ok && ident.Name == "recover" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -455,7 +456,8 @@ func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *
 			slog.Warn("failed to check existing version", "version", version, "error", err)
 		} else if existing != nil {
 			slog.Debug("version already exists; checking for missing docs", "version", version)
-			go p.reanalyzeExistingVersion(ctx, moduleSourceRepo.ModuleID.String(), existing)
+			moduleIDStr := moduleSourceRepo.ModuleID.String()
+			safego.Go(func() { p.reanalyzeExistingVersion(ctx, moduleIDStr, existing) })
 			continue
 		}
 
@@ -470,7 +472,7 @@ func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *
 		// Process this tag push (without a webhook log ID since this is manual)
 		// We'll pass a nil UUID since webhook logging isn't applicable here
 		slog.Debug("starting goroutine to process tag", "tag", tag.TagName, "commit", tag.TargetCommit)
-		go p.processTagForManualSync(ctx, moduleSourceRepo, hook, connector, token)
+		safego.Go(func() { p.processTagForManualSync(ctx, moduleSourceRepo, hook, connector, token) })
 	}
 
 	slog.Debug("manual sync tag matching complete", "matching_tags", matchingTags, "total_tags", len(tags))

--- a/backend/internal/services/storage_migration.go
+++ b/backend/internal/services/storage_migration.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
 
@@ -189,7 +190,7 @@ func (s *StorageMigrationService) StartMigration(ctx context.Context, sourceConf
 	// Launch background execution
 	bgCtx, cancel := context.WithCancel(context.Background())
 	s.cancelFuncs.Store(migrationID, cancel)
-	go s.executeMigration(bgCtx, migrationID)
+	safego.Go(func() { s.executeMigration(bgCtx, migrationID) })
 
 	return migration, nil
 }
@@ -408,7 +409,8 @@ func (s *StorageMigrationService) executeMigration(ctx context.Context, migratio
 
 			wg.Add(1)
 			sem <- struct{}{}
-			go func(itm *models.StorageMigrationItem) {
+			itm := item
+			safego.Go(func() {
 				defer wg.Done()
 				defer func() { <-sem }()
 
@@ -428,7 +430,7 @@ func (s *StorageMigrationService) executeMigration(ctx context.Context, migratio
 				if total%10 == 0 {
 					s.updateProgress(migrationID, &migrated, &failed, &skipped)
 				}
-			}(item)
+			})
 		}
 
 		wg.Wait()
@@ -498,6 +500,22 @@ func (s *StorageMigrationService) migrateItem(
 
 	go func() {
 		defer close(uploadDone)
+		// Recover locally (rather than via safego.Go) so a panic inside Upload
+		// still sets uploadErr instead of leaving it nil, which would make the
+		// caller below treat a crashed upload as a silent success.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("recovered panic in storage migration upload", "panic", r)
+				if uploadErr == nil {
+					uploadErr = fmt.Errorf("panic during upload: %v", r)
+				}
+				// Unblock the caller's io.Copy(pw, reader): without closing pr here,
+				// a panic before Upload has drained pr would leave pw.Write() blocked
+				// forever (io.Pipe only unblocks on a matching Read or Close), leaking
+				// the calling goroutine and its worker-pool slot.
+				_ = pr.CloseWithError(uploadErr)
+			}
+		}()
 		_, uploadErr = tgtStorage.Upload(ctx, item.SourcePath, pr, size)
 		if uploadErr != nil {
 			_ = pr.CloseWithError(uploadErr)

--- a/backend/internal/services/storage_migration_test.go
+++ b/backend/internal/services/storage_migration_test.go
@@ -1,8 +1,11 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -11,6 +14,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 
 	// Register the local storage backend for buildStorageFromConfig tests.
 	_ "github.com/terraform-registry/terraform-registry/internal/storage/local"
@@ -1348,4 +1352,106 @@ func TestBuildStorageFromConfig_GCS(t *testing.T) {
 
 	_, err := svc.buildStorageFromConfig(sc)
 	_ = err // Will fail at GCS client creation, but branch is exercised
+}
+
+// ---------------------------------------------------------------------------
+// migrateItem — panic recovery in the upload goroutine must not deadlock
+// ---------------------------------------------------------------------------
+
+// panicUploadStorage is a storage.Storage whose Upload panics before reading
+// from the supplied reader, simulating a nil-pointer dereference (or similar)
+// during request setup in a real backend.
+type panicUploadStorage struct{}
+
+func (panicUploadStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	panic("simulated panic during upload request setup")
+}
+
+func (panicUploadStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (panicUploadStorage) Delete(ctx context.Context, path string) error { return nil }
+
+func (panicUploadStorage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	return "", nil
+}
+
+func (panicUploadStorage) Exists(ctx context.Context, path string) (bool, error) { return false, nil }
+
+func (panicUploadStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
+	return nil, errors.New("not implemented")
+}
+
+// sourceStorage is a minimal storage.Storage that serves fixed content for Download.
+type sourceStorage struct {
+	content []byte
+}
+
+func (s sourceStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s sourceStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(s.content)), nil
+}
+
+func (s sourceStorage) Delete(ctx context.Context, path string) error { return nil }
+
+func (s sourceStorage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	return "", nil
+}
+
+func (s sourceStorage) Exists(ctx context.Context, path string) (bool, error) { return false, nil }
+
+func (s sourceStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
+	return &storage.FileMetadata{Size: int64(len(s.content))}, nil
+}
+
+// TestMigrateItem_UploadPanicDoesNotDeadlock is a regression test: a panic
+// inside tgtStorage.Upload (before it has read anything from the io.Pipe)
+// must not leave the caller's io.Copy(pw, reader) blocked forever on
+// pw.Write(). Without pr.CloseWithError in the recover block, this test
+// hangs instead of returning an error.
+func TestMigrateItem_UploadPanicDoesNotDeadlock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewStorageMigrationRepository(sqlxDB)
+	svc := NewStorageMigrationService(repo, nil, nil, nil, nil, nil)
+
+	mock.ExpectExec("UPDATE storage_migration_items").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	item := &models.StorageMigrationItem{
+		ID:           "item-1",
+		ArtifactType: "module",
+		ArtifactID:   "artifact-1",
+		SourcePath:   "path/to/artifact.tgz",
+	}
+
+	src := sourceStorage{content: []byte("some artifact bytes")}
+	tgt := panicUploadStorage{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.migrateItem(context.Background(), src, tgt, item, "target-backend")
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected migrateItem to return an error after upload panic, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("migrateItem deadlocked after panic in tgtStorage.Upload (io.PipeReader was not closed on the panic path)")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
 }

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -233,6 +233,25 @@ var RateLimitRejectionsTotal = promauto.NewCounterVec(
 	[]string{"tier", "key_type"},
 )
 
+// RateLimitBackendErrorsTotal is a CounterVec with labels {tier, key_type}
+// incremented each time a rate limiter backend (e.g. Redis) returns an error
+// and the middleware fails open, allowing the request through unthrottled
+// (issue #661, CWE-636). tier/key_type match RateLimitRejectionsTotal. A
+// sustained Redis outage disables rate limiting fleet-wide for the affected
+// tier — including the auth brute-force guard and upload limits — with
+// otherwise only a log line to signal it; this metric makes that alertable.
+//
+// Example PromQL queries:
+//   - Backend error rate by tier: sum by (tier) (rate(rate_limit_backend_errors_total[5m]))
+//   - Alert on any sustained fail-open: rate(rate_limit_backend_errors_total[5m]) > 0
+var RateLimitBackendErrorsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "rate_limit_backend_errors_total",
+		Help: "Total number of requests allowed through unthrottled because the rate limiter backend returned an error (fail-open), by tier and key type.",
+	},
+	[]string{"tier", "key_type"},
+)
+
 // AppInfo is a GaugeVec that exposes build information as Prometheus labels.
 // Set once at startup with value 1 so the info is available via the /metrics endpoint.
 //

--- a/backend/internal/telemetry/metrics_test.go
+++ b/backend/internal/telemetry/metrics_test.go
@@ -23,6 +23,7 @@ func TestMetricRegistration(t *testing.T) {
 		{"MirrorSyncErrorsTotal", MirrorSyncErrorsTotal},
 		{"APIKeyExpiryNotificationsSentTotal", APIKeyExpiryNotificationsSentTotal},
 		{"RateLimitRejectionsTotal", RateLimitRejectionsTotal},
+		{"RateLimitBackendErrorsTotal", RateLimitBackendErrorsTotal},
 		{"AppInfo", AppInfo},
 		{"ModuleScanQueueDepth", ModuleScanQueueDepth},
 		{"ModuleScanDuration", ModuleScanDuration},
@@ -73,6 +74,10 @@ func TestMirrorSyncErrorsTotalLabels(t *testing.T) {
 
 func TestRateLimitRejectionsTotalLabels(t *testing.T) {
 	RateLimitRejectionsTotal.WithLabelValues("individual", "apikey").Inc()
+}
+
+func TestRateLimitBackendErrorsTotalLabels(t *testing.T) {
+	RateLimitBackendErrorsTotal.WithLabelValues("individual", "apikey").Inc()
 }
 
 func TestAppInfoLabels(t *testing.T) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -18,6 +18,8 @@ database:
   password: ${DATABASE_PASSWORD}
   ssl_mode: prefer
   max_connections: 25
+  # statement_timeout_secs: 30            # cancel queries running longer than this; 0 disables (default 30)
+  # idle_in_transaction_timeout_secs: 30  # cancel sessions idle inside an open transaction; 0 disables (default 30)
 
 storage:
   default_backend: local # Options: azure, s3, local

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,16 @@ database:
 
 `min_idle_connections` (env `TFR_DATABASE_MIN_IDLE_CONNECTIONS`, default `5`) sets the minimum number of idle connections kept warm in the pool, so the first requests after an idle period do not pay the connection-establishment cost.
 
+### Query Timeouts
+
+`statement_timeout_secs` (env `TFR_DATABASE_STATEMENT_TIMEOUT_SECS`, default `30`) bounds how long a single query may run before PostgreSQL cancels it, so a stuck or lock-contended query cannot hold a pooled connection indefinitely and exhaust `max_connections`. Set to `0` to disable.
+
+`idle_in_transaction_timeout_secs` (env `TFR_DATABASE_IDLE_IN_TRANSACTION_TIMEOUT_SECS`, default `30`) bounds how long a session may sit idle inside an open transaction before PostgreSQL cancels it. Set to `0` to disable.
+
+Both settings apply only to request-serving connections. Schema migrations (automatic on startup, or via `server migrate up`/`down`) always run on a separate connection that ignores `statement_timeout_secs`, since a large one-off backfill or index build can legitimately run longer than the timeout sized for normal request traffic.
+
+The identity database (below) has its own `statement_timeout_secs` / `idle_in_transaction_timeout_secs` (env `TFR_IDENTITY_DATABASE_STATEMENT_TIMEOUT_SECS` / `TFR_IDENTITY_DATABASE_IDLE_IN_TRANSACTION_TIMEOUT_SECS`) that default to inheriting the primary database's values when unset.
+
 ---
 
 ## Server


### PR DESCRIPTION
Closes #659
Closes #660
Closes #661
Closes #664
Closes #686
Part of #562 (safego adoption sweep)

Batch `d-resilience` from the 2026-07-22 blind security audit.

- **#659** — the audit external shipper and audit log-scope config were wired with hardcoded `nil`s and never active in production. Now constructed at startup and passed to `AuditMiddlewareWithShipper`.
- **#660** — audit webhook batch flush could use a zero-duration context timeout, failing every batched delivery; defaults to 5s when unset.
- **#661** — a dedicated `RateLimitBackendErrorsTotal` metric now makes the fail-open path alertable at all four `Allow()` error sites. **Read this one carefully:** the middleware still *allows* the request when the limiter backend errors. That is deliberate and matches the issue's recommendation ("add a counter metric for the fail-open path so it's alertable, and *consider* a bounded fail-closed fallback for the auth/upload tiers") — denying every request during a Redis blip trades a rate-limit gap for a full outage. The optional bounded in-memory fallback for the auth/upload tiers is **not** implemented here and is a reasonable follow-up.
- **#664** — Postgres `statement_timeout` / `idle_in_transaction_session_timeout` are now configurable and applied to the request-serving pool. Migrations use a separate `GetMigrationDSN()` that deliberately omits `statement_timeout`, so a long migration can't be killed mid-flight.
- **#686** — listener startup failure now reports through an error channel instead of `log.Fatalf` inside a goroutine, so graceful shutdown isn't bypassed.
- **#562 sweep** — 22 files converted from raw `go func()` to `safego.Go` for panic recovery.

## Operator note — please include in release notes

Fixing #659 has an **activation-on-upgrade** effect: operators who already set `audit.log_read_operations`, `audit.log_failed_requests`, or `audit.shippers` in YAML have had that config silently inert (that was the bug). On upgrade it becomes live — GET/failed-request audit rows begin appearing and any configured external shipper starts receiving traffic. Correct behavior, but a surprise if unannounced.

## Follow-up spotted during review (not fixed here)

In `cmd/server/main.go`'s shutdown path, `bgServices.Shutdown()` (rate limiters, audit shipper flush) is skipped when a graceful shutdown itself errors or times out. This pre-dates the batch and is outside #686's scope, but the code was touched nearby — worth its own issue.

Verification: adversarial review panel consensus, then rebased onto current main. All seven rebase conflicts were import-block collisions composed to keep both sides (main's log-hygiene redaction helper alongside this branch's `safego` import; both sides' test additions retained). `gofmt`, `go build`, `go vet` clean; full `go test ./...` passes 60/60 packages.