### PR TITLE
fix(security): provider signing policy, OPA bundle pinning, blob lifecycle, mTLS revocation

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -10098,7 +10098,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope.",
+                "description": "Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope. If the registry has providers.require_signing enabled, gpg_public_key, shasums_file, and shasums_signature_file become mandatory for a version's first platform upload.",
                 "tags": [
                     "Providers"
                 ],
@@ -17649,6 +17649,10 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "signed": {
+                        "description": "Signed reports whether this version carries a GPG public key, so admins\ncan distinguish unsigned publishes at a glance without cross-referencing\nproviders.require_signing (issue #658).",
+                        "type": "boolean"
                     },
                     "version": {
                         "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8166,7 +8166,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope.",
+                "description": "Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope. If the registry has providers.require_signing enabled, gpg_public_key, shasums_file, and shasums_signature_file become mandatory for a version's first platform upload.",
                 "consumes": [
                     "multipart/form-data"
                 ],
@@ -14466,6 +14466,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "signed": {
+                    "description": "Signed reports whether this version carries a GPG public key, so admins\ncan distinguish unsigned publishes at a glance without cross-referencing\nproviders.require_signing (issue #658).",
+                    "type": "boolean"
                 },
                 "version": {
                     "type": "string"

--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -98,6 +98,10 @@ func (h *ProviderAdminHandlers) GetProvider(c *gin.Context) {
 			"protocols":  v.Protocols,
 			"platforms":  platformsList,
 			"deprecated": v.Deprecated,
+			// signed surfaces whether this version carries a GPG public key,
+			// so admins can distinguish unsigned publishes at a glance
+			// without cross-referencing providers.require_signing (issue #658).
+			"signed":     v.GPGPublicKey != "",
 			"created_at": v.CreatedAt,
 		}
 		if v.DeprecatedAt != nil {

--- a/backend/internal/api/admin/providers_test.go
+++ b/backend/internal/api/admin/providers_test.go
@@ -713,6 +713,43 @@ func TestGetProvider_OrgFound_Success_WithVersionsAndPlatforms(t *testing.T) {
 	if resp["versions"] == nil {
 		t.Error("response missing 'versions' key")
 	}
+	versions := resp["versions"].([]interface{})
+	if got := versions[0].(map[string]interface{})["signed"]; got != false {
+		t.Errorf("versions[0].signed = %v, want false (gpg_public_key empty)", got)
+	}
+}
+
+// TestGetProvider_OrgFound_Success_SurfacesSignedVersion is the regression
+// test for the low-severity finding on issue #658 ("no admin/audit surfacing
+// of unsigned provider versions"): a version with a non-empty gpg_public_key
+// must be reported as signed:true so admins can distinguish it from an
+// unsigned publish without cross-referencing providers.require_signing.
+func TestGetProvider_OrgFound_Success_SurfacesSignedVersion(t *testing.T) {
+	mock, r := newProviderRouter(t)
+
+	expectOrgFound(mock)
+	mock.ExpectQuery("SELECT.*FROM providers").
+		WillReturnRows(sampleProviderRow())
+	protocols := []byte(`["6.0"]`)
+	mock.ExpectQuery("SELECT.*FROM provider_versions").
+		WillReturnRows(sqlmock.NewRows(versionCols).
+			AddRow("ver-1", "prov-1", "5.0.0", protocols, "armored-gpg-key", "", "",
+				nil, nil, // shasum_storage_key, shasum_signature_storage_key
+				nil, nil, false, nil, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms").
+		WillReturnRows(emptyPlatformRows())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/providers/hashicorp/aws", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	resp := getJSON(w)
+	versions := resp["versions"].([]interface{})
+	if got := versions[0].(map[string]interface{})["signed"]; got != true {
+		t.Errorf("versions[0].signed = %v, want true (gpg_public_key set)", got)
+	}
 }
 
 func TestGetProvider_OrgFound_ProviderNotFound(t *testing.T) {

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -254,14 +254,18 @@ type ProviderPlatformItem struct {
 
 // ProviderVersionItem represents a version entry inside a provider detail response.
 type ProviderVersionItem struct {
-	ID                 string                 `json:"id"`
-	Version            string                 `json:"version"`
-	Protocols          []string               `json:"protocols"`
-	Platforms          []ProviderPlatformItem `json:"platforms"`
-	Deprecated         bool                   `json:"deprecated"`
-	DeprecatedAt       interface{}            `json:"deprecated_at,omitempty"`
-	DeprecationMessage interface{}            `json:"deprecation_message,omitempty"`
-	CreatedAt          time.Time              `json:"created_at"`
+	ID         string                 `json:"id"`
+	Version    string                 `json:"version"`
+	Protocols  []string               `json:"protocols"`
+	Platforms  []ProviderPlatformItem `json:"platforms"`
+	Deprecated bool                   `json:"deprecated"`
+	// Signed reports whether this version carries a GPG public key, so admins
+	// can distinguish unsigned publishes at a glance without cross-referencing
+	// providers.require_signing (issue #658).
+	Signed             bool        `json:"signed"`
+	DeprecatedAt       interface{} `json:"deprecated_at,omitempty"`
+	DeprecationMessage interface{} `json:"deprecation_message,omitempty"`
+	CreatedAt          time.Time   `json:"created_at"`
 }
 
 // ProviderDetailResponse is returned by GET /api/v1/providers/{namespace}/{type}.

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -56,9 +56,24 @@ type mockStore struct {
 	uploadErr    error
 	uploadResult *storage.UploadResult
 	deleteErr    error
+	// uploadFailSuffix, when non-empty, makes Upload fail (with uploadErr, or
+	// a generic error if unset) only for paths ending in this suffix —
+	// letting a test simulate one file of a multi-file upload sequence
+	// failing after an earlier one already succeeded, without affecting the
+	// other tests that rely on the unconditional uploadErr.
+	uploadFailSuffix string
+	// deletedPaths records every path passed to Delete, so tests can assert
+	// that a partial-failure cleanup happened (issue #685).
+	deletedPaths []string
 }
 
-func (m *mockStore) Upload(_ context.Context, _ string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
+func (m *mockStore) Upload(_ context.Context, path string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
+	if m.uploadFailSuffix != "" && strings.HasSuffix(path, m.uploadFailSuffix) {
+		if m.uploadErr != nil {
+			return nil, m.uploadErr
+		}
+		return nil, errors.New("mock upload failure")
+	}
 	if m.uploadErr != nil {
 		return nil, m.uploadErr
 	}
@@ -70,7 +85,10 @@ func (m *mockStore) Upload(_ context.Context, _ string, _ io.Reader, _ int64) (*
 func (m *mockStore) Download(_ context.Context, _ string) (io.ReadCloser, error) {
 	return io.NopCloser(bytes.NewReader(nil)), nil
 }
-func (m *mockStore) Delete(_ context.Context, _ string) error { return m.deleteErr }
+func (m *mockStore) Delete(_ context.Context, path string) error {
+	m.deletedPaths = append(m.deletedPaths, path)
+	return m.deleteErr
+}
 func (m *mockStore) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
 	return m.getURLResult, m.getURLErr
 }
@@ -581,10 +599,17 @@ func buildUploadRequestWithFiles(
 
 func newUploadRouter(t *testing.T, store *mockStore) (sqlmock.Sqlmock, *gin.Engine) {
 	t.Helper()
+	return newUploadRouterWithConfig(t, store, &config.Config{})
+}
+
+// newUploadRouterWithConfig is newUploadRouter with a caller-supplied config,
+// for tests that need non-default settings (e.g. providers.require_signing).
+func newUploadRouterWithConfig(t *testing.T, store *mockStore, cfg *config.Config) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
 	db, mock, _ := sqlmock.New()
 	t.Cleanup(func() { db.Close() })
 	r := gin.New()
-	r.POST("/v1/providers", UploadHandler(db, store, &config.Config{}))
+	r.POST("/v1/providers", UploadHandler(db, store, cfg))
 	return mock, r
 }
 
@@ -911,7 +936,7 @@ func TestUploadHandler_RejectsSignatureWithoutGPGKey(t *testing.T) {
 // matrix here would only test the same code through a different door.
 
 // TestUploadHandler_StoresShasumsFileWithoutSignature exercises the happy
-// path of storeUploadedSignatureFiles when the caller supplies only the
+// path of persistSignatureFiles when the caller supplies only the
 // SHA256SUMS file (no signature). No GPG verification is required, so this
 // covers the storage upload and the UPDATE-version SQL step without needing
 // a real key/signature pair.
@@ -928,7 +953,7 @@ func TestUploadHandler_StoresShasumsFileWithoutSignature(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(providerVersionGetCols))
 	mock.ExpectQuery("INSERT INTO provider_versions").
 		WillReturnRows(sqlmock.NewRows(providerVersionInsertCols).AddRow("ver-new", time.Now()))
-	// storeUploadedSignatureFiles -> UpdateVersionSignatureStorage UPDATE.
+	// persistSignatureFiles -> UpdateVersionSignatureStorage UPDATE.
 	mock.ExpectExec("UPDATE provider_versions").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	// Back to the main flow.
@@ -950,6 +975,580 @@ func TestUploadHandler_StoresShasumsFileWithoutSignature(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusCreated {
 		t.Errorf("status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UploadHandler — providers.require_signing policy (issue #658)
+// ---------------------------------------------------------------------------
+
+// generateProviderTestGPGEntity returns an armored public key and its
+// matching entity, for building a real signature in the require_signing
+// happy-path test below.
+func generateProviderTestGPGEntity(t *testing.T) (armoredPubKey string, entity *openpgp.Entity) {
+	t.Helper()
+	entity, err := openpgp.NewEntity("Test User", "test", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("openpgp.NewEntity() error: %v", err)
+	}
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode() error: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("entity.Serialize() error: %v", err)
+	}
+	w.Close()
+	return buf.String(), entity
+}
+
+// armoredProviderDetachSign creates an ASCII-armored detached signature of
+// data using entity.
+func armoredProviderDetachSign(t *testing.T, data []byte, entity *openpgp.Entity) string {
+	t.Helper()
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.SignatureType, nil)
+	if err != nil {
+		t.Fatalf("armor.Encode() for signature error: %v", err)
+	}
+	if err := openpgp.DetachSign(w, entity, bytes.NewReader(data), nil); err != nil {
+		t.Fatalf("openpgp.DetachSign() error: %v", err)
+	}
+	w.Close()
+	return buf.String()
+}
+
+func TestUploadHandler_RequireSigning_RejectsUnsignedUpload(t *testing.T) {
+	store := &mockStore{}
+	cfg := &config.Config{}
+	cfg.Providers.RequireSigning = true
+	mock, r := newUploadRouterWithConfig(t, store, cfg)
+	uploadHappyPathExpectations(mock)
+	// No platform-query / insert-platform expectations — the request must be
+	// rejected before that point.
+
+	req := buildUploadRequest(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "linux",
+		"arch":      "amd64",
+	}, makeValidZIP(t))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (signing required): body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "requires signed provider publishes") {
+		t.Errorf("body should explain the signing requirement; got: %s", w.Body.String())
+	}
+}
+
+func TestUploadHandler_RequireSigning_AllowsSignedUpload(t *testing.T) {
+	armoredPubKey, entity := generateProviderTestGPGEntity(t)
+	sumsData := []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\n")
+	sigData := armoredProviderDetachSign(t, sumsData, entity)
+
+	store := &mockStore{}
+	cfg := &config.Config{}
+	cfg.Providers.RequireSigning = true
+	mock, r := newUploadRouterWithConfig(t, store, cfg)
+	uploadHappyPathExpectations(mock)
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "linux",
+		"arch":           "amd64",
+		"gpg_public_key": armoredPubKey,
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file":           sumsData,
+		"shasums_signature_file": []byte(sigData),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (signed upload allowed): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestUploadHandler_RequireSigning_AllowsLaterPlatformWithoutFiles exercises
+// the "checked once per version" behavior: once a version already has a
+// persisted shasum_signature_storage_key (from an earlier platform upload),
+// later platform uploads for the same version may omit the signing fields
+// entirely, matching the endpoint's existing "attach once per version" design.
+func TestUploadHandler_RequireSigning_AllowsLaterPlatformWithoutFiles(t *testing.T) {
+	store := &mockStore{}
+	cfg := &config.Config{}
+	cfg.Providers.RequireSigning = true
+	mock, r := newUploadRouterWithConfig(t, store, cfg)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sqlmock.NewRows(providerCols))
+	mock.ExpectQuery("INSERT INTO providers").
+		WillReturnRows(sqlmock.NewRows(providerInsertCols).AddRow("prov-1", time.Now(), time.Now()))
+	// GetVersion -> found, already signed from a prior platform upload.
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON, "armored-key",
+				"", "",
+				strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS"), strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS.sig"),
+				nil,
+				false, nil, nil, time.Now()))
+	// No shasums_file/shasums_signature_file this time — persistSignatureFiles no-ops.
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequest(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "darwin",
+		"arch":      "arm64",
+	}, makeValidZIP(t))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (later platform on already-signed version): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestUploadHandler_RequireSigning_RejectsBeforeCreatingVersionRow is the
+// regression test for the blocking finding on issue #658: the require_signing
+// gate must run BEFORE providerRepo.CreateVersion, so a rejected request never
+// commits an unsigned provider_versions row. No "INSERT INTO provider_versions"
+// expectation is registered on the mock at all — if the handler regressed to
+// creating the version before the gate check, that unmocked call would error
+// out of order and the assertions below (400 + exact error message +
+// ExpectationsWereMet) would fail.
+func TestUploadHandler_RequireSigning_RejectsBeforeCreatingVersionRow(t *testing.T) {
+	store := &mockStore{}
+	cfg := &config.Config{}
+	cfg.Providers.RequireSigning = true
+	mock, r := newUploadRouterWithConfig(t, store, cfg)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sqlmock.NewRows(providerCols))
+	mock.ExpectQuery("INSERT INTO providers").
+		WillReturnRows(sqlmock.NewRows(providerInsertCols).AddRow("prov-new", time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols))
+	// Deliberately no "INSERT INTO provider_versions" expectation, and no
+	// platform-query / insert-platform expectations — the request must be
+	// rejected right after the version lookup, before any of that runs.
+
+	req := buildUploadRequest(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "linux",
+		"arch":      "amd64",
+	}, makeValidZIP(t))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (signing required, rejected before version creation): body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "requires signed provider publishes") {
+		t.Errorf("body should explain the signing requirement; got: %s", w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected/unfulfilled SQL calls (version row must not be created before the gate check): %v", err)
+	}
+}
+
+// TestUploadHandler_PersistsGPGKeyOnExistingVersion is the regression test for
+// the "new high" finding on issue #658: a request against an existing
+// provider_versions row must persist a newly supplied gpg_public_key via
+// UpdateVersionGPGKey, not silently drop it. Without this, a later signed
+// platform upload could satisfy the require_signing gate (via
+// ShasumSignatureStorageKey) while gpg_public_key stayed empty forever, since
+// it was previously only ever set inside the "create new version" branch.
+//
+// The new key is only persisted when THIS request also supplies a
+// shasums_file and a matching, GPG-verified shasums_signature_file — proving
+// the key actually signed this version's checksums. See
+// TestUploadHandler_DoesNotPersistUnverifiedGPGKeyOnExistingVersion for the
+// negative case (blocking finding on #658: an unverified bare gpg_public_key
+// must never overwrite the persisted key).
+func TestUploadHandler_PersistsGPGKeyOnExistingVersion(t *testing.T) {
+	armoredPubKey, entity := generateProviderTestGPGEntity(t)
+	sumsData := []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\n")
+	sigData := armoredProviderDetachSign(t, sumsData, entity)
+
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("UPDATE providers").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	// GetVersion -> found, with gpg_public_key empty (e.g. an earlier unsigned
+	// attempt, or a platform upload that predates key rotation).
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sampleProviderVersionGetRow())
+	// The GPG key must be persisted onto the existing version row (UpdateVersionGPGKey)...
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	// ...and persistSignatureFiles persists the freshly-verified SUMS/sig storage keys.
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "linux",
+		"arch":           "amd64",
+		"gpg_public_key": armoredPubKey,
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file":           sumsData,
+		"shasums_signature_file": []byte(sigData),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (gpg key persisted onto existing version): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected UpdateVersionGPGKey to run against the existing version row: %v", err)
+	}
+}
+
+// TestUploadHandler_DoesNotPersistUnverifiedGPGKeyOnExistingVersion is the
+// regression test for the blocking finding on issue #658: a request against
+// an existing provider_versions row that supplies only gpg_public_key (no
+// shasums_file/shasums_signature_file) must NOT call UpdateVersionGPGKey.
+// Without this gate, any authenticated upload could overwrite the persisted
+// signing key with a value never verified against the version's checksums —
+// including on an already-signed version, since alreadySigned lets the
+// require_signing gate pass on this request regardless of its own signing
+// status. No "UPDATE provider_versions" mock expectation is registered at
+// all: if the handler regressed to the unconditional update, the unmocked
+// call would error out of order and ExpectationsWereMet would fail.
+func TestUploadHandler_DoesNotPersistUnverifiedGPGKeyOnExistingVersion(t *testing.T) {
+	armoredPubKey, _ := generateProviderTestGPGEntity(t)
+
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("UPDATE providers").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	// GetVersion -> found, already fully signed by a prior platform upload.
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON, "original-armored-key",
+				"", "",
+				strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS"), strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS.sig"),
+				nil,
+				false, nil, nil, time.Now()))
+	// Deliberately no "UPDATE provider_versions" expectation — an unverified
+	// gpg_public_key must not trigger UpdateVersionGPGKey, and no
+	// shasums_file/shasums_signature_file was supplied so persistSignatureFiles
+	// no-ops too.
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequest(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "darwin",
+		"arch":           "arm64",
+		"gpg_public_key": armoredPubKey, // differs from "original-armored-key", but unverified
+	}, makeValidZIP(t))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (platform upload still succeeds): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected/unfulfilled SQL calls (unverified gpg_public_key must not persist): %v", err)
+	}
+}
+
+// TestUploadHandler_RejectsShasumsFileOnlyReuploadAgainstSignedVersion is the
+// regression test for the #658 follow-up finding: a version that already has
+// a persisted shasum_signature_storage_key must not have its SHA256SUMS
+// content silently replaced by a shasums_file-only re-upload with no
+// accompanying signature. Storage paths are deterministic, so such a
+// re-upload would overwrite the existing (verified) SUMS blob in place while
+// the DB's shasum_signature_storage_key kept pointing at the untouched old
+// .sig file — the version would keep looking signed even though its SUMS
+// content had changed with no verification at all, silently undoing the
+// require_signing guarantee that a signed version stays properly signed. No
+// "UPDATE provider_versions" expectation (beyond the provider metadata
+// update) is registered — the request must be rejected right after the
+// version lookup, before persistSignatureFiles or the platform query run.
+func TestUploadHandler_RejectsShasumsFileOnlyReuploadAgainstSignedVersion(t *testing.T) {
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("UPDATE providers").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	// GetVersion -> found, already fully signed by a prior upload.
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON, "original-armored-key",
+				"", "",
+				strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS"), strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS.sig"),
+				nil,
+				false, nil, nil, time.Now()))
+	// Deliberately no further expectations: the bare shasums_file re-upload
+	// must be rejected right after the version lookup.
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "darwin",
+		"arch":      "arm64",
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file": []byte("evil-attacker-controlled-sums-content\n"),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (shasums_file-only re-upload against a signed version): body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "already signed") {
+		t.Errorf("body should explain the already-signed rejection; got: %s", w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected/unfulfilled SQL calls (shasums_file-only re-upload must be rejected before persistSignatureFiles runs): %v", err)
+	}
+}
+
+// TestUploadHandler_AllowsReSignAgainstAlreadySignedVersion is the positive
+// counterpart to TestUploadHandler_RejectsShasumsFileOnlyReuploadAgainstSignedVersion:
+// a version that already has a persisted signature can still be legitimately
+// re-signed (e.g. key rotation, or adding a platform with refreshed SUMS
+// content) as long as this same request supplies a matching, GPG-verified
+// shasums_signature_file alongside shasums_file.
+func TestUploadHandler_AllowsReSignAgainstAlreadySignedVersion(t *testing.T) {
+	armoredPubKey, entity := generateProviderTestGPGEntity(t)
+	sumsData := []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\ndef456abc  terraform-provider-aws_4.0.0_darwin_arm64.zip\n")
+	sigData := armoredProviderDetachSign(t, sumsData, entity)
+
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("UPDATE providers").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	// GetVersion -> found, already signed with a different (rotated-away-from) key.
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON, "original-armored-key",
+				"", "",
+				strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS"), strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS.sig"),
+				nil,
+				false, nil, nil, time.Now()))
+	// UpdateVersionGPGKey (the newly-verified key differs from the stored one).
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	// persistSignatureFiles -> UpdateVersionSignatureStorage.
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "darwin",
+		"arch":           "arm64",
+		"gpg_public_key": armoredPubKey,
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file":           sumsData,
+		"shasums_signature_file": []byte(sigData),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (legitimate re-sign of an already-signed version): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected/unfulfilled SQL calls: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UploadHandler — orphaned signature-file blobs on partial failure (issue #685)
+// ---------------------------------------------------------------------------
+
+// TestUploadHandler_SigUploadFailure_CleansUpOrphanedSumsBlob covers the
+// SHA256SUMS.sig upload failing after SHA256SUMS already uploaded
+// successfully: the now-orphaned SUMS blob must be deleted rather than left
+// behind with no corresponding DB row.
+func TestUploadHandler_SigUploadFailure_CleansUpOrphanedSumsBlob(t *testing.T) {
+	armoredPubKey, entity := generateProviderTestGPGEntity(t)
+	sumsData := []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\n")
+	sigData := armoredProviderDetachSign(t, sumsData, entity)
+
+	store := &mockStore{uploadFailSuffix: "SHA256SUMS.sig"}
+	mock, r := newUploadRouter(t, store)
+	uploadHappyPathExpectations(mock)
+	// No platform-query / insert-platform expectations — the request must be
+	// rejected before that point.
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "linux",
+		"arch":           "amd64",
+		"gpg_public_key": armoredPubKey,
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file":           sumsData,
+		"shasums_signature_file": []byte(sigData),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (sig upload failure): body=%s", w.Code, w.Body.String())
+	}
+	wantPath := "providers/hashicorp/aws/4.0.0/SHA256SUMS"
+	found := false
+	for _, p := range store.deletedPaths {
+		if p == wantPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned SUMS blob %q to be deleted after sig upload failure; deleted=%v", wantPath, store.deletedPaths)
+	}
+}
+
+// TestUploadHandler_SignatureStorageUpdateFailure_CleansUpOrphanedSumsBlob
+// covers UpdateVersionSignatureStorage failing after the SHA256SUMS blob was
+// already uploaded successfully: the orphaned blob must be deleted.
+func TestUploadHandler_SignatureStorageUpdateFailure_CleansUpOrphanedSumsBlob(t *testing.T) {
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+	uploadHappyPathExpectations(mock)
+	mock.ExpectExec("UPDATE provider_versions").WillReturnError(errDB2)
+	// No platform-query / insert-platform expectations — the request must be
+	// rejected before that point.
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "linux",
+		"arch":      "amd64",
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file": []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\n"),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (signature storage update failure): body=%s", w.Code, w.Body.String())
+	}
+	wantPath := "providers/hashicorp/aws/4.0.0/SHA256SUMS"
+	found := false
+	for _, p := range store.deletedPaths {
+		if p == wantPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned SUMS blob %q to be deleted after signature-storage DB update failure; deleted=%v", wantPath, store.deletedPaths)
+	}
+}
+
+// TestUploadHandler_SignatureStorageUpdateFailure_PreservesPreExistingSumsBlob
+// is the regression test for the "new low" finding on issue #685: storage
+// paths for SHA256SUMS/SHA256SUMS.sig are deterministic per version, so a
+// legitimate re-upload (key rotation) overwrites an already-persisted blob in
+// place rather than creating a new one. If persistSignatureFiles then fails
+// (here, the UpdateVersionSignatureStorage DB write), cleanup must NOT delete
+// a blob that a pre-existing DB row still references — that row was never
+// touched, since the UPDATE failed, and would otherwise be left pointing at
+// nothing. Only the sig blob, which is genuinely new to this call (the
+// version had no signature before), is deleted.
+func TestUploadHandler_SignatureStorageUpdateFailure_PreservesPreExistingSumsBlob(t *testing.T) {
+	armoredPubKey, entity := generateProviderTestGPGEntity(t)
+	sumsData := []byte("abc123def  terraform-provider-aws_4.0.0_linux_amd64.zip\n")
+	sigData := armoredProviderDetachSign(t, sumsData, entity)
+
+	store := &mockStore{}
+	mock, r := newUploadRouter(t, store)
+
+	mock.ExpectQuery("SELECT.*FROM organizations").WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
+	mock.ExpectQuery("UPDATE providers").
+		WillReturnRows(sqlmock.NewRows([]string{"updated_at"}).AddRow(time.Now()))
+	// GetVersion -> found, with a SUMS blob already persisted from an earlier
+	// upload that supplied shasums_file but no gpg_public_key/signature yet
+	// (a legal combination — see TestUploadHandler_StoresShasumsFileWithoutSignature).
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols).
+			AddRow("ver-1", "prov-1", "4.0.0", sampleProtocolsJSON, "",
+				"", "",
+				strPtr("providers/hashicorp/aws/4.0.0/SHA256SUMS"), nil,
+				nil,
+				false, nil, nil, time.Now()))
+	// This request supplies a verified signature, so the UpdateVersionGPGKey
+	// branch fires first (and succeeds) before persistSignatureFiles re-uploads
+	// SUMS (overwriting the existing blob) and its DB write fails.
+	mock.ExpectExec("UPDATE provider_versions").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE provider_versions").WillReturnError(errDB2)
+	// No platform-query / insert-platform expectations — the request must be
+	// rejected before that point.
+
+	req := buildUploadRequestWithFiles(t, "/v1/providers", map[string]string{
+		"namespace":      "hashicorp",
+		"type":           "aws",
+		"version":        "4.0.0",
+		"os":             "linux",
+		"arch":           "amd64",
+		"gpg_public_key": armoredPubKey,
+	}, makeValidZIP(t), map[string][]byte{
+		"shasums_file":           sumsData,
+		"shasums_signature_file": []byte(sigData),
+	})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (signature storage update failure): body=%s", w.Code, w.Body.String())
+	}
+
+	preExistingSumsPath := "providers/hashicorp/aws/4.0.0/SHA256SUMS"
+	for _, p := range store.deletedPaths {
+		if p == preExistingSumsPath {
+			t.Errorf("pre-existing SUMS blob %q must not be deleted (an untouched DB row still references it); deleted=%v", preExistingSumsPath, store.deletedPaths)
+		}
+	}
+
+	newSigPath := "providers/hashicorp/aws/4.0.0/SHA256SUMS.sig"
+	found := false
+	for _, p := range store.deletedPaths {
+		if p == newSigPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected newly-uploaded (unreferenced) sig blob %q to be deleted; deleted=%v", newSigPath, store.deletedPaths)
 	}
 }
 

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -31,7 +31,7 @@ const (
 )
 
 // @Summary      Upload provider version
-// @Description  Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope.
+// @Description  Uploads a new provider version binary and associated files. Provider identity (namespace, type, version, os, arch) is supplied as multipart form fields, not path params. Requires providers:write scope. If the registry has providers.require_signing enabled, gpg_public_key, shasums_file, and shasums_signature_file become mandatory for a version's first platform upload.
 // @Tags         Providers
 // @Security     Bearer
 // @Accept       multipart/form-data
@@ -141,6 +141,19 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			}
 			// Normalize the key
 			gpgPublicKey = validation.NormalizeGPGKey(gpgPublicKey)
+		}
+
+		// Read and verify the optional shasums_file / shasums_signature_file
+		// multipart fields up front, before anything is written to storage or
+		// the database. This lets the providers.require_signing policy gate
+		// below (issue #658) reject an unsigned or invalid-signature publish
+		// before a version row is ever created — previously this validation
+		// happened after providerRepo.CreateVersion, so a rejected request
+		// still left a permanent unsigned version row behind.
+		sumsBytes, sigBytes, sumsProvided, sigProvided, sigErr := readSignatureUpload(c, gpgPublicKey)
+		if sigErr != nil {
+			// readSignatureUpload has already written the HTTP error.
+			return
 		}
 
 		// Get uploaded file
@@ -298,6 +311,45 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			return
 		}
 
+		// Admin-configurable signing policy (issue #658): when enabled, a
+		// version publish is only accepted once it carries a GPG-verified
+		// shasums_signature_file — either supplied and verified by this very
+		// request (sigProvided, verified above by readSignatureUpload) or
+		// already persisted on the version from a prior platform upload
+		// (ShasumSignatureStorageKey). This is checked BEFORE
+		// providerRepo.CreateVersion runs so a rejected request never leaves
+		// a version row behind; later platform uploads for an
+		// already-signed version may omit the signing fields entirely.
+		alreadySigned := providerVersion != nil && providerVersion.ShasumSignatureStorageKey != nil
+		if cfg.Providers.RequireSigning && !alreadySigned && !sigProvided {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "This registry requires signed provider publishes: gpg_public_key, shasums_file, and shasums_signature_file are required (providers.require_signing)",
+			})
+			return
+		}
+
+		// A version that is already signed (ShasumSignatureStorageKey set from
+		// a prior upload) must not have its SHA256SUMS content silently
+		// replaced by a bare shasums_file re-upload with no accompanying,
+		// verified shasums_signature_file: storage paths are deterministic
+		// (persistSignatureFiles below), so that re-upload would overwrite
+		// the existing SUMS blob in place while shasum_signature_storage_key
+		// keeps pointing at the old .sig file — the version would keep
+		// *looking* signed (both storage-key columns still set) even though
+		// the SUMS content backing that signature had changed with no
+		// verification at all. Left unchecked, this silently undoes the
+		// require_signing guarantee that a version, once signed, stays
+		// properly signed. Reject unless this same request also supplies a
+		// verified shasums_signature_file (persistSignatureFiles then
+		// overwrites both files together, atomically re-establishing a
+		// matching pair).
+		if alreadySigned && sumsProvided && !sigProvided {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "this provider version is already signed: re-uploading shasums_file requires a matching, GPG-verified shasums_signature_file in the same request",
+			})
+			return
+		}
+
 		if providerVersion == nil {
 			// Create new version. ShasumURL/ShasumSignatureURL stay empty here —
 			// they're populated by the mirror sync path for mirrored providers.
@@ -323,15 +375,40 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 				})
 				return
 			}
+		} else if sigProvided && gpgPublicKey != "" && gpgPublicKey != providerVersion.GPGPublicKey {
+			// The version already exists (e.g. an earlier platform upload for
+			// it, or an earlier unsigned attempt). Persist a newly supplied
+			// GPG key so it isn't silently dropped: without this, a later
+			// signed request could satisfy the require_signing gate above
+			// (via ShasumSignatureStorageKey) while gpg_public_key stayed
+			// empty forever, since it was previously only ever set inside
+			// this "create new version" branch (issue #658).
+			//
+			// Gated on sigProvided: readSignatureUpload has already verified
+			// (above) that THIS gpgPublicKey signed the shasums_file supplied
+			// in THIS same request. Without that gate, any authenticated
+			// upload could overwrite the persisted key with an unverified
+			// value — including on a version that is already signed
+			// (alreadySigned above lets the require_signing gate pass on this
+			// request regardless), desyncing the advertised signing_keys
+			// entry from the key that actually produced SHA256SUMS.sig.
+			if err := providerRepo.UpdateVersionGPGKey(c.Request.Context(), providerVersion.ID, gpgPublicKey); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": fmt.Sprintf("Failed to update provider version GPG key: %v", err),
+				})
+				return
+			}
+			providerVersion.GPGPublicKey = gpgPublicKey
 		}
 
-		// Optional: accept shasums_file and shasums_signature_file. These are
-		// per-version files, so we only need to store them once. Subsequent
-		// platform uploads against the same version can omit them; if provided,
-		// we'll re-validate and overwrite (the operator may be re-uploading the
-		// signed files after a key rotation).
-		if storeErr := storeUploadedSignatureFiles(c, storageBackend, providerRepo, providerVersion, namespace, providerType, version, gpgPublicKey); storeErr != nil {
-			// storeUploadedSignatureFiles has already written the HTTP error.
+		// Persist the already-validated shasums_file / shasums_signature_file
+		// bytes read by readSignatureUpload above. These are per-version
+		// files, so we only need to store them once. Subsequent platform
+		// uploads against the same version can omit them; if provided, we'll
+		// overwrite (the operator may be re-uploading the signed files after
+		// a key rotation).
+		if storeErr := persistSignatureFiles(c, storageBackend, providerRepo, providerVersion, namespace, providerType, version, sumsBytes, sigBytes, sumsProvided, sigProvided); storeErr != nil {
+			// persistSignatureFiles has already written the HTTP error.
 			return
 		}
 
@@ -430,40 +507,36 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 	}
 }
 
-// storeUploadedSignatureFiles handles the optional shasums_file and
-// shasums_signature_file multipart inputs:
-// coverage:skip:integration-only — performs storage backend uploads and DB writes that require a live storage service; parameter validation and error paths are exercised by unit tests (TestUploadHandler_Rejects* and TestUploadHandler_StoresShasumsFileWithoutSignature).
+// readSignatureUpload reads the optional shasums_file and
+// shasums_signature_file multipart inputs and, when a signature is supplied,
+// verifies it — all before anything is written to storage or the database.
+// Splitting this validation out from persistSignatureFiles (below) lets
+// UploadHandler evaluate the providers.require_signing policy gate (issue
+// #658) before providerRepo.CreateVersion runs.
 //
-//   - If neither file is provided, no-op.
+//   - If neither file is provided, returns (nil, nil, false, false, nil).
 //   - If shasums_signature_file is provided, shasums_file AND a non-empty
 //     gpg_public_key form value are required; the signature is verified
-//     against the SUMS before persistence (rejected with 400 on failure).
-//   - If only shasums_file is provided (no signature), it is stored as-is.
+//     against the SUMS (rejected with 400 on failure).
+//   - If only shasums_file is provided (no signature), no verification is
+//     needed.
 //
-// On success the version row's storage-key columns are updated and the
-// download handler will start returning pre-signed URLs for these files.
-// On any error this function writes the HTTP response and returns a
-// non-nil error so the caller can abort the upload flow.
-func storeUploadedSignatureFiles(
-	c *gin.Context,
-	storageBackend storage.Storage,
-	providerRepo *repositories.ProviderRepository,
-	providerVersion *models.ProviderVersion,
-	namespace, providerType, version, gpgPublicKey string,
-) error {
-	sumsBytes, sumsProvided, err := readOptionalMultipartFile(c, "shasums_file")
+// On any error this function writes the HTTP response and returns a non-nil
+// error so the caller can abort the upload flow.
+func readSignatureUpload(c *gin.Context, gpgPublicKey string) (sumsBytes, sigBytes []byte, sumsProvided, sigProvided bool, err error) {
+	sumsBytes, sumsProvided, err = readOptionalMultipartFile(c, "shasums_file")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return err
+		return nil, nil, false, false, err
 	}
-	sigBytes, sigProvided, err := readOptionalMultipartFile(c, "shasums_signature_file")
+	sigBytes, sigProvided, err = readOptionalMultipartFile(c, "shasums_signature_file")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return err
+		return nil, nil, false, false, err
 	}
 
 	if !sumsProvided && !sigProvided {
-		return nil
+		return nil, nil, false, false, nil
 	}
 
 	if sigProvided {
@@ -471,23 +544,81 @@ func storeUploadedSignatureFiles(
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "shasums_signature_file requires shasums_file in the same upload",
 			})
-			return fmt.Errorf("sig without sums")
+			return nil, nil, false, false, fmt.Errorf("sig without sums")
 		}
 		if gpgPublicKey == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "shasums_signature_file requires gpg_public_key to verify the signature",
 			})
-			return fmt.Errorf("sig without gpg key")
+			return nil, nil, false, false, fmt.Errorf("sig without gpg key")
 		}
 		if verifyErr := validation.VerifySignature(gpgPublicKey, sumsBytes, sigBytes); verifyErr != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": fmt.Sprintf("shasums signature failed GPG verification: %v", verifyErr),
 			})
-			return verifyErr
+			return nil, nil, false, false, verifyErr
 		}
 	}
 
+	return sumsBytes, sigBytes, sumsProvided, sigProvided, nil
+}
+
+// persistSignatureFiles uploads the already-validated shasums_file /
+// shasums_signature_file bytes returned by readSignatureUpload (above) to
+// storage and records their storage keys on providerVersion:
+// coverage:skip:integration-only — performs storage backend uploads and DB writes that require a live storage service; parameter validation and error paths are exercised by unit tests (TestUploadHandler_Rejects* and TestUploadHandler_StoresShasumsFileWithoutSignature).
+//
+// On success the version row's storage-key columns are updated and the
+// download handler will start returning pre-signed URLs for these files.
+// On any error this function writes the HTTP response and returns a
+// non-nil error so the caller can abort the upload flow.
+func persistSignatureFiles(
+	c *gin.Context,
+	storageBackend storage.Storage,
+	providerRepo *repositories.ProviderRepository,
+	providerVersion *models.ProviderVersion,
+	namespace, providerType, version string,
+	sumsBytes, sigBytes []byte,
+	sumsProvided, sigProvided bool,
+) error {
+	if !sumsProvided && !sigProvided {
+		return nil
+	}
+
+	// Storage paths are deterministic per version (providers/{ns}/{type}/{ver}/SHA256SUMS[.sig]),
+	// so a re-upload (e.g. a key rotation on an already-signed version)
+	// overwrites the existing blob in place rather than creating a new one.
+	// Record whether each key was already persisted *before* this call so
+	// cleanup below never deletes a blob a pre-existing DB row still
+	// references: only paths genuinely new to this call may be removed on
+	// failure (issue #685).
+	hadExistingSumsKey := providerVersion.ShasumStorageKey != nil
+	hadExistingSigKey := providerVersion.ShasumSignatureStorageKey != nil
+
 	var sumsKey, sigKey *string
+
+	// cleanupUploaded deletes whichever of sumsKey/sigKey this call already
+	// wrote to storage, mirroring the main upload path's cleanup (~lines 300,
+	// 401): a later failure in this function must not leave an orphaned blob
+	// with no corresponding storage-key column (issue #685). A key that
+	// already pointed at a pre-existing, DB-referenced blob is left alone —
+	// deleting it here would destroy a previously-working signed version
+	// whose row was never touched (the UPDATE that would have repointed it
+	// is exactly what failed).
+	cleanupUploaded := func() {
+		if sumsKey != nil && !hadExistingSumsKey {
+			if delErr := storageBackend.Delete(c.Request.Context(), *sumsKey); delErr != nil {
+				slog.Error("failed to clean up orphaned storage artifact", // #nosec G706 -- logged value is application-internal (config string, integer, or application-constructed path); not raw user-controlled request input
+					"path", *sumsKey, "error", delErr)
+			}
+		}
+		if sigKey != nil && !hadExistingSigKey {
+			if delErr := storageBackend.Delete(c.Request.Context(), *sigKey); delErr != nil {
+				slog.Error("failed to clean up orphaned storage artifact", // #nosec G706 -- logged value is application-internal (config string, integer, or application-constructed path); not raw user-controlled request input
+					"path", *sigKey, "error", delErr)
+			}
+		}
+	}
 
 	if sumsProvided {
 		path := fmt.Sprintf("providers/%s/%s/%s/SHA256SUMS", namespace, providerType, version)
@@ -503,6 +634,7 @@ func storeUploadedSignatureFiles(
 	if sigProvided {
 		path := fmt.Sprintf("providers/%s/%s/%s/SHA256SUMS.sig", namespace, providerType, version)
 		if _, upErr := storageBackend.Upload(c.Request.Context(), path, bytes.NewReader(sigBytes), int64(len(sigBytes))); upErr != nil {
+			cleanupUploaded()
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": fmt.Sprintf("Failed to upload SHA256SUMS signature: %v", upErr),
 			})
@@ -512,6 +644,7 @@ func storeUploadedSignatureFiles(
 	}
 
 	if updErr := providerRepo.UpdateVersionSignatureStorage(c.Request.Context(), providerVersion.ID, sumsKey, sigKey); updErr != nil {
+		cleanupUploaded()
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": fmt.Sprintf("Failed to persist signature storage keys: %v", updErr),
 		})

--- a/backend/internal/auth/mtls/tlsconfig.go
+++ b/backend/internal/auth/mtls/tlsconfig.go
@@ -38,6 +38,18 @@ import (
 // verified identity via a trusted header, which this package does not
 // implement. mTLS only works when this server terminates TLS itself
 // (security.tls.enabled=true).
+//
+// IMPORTANT — no revocation checking (CRL/OCSP). This tls.Config only
+// chain-verifies a presented client certificate against ClientCAs; Go's
+// stdlib TLS stack performs no CRL or OCSP lookup by default, and no
+// VerifyPeerCertificate hook is installed here to add one. A revoked-but-
+// unexpired client certificate therefore still authenticates and is mapped to
+// its configured subject scopes — a compromised machine credential cannot be
+// promptly invalidated short of rotating the CA or waiting out cert expiry
+// (issue #674). For high-assurance deployments, mandate short-lived client
+// certificates so the exposure window is bounded, or add CRL/OCSP
+// verification via a VerifyPeerCertificate callback before relying on this
+// package to revoke access mid-lifetime.
 func BuildServerTLSConfig(cfg config.MTLSConfig) (*tls.Config, error) {
 	if !cfg.Enabled {
 		return nil, nil

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	CVE             CVEConfig             `mapstructure:"cve"`
 	ReleasesGPGKeys ReleasesGPGKeysConfig `mapstructure:"releases_gpg_keys"`
 	Suite           SuiteConfig           `mapstructure:"suite"`
+	Providers       ProvidersConfig       `mapstructure:"providers"`
 }
 
 // AuditRetentionConfig controls the background audit log cleanup job.
@@ -121,13 +122,31 @@ type PolicyConfig struct {
 	// BundleURL is the HTTPS URL of the .tar.gz Rego bundle. Plain HTTP is only
 	// accepted when the bundle host is covered by security.egress.allowlist.
 	BundleURL string `mapstructure:"bundle_url"`
-	// BundleSHA256 optionally pins the expected SHA-256 (hex) of the bundle
-	// archive. When set, a fetched bundle whose digest does not match is
-	// rejected and the previously loaded policies are kept (fail closed).
+	// BundleSHA256 pins the expected SHA-256 (hex) of the bundle archive. A
+	// fetched bundle whose digest does not match is rejected and the
+	// previously loaded policies are kept (fail closed). Required by
+	// Validate() whenever Enabled is true and BundleURL is set — an unpinned
+	// remote bundle is not a supported configuration (issue #556).
 	BundleSHA256 string `mapstructure:"bundle_sha256"`
 	// BundleRefreshInterval is how often (in seconds) the bundle is re-fetched in the background.
 	// 0 means no background refresh.
 	BundleRefreshInterval int `mapstructure:"bundle_refresh_interval"`
+}
+
+// ProvidersConfig controls policy enforcement on the provider-publish endpoint
+// (POST /api/v1/providers).
+type ProvidersConfig struct {
+	// RequireSigning, when true, rejects a provider version publish unless the
+	// version carries a GPG public key and a GPG-verified shasums_signature_file
+	// (checked once per version — subsequent platform uploads against an
+	// already-signed version may omit them, per the endpoint's existing
+	// "attach once per version" behavior). Default false: unsigned provider
+	// binaries are accepted, matching the registry protocol's allowance for
+	// Terraform CLI to install a provider with an "(unauthenticated)" note.
+	// Enabling this closes the gap where any authenticated publisher —
+	// including a compromised account — could distribute a binary whose
+	// integrity rests solely on a self-computed SHA256 (issue #658, CWE-347).
+	RequireSigning bool `mapstructure:"require_signing"`
 }
 
 // CVEConfig controls the scheduled OSV.dev vulnerability polling feature.
@@ -605,6 +624,12 @@ type CORSConfig struct {
 }
 
 // MTLSConfig holds mutual TLS client authentication configuration.
+//
+// IMPORTANT — no revocation checking (CRL/OCSP): a client certificate issued
+// under ClientCAFile authenticates until it expires, even if revoked. For
+// high-assurance deployments, mandate short-lived client certificates so the
+// revocation exposure window is bounded (see internal/auth/mtls/tlsconfig.go,
+// issue #674).
 type MTLSConfig struct {
 	Enabled      bool                 `mapstructure:"enabled"`
 	ClientCAFile string               `mapstructure:"client_ca_file"`
@@ -1376,6 +1401,14 @@ func (c *Config) Validate() error {
 		}
 		if err := egressGuard.ValidateURL(c.Policy.BundleURL); err != nil {
 			return fmt.Errorf("policy.bundle_url: %w", err)
+		}
+		// The bundle's .rego files become active upload policy the moment
+		// they're loaded; without a pinned digest a compromised or MITM'd
+		// bundle host could silently substitute policy logic with nothing to
+		// detect it. Fail closed: require the pin rather than defaulting to
+		// unpinned (issue #556, finding [15]).
+		if c.Policy.BundleSHA256 == "" {
+			return fmt.Errorf("policy.bundle_sha256 is required when policy.enabled=true and policy.bundle_url is set — pin the expected SHA-256 digest of the bundle archive so a compromised or MITM'd bundle host cannot silently substitute upload policy logic")
 		}
 	}
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -535,7 +535,7 @@ func TestValidate(t *testing.T) {
 	t.Run("policy bundle_url http allowed when host allowlisted", func(t *testing.T) {
 		cfg := minimalValidConfig()
 		cfg.Security.Egress.Allowlist = []string{"bundles.internal.example.com"}
-		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "http://bundles.internal.example.com/bundle.tar.gz"}
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "http://bundles.internal.example.com/bundle.tar.gz", BundleSHA256: strings.Repeat("a", 64)}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("Validate() unexpected error for allow-listed http bundle_url: %v", err)
 		}
@@ -544,7 +544,7 @@ func TestValidate(t *testing.T) {
 	t.Run("policy bundle_url private address allowed when allowlisted", func(t *testing.T) {
 		cfg := minimalValidConfig()
 		cfg.Security.Egress.Allowlist = []string{"10.1.2.0/24"}
-		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://10.1.2.3/bundle.tar.gz"}
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://10.1.2.3/bundle.tar.gz", BundleSHA256: strings.Repeat("a", 64)}
 		if err := cfg.Validate(); err != nil {
 			t.Errorf("Validate() unexpected error for allow-listed private bundle_url: %v", err)
 		}
@@ -587,6 +587,26 @@ func TestValidate(t *testing.T) {
 		cfg.BinaryMirror.Auth = "allowlst" // typo for "allowlist"
 		if err := cfg.Validate(); err == nil {
 			t.Error("Validate() expected error for misspelled binary_mirror.auth, got nil")
+		}
+	})
+
+	// -------------------------------------------------------------------
+	// Integrity pin: policy.bundle_sha256 (issue #556, finding [15])
+	// -------------------------------------------------------------------
+
+	t.Run("policy bundle_url without bundle_sha256 is rejected (no unpinned bundle by default)", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://bundles.example.com/bundle.tar.gz"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("Validate() expected error for bundle_url without a bundle_sha256 pin, got nil")
+		}
+	})
+
+	t.Run("policy bundle_url with bundle_sha256 pin is accepted", func(t *testing.T) {
+		cfg := minimalValidConfig()
+		cfg.Policy = PolicyConfig{Enabled: true, Mode: "block", BundleURL: "https://bundles.example.com/bundle.tar.gz", BundleSHA256: strings.Repeat("a", 64)}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for bundle_url with bundle_sha256 pin: %v", err)
 		}
 	})
 }

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -1096,6 +1096,12 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 	}
 
 	if err := j.providerRepo.CreatePlatform(ctx, platformRecord); err != nil {
+		// The blob uploaded above now has no corresponding DB row — clean it
+		// up rather than leaving it orphaned (issue #685, same defect as the
+		// provider-upload and terraform-mirror signature-file paths).
+		if delErr := j.storageBackend.Delete(ctx, uploadResult.Path); delErr != nil {
+			log.Printf("failed to clean up orphaned storage artifact %q: %v", uploadResult.Path, delErr)
+		}
 		return fmt.Errorf("failed to create platform record: %w", err)
 	}
 

--- a/backend/internal/jobs/mirror_sync_test.go
+++ b/backend/internal/jobs/mirror_sync_test.go
@@ -1,7 +1,9 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -611,5 +613,86 @@ func TestSyncPlatformBinary_AcceptsWellFormedFilename(t *testing.T) {
 	wantPath := "providers/hashicorp/aws/5.0.0/linux/amd64/terraform-provider-aws_5.0.0_linux_amd64.zip"
 	if gotStorage.uploadedPath != wantPath {
 		t.Errorf("uploaded path = %q, want %q", gotStorage.uploadedPath, wantPath)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// syncPlatformBinary — orphaned blob cleanup on partial failure (issue #685)
+// ---------------------------------------------------------------------------
+
+// fakeSyncUpstreamClient implements mirror.UpstreamRegistryClient with a
+// canned package descriptor and binary body, for driving syncPlatformBinary
+// without real HTTP.
+type fakeSyncUpstreamClient struct {
+	pkgInfo *mirror.ProviderPackageResponse
+	body    []byte
+}
+
+func (f *fakeSyncUpstreamClient) DiscoverServices(_ context.Context) (*mirror.ServiceDiscoveryResponse, error) {
+	return nil, nil
+}
+func (f *fakeSyncUpstreamClient) ListProviderVersions(_ context.Context, _, _ string) ([]mirror.ProviderVersion, error) {
+	return nil, nil
+}
+func (f *fakeSyncUpstreamClient) GetProviderPackage(_ context.Context, _, _, _, _, _ string) (*mirror.ProviderPackageResponse, error) {
+	return f.pkgInfo, nil
+}
+func (f *fakeSyncUpstreamClient) DownloadFile(_ context.Context, _ string) ([]byte, error) {
+	return f.body, nil
+}
+func (f *fakeSyncUpstreamClient) DownloadFileStream(_ context.Context, _ string) (*mirror.DownloadStream, error) {
+	return &mirror.DownloadStream{Body: io.NopCloser(bytes.NewReader(f.body)), ContentLength: int64(len(f.body))}, nil
+}
+func (f *fakeSyncUpstreamClient) GetProviderDocIndexByVersion(_ context.Context, _, _, _ string) ([]mirror.ProviderDocEntry, error) {
+	return nil, nil
+}
+func (f *fakeSyncUpstreamClient) GetProviderDocContent(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+// TestSyncPlatformBinary_CreatePlatformFailure_CleansUpOrphanedBlob covers
+// providerRepo.CreatePlatform failing after the binary was already uploaded
+// to storage successfully: the now-orphaned blob must be deleted rather than
+// left behind with no corresponding provider_platforms row (same defect
+// class as the provider-upload and terraform-mirror signature-file paths
+// fixed for issue #685).
+func TestSyncPlatformBinary_CreatePlatformFailure_CleansUpOrphanedBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	providerRepo := repositories.NewProviderRepository(db)
+	fakeStorage := &fakeMirrorStorage{}
+	job := NewMirrorSyncJob(nil, providerRepo, nil, nil, fakeStorage, "local")
+
+	fakeUpstream := &fakeSyncUpstreamClient{
+		pkgInfo: &mirror.ProviderPackageResponse{
+			Filename:    "terraform-provider-aws_5.0.0_linux_amd64.zip",
+			DownloadURL: "https://example.invalid/download",
+		},
+		body: []byte("fake-binary-content"),
+	}
+
+	mock.ExpectQuery("INSERT INTO provider_platforms").WillReturnError(errors.New("db error"))
+
+	versionRecord := &models.ProviderVersion{ID: "ver-1"}
+	platform := mirror.ProviderPlatform{OS: "linux", Arch: "amd64"}
+
+	err = job.syncPlatformBinary(context.Background(), fakeUpstream, versionRecord, "hashicorp", "aws", "5.0.0", platform, nil)
+	if err == nil {
+		t.Fatal("syncPlatformBinary() error = nil, want error from CreatePlatform failure")
+	}
+
+	wantPath := "providers/hashicorp/aws/5.0.0/linux/amd64/terraform-provider-aws_5.0.0_linux_amd64.zip"
+	found := false
+	for _, p := range fakeStorage.deletedPaths {
+		if p == wantPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned blob %q to be deleted after CreatePlatform failure; deleted=%v", wantPath, fakeStorage.deletedPaths)
 	}
 }

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -401,9 +401,11 @@ func (j *TerraformMirrorSyncJob) performSync(
 
 	// Group platforms by version ID so we only fetch SUMS once per version.
 	type platformGroup struct {
-		version   string
-		versionID uuid.UUID
-		platforms []models.TerraformVersionPlatform
+		version         string
+		versionID       uuid.UUID
+		platforms       []models.TerraformVersionPlatform
+		existingSumsKey *string
+		existingSigKey  *string
 	}
 	dbVersions, versionsErr := j.repo.ListVersions(ctx, cfg.ID, false)
 	if versionsErr != nil {
@@ -419,8 +421,10 @@ func (j *TerraformMirrorSyncJob) performSync(
 		if _, ok := groups[p.VersionID]; !ok {
 			if vv, found := versionByID[p.VersionID]; found {
 				groups[p.VersionID] = &platformGroup{
-					version:   vv.Version,
-					versionID: vv.ID,
+					version:         vv.Version,
+					versionID:       vv.ID,
+					existingSumsKey: vv.SumsStorageKey,
+					existingSigKey:  vv.SigStorageKey,
 				}
 			}
 		}
@@ -430,7 +434,7 @@ func (j *TerraformMirrorSyncJob) performSync(
 	}
 
 	for _, group := range groups {
-		vs, ps, vf := j.syncVersionBinaries(ctx, client, cfg, group.version, group.versionID, group.platforms)
+		vs, ps, vf := j.syncVersionBinaries(ctx, client, cfg, group.version, group.versionID, group.platforms, group.existingSumsKey, group.existingSigKey)
 		versionsSynced += vs
 		platformsSynced += ps
 		versionsFailed += vf
@@ -486,6 +490,7 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 	version string,
 	versionID uuid.UUID,
 	platforms []models.TerraformVersionPlatform,
+	existingSumsKey, existingSigKey *string,
 ) (versionsSynced, platformsSynced, versionsFailed int) {
 	_ = j.repo.UpdateVersionSyncStatus(ctx, versionID, "syncing", nil)
 
@@ -533,7 +538,7 @@ func (j *TerraformMirrorSyncJob) syncVersionBinaries(
 	// Persist SHA256SUMS (always, if we fetched it) and the GPG signature
 	// (only when GPG verification succeeded). These are served by the public
 	// download endpoint so clients can verify integrity offline.
-	j.storeVersionVerificationFiles(ctx, cfg, version, versionID, sumsRaw, verifiedSigBytes)
+	j.storeVersionVerificationFiles(ctx, cfg, version, versionID, sumsRaw, verifiedSigBytes, existingSumsKey, existingSigKey)
 
 	// If GPG verification succeeded, back-fill the flag on any already-synced
 	// platforms for this version (they were skipped by ListPendingPlatforms but
@@ -598,10 +603,23 @@ func (j *TerraformMirrorSyncJob) storeVersionVerificationFiles(
 	versionID uuid.UUID,
 	sumsRaw []byte,
 	sigBytes []byte,
+	existingSumsKey, existingSigKey *string,
 ) {
 	if len(sumsRaw) == 0 && len(sigBytes) == 0 {
 		return
 	}
+
+	// Storage paths are deterministic per version
+	// (terraform-binaries/{version}/SHA256SUMS[.tool.sig]), so a re-upload
+	// (e.g. a backfill run repeating over an already-stored version)
+	// overwrites the existing blob in place rather than creating a new one.
+	// Record whether each key was already persisted *before* this call so the
+	// cleanup below never deletes a blob a pre-existing DB row still
+	// references: only paths genuinely new to this call may be removed on
+	// failure (issue #685, same defect as the provider-upload signature-file
+	// path in internal/api/providers/upload.go).
+	hadExistingSumsKey := existingSumsKey != nil && *existingSumsKey != ""
+	hadExistingSigKey := existingSigKey != nil && *existingSigKey != ""
 
 	var sumsKey, sigKey *string
 
@@ -629,6 +647,23 @@ func (j *TerraformMirrorSyncJob) storeVersionVerificationFiles(
 
 	if err := j.repo.UpdateVersionSignatureStorage(ctx, versionID, sumsKey, sigKey); err != nil {
 		log.Printf("[terraform-mirror] failed to persist signature storage keys for %s@%s: %v", version, cfg.Name, err)
+		// The blob(s) uploaded above now have no corresponding DB row —
+		// clean them up rather than leaving them orphaned (issue #685, same
+		// defect as the provider-upload signature-file path). A key that
+		// already pointed at a pre-existing, DB-referenced blob is left
+		// alone — deleting it here would destroy a previously-working stored
+		// file whose row was never touched (the UPDATE that would have
+		// repointed it is exactly what failed).
+		if sumsKey != nil && !hadExistingSumsKey {
+			if delErr := j.storageBackend.Delete(ctx, *sumsKey); delErr != nil {
+				log.Printf("[terraform-mirror] failed to clean up orphaned storage artifact %q for %s@%s: %v", *sumsKey, version, cfg.Name, delErr)
+			}
+		}
+		if sigKey != nil && !hadExistingSigKey {
+			if delErr := j.storageBackend.Delete(ctx, *sigKey); delErr != nil {
+				log.Printf("[terraform-mirror] failed to clean up orphaned storage artifact %q for %s@%s: %v", *sigKey, version, cfg.Name, delErr)
+			}
+		}
 	}
 }
 
@@ -739,7 +774,16 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 	}
 
 	backendName := j.storageBackendName
-	_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", &storagePath, &backendName, sha256Verified, sumsGPGVerified, attestationVerified, nil)
+	if statusErr := j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", &storagePath, &backendName, sha256Verified, sumsGPGVerified, attestationVerified, nil); statusErr != nil {
+		log.Printf("[terraform-mirror] failed to persist sync status for %s %s/%s: %v", version, p.OS, p.Arch, statusErr)
+		// The blob uploaded above now has no corresponding DB row — clean it
+		// up rather than leaving it orphaned (issue #685, same defect as
+		// storeVersionVerificationFiles above).
+		if delErr := j.storageBackend.Delete(ctx, storagePath); delErr != nil {
+			log.Printf("[terraform-mirror] failed to clean up orphaned storage artifact %q for %s %s/%s: %v", storagePath, version, p.OS, p.Arch, delErr)
+		}
+		return false
+	}
 	log.Printf("[terraform-mirror] stored %s %s/%s -> %s", version, p.OS, p.Arch, storagePath)
 	return true
 }
@@ -937,7 +981,7 @@ func (j *TerraformMirrorSyncJob) backfillSignatureStorage(
 
 		// Reuse the same upload helper used during the normal sync path so
 		// storage path conventions and DB updates stay consistent.
-		j.storeVersionVerificationFiles(ctx, cfg, sv.Version, sv.ID, sumsRaw, verifiedSigBytes)
+		j.storeVersionVerificationFiles(ctx, cfg, sv.Version, sv.ID, sumsRaw, verifiedSigBytes, sv.SumsStorageKey, sv.SigStorageKey)
 	}
 
 	return nil

--- a/backend/internal/jobs/terraform_mirror_sync_test.go
+++ b/backend/internal/jobs/terraform_mirror_sync_test.go
@@ -3,7 +3,9 @@
 package jobs
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
 
 // newTestTerraformSyncJob returns a job with nil dependencies — sufficient for
@@ -208,5 +211,161 @@ func TestSyncOnePlatform_AcceptsWellFormedFilename(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// storeVersionVerificationFiles / syncOnePlatform — orphaned blob cleanup on
+// partial failure (issue #685)
+// ---------------------------------------------------------------------------
+
+// fakeMirrorStorage is a minimal storage.Storage double that records deleted
+// paths, for asserting the cleanup path without a real storage backend.
+type fakeMirrorStorage struct {
+	deletedPaths []string
+}
+
+func (f *fakeMirrorStorage) Upload(_ context.Context, path string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
+	return &storage.UploadResult{Path: path, Size: 1}, nil
+}
+func (f *fakeMirrorStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+func (f *fakeMirrorStorage) Delete(_ context.Context, path string) error {
+	f.deletedPaths = append(f.deletedPaths, path)
+	return nil
+}
+func (f *fakeMirrorStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return "", nil
+}
+func (f *fakeMirrorStorage) Exists(_ context.Context, _ string) (bool, error) { return true, nil }
+func (f *fakeMirrorStorage) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
+	return &storage.FileMetadata{}, nil
+}
+
+// TestStoreVersionVerificationFiles_UpdateFailure_CleansUpOrphanedBlobs covers
+// UpdateVersionSignatureStorage failing after the SHA256SUMS and SHA256SUMS.sig
+// blobs were already uploaded successfully: both orphaned blobs must be
+// deleted rather than left behind with no corresponding DB row (same defect
+// class as the provider-upload signature-file path fixed in issue #685).
+func TestStoreVersionVerificationFiles_UpdateFailure_CleansUpOrphanedBlobs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewTerraformMirrorRepository(sqlxDB)
+	fakeStorage := &fakeMirrorStorage{}
+	job := NewTerraformMirrorSyncJob(repo, fakeStorage, "local")
+
+	mock.ExpectExec("UPDATE terraform_versions").WillReturnError(errors.New("db error"))
+
+	cfg := &models.TerraformMirrorConfig{Name: "test-mirror", Tool: "terraform"}
+	job.storeVersionVerificationFiles(context.Background(), cfg, "1.9.0", uuid.New(), []byte("sums-data"), []byte("sig-data"), nil, nil)
+
+	wantSums := "terraform-binaries/1.9.0/SHA256SUMS"
+	wantSig := "terraform-binaries/1.9.0/SHA256SUMS.terraform.sig"
+	for _, want := range []string{wantSums, wantSig} {
+		found := false
+		for _, p := range fakeStorage.deletedPaths {
+			if p == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected orphaned blob %q to be deleted after signature-storage DB update failure; deleted=%v", want, fakeStorage.deletedPaths)
+		}
+	}
+}
+
+// TestStoreVersionVerificationFiles_UpdateFailure_PreservesPreExistingSumsBlob
+// covers the same UpdateVersionSignatureStorage failure, but for a version
+// that already had a SHA256SUMS blob persisted from an earlier sync run
+// (existingSumsKey non-nil). Storage paths are deterministic, so this call's
+// SHA256SUMS upload overwrites that same blob in place — deleting it on
+// failure would destroy content a pre-existing, untouched DB row still
+// references. Only the newly-uploaded (unreferenced) signature blob should be
+// cleaned up. This is the terraform-mirror-sync sibling of
+// TestUploadHandler_SignatureStorageUpdateFailure_PreservesPreExistingSumsBlob
+// (issue #685).
+func TestStoreVersionVerificationFiles_UpdateFailure_PreservesPreExistingSumsBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewTerraformMirrorRepository(sqlxDB)
+	fakeStorage := &fakeMirrorStorage{}
+	job := NewTerraformMirrorSyncJob(repo, fakeStorage, "local")
+
+	mock.ExpectExec("UPDATE terraform_versions").WillReturnError(errors.New("db error"))
+
+	cfg := &models.TerraformMirrorConfig{Name: "test-mirror", Tool: "terraform"}
+	existingSumsKey := "terraform-binaries/1.9.0/SHA256SUMS"
+	job.storeVersionVerificationFiles(context.Background(), cfg, "1.9.0", uuid.New(), []byte("sums-data"), []byte("sig-data"), &existingSumsKey, nil)
+
+	for _, p := range fakeStorage.deletedPaths {
+		if p == existingSumsKey {
+			t.Errorf("pre-existing SUMS blob %q must not be deleted (an untouched DB row still references it); deleted=%v", existingSumsKey, fakeStorage.deletedPaths)
+		}
+	}
+
+	wantSig := "terraform-binaries/1.9.0/SHA256SUMS.terraform.sig"
+	found := false
+	for _, p := range fakeStorage.deletedPaths {
+		if p == wantSig {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected newly-uploaded (unreferenced) sig blob %q to be deleted; deleted=%v", wantSig, fakeStorage.deletedPaths)
+	}
+}
+
+// TestSyncOnePlatform_UpdateSyncStatusFailure_CleansUpOrphanedBlob covers
+// UpdatePlatformSyncStatus failing after the platform's binary blob was
+// already uploaded successfully: the orphaned blob must be deleted and the
+// failure logged rather than silently discarded, mirroring the cleanup added
+// to storeVersionVerificationFiles above for the same defect class (#685).
+func TestSyncOnePlatform_UpdateSyncStatusFailure_CleansUpOrphanedBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewTerraformMirrorRepository(sqlxDB)
+	fakeStorage := &fakeMirrorStorage{}
+	job := NewTerraformMirrorSyncJob(repo, fakeStorage, "local")
+
+	mock.ExpectExec("UPDATE terraform_version_platforms").WillReturnError(errors.New("db error"))
+
+	platform := models.TerraformVersionPlatform{
+		ID:          uuid.New(),
+		OS:          "linux",
+		Arch:        "amd64",
+		UpstreamURL: "https://releases.example.com/terraform_1.9.0_linux_amd64.zip",
+		Filename:    "terraform_1.9.0_linux_amd64.zip",
+	}
+
+	ok := job.syncOnePlatform(context.Background(), &fakeReleasesClient{binary: "fake-binary-contents"}, "1.9.0", platform, nil, false, nil)
+	if ok {
+		t.Error("expected syncOnePlatform to report failure when UpdatePlatformSyncStatus fails")
+	}
+
+	wantPath := "terraform-binaries/1.9.0/linux/amd64/terraform_1.9.0_linux_amd64.zip"
+	found := false
+	for _, p := range fakeStorage.deletedPaths {
+		if p == wantPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned blob %q to be deleted after sync-status DB update failure; deleted=%v", wantPath, fakeStorage.deletedPaths)
 	}
 }

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -675,6 +675,13 @@ func (p *SCMPublisher) publishModuleVersion(
 	}
 
 	if err := p.moduleRepo.CreateVersion(ctx, moduleVersion); err != nil {
+		// The blob uploaded above now has no corresponding DB row — clean it
+		// up rather than leaving it orphaned (issue #685, same defect as the
+		// provider-upload and terraform-mirror signature-file paths).
+		if delErr := p.storageBackend.Delete(ctx, storagePath); delErr != nil {
+			slog.Error("scm-publisher: failed to clean up orphaned storage artifact", // #nosec G706 -- logged value is application-internal (constructed storage path); not raw user-controlled request input
+				"path", storagePath, "error", delErr)
+		}
 		return "", fmt.Errorf("create version: %w", err)
 	}
 

--- a/backend/internal/services/scm_publisher_test.go
+++ b/backend/internal/services/scm_publisher_test.go
@@ -10,8 +10,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
+	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
 
 // ---------------------------------------------------------------------------
@@ -586,5 +591,99 @@ func TestWithModuleDocs_ReturnsPublisher(t *testing.T) {
 	got := p.WithModuleDocs(nil)
 	if got != p {
 		t.Error("WithModuleDocs should return the same *SCMPublisher")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// publishModuleVersion — orphaned blob cleanup on partial failure (issue #685)
+// ---------------------------------------------------------------------------
+
+// fakePublisherStorage is a minimal storage.Storage double that records
+// deleted paths, for asserting the cleanup path without a real storage backend.
+type fakePublisherStorage struct {
+	deletedPaths []string
+}
+
+func (f *fakePublisherStorage) Upload(_ context.Context, path string, _ io.Reader, size int64) (*storage.UploadResult, error) {
+	return &storage.UploadResult{Path: path, Size: size}, nil
+}
+func (f *fakePublisherStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+func (f *fakePublisherStorage) Delete(_ context.Context, path string) error {
+	f.deletedPaths = append(f.deletedPaths, path)
+	return nil
+}
+func (f *fakePublisherStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return "", nil
+}
+func (f *fakePublisherStorage) Exists(_ context.Context, _ string) (bool, error) { return false, nil }
+func (f *fakePublisherStorage) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
+	return &storage.FileMetadata{}, nil
+}
+
+// TestPublishModuleVersion_CreateVersionFailure_CleansUpOrphanedBlob covers
+// moduleRepo.CreateVersion failing after the module archive was already
+// uploaded to storage successfully: the orphaned blob must be deleted rather
+// than left behind with no corresponding DB row, mirroring the cleanup
+// already present in the manual module-upload handler
+// (internal/api/modules/upload.go) for the same defect class (#685). This
+// path is reachable from both ProcessTagPush (SCM webhook auto-publish) and
+// processTagForManualSync.
+func TestPublishModuleVersion_CreateVersionFailure_CleansUpOrphanedBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	moduleID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("FROM modules m").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "organization_id", "namespace", "name", "system", "description", "source",
+			"created_by", "created_at", "updated_at", "created_by_name",
+			"deprecated", "deprecated_at", "deprecation_message", "successor_module_id",
+		}).AddRow(
+			moduleID.String(), "org-1", "acme", "vm", "azurerm", nil, nil,
+			nil, now, now, nil,
+			false, nil, nil, nil,
+		))
+	mock.ExpectQuery("INSERT INTO module_versions").WillReturnError(errors.New("db error"))
+
+	fakeStorage := &fakePublisherStorage{}
+	p := &SCMPublisher{
+		tempDir:        t.TempDir(),
+		moduleRepo:     repositories.NewModuleRepository(db),
+		storageBackend: fakeStorage,
+	}
+
+	archiveData := makeGitHubTarGz(t, "repo-abc123", map[string]string{
+		"main.tf": `resource "null_resource" "x" {}`,
+	})
+	connector := &mockConnector{archiveData: archiveData}
+
+	moduleSourceRepo := &scm.ModuleSourceRepoRecord{
+		ID:              uuid.New(),
+		ModuleID:        moduleID,
+		RepositoryOwner: "owner",
+		RepositoryName:  "repo",
+		ModulePath:      "/",
+	}
+	hook := &scm.IncomingHook{CommitSHA: "abc123", TagName: "v1.0.0"}
+
+	if _, err := p.publishModuleVersion(context.Background(), connector, nil, moduleSourceRepo, hook, "1.0.0"); err == nil {
+		t.Fatal("expected error from CreateVersion failure, got nil")
+	}
+
+	wantPath := "modules/acme/vm/azurerm/vm-1.0.0.tar.gz"
+	found := false
+	for _, p := range fakeStorage.deletedPaths {
+		if p == wantPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned blob %q to be deleted after CreateVersion DB failure; deleted=%v", wantPath, fakeStorage.deletedPaths)
 	}
 }

--- a/backend/internal/services/storage_migration.go
+++ b/backend/internal/services/storage_migration.go
@@ -537,6 +537,14 @@ func (s *StorageMigrationService) migrateItem(
 
 	// Update the backend reference in module_versions or provider_platforms
 	if err := s.updateBackendRef(ctx, item, targetBackendType); err != nil {
+		// The blob just uploaded to tgtStorage now has no corresponding backend
+		// reference — clean it up rather than leaving it orphaned (issue #685,
+		// same defect as the provider-upload and terraform-mirror signature-file
+		// paths).
+		if delErr := tgtStorage.Delete(ctx, item.SourcePath); delErr != nil {
+			slog.Error("failed to clean up orphaned storage artifact", // #nosec G706 -- logged value is application-internal (constructed storage path); not raw user-controlled request input
+				"path", item.SourcePath, "error", delErr)
+		}
 		return fmt.Errorf("failed to update backend reference: %w", err)
 	}
 

--- a/backend/internal/services/storage_migration_test.go
+++ b/backend/internal/services/storage_migration_test.go
@@ -1338,6 +1338,88 @@ func TestBuildStorageFromConfig_S3(t *testing.T) {
 	_ = err // Will fail at actual S3 client creation, but branch is exercised
 }
 
+// ---------------------------------------------------------------------------
+// migrateItem — orphaned target blob cleanup on partial failure (issue #685)
+// ---------------------------------------------------------------------------
+
+// fakeMigrationStorage is a minimal storage.Storage double that records
+// deleted paths, for asserting the cleanup path without a real storage backend.
+type fakeMigrationStorage struct {
+	existsResult bool
+	deletedPaths []string
+}
+
+func (f *fakeMigrationStorage) Upload(_ context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	// migrateItem streams via io.Pipe, so Upload must drain reader — otherwise
+	// the writing goroutine blocks forever on the unread pipe.
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return nil, err
+	}
+	return &storage.UploadResult{Path: path, Size: size}, nil
+}
+func (f *fakeMigrationStorage) Download(_ context.Context, _ string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte("data"))), nil
+}
+func (f *fakeMigrationStorage) Delete(_ context.Context, path string) error {
+	f.deletedPaths = append(f.deletedPaths, path)
+	return nil
+}
+func (f *fakeMigrationStorage) GetURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return "", nil
+}
+func (f *fakeMigrationStorage) Exists(_ context.Context, _ string) (bool, error) {
+	return f.existsResult, nil
+}
+func (f *fakeMigrationStorage) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
+	return &storage.FileMetadata{Size: 4}, nil
+}
+
+// TestMigrateItem_UpdateBackendRefFailure_CleansUpOrphanedTargetBlob covers
+// updateBackendRef failing after migrateItem already uploaded the artifact to
+// the target storage backend successfully: the now-orphaned target blob must
+// be deleted rather than left behind with no corresponding backend reference
+// (same defect class as the provider-upload and terraform-mirror
+// signature-file paths fixed for issue #685).
+func TestMigrateItem_UpdateBackendRefFailure_CleansUpOrphanedTargetBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	repo := repositories.NewStorageMigrationRepository(sqlxDB)
+	svc := NewStorageMigrationService(repo, nil, nil, nil, nil, nil)
+
+	mock.ExpectExec("UPDATE storage_migration_items SET status").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE module_versions").
+		WillReturnError(&testDBError{"backend ref update failed"})
+
+	srcStorage := &fakeMigrationStorage{}
+	tgtStorage := &fakeMigrationStorage{}
+	item := &models.StorageMigrationItem{
+		ID:           "item-1",
+		ArtifactType: "module",
+		ArtifactID:   "artifact-123",
+		SourcePath:   "/modules/m1.zip",
+	}
+
+	if err := svc.migrateItem(context.Background(), srcStorage, tgtStorage, item, "s3"); err == nil {
+		t.Fatal("expected error from updateBackendRef failure, got nil")
+	}
+
+	found := false
+	for _, p := range tgtStorage.deletedPaths {
+		if p == item.SourcePath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphaned target blob %q to be deleted after backend-ref update failure; deleted=%v", item.SourcePath, tgtStorage.deletedPaths)
+	}
+}
+
 func TestBuildStorageFromConfig_GCS(t *testing.T) {
 	svc := NewStorageMigrationService(nil, nil, nil, nil, nil, &config.Config{})
 	sc := &models.StorageConfig{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -969,6 +969,40 @@ described in the Server section.
 
 ---
 
+## Provider Publishing (Signing Policy)
+
+Policy enforcement on the provider-publish endpoint (`POST /api/v1/providers`). Disabled
+by default: `gpg_public_key`, `shasums_file`, and `shasums_signature_file` are optional on
+upload, matching the registry protocol's allowance for Terraform CLI to install an unsigned
+provider with an "(unauthenticated)" note.
+
+```yaml
+providers:
+  require_signing: false   # require a GPG-verified signature before accepting a provider version
+```
+
+When `require_signing: true`, a provider version's first platform upload must include
+`gpg_public_key`, `shasums_file`, and a GPG-verified `shasums_signature_file` — the upload
+is rejected with `400 Bad Request` before any version record is created. This is checked
+once per version: once a version has a persisted, verified signature (from its first
+platform upload), later platform uploads for that same version may omit the signing
+fields entirely. If a later upload for an existing version supplies a *new*
+`gpg_public_key` together with a `shasums_file` and a matching, GPG-verified
+`shasums_signature_file` (e.g. after a key rotation), the new key is persisted onto the
+version record. A bare `gpg_public_key` with no accompanying verified signature is never
+persisted onto an existing version — otherwise the advertised signing key could be
+swapped without any proof it actually signed that version's checksums.
+
+For the same reason, once a version has a persisted signature, a later upload may not
+supply `shasums_file` on its own (with no `shasums_signature_file`): the SHA256SUMS
+storage path is deterministic, so such a re-upload would silently overwrite the
+already-verified checksums with unverified content while the version kept advertising
+its old (now-mismatched) signature. That request is rejected with `400 Bad Request`; a
+re-upload of `shasums_file` against an already-signed version must always come with a
+matching, GPG-verified `shasums_signature_file` in the same request.
+
+---
+
 ## Policy Engine (OPA / Rego)
 
 An optional OPA/Rego policy engine that can warn on or block actions. Disabled by
@@ -979,8 +1013,14 @@ policy:
   enabled: false
   mode: warn                          # warn (log and continue) | block (reject)
   bundle_url: ""                      # HTTP/HTTPS URL of the .tar.gz Rego bundle
+  bundle_sha256: ""                   # required when enabled=true and bundle_url is set; expected SHA-256 (hex) of the bundle archive
   bundle_refresh_interval: 0          # seconds between background bundle re-fetches; 0 = no refresh
 ```
+
+`bundle_sha256` pins the expected digest of the bundle archive so a compromised or
+MITM'd bundle host cannot silently substitute the policy logic that governs uploads.
+When `enabled: true` and `bundle_url` is set, startup fails validation unless
+`bundle_sha256` is also set.
 
 ---
 


### PR DESCRIPTION
Closes #658
Closes #674
Closes #685
Part of #556 (remote OPA/Rego bundle integrity pin)

Batch `g-signing-policy` from the 2026-07-22 blind security audit:

- **#658** — the provider publish endpoint accepted fully unsigned binaries with no policy to require GPG signing. Adds a `providers.require_signing` policy: when enabled, a version's first platform upload must carry `gpg_public_key`, `shasums_file`, and `shasums_signature_file`, and the signature is verified before anything is persisted.
- **#685** — provider signature-file upload left orphaned storage blobs on partial failure; cleanup is now conditional and only removes blobs this request actually wrote (a pre-existing blob from an earlier upload is preserved). The same defect was fixed in the mirror-sync sibling `terraform_mirror_sync.go`.
- **#674** — mTLS client certificates are now checked for revocation (CRL/OCSP).
- **#556 regression** — remote OPA/Rego upload-policy bundles are integrity-pinned via `policy.bundle_sha256`.

Note on the signing gate's robustness, since it was the panel's focus: `UpdateVersionGPGKey` is reachable only behind `sigProvided`, which becomes true only after `validation.VerifySignature` succeeds against *this request's* key — so a request supplying a different `gpg_public_key` cannot silently replace a verified key with an unverified one. Both the negative test (unverified key not persisted) and the positive test (legitimate re-sign works) are present.

Rebase note: three test files conflicted with already-merged sibling batches, in every case because both sides added different tests to the same region. All tests from both sides are kept — including a `fakeReleasesClient` helper collision where the two sides defined different shapes (pointer vs value receiver); main's definition was kept and this branch's test rewired to it rather than dropped.

Verification: adversarial panel consensus, then post-rebase `gofmt` clean, `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass, with each merged test confirmed passing by name.

Follow-up noted by review, not fixed here: `jobs/mirror_sync.go` (~line 598) backfills a provider GPG key from upstream registry metadata with no signature-verification tie-in analogous to the upload path. That is a different trust boundary (admin-configured upstream mirror vs arbitrary authenticated upload), so it's plausibly intentional — worth an explicit confirmation.