### PR TITLE
fix(security): registry/OCI protocol correctness and CORS hardening

### DIFF
--- a/backend/internal/api/mirror/index.go
+++ b/backend/internal/api/mirror/index.go
@@ -50,13 +50,13 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -65,7 +65,7 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider",
+				"errors": []string{"Failed to query provider"},
 			})
 			return
 		}
@@ -100,7 +100,7 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 		versions, err := providerRepo.ListVisibleVersions(c.Request.Context(), provider.ID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to list provider versions",
+				"errors": []string{"Failed to list provider versions"},
 			})
 			return
 		}
@@ -132,7 +132,7 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 		// [WARN] from terraform init.
 		data, err := json.Marshal(response)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to serialize response"})
+			c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to serialize response"}})
 			return
 		}
 		c.Data(http.StatusOK, "application/json", data)

--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,26 @@ import (
 )
 
 var mirrorErrDB = errors.New("db error")
+
+// assertErrorsArrayBody fails the test unless the response body is shaped
+// {"errors": [...]}, the protocol-correct shape already used by the 404/502
+// pull-through paths of these same handlers. Issue #696 sibling: 500 paths
+// in mirror/index.go and mirror/platform_index.go must not fall back to a
+// singular {"error": "..."} string.
+func assertErrorsArrayBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body: %v; body=%s", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf(`response body uses singular "error" key, want "errors" array; body=%s`, w.Body.String())
+	}
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Errorf(`response body missing "errors" array; body=%s`, w.Body.String())
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Column definitions  (positional scans from the repositories)
@@ -91,6 +112,7 @@ func TestIndex_OrgDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestIndex_OrgNotFound(t *testing.T) {
@@ -105,6 +127,7 @@ func TestIndex_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestIndex_ProviderDBError(t *testing.T) {
@@ -120,6 +143,7 @@ func TestIndex_ProviderDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestIndex_ProviderNotFound(t *testing.T) {
@@ -153,6 +177,7 @@ func TestIndex_ListVersionsDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestIndex_Success_NoVersions(t *testing.T) {
@@ -199,6 +224,7 @@ func TestPlatformIndex_OrgDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_OrgNotFound(t *testing.T) {
@@ -212,6 +238,7 @@ func TestPlatformIndex_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_ProviderNotFound(t *testing.T) {
@@ -322,6 +349,7 @@ func TestPlatformIndex_ProviderDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_GetVersionDBError(t *testing.T) {
@@ -339,6 +367,30 @@ func TestPlatformIndex_GetVersionDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
+}
+
+// TestPlatformIndex_ApprovalStatusDBError covers the 500 path from a genuine
+// approval-status query failure (as opposed to sql.ErrNoRows, which means
+// "not gated" and is not an error). Issue #696 sibling.
+func TestPlatformIndex_ApprovalStatusDBError(t *testing.T) {
+	mock, r := newMirrorAPIRouter(t)
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WillReturnRows(sampleMirrorAPIOrg())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+		WillReturnRows(sampleMirrorAPIProvider())
+	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
+		WillReturnRows(sampleMirrorVersionGetRow())
+	mock.ExpectQuery("SELECT.*approval_status.*FROM mirrored_provider_versions").
+		WillReturnError(mirrorErrDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/providers/registry.terraform.io/hashicorp/aws/1.2.3.json", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_ListPlatformsDBError(t *testing.T) {
@@ -360,6 +412,7 @@ func TestPlatformIndex_ListPlatformsDBError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_StorageInitError(t *testing.T) {
@@ -394,6 +447,7 @@ func TestPlatformIndex_StorageInitError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestPlatformIndex_Success_EmptyPlatforms(t *testing.T) {

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -84,13 +84,13 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -99,7 +99,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider",
+				"errors": []string{"Failed to query provider"},
 			})
 			return
 		}
@@ -132,7 +132,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		providerVersion, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, version)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider version",
+				"errors": []string{"Failed to query provider version"},
 			})
 			return
 		}
@@ -168,7 +168,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		approvalStatus, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), providerVersion.ID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider version",
+				"errors": []string{"Failed to query provider version"},
 			})
 			return
 		}
@@ -181,7 +181,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		platforms, err := providerRepo.ListPlatforms(c.Request.Context(), providerVersion.ID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to list provider platforms",
+				"errors": []string{"Failed to list provider platforms"},
 			})
 			return
 		}
@@ -192,7 +192,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		})
 		if storageErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to initialize storage backend",
+				"errors": []string{"Failed to initialize storage backend"},
 			})
 			return
 		}
@@ -224,7 +224,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			downloadURL, err := storageBackend.GetURL(c.Request.Context(), platform.StoragePath, 1*time.Hour)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": fmt.Sprintf("Failed to generate download URL for %s", platformKey),
+					"errors": []string{fmt.Sprintf("Failed to generate download URL for %s", platformKey)},
 				})
 				return
 			}
@@ -357,7 +357,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 		// [WARN] from terraform init.
 		data, err := json.Marshal(response)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to serialize response"})
+			c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to serialize response"}})
 			return
 		}
 		c.Data(http.StatusOK, "application/json", data)

--- a/backend/internal/api/modules/download.go
+++ b/backend/internal/api/modules/download.go
@@ -60,13 +60,13 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -75,7 +75,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		module, err := moduleRepo.GetModule(c.Request.Context(), org.ID, namespace, name, system)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query module",
+				"errors": []string{"Failed to query module"},
 			})
 			return
 		}
@@ -90,7 +90,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		moduleVersion, err := moduleRepo.GetVersion(c.Request.Context(), module.ID, version)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query module version",
+				"errors": []string{"Failed to query module version"},
 			})
 			return
 		}
@@ -106,7 +106,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		downloadURL, err := storageBackend.GetURL(c.Request.Context(), moduleVersion.StoragePath, 15*time.Minute)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to generate download URL",
+				"errors": []string{"Failed to generate download URL"},
 			})
 			return
 		}

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -20,6 +21,25 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
+
+// assertErrorsArrayBody fails the test unless the response body is shaped
+// {"errors": [...]}, the protocol-correct shape already used by the 4xx
+// paths of these same handlers. Issue #696: 500 paths must not fall back to
+// a singular {"error": "..."} string.
+func assertErrorsArrayBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body: %v; body=%s", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf(`response body uses singular "error" key, want "errors" array; body=%s`, w.Body.String())
+	}
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Errorf(`response body missing "errors" array; body=%s`, w.Body.String())
+	}
+}
 
 func init() {
 	gin.SetMode(gin.TestMode)
@@ -216,6 +236,7 @@ func TestListVersionsHandler_OrgError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_OrgNotFound(t *testing.T) {
@@ -227,6 +248,7 @@ func TestListVersionsHandler_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_ModuleError(t *testing.T) {
@@ -239,6 +261,7 @@ func TestListVersionsHandler_ModuleError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_ModuleNotFound(t *testing.T) {
@@ -264,6 +287,7 @@ func TestListVersionsHandler_VersionsError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_DeprecationBlock(t *testing.T) {
@@ -439,6 +463,7 @@ func TestDownloadHandler_OrgError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_ModuleNotFound(t *testing.T) {
@@ -495,6 +520,7 @@ func TestDownloadHandler_StorageError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 // ---------------------------------------------------------------------------
@@ -510,6 +536,7 @@ func TestServeFileHandler_SlashOnlyPath(t *testing.T) {
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestServeFileHandler_NotFound(t *testing.T) {
@@ -520,6 +547,7 @@ func TestServeFileHandler_NotFound(t *testing.T) {
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestServeFileHandler_ExistsError(t *testing.T) {
@@ -530,6 +558,7 @@ func TestServeFileHandler_ExistsError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestServeFileHandler_MetadataError(t *testing.T) {
@@ -540,6 +569,7 @@ func TestServeFileHandler_MetadataError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestServeFileHandler_Success(t *testing.T) {
@@ -549,6 +579,35 @@ func TestServeFileHandler_Success(t *testing.T) {
 	w := doGET(r, "/v1/files/path/to/file.tgz")
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// Issue #681: provider archives (.zip) must be served with Content-Type
+// application/zip, not the module archive's application/gzip.
+func TestServeFileHandler_ProviderContentType(t *testing.T) {
+	store := &mockStore{existsResult: true}
+	r := newServeRouter(t, store)
+
+	w := doGET(r, "/v1/files/providers/hashicorp/aws/1.0.0/linux/amd64/terraform-provider-aws.zip")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("Content-Type = %q, want application/zip", ct)
+	}
+}
+
+// Module archives keep the pre-existing application/gzip Content-Type.
+func TestServeFileHandler_ModuleContentType(t *testing.T) {
+	store := &mockStore{existsResult: true}
+	r := newServeRouter(t, store)
+
+	w := doGET(r, "/v1/files/modules/hashicorp/consul/aws/1.0.0.tar.gz")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/gzip" {
+		t.Errorf("Content-Type = %q, want application/gzip", ct)
 	}
 }
 
@@ -562,6 +621,7 @@ func TestServeFileHandler_PathTraversal(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestServeFileHandler_DoubleSlashTraversal(t *testing.T) {
@@ -572,6 +632,7 @@ func TestServeFileHandler_DoubleSlashTraversal(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 // TestServeFileHandler_URLEncodedTraversal documents how gin's wildcard param
@@ -600,6 +661,7 @@ func TestServeFileHandler_URLEncodedTraversal(t *testing.T) {
 			if w.Code != http.StatusBadRequest {
 				t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 			}
+			assertErrorsArrayBody(t, w)
 		})
 	}
 }
@@ -883,6 +945,7 @@ func TestDownloadHandler_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_ModuleError(t *testing.T) {
@@ -895,6 +958,7 @@ func TestDownloadHandler_ModuleError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_VersionError(t *testing.T) {
@@ -908,6 +972,7 @@ func TestDownloadHandler_VersionError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_SuccessWithAuditContext(t *testing.T) {

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -45,7 +45,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		filePath := c.Param("filepath")
 		if filePath == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "File path is required",
+				"errors": []string{"File path is required"},
 			})
 			return
 		}
@@ -60,7 +60,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		// call so that GET /v1/files/../../etc/passwd cannot escape the storage root.
 		if strings.Contains(filePath, "..") || strings.Contains(filePath, "//") {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"error": "Invalid file path",
+				"errors": []string{"Invalid file path"},
 			})
 			return
 		}
@@ -82,7 +82,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 							status, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), pv.ID)
 							if err == nil && status != nil && *status != models.VersionApprovalStatusApproved {
 								c.JSON(http.StatusNotFound, gin.H{
-									"error": "File not found",
+									"errors": []string{"File not found"},
 								})
 								return
 							}
@@ -96,13 +96,13 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		exists, err := storageBackend.Exists(c.Request.Context(), filePath)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to check file existence",
+				"errors": []string{"Failed to check file existence"},
 			})
 			return
 		}
 		if !exists {
 			c.JSON(http.StatusNotFound, gin.H{
-				"error": "File not found",
+				"errors": []string{"File not found"},
 			})
 			return
 		}
@@ -111,7 +111,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		metadata, err := storageBackend.GetMetadata(c.Request.Context(), filePath)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get file metadata",
+				"errors": []string{"Failed to get file metadata"},
 			})
 			return
 		}
@@ -120,7 +120,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		reader, err := storageBackend.Download(c.Request.Context(), filePath)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to read file",
+				"errors": []string{"Failed to read file"},
 			})
 			return
 		}
@@ -134,14 +134,19 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 			}
 		}
 
+		// Determine resource type and Content-Type from the path prefix.
+		// Provider archives are .zip; module archives are .tar.gz.
+		resourceType := "file"
+		contentType := "application/gzip"
+		if strings.HasPrefix(filePath, "providers/") {
+			resourceType = "provider"
+			contentType = "application/zip"
+		} else if strings.HasPrefix(filePath, "modules/") {
+			resourceType = "module"
+		}
+
 		// Audit log the file download event asynchronously
 		if auditRepo != nil {
-			resourceType := "file"
-			if strings.HasPrefix(filePath, "providers/") {
-				resourceType = "provider"
-			} else if strings.HasPrefix(filePath, "modules/") {
-				resourceType = "module"
-			}
 			// Route through the same redaction helper AuditMiddleware/LoggerMiddleware
 			// use rather than logging the raw path (issue #678 sibling).
 			action := "GET " + middleware.RedactSensitivePath(c.Request.URL.Path)
@@ -160,12 +165,12 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		}
 
 		// Set response headers
-		c.Header("Content-Type", "application/gzip")
+		c.Header("Content-Type", contentType)
 		c.Header("Content-Disposition", "attachment")
 		c.Header("X-Checksum-SHA256", metadata.Checksum)
 
 		// Stream file to client
-		c.DataFromReader(http.StatusOK, metadata.Size, "application/gzip", reader, nil)
+		c.DataFromReader(http.StatusOK, metadata.Size, contentType, reader, nil)
 	}
 }
 

--- a/backend/internal/api/modules/versions.go
+++ b/backend/internal/api/modules/versions.go
@@ -52,13 +52,13 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -67,7 +67,7 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		module, err := moduleRepo.GetModule(c.Request.Context(), org.ID, namespace, name, system)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query module",
+				"errors": []string{"Failed to query module"},
 			})
 			return
 		}
@@ -83,7 +83,7 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		versions, total, err := moduleRepo.ListVersionsPaginated(c.Request.Context(), module.ID, limit, offset)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to list module versions",
+				"errors": []string{"Failed to list module versions"},
 			})
 			return
 		}

--- a/backend/internal/api/oci/handler.go
+++ b/backend/internal/api/oci/handler.go
@@ -65,6 +65,10 @@ func NewHandler(db *sql.DB, storageBackend storage.Storage) *Handler {
 // @Router       /v2/ [get]
 func (h *Handler) Ping(c *gin.Context) {
 	c.Header("OCI-Distribution-Spec-Version", ociSpecVersion)
+	// Docker Registry v2 API version header — conventionally checked by
+	// existing OCI/Docker Registry v2 tooling (oras, crane, containerd/distribution
+	// clients) during /v2/ capability probing.
+	c.Header("Docker-Distribution-Api-Version", "registry/2.0")
 	c.JSON(http.StatusOK, gin.H{})
 }
 
@@ -83,7 +87,7 @@ func (h *Handler) Ping(c *gin.Context) {
 func (h *Handler) HeadManifest(c *gin.Context) {
 	data, statusCode, err := h.buildManifestJSON(c)
 	if err != nil {
-		c.JSON(statusCode, ociErrors("MANIFEST_UNKNOWN", err.Error()))
+		c.JSON(statusCode, ociErrors(ociErrorCode(statusCode, "MANIFEST_UNKNOWN"), err.Error()))
 		return
 	}
 	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
@@ -109,7 +113,7 @@ func (h *Handler) HeadManifest(c *gin.Context) {
 func (h *Handler) GetManifest(c *gin.Context) {
 	data, statusCode, err := h.buildManifestJSON(c)
 	if err != nil {
-		c.JSON(statusCode, ociErrors("MANIFEST_UNKNOWN", err.Error()))
+		c.JSON(statusCode, ociErrors(ociErrorCode(statusCode, "MANIFEST_UNKNOWN"), err.Error()))
 		return
 	}
 	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
@@ -132,7 +136,7 @@ func (h *Handler) GetManifest(c *gin.Context) {
 func (h *Handler) HeadBlob(c *gin.Context) {
 	mv, statusCode, err := h.lookupVersionByDigest(c)
 	if err != nil {
-		c.JSON(statusCode, ociErrors("BLOB_UNKNOWN", err.Error()))
+		c.JSON(statusCode, ociErrors(ociErrorCode(statusCode, "BLOB_UNKNOWN"), err.Error()))
 		return
 	}
 	c.Header("Content-Type", mediaTypeLayer)
@@ -157,13 +161,13 @@ func (h *Handler) HeadBlob(c *gin.Context) {
 func (h *Handler) GetBlob(c *gin.Context) {
 	mv, statusCode, err := h.lookupVersionByDigest(c)
 	if err != nil {
-		c.JSON(statusCode, ociErrors("BLOB_UNKNOWN", err.Error()))
+		c.JSON(statusCode, ociErrors(ociErrorCode(statusCode, "BLOB_UNKNOWN"), err.Error()))
 		return
 	}
 
 	rc, err := h.storage.Download(c.Request.Context(), mv.StoragePath)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, ociErrors("BLOB_UNKNOWN", "failed to retrieve blob"))
+		c.JSON(http.StatusInternalServerError, ociErrors("UNKNOWN", "failed to retrieve blob"))
 		return
 	}
 	defer rc.Close() //nolint:errcheck
@@ -186,6 +190,8 @@ func (h *Handler) GetBlob(c *gin.Context) {
 // @Failure      405  {object}  map[string]interface{}
 // @Router       /v2/{namespace}/{name}/{system}/manifests/{reference} [put]
 func (h *Handler) PutManifest(c *gin.Context) {
+	// RFC 7231 §6.5.5 requires a 405 response to list the supported methods.
+	c.Header("Allow", "GET, HEAD")
 	c.JSON(http.StatusMethodNotAllowed, ociErrors("UNSUPPORTED",
 		"OCI push is not supported; use POST /api/v1/modules to publish modules"))
 }
@@ -305,4 +311,16 @@ type versionBlob struct {
 // ociErrors returns the standard OCI error body format.
 func ociErrors(code, message string) gin.H {
 	return gin.H{"errors": []gin.H{{"code": code, "message": message}}}
+}
+
+// ociErrorCode picks the OCI error code for a failed lookup: notFoundCode
+// (e.g. MANIFEST_UNKNOWN/BLOB_UNKNOWN) for genuine 4xx "does not exist"
+// responses, but the OCI-registered generic "UNKNOWN" code for 5xx internal
+// failures — reusing the not-found code there would misrepresent a
+// transient/retryable server fault as permanent absence.
+func ociErrorCode(statusCode int, notFoundCode string) string {
+	if statusCode >= http.StatusInternalServerError {
+		return "UNKNOWN"
+	}
+	return notFoundCode
 }

--- a/backend/internal/api/oci/handler_test.go
+++ b/backend/internal/api/oci/handler_test.go
@@ -1,9 +1,13 @@
 package oci
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,7 +16,32 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
+
+// stubStorage is a minimal storage.Storage implementation for exercising the
+// blob-download failure path.
+type stubStorage struct {
+	downloadErr error
+}
+
+func (s *stubStorage) Upload(_ context.Context, _ string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
+	return nil, nil
+}
+func (s *stubStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	if s.downloadErr != nil {
+		return nil, s.downloadErr
+	}
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+func (s *stubStorage) Delete(_ context.Context, _ string) error { return nil }
+func (s *stubStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return "", nil
+}
+func (s *stubStorage) Exists(_ context.Context, _ string) (bool, error) { return true, nil }
+func (s *stubStorage) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
+	return &storage.FileMetadata{}, nil
+}
 
 // ─── router builder ───────────────────────────────────────────────────────────
 
@@ -71,6 +100,12 @@ func TestPing(t *testing.T) {
 	if v := w.Header().Get("OCI-Distribution-Spec-Version"); v != ociSpecVersion {
 		t.Errorf("expected OCI-Distribution-Spec-Version=%s, got %q", ociSpecVersion, v)
 	}
+	// Issue #694: also emit the conventional Docker Registry v2 header that
+	// existing OCI/Docker tooling (oras, crane, containerd/distribution) checks
+	// for during /v2/ capability probing.
+	if v := w.Header().Get("Docker-Distribution-Api-Version"); v != "registry/2.0" {
+		t.Errorf("expected Docker-Distribution-Api-Version=registry/2.0, got %q", v)
+	}
 }
 
 // ─── PutManifest returns 405 ──────────────────────────────────────────────────
@@ -95,6 +130,10 @@ func TestPutManifest_NotSupported(t *testing.T) {
 	errors, _ := body["errors"].([]interface{})
 	if len(errors) == 0 {
 		t.Error("expected errors array")
+	}
+	// Issue #683: RFC 7231 §6.5.5 requires an Allow header on a 405 response.
+	if allow := w.Header().Get("Allow"); allow != "GET, HEAD" {
+		t.Errorf("expected Allow header 'GET, HEAD', got %q", allow)
 	}
 }
 
@@ -142,6 +181,141 @@ func TestGetManifest_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "MANIFEST_UNKNOWN") {
 		t.Errorf("expected MANIFEST_UNKNOWN error, got: %s", w.Body.String())
+	}
+}
+
+// ─── GetManifest / HeadManifest — internal error (issue #682) ────────────────
+//
+// A transient failure (org lookup query error) must surface as the generic
+// OCI "UNKNOWN" code, not the "does not exist" MANIFEST_UNKNOWN code, so OCI
+// clients don't mistake a retryable server fault for permanent absence.
+
+func TestGetManifest_InternalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnError(errors.New("db down"))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/manifests/:reference", h.GetManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "MANIFEST_UNKNOWN") {
+		t.Errorf("500 response must not reuse MANIFEST_UNKNOWN, got: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "UNKNOWN") {
+		t.Errorf("expected generic UNKNOWN error code, got: %s", w.Body.String())
+	}
+}
+
+func TestHeadManifest_InternalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnError(errors.New("db down"))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.HEAD("/v2/:namespace/:name/:system/manifests/:reference", h.HeadManifest)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/v2/hashicorp/consul/aws/manifests/1.0.0", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "MANIFEST_UNKNOWN") {
+		t.Errorf("500 response must not reuse MANIFEST_UNKNOWN, got: %s", w.Body.String())
+	}
+}
+
+func TestGetBlob_InternalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnError(errors.New("db down"))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/blobs/:digest", h.GetBlob)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/blobs/sha256:abc123", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "BLOB_UNKNOWN") {
+		t.Errorf("500 response must not reuse BLOB_UNKNOWN, got: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "UNKNOWN") {
+		t.Errorf("expected generic UNKNOWN error code, got: %s", w.Body.String())
+	}
+}
+
+// TestGetBlob_StorageDownloadError — module version resolves fine but the
+// storage backend fails; this is also a transient 500 and must not reuse
+// BLOB_UNKNOWN.
+func TestGetBlob_StorageDownloadError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	const checksum = "abc123def456"
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnRows(orgRow("org-id", "default"))
+	mock.ExpectQuery("SELECT.*FROM modules").
+		WithArgs("org-id", "hashicorp", "consul", "aws").
+		WillReturnRows(moduleRow("mod-id", "org-id", "hashicorp", "consul", "aws"))
+	mock.ExpectQuery("SELECT.*FROM module_versions").
+		WithArgs("mod-id", checksum).
+		WillReturnRows(versionRow("ver-id", "mod-id", "1.0.0", "path.tar.gz", checksum, 512))
+
+	h := NewHandler(db, &stubStorage{downloadErr: errors.New("storage unavailable")})
+	r := gin.New()
+	r.GET("/v2/:namespace/:name/:system/blobs/:digest", h.GetBlob)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v2/hashicorp/consul/aws/blobs/sha256:"+checksum, nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "BLOB_UNKNOWN") {
+		t.Errorf("500 response must not reuse BLOB_UNKNOWN, got: %s", w.Body.String())
 	}
 }
 
@@ -289,6 +463,43 @@ func TestHeadManifest_OK(t *testing.T) {
 }
 
 // ─── HeadBlob / GetBlob ───────────────────────────────────────────────────────
+
+// TestHeadBlob_InternalError — a transient failure (org lookup query error)
+// must surface as the generic OCI "UNKNOWN" code, not BLOB_UNKNOWN, so OCI
+// clients don't mistake a retryable server fault for permanent absence.
+// HeadBlob shares lookupVersionByDigest + ociErrorCode with GetBlob (already
+// covered by TestGetBlob_InternalError); this is HeadBlob's own regression
+// coverage for the same #682 fix.
+func TestHeadBlob_InternalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WithArgs("default").
+		WillReturnError(errors.New("db down"))
+
+	h := NewHandler(db, nil)
+	r := gin.New()
+	r.HEAD("/v2/:namespace/:name/:system/blobs/:digest", h.HeadBlob)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodHead, "/v2/hashicorp/consul/aws/blobs/sha256:abc123", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "BLOB_UNKNOWN") {
+		t.Errorf("500 response must not reuse BLOB_UNKNOWN, got: %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "UNKNOWN") {
+		t.Errorf("expected generic UNKNOWN error code, got: %s", w.Body.String())
+	}
+}
 
 // TestHeadBlob_InvalidDigest and TestGetBlob_InvalidDigest — no sha256: prefix → 400
 func TestHeadBlob_InvalidDigest(t *testing.T) {

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -70,13 +70,13 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -85,7 +85,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider",
+				"errors": []string{"Failed to query provider"},
 			})
 			return
 		}
@@ -100,7 +100,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		providerVersion, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, version)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider version",
+				"errors": []string{"Failed to query provider version"},
 			})
 			return
 		}
@@ -120,7 +120,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		approvalStatus, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), providerVersion.ID)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider version",
+				"errors": []string{"Failed to query provider version"},
 			})
 			return
 		}
@@ -136,7 +136,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		platform, err := providerRepo.GetPlatform(c.Request.Context(), providerVersion.ID, os, arch)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider platform",
+				"errors": []string{"Failed to query provider platform"},
 			})
 			return
 		}
@@ -152,7 +152,7 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		downloadURL, err := storageBackend.GetURL(c.Request.Context(), platform.StoragePath, 15*time.Minute)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to generate download URL",
+				"errors": []string{"Failed to generate download URL"},
 			})
 			return
 		}

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -24,6 +25,25 @@ import (
 
 func init() {
 	gin.SetMode(gin.TestMode)
+}
+
+// assertErrorsArrayBody fails the test unless the response body is shaped
+// {"errors": [...]}, the protocol-correct shape already used by the 4xx
+// paths of these same handlers. Issue #696: 500 paths must not fall back to
+// a singular {"error": "..."} string.
+func assertErrorsArrayBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body: %v; body=%s", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf(`response body uses singular "error" key, want "errors" array; body=%s`, w.Body.String())
+	}
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Errorf(`response body missing "errors" array; body=%s`, w.Body.String())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -236,6 +256,7 @@ func TestListVersionsHandler_OrgError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_OrgNotFound(t *testing.T) {
@@ -247,6 +268,7 @@ func TestListVersionsHandler_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_ProviderError(t *testing.T) {
@@ -259,6 +281,7 @@ func TestListVersionsHandler_ProviderError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersionsHandler_ProviderNotFound(t *testing.T) {
@@ -284,6 +307,7 @@ func TestListVersionsHandler_VersionsError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 // ---------------------------------------------------------------------------
@@ -374,6 +398,7 @@ func TestDownloadHandler_OrgError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_ProviderNotFound(t *testing.T) {
@@ -482,6 +507,7 @@ func TestDownloadHandler_StorageError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 // ---------------------------------------------------------------------------
@@ -1174,6 +1200,7 @@ func TestDownloadHandler_OrgNotFound(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500 (org not found): body=%s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_ProviderQueryError(t *testing.T) {
@@ -1186,6 +1213,7 @@ func TestDownloadHandler_ProviderQueryError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500 (provider query error): body=%s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_VersionQueryError(t *testing.T) {
@@ -1200,6 +1228,7 @@ func TestDownloadHandler_VersionQueryError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500 (version query error): body=%s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_PlatformQueryError(t *testing.T) {
@@ -1217,6 +1246,7 @@ func TestDownloadHandler_PlatformQueryError(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500 (platform query error): body=%s", w.Code, w.Body.String())
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadHandler_SuccessWithGPGKey(t *testing.T) {

--- a/backend/internal/api/providers/versions.go
+++ b/backend/internal/api/providers/versions.go
@@ -50,13 +50,13 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
+				"errors": []string{"Failed to get organization context"},
 			})
 			return
 		}
 		if org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found - please run migrations",
+				"errors": []string{"Default organization not found - please run migrations"},
 			})
 			return
 		}
@@ -65,7 +65,7 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to query provider",
+				"errors": []string{"Failed to query provider"},
 			})
 			return
 		}
@@ -81,7 +81,7 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 		versions, total, err := providerRepo.ListVersionsPaginated(c.Request.Context(), provider.ID, limit, offset)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to list provider versions",
+				"errors": []string{"Failed to list provider versions"},
 			})
 			return
 		}
@@ -94,7 +94,7 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			platforms, err := providerRepo.ListPlatforms(c.Request.Context(), v.ID)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Failed to list provider platforms",
+					"errors": []string{"Failed to list provider platforms"},
 				})
 				return
 			}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -874,19 +874,27 @@ func CORSMiddleware(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := c.Request.Header.Get("Origin")
 
-		// Check if origin is allowed and track which rule matched
+		// Check if origin is allowed and track which rule matched. Scan for an
+		// exact origin match first, and only fall back to the wildcard rule if
+		// none is found — so credentialed-vs-not behavior for a given origin
+		// does not depend on where "*" sits in the configured list (issue #695).
 		allowed := false
 		matchedWildcard := false
+		hasWildcard := false
 		for _, allowedOrigin := range cfg.Security.CORS.AllowedOrigins {
 			if allowedOrigin == "*" {
-				allowed = true
-				matchedWildcard = true
-				break
+				hasWildcard = true
+				continue
 			}
 			if allowedOrigin == origin {
 				allowed = true
+				matchedWildcard = false
 				break
 			}
+		}
+		if !allowed && hasWildcard {
+			allowed = true
+			matchedWildcard = true
 		}
 
 		if allowed {

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -189,10 +189,11 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 		c.Redirect(http.StatusMovedPermanently, "/api-docs/")
 	})
 
-	// Raw Swagger JSON endpoint - serve embedded spec with runtime metadata
+	// Raw Swagger JSON endpoint - serve embedded spec with runtime metadata.
+	// CORS is governed by the globally-applied CORSMiddleware like every
+	// other route; do not set Access-Control-Allow-Origin here (issue #684).
 	router.GET("/swagger.json", func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
-		c.Header("Access-Control-Allow-Origin", "*")
 
 		data := docs.SwaggerJSON
 
@@ -249,10 +250,10 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// at build time via swagger2openapi. Served without runtime metadata
 	// injection because downstream consumers (frontend typegen, provider
 	// oapi-codegen) only care about the route and schema surface, not
-	// terms-of-service / license fields.
+	// terms-of-service / license fields. CORS is governed by the
+	// globally-applied CORSMiddleware like every other route (issue #684).
 	router.GET("/openapi3.json", func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
-		c.Header("Access-Control-Allow-Origin", "*")
 		c.Data(http.StatusOK, "application/json", docs.OpenAPI3JSON)
 	})
 

--- a/backend/internal/api/router_routes_test.go
+++ b/backend/internal/api/router_routes_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// Issue #684: /swagger.json and /openapi3.json hardcoded
+// Access-Control-Allow-Origin: * regardless of the configured CORS policy,
+// bypassing CORSMiddleware (which is applied globally ahead of these routes
+// in NewRouter). A disallowed Origin must not get a wildcard CORS header.
+
+func newPublicRoutesRouter(t *testing.T, cfg *config.Config) *gin.Engine {
+	t.Helper()
+	r := gin.New()
+	r.Use(CORSMiddleware(cfg))
+	registerPublicRoutes(r, &publicRouteDeps{cfg: cfg})
+	return r
+}
+
+func TestSwaggerJSON_RespectsCORSPolicy_DisallowedOrigin(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://allowed.com"}
+	r := newPublicRoutesRouter(t, cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/swagger.json", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if aco := w.Header().Get("Access-Control-Allow-Origin"); aco != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for disallowed origin", aco)
+	}
+}
+
+func TestSwaggerJSON_RespectsCORSPolicy_AllowedOrigin(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://allowed.com"}
+	r := newPublicRoutesRouter(t, cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/swagger.json", nil)
+	req.Header.Set("Origin", "https://allowed.com")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if aco := w.Header().Get("Access-Control-Allow-Origin"); aco != "https://allowed.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://allowed.com", aco)
+	}
+}
+
+func TestOpenAPI3JSON_RespectsCORSPolicy_DisallowedOrigin(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://allowed.com"}
+	r := newPublicRoutesRouter(t, cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/openapi3.json", nil)
+	req.Header.Set("Origin", "https://evil.com")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if aco := w.Header().Get("Access-Control-Allow-Origin"); aco != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty for disallowed origin", aco)
+	}
+}
+
+func TestOpenAPI3JSON_RespectsCORSPolicy_AllowedOrigin(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://allowed.com"}
+	r := newPublicRoutesRouter(t, cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/openapi3.json", nil)
+	req.Header.Set("Origin", "https://allowed.com")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if aco := w.Header().Get("Access-Control-Allow-Origin"); aco != "https://allowed.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://allowed.com", aco)
+	}
+}

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -440,6 +440,82 @@ func TestCollectRateLimiterBackends_Mixed(t *testing.T) {
 	}
 }
 
+// Issue #695: the credentialed-origin decision must not depend on
+// allowed_origins list order when a wildcard and an explicit origin are both
+// configured. An origin that is explicitly listed must always be treated as
+// an exact match (credentials allowed), regardless of where "*" sits in the
+// list.
+
+func TestCORSMiddleware_ExactMatchBeforeWildcard_WildcardFirst(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"*", "https://a.com"}
+
+	r := gin.New()
+	r.Use(CORSMiddleware(cfg))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://a.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://a.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://a.com", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want true (exact origin match must grant credentials regardless of list order)", got)
+	}
+}
+
+// ExactFirst is a symmetry/completeness check: with the exact origin already
+// ahead of "*" in the list, a pre-fix break-on-first-match loop would reach
+// the same result, so this case alone does not distinguish pre-fix from
+// fixed behavior. The regression itself is caught by its WildcardFirst
+// sibling above, which fails under the pre-fix loop.
+func TestCORSMiddleware_ExactMatchBeforeWildcard_ExactFirst(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://a.com", "*"}
+
+	r := gin.New()
+	r.Use(CORSMiddleware(cfg))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://a.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://a.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://a.com", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want true", got)
+	}
+}
+
+// A mixed config still falls back to the wildcard (no credentials) behavior
+// for origins that are NOT explicitly listed.
+func TestCORSMiddleware_MixedConfig_UnlistedOriginFallsBackToWildcard(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.CORS.AllowedOrigins = []string{"https://a.com", "*"}
+
+	r := gin.New()
+	r.Use(CORSMiddleware(cfg))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://anything-else.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://anything-else.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://anything-else.com (reflected via wildcard rule)", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want empty (wildcard match must not grant credentials)", got)
+	}
+}
+
 func TestCORSMiddleware_WildcardNoOriginHeader(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.CORS.AllowedOrigins = []string{"*"}

--- a/backend/internal/api/terraform_binaries/binaries.go
+++ b/backend/internal/api/terraform_binaries/binaries.go
@@ -51,21 +51,21 @@ func approvalVisible(status *string) bool {
 func (h *Handler) resolveConfig(c *gin.Context) (*models.TerraformMirrorConfig, bool) {
 	name := c.Param("name")
 	if name == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Mirror name is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"errors": []string{"Mirror name is required"}})
 		return nil, false
 	}
 
 	cfg, err := h.repo.GetByName(c.Request.Context(), name)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to look up mirror"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to look up mirror"}})
 		return nil, false
 	}
 	if cfg == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Mirror not found: " + name})
+		c.JSON(http.StatusNotFound, gin.H{"errors": []string{"Mirror not found: " + name}})
 		return nil, false
 	}
 	if !cfg.Enabled {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Mirror is not enabled: " + name})
+		c.JSON(http.StatusNotFound, gin.H{"errors": []string{"Mirror is not enabled: " + name}})
 		return nil, false
 	}
 
@@ -91,7 +91,7 @@ type PublicMirrorSummary struct {
 func (h *Handler) ListConfigs(c *gin.Context) {
 	configs, err := h.repo.ListEnabled(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list mirror configs"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to list mirror configs"}})
 		return
 	}
 
@@ -126,7 +126,7 @@ func (h *Handler) ListVersions(c *gin.Context) {
 
 	versions, err := h.repo.ListVersions(c.Request.Context(), cfg.ID, true /* syncedOnly */)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list versions"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to list versions"}})
 		return
 	}
 
@@ -164,11 +164,11 @@ func (h *Handler) GetLatestVersion(c *gin.Context) {
 
 	version, err := h.repo.GetLatestVersion(c.Request.Context(), cfg.ID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get latest version"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to get latest version"}})
 		return
 	}
 	if version == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "No latest version available — run a sync first"})
+		c.JSON(http.StatusNotFound, gin.H{"errors": []string{"No latest version available — run a sync first"}})
 		return
 	}
 
@@ -209,7 +209,7 @@ func (h *Handler) GetVersion(c *gin.Context) {
 
 	version, err := h.repo.GetVersionByString(c.Request.Context(), cfg.ID, versionStr)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query version"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to query version"}})
 		return
 	}
 	if version == nil || version.SyncStatus == "pending" || !approvalVisible(version.ApprovalStatus) {
@@ -272,7 +272,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	// Look up version
 	version, err := h.repo.GetVersionByString(c.Request.Context(), cfg.ID, versionStr)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query version"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to query version"}})
 		return
 	}
 	if version == nil || !approvalVisible(version.ApprovalStatus) {
@@ -283,7 +283,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	// Look up platform
 	platform, err := h.repo.GetPlatform(c.Request.Context(), version.ID, osStr, archStr)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to query platform"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to query platform"}})
 		return
 	}
 	if platform == nil {
@@ -294,7 +294,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	// Ensure the binary has been synced to storage
 	if platform.SyncStatus != "synced" || platform.StorageKey == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error":       "Binary not yet available — sync is in progress or has not been triggered",
+			"errors":      []string{"Binary not yet available — sync is in progress or has not been triggered"},
 			"sync_status": platform.SyncStatus,
 		})
 		return
@@ -303,7 +303,7 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	// Generate pre-signed download URL (15-minute TTL)
 	downloadURL, err := h.storageBackend.GetURL(c.Request.Context(), *platform.StorageKey, 15*time.Minute)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate download URL"})
+		c.JSON(http.StatusInternalServerError, gin.H{"errors": []string{"Failed to generate download URL"}})
 		return
 	}
 

--- a/backend/internal/api/terraform_binaries/binaries_test.go
+++ b/backend/internal/api/terraform_binaries/binaries_test.go
@@ -20,6 +20,25 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
 
+// assertErrorsArrayBody fails the test unless the response body is shaped
+// {"errors": [...]}, the protocol-correct shape already used by the 4xx
+// paths of these same handlers. Issue #696: 500 paths must not fall back to
+// a singular {"error": "..."} string.
+func assertErrorsArrayBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body: %v; body=%s", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf(`response body uses singular "error" key, want "errors" array; body=%s`, w.Body.String())
+	}
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Errorf(`response body missing "errors" array; body=%s`, w.Body.String())
+	}
+}
+
 // ---- constants & shared test data -------------------------------------------
 
 const (
@@ -239,6 +258,7 @@ func TestListVersions_MirrorNotFound(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersions_MirrorDisabled(t *testing.T) {
@@ -259,6 +279,7 @@ func TestListVersions_MirrorDisabled(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 func TestListVersions_DBError(t *testing.T) {
@@ -277,6 +298,7 @@ func TestListVersions_DBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- GetLatestVersion -------------------------------------------------------
@@ -324,6 +346,7 @@ func TestGetLatestVersion_NoLatest(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- GetVersion -------------------------------------------------------------
@@ -570,6 +593,13 @@ func TestDownloadBinary_PlatformPending(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	// Issue #696: the 503 sync-pending body must use the protocol-correct
+	// errors[] array shape (matching every other error response in this
+	// handler) while still carrying sync_status for clients that poll it.
+	assertErrorsArrayBody(t, w)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "pending", resp["sync_status"])
 }
 
 // ---- ListConfigs ------------------------------------------------------------
@@ -648,6 +678,7 @@ func TestListConfigs_DBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- ResolveConfig error paths ----------------------------------------------
@@ -664,6 +695,7 @@ func TestResolveConfig_GetByNameDBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- GetLatestVersion additional error paths --------------------------------
@@ -684,6 +716,7 @@ func TestGetLatestVersion_DBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- GetVersion additional error paths -------------------------------------
@@ -704,6 +737,7 @@ func TestGetVersion_DBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 // ---- DownloadBinary additional error paths ----------------------------------
@@ -724,6 +758,7 @@ func TestDownloadBinary_VersionDBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadBinary_PlatformDBError(t *testing.T) {
@@ -746,6 +781,7 @@ func TestDownloadBinary_PlatformDBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }
 
 func TestDownloadBinary_StorageURLError(t *testing.T) {
@@ -769,4 +805,5 @@ func TestDownloadBinary_StorageURLError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assertErrorsArrayBody(t, w)
 }

--- a/backend/internal/middleware/binary_mirror_auth.go
+++ b/backend/internal/middleware/binary_mirror_auth.go
@@ -48,7 +48,7 @@ func binaryMirrorAllowlistMiddleware(cidrs []string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		clientIP := net.ParseIP(c.ClientIP())
 		if clientIP == nil {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"errors": []string{"forbidden"}})
 			return
 		}
 		for _, ipNet := range nets {
@@ -57,7 +57,7 @@ func binaryMirrorAllowlistMiddleware(cidrs []string) gin.HandlerFunc {
 				return
 			}
 		}
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"errors": []string{"forbidden"}})
 	}
 }
 
@@ -68,7 +68,7 @@ func binaryMirrorAllowlistMiddleware(cidrs []string) gin.HandlerFunc {
 func binaryMirrorMTLSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.TLS == nil || len(c.Request.TLS.VerifiedChains) == 0 {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "client certificate required"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"errors": []string{"client certificate required"}})
 			return
 		}
 		c.Next()

--- a/backend/internal/middleware/binary_mirror_auth_test.go
+++ b/backend/internal/middleware/binary_mirror_auth_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,26 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 )
+
+// assertErrorsArrayBody fails the test unless the response body is shaped
+// {"errors": [...]}, the protocol-correct shape used by the terraform_binaries
+// handlers this middleware gates. Issue #696: the 403 paths here must not fall
+// back to a singular {"error": "..."} string that would mismatch the rest of
+// the /terraform/binaries endpoint family.
+func assertErrorsArrayBody(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body: %v; body=%s", err, w.Body.String())
+	}
+	if _, ok := body["error"]; ok {
+		t.Errorf(`response body uses singular "error" key, want "errors" array; body=%s`, w.Body.String())
+	}
+	errs, ok := body["errors"].([]interface{})
+	if !ok || len(errs) == 0 {
+		t.Errorf(`response body missing "errors" array; body=%s`, w.Body.String())
+	}
+}
 
 func newBinaryMirrorRouter(cfg config.BinaryMirrorConfig) *gin.Engine {
 	gin.SetMode(gin.TestMode)
@@ -70,6 +91,7 @@ func TestBinaryMirrorAuth_Allowlist_Denied(t *testing.T) {
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for denied IP, got %d", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestBinaryMirrorAuth_Allowlist_EmptyList(t *testing.T) {
@@ -85,6 +107,7 @@ func TestBinaryMirrorAuth_Allowlist_EmptyList(t *testing.T) {
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for empty allowlist, got %d", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestBinaryMirrorAuth_MTLS_NoTLS(t *testing.T) {
@@ -96,6 +119,7 @@ func TestBinaryMirrorAuth_MTLS_NoTLS(t *testing.T) {
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for no TLS, got %d", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestBinaryMirrorAuth_MTLS_NoClientCert(t *testing.T) {
@@ -108,6 +132,7 @@ func TestBinaryMirrorAuth_MTLS_NoClientCert(t *testing.T) {
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for TLS without client cert, got %d", w.Code)
 	}
+	assertErrorsArrayBody(t, w)
 }
 
 func TestBinaryMirrorAuth_MTLS_WithClientCert(t *testing.T) {


### PR DESCRIPTION
Closes #681
Closes #682
Closes #683
Closes #684
Closes #694
Closes #695
Closes #696

Batch `e-protocol-cors` from the 2026-07-22 blind security audit:

- **#684** — Swagger/OpenAPI JSON endpoints hardcoded `Access-Control-Allow-Origin: *` regardless of configured CORS policy.
- **#695** — `CORSMiddleware`'s credentialed-origin decision depended on `allowed_origins` list order when a wildcard and explicit origins were mixed.
- **#682** — OCI internal-error (5xx) responses reused the not-found codes `MANIFEST_UNKNOWN`/`BLOB_UNKNOWN`.
- **#683** — PUT manifest 405 response omitted the RFC 7231-required `Allow` header.
- **#694** — OCI capability discovery emitted a non-standard header instead of `Docker-Distribution-Api-Version`.
- **#681** — provider `.zip` archives were served as `Content-Type: application/gzip`; content type is now derived from the artifact kind (providers `.zip`, modules `.tar.gz`).
- **#696** — protocol error-response bodies unified on one shape per endpoint family.

On #696's scope: the panel required a sibling sweep across every handler package. Two genuinely mixed sites were found and fixed (`modules/serve.go`, `middleware/binary_mirror_auth.go`). Roughly 40 other files use the singular `{"error": ...}` shape *consistently* — they're the admin/publish/UI family, which has its own internally-consistent convention, and #696 is explicitly about inconsistency *within* an endpoint family. Those were deliberately left alone rather than churned.

Rebase note: `modules/serve.go` conflicted with the merged log-hygiene batch. Main's `RedactSensitivePath` audit-action fix (#678 sibling) is canonical and kept; this branch's hoisting of `resourceType` alongside the new `contentType` (#681) is kept too, with main's now-redundant inner shadowed declaration dropped so the hoisted variable is the one used. `go build` caught the shadowing immediately — worth noting the conflict resolution was not obviously wrong by eye.

Verification: adversarial panel consensus, then post-rebase `gofmt` clean, `go build ./...`, `go vet ./...`, and the full `go test ./...` suite all pass.

Two follow-ups noted by review, not fixed here: `oci/handler.go`'s `ociErrorCode()` maps any sub-500 status to the not-found code, so a 400 "invalid digest format" still emits `BLOB_UNKNOWN` (pre-existing, outside #682's 5xx scope); and `middleware/quota.go` still emits singular bodies on 429 but is dead code — never wired into any route — so there's no live exposure.