### PR TITLE
fix(security): middleware parity, single-use OAuth state, unified extraction guard

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -347,16 +347,22 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 
 		// Check state expiration (5 minutes)
 		if time.Since(sessionState.CreatedAt) > 5*time.Minute {
-			// State was already consumed by Load (single-use in Redis) but check TTL anyway
+			// State was already consumed by Load (single-use in both the Redis and
+			// in-memory stores) but check TTL anyway
 			callbackError("state_expired", "Login session expired. Please try logging in again.")
 			return
 		}
 
-		// State was already atomically consumed by Load (Redis) or needs explicit delete (memory).
-		// Explicit delete is a no-op for Redis since Load already removed it.
+		// State was already atomically consumed by Load (both the Redis and
+		// in-memory stores delete on read); this Delete is a no-op belt-and-braces
+		// call in case a future StateStore implementation is not read-consuming.
 		_ = h.stateStore.Delete(c.Request.Context(), state)
 
-		ctx := context.Background()
+		// Request-bound: the OIDC/AzureAD code exchange, ID-token verification, and
+		// user-info extraction below are synchronous external IdP calls made before
+		// any response is written, so they should observe this request's
+		// cancellation/deadline like the state-store calls above.
+		ctx := c.Request.Context()
 
 		var sub, email, name string
 		var err error
@@ -1224,7 +1230,11 @@ func (h *AuthHandlers) SAMLACSHandler() gin.HandlerFunc {
 		// Use NameID as the unique subject identifier
 		sub := fmt.Sprintf("saml:%s:%s", idpName, userInfo.NameID)
 
-		ctx := context.Background()
+		// Request-bound, matching CallbackHandler (issue #689): the user
+		// lookup/creation and scope-fetch calls below are synchronous and made
+		// before any response is written, so they should observe this request's
+		// cancellation/deadline like the state-store calls above.
+		ctx := c.Request.Context()
 
 		if err := h.guardEmailRebind(ctx, sub, userInfo.Email); err != nil {
 			callbackError("email_bound", err.Error())

--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -404,8 +404,11 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	// Refresh token using the refresh token string
-	newToken, err := connector.RenewToken(context.Background(), refreshToken)
+	// Refresh token using the refresh token string. Request-bound (issue #689
+	// sibling): this is a synchronous external SCM provider call made before any
+	// response is written, consistent with the c.Request.Context() used for the
+	// token/provider lookups above.
+	newToken, err := connector.RenewToken(c.Request.Context(), refreshToken)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("token refresh failed: %v", err)})
 		return

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -1034,22 +1034,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			}
 		}
 
-		// SCIM 2.0 provisioning endpoints — bearer token auth only (no CSRF, no cookie auth).
-		// Require admin or scim:provision scope.
-		scimGroup := router.Group("/scim/v2")
-		scimGroup.Use(middleware.AuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
-		scimGroup.Use(middleware.RequireScope(auth.ScopeSCIMProvision))
-		{
-			scimHandlers := scim.NewHandlers(cfg, db)
-			scimGroup.GET("/Users", scimHandlers.ListUsers())
-			scimGroup.GET("/Users/:id", scimHandlers.GetUser())
-			scimGroup.POST("/Users", scimHandlers.CreateUser())
-			scimGroup.PUT("/Users/:id", scimHandlers.PutUser())
-			scimGroup.PATCH("/Users/:id", scimHandlers.PatchUser())
-			scimGroup.DELETE("/Users/:id", scimHandlers.DeleteUser())
-			scimGroup.GET("/Groups", scimHandlers.ListGroups())
-			scimGroup.GET("/Groups/:id", scimHandlers.GetGroup())
-		}
+		registerSCIMRoutes(router, d)
 
 		// Development-only endpoints (guarded by DevModeMiddleware)
 		devGroup := apiV1.Group("/dev")
@@ -1071,4 +1056,41 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 	router.POST("/webhooks/scm/:module_source_repo_id/:secret", scmWebhookHandler.HandleWebhook)
 	// Single-use approval token redemption — no auth, token possession is the credential.
 	router.POST("/webhooks/approvals/:token", approvalWebhookHandler.RedeemApprovalToken)
+}
+
+// registerSCIMRoutes wires the SCIM 2.0 provisioning group onto router.
+// Extracted from registerAPIV1Routes (same pattern as registerPublicRoutes /
+// registerAPIV1Routes themselves, issue #565 finding [39]) so the group's
+// middleware ordering can be exercised directly by a test against the real
+// production wiring instead of a stand-in gin.Engine.
+//
+// SCIM 2.0 provisioning endpoints — bearer token auth only (no CSRF, no cookie auth).
+// Require admin or scim:provision scope. Audited and rate-limited the same as
+// every other authenticated mutating route (authenticatedGroup above): external
+// IdP-driven user/group provisioning should leave the same audit trail and be
+// subject to the same abuse protection as admin-initiated mutations.
+func registerSCIMRoutes(router *gin.Engine, d *apiV1RouteDeps) {
+	scimGroup := router.Group("/scim/v2")
+	scimGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo))
+	scimGroup.Use(middleware.PrincipalRateLimitMiddleware(d.generalRateLimiter, d.principalOverrides))
+	scimGroup.Use(middleware.OrgRateLimitMiddleware(d.generalRateLimiter, d.orgRateLimiter))
+	scimGroup.Use(middleware.AuditMiddleware(d.auditRepo))
+	// RequireScope runs last so a scope-check failure still passes through
+	// rate limiting and auditing above, matching how every other
+	// authenticated mutating route in this file orders RBAC after the
+	// group's rate-limit/audit middleware (see advisoryAdminGroup /
+	// policyGroup above, and the per-route RequireScope calls under
+	// authenticatedGroup).
+	scimGroup.Use(middleware.RequireScope(auth.ScopeSCIMProvision))
+	{
+		scimHandlers := scim.NewHandlers(d.cfg, d.db)
+		scimGroup.GET("/Users", scimHandlers.ListUsers())
+		scimGroup.GET("/Users/:id", scimHandlers.GetUser())
+		scimGroup.POST("/Users", scimHandlers.CreateUser())
+		scimGroup.PUT("/Users/:id", scimHandlers.PutUser())
+		scimGroup.PATCH("/Users/:id", scimHandlers.PatchUser())
+		scimGroup.DELETE("/Users/:id", scimHandlers.DeleteUser())
+		scimGroup.GET("/Groups", scimHandlers.ListGroups())
+		scimGroup.GET("/Groups/:id", scimHandlers.GetGroup())
+	}
 }

--- a/backend/internal/api/scim_routes_test.go
+++ b/backend/internal/api/scim_routes_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// TestRegisterSCIMRoutes_RateLimitRunsAheadOfScopeCheck is a regression test
+// for the scimGroup middleware-ordering defect (follow-up to issue #666): a
+// SCIM request that authenticates successfully but lacks the scim:provision
+// scope must still pass through PrincipalRateLimitMiddleware /
+// OrgRateLimitMiddleware, matching every other authenticated mutating route
+// in this file (see registerSCIMRoutes / authenticatedGroup).
+//
+// Unlike a stand-in gin.Engine, this drives registerSCIMRoutes — the exact
+// function registerAPIV1Routes calls to mount /scim/v2 — so it fails if the
+// .Use() order in router_routes.go ever regresses to registering
+// RequireScope before the rate-limit/audit middleware: in that broken
+// ordering, RequireScope aborts the chain before the rate limiter runs, so
+// the limiter's counter is never incremented and no request in this test
+// would ever see 429.
+func TestRegisterSCIMRoutes_RateLimitRunsAheadOfScopeCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// auth.GetJWTSecret (invoked by GenerateJWT/ValidateJWT) panics outside
+	// dev mode unless TFR_JWT_SECRET is set; no other test in this package
+	// exercises the JWT path, so it is safe to set here.
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	userRepo := repositories.NewUserRepository(db)
+
+	// registerSCIMRoutes wires both PrincipalRateLimitMiddleware and
+	// OrgRateLimitMiddleware onto the same generalRateLimiter/principal key,
+	// so each request consumes 2 tokens from the shared bucket (one per
+	// middleware). BurstSize 4 lets exactly the first two requests through.
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 60, BurstSize: 4, CleanupInterval: time.Minute,
+	})
+	defer limiter.Stop()
+
+	r := gin.New()
+	registerSCIMRoutes(r, &apiV1RouteDeps{
+		cfg:                &config.Config{},
+		userRepo:           userRepo,
+		generalRateLimiter: limiter,
+		orgRateLimiter:     limiter,
+	})
+
+	// A valid JWT with no scopes: AuthMiddleware succeeds (sets user_id, so
+	// every request shares one rate-limit principal/bucket) but
+	// RequireScope(scim:provision) will reject it.
+	token, err := auth.GenerateJWT("user-1", "svc@example.com", nil, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+
+	userCols := []string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}
+	const requests = 3 // burst size is 2: the 3rd request must hit the rate limit
+	for i := 0; i < requests; i++ {
+		mock.ExpectQuery("SELECT.*FROM users WHERE id").
+			WillReturnRows(sqlmock.NewRows(userCols).
+				AddRow("user-1", "svc@example.com", "Service", nil, time.Now(), time.Now()))
+	}
+
+	var codes []int
+	for i := 0; i < requests; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		r.ServeHTTP(w, req)
+		codes = append(codes, w.Code)
+	}
+
+	if codes[0] != http.StatusForbidden || codes[1] != http.StatusForbidden {
+		t.Fatalf("codes = %v, want first two requests = 403 (authenticated, missing scope)", codes)
+	}
+	if codes[2] != http.StatusTooManyRequests {
+		t.Fatalf("codes = %v, want third request = 429 (rate limit reached before the scope check runs)", codes)
+	}
+}

--- a/backend/internal/archivelimits/archivelimits.go
+++ b/backend/internal/archivelimits/archivelimits.go
@@ -1,0 +1,21 @@
+// Package archivelimits defines the size and entry-count caps that every tar.gz
+// archive guard in this codebase must enforce: validation.ValidateArchive
+// (upload-time validation) and archiver.ExtractTarGz (scan/analyze-time
+// extraction). Both guards independently walk the same tar.gz structure and
+// must apply identical caps; centralizing the numbers here means a future
+// change to one guard's limit is automatically a change to both, rather than
+// two constants that can silently drift apart.
+package archivelimits
+
+const (
+	// MaxBytes is the maximum cumulative decompressed size of a module/provider
+	// archive (100 MB).
+	MaxBytes = 100 << 20
+
+	// MaxEntries bounds the number of tar entries in an archive. Without this,
+	// an archive of millions of zero-byte file entries never trips MaxBytes
+	// (which only tracks decompressed body bytes) while still exhausting
+	// inodes/metadata when later extracted. A ~1MB gzip can encode ~2M such
+	// entries, so this must be checked independently of the byte cap.
+	MaxEntries = 100000
+)

--- a/backend/internal/archivelimits/archivelimits_test.go
+++ b/backend/internal/archivelimits/archivelimits_test.go
@@ -1,0 +1,16 @@
+package archivelimits
+
+import "testing"
+
+// TestLimitsAreSourceOfTruth pins the values both the upload-time validator
+// (internal/validation) and the extraction guard (internal/archiver) rely on,
+// so a change here is a deliberate, reviewed change to both guards rather
+// than an accidental drift between two independently-defined constants.
+func TestLimitsAreSourceOfTruth(t *testing.T) {
+	if MaxBytes != 100<<20 {
+		t.Errorf("MaxBytes = %d, want %d", MaxBytes, 100<<20)
+	}
+	if MaxEntries != 100000 {
+		t.Errorf("MaxEntries = %d, want %d", MaxEntries, 100000)
+	}
+}

--- a/backend/internal/archiver/tarball.go
+++ b/backend/internal/archiver/tarball.go
@@ -11,23 +11,27 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/terraform-registry/terraform-registry/internal/archivelimits"
 )
 
-// maxExtractBytes is the cumulative decompressed-bytes limit across all entries;
-// matches the 100 MB cap enforced by validation.ValidateArchive at upload time.
-const maxExtractBytes = 100 << 20 // 100 MB total
+// maxExtractBytes is the cumulative decompressed-bytes limit across all entries.
+// Sourced from archivelimits so this cannot silently drift from the cap
+// validation.ValidateArchive enforces at upload time.
+const maxExtractBytes = archivelimits.MaxBytes
 
 // maxExtractEntries bounds the number of tar entries extracted. Without this, an
 // archive of millions of zero-byte file entries writes 0 body bytes (never tripping
 // maxExtractBytes) while still exhausting inodes/metadata on the extraction worker.
 // A ~1MB gzip can encode ~2M such entries, so this must be checked independently of
-// the byte cap. Matches the cap enforced by validation.ValidateArchive at upload time.
-const maxExtractEntries = 100000
+// the byte cap. Sourced from archivelimits so this cannot silently drift from
+// validation.ValidateArchive's cap.
+const maxExtractEntries = archivelimits.MaxEntries
 
 // maxCompressedInputBytes bounds the compressed (gzip) input stream itself, mirroring
 // validation.ValidateArchive's io.LimitReader wrap. Without this, ExtractTarGz would
 // read an unbounded compressed stream even though the decompressed output is capped.
-const maxCompressedInputBytes = 100 << 20 // 100 MB
+const maxCompressedInputBytes = archivelimits.MaxBytes
 
 // ExtractTarGz extracts a gzipped tar archive from reader into destDir.
 // Enforces path traversal protection, a 100 MB cumulative extraction limit, a

--- a/backend/internal/auth/statestore_memory.go
+++ b/backend/internal/auth/statestore_memory.go
@@ -65,7 +65,12 @@ func (s *MemoryStateStore) Save(_ context.Context, state string, data *SessionSt
 	return nil
 }
 
-// Load retrieves and returns a session state. Returns nil, nil if not found or expired.
+// Load retrieves and atomically deletes the session state (single-use token),
+// mirroring RedisStateStore's atomic GET+DEL. Returns nil, nil if not found or
+// expired. Deleting on every successful read (not just the expiry branch)
+// closes a Load-then-Delete race: without this, two concurrent callers
+// presenting the same state could both observe a live entry before either one
+// deletes it, so the state token would not be strictly single-use.
 func (s *MemoryStateStore) Load(_ context.Context, state string) (*SessionState, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -73,8 +78,8 @@ func (s *MemoryStateStore) Load(_ context.Context, state string) (*SessionState,
 	if !ok {
 		return nil, nil
 	}
+	delete(s.entries, state)
 	if time.Now().After(e.expiresAt) {
-		delete(s.entries, state)
 		return nil, nil
 	}
 	return e.data, nil

--- a/backend/internal/auth/statestore_test.go
+++ b/backend/internal/auth/statestore_test.go
@@ -84,6 +84,40 @@ func TestMemoryStateStore_ReserveExpires(t *testing.T) {
 	}
 }
 
+// TestMemoryStateStore_LoadIsSingleUse is a regression test for issue #675:
+// Load previously returned the stored state without deleting it, requiring a
+// separate Delete call to make it single-use. Two concurrent callers could
+// both observe a live entry before either deleted it. Load must now
+// atomically consume the entry (mirroring RedisStateStore's GET+DEL), so a
+// second Load for the same state — simulating a replay that raced the first
+// caller's Delete — must see it as already gone.
+func TestMemoryStateStore_LoadIsSingleUse(t *testing.T) {
+	store := NewMemoryStateStore(time.Hour)
+	defer store.Close()
+	ctx := context.Background()
+
+	data := &SessionState{State: "single-use-test", ProviderType: "oidc"}
+	if err := store.Save(ctx, "single-use-test", data, 10*time.Minute); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	first, err := store.Load(ctx, "single-use-test")
+	if err != nil {
+		t.Fatalf("first Load() error: %v", err)
+	}
+	if first == nil {
+		t.Fatal("first Load() = nil, want the saved session state")
+	}
+
+	second, err := store.Load(ctx, "single-use-test")
+	if err != nil {
+		t.Fatalf("second Load() error: %v", err)
+	}
+	if second != nil {
+		t.Error("second Load() for the same state = non-nil, want nil (state must be single-use)")
+	}
+}
+
 func TestMemoryStateStore_LoadNonExistent(t *testing.T) {
 	store := NewMemoryStateStore(time.Hour)
 	defer store.Close()

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -217,6 +217,11 @@ func getResourceType(c *gin.Context) string {
 		return "setup"
 	case strings.HasPrefix(fullPath, "/api/v1/auth"):
 		return "auth"
+	// SCIM 2.0 provisioning is mounted directly on the router at /scim/v2,
+	// not under /api/v1, so it needs its own case rather than falling
+	// through to "unknown".
+	case strings.HasPrefix(fullPath, "/scim/v2"):
+		return "scim_provisioning"
 	default:
 		return "unknown"
 	}

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -237,6 +237,10 @@ func TestAuditMiddleware_ResourceTypeDetection(t *testing.T) {
 		// and the forward-compat /admin/binary-mirror prefix both audit as "binary_mirror".
 		{"/api/v1/admin/terraform-mirrors/some-id", "binary_mirror"},
 		{"/api/v1/admin/binary-mirror/x", "binary_mirror"},
+		// SCIM 2.0 provisioning is mounted directly at /scim/v2 (not under
+		// /api/v1) and must be audited distinctly rather than falling through
+		// to "unknown" — see issue #666.
+		{"/scim/v2/Users", "scim_provisioning"},
 		{"/other/z", "unknown"},
 	}
 

--- a/backend/internal/middleware/scim_provisioning_test.go
+++ b/backend/internal/middleware/scim_provisioning_test.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestSCIMProvisioning_AuditAndRateLimit_Composition documents, in isolation,
+// that PrincipalRateLimitMiddleware + OrgRateLimitMiddleware + AuditMiddleware
+// compose correctly with each other (audit fires on a legit mutation; a
+// burst past the limit gets 429). It builds its own stand-in gin.Engine and
+// does NOT exercise the real scimGroup registration in
+// internal/api/router_routes.go, so it would pass unchanged even if that
+// wiring regressed — it is not, by itself, the regression guard for issue
+// #666/its ordering follow-up.
+//
+// TestRegisterSCIMRoutes_RateLimitRunsAheadOfScopeCheck (internal/api package)
+// is the regression test that exercises the real registerSCIMRoutes wiring
+// and fails if RequireScope is ever registered ahead of the rate-limit/audit
+// middleware again.
+func TestSCIMProvisioning_AuditAndRateLimit_Composition(t *testing.T) {
+	// Positive path: a legitimate provisioning mutation is both audited and
+	// allowed through while under the rate limit.
+	t.Run("legit mutation is audited", func(t *testing.T) {
+		cs := newCaptureShipper(1)
+		limiter := NewRateLimiter(RateLimitConfig{RequestsPerMinute: 200, BurstSize: 50, CleanupInterval: time.Minute})
+		defer limiter.Stop()
+
+		r := gin.New()
+		scimGroup := r.Group("/scim/v2")
+		scimGroup.Use(PrincipalRateLimitMiddleware(limiter, nil))
+		scimGroup.Use(OrgRateLimitMiddleware(limiter, nil))
+		scimGroup.Use(AuditMiddlewareWithShipper(nil, cs, nil))
+		scimGroup.POST("/Users", func(c *gin.Context) { c.Status(http.StatusCreated) })
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodPost, "/scim/v2/Users", nil)
+		req.RemoteAddr = "10.0.0.5:1234"
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201", w.Code)
+		}
+		entry := cs.waitForEntry(t, 500*time.Millisecond)
+		if entry.ResourceType != "scim_provisioning" {
+			t.Errorf("audit entry ResourceType = %q, want %q", entry.ResourceType, "scim_provisioning")
+		}
+	})
+
+	// Negative path: a burst of provisioning requests past the configured
+	// limit is rejected with 429, same as every other authenticated mutating
+	// route — proving rate limiting now actually applies to SCIM.
+	t.Run("burst beyond limit is rejected", func(t *testing.T) {
+		limiter := NewRateLimiter(RateLimitConfig{RequestsPerMinute: 60, BurstSize: 2, CleanupInterval: time.Minute})
+		defer limiter.Stop()
+
+		r := gin.New()
+		scimGroup := r.Group("/scim/v2")
+		scimGroup.Use(PrincipalRateLimitMiddleware(limiter, nil))
+		scimGroup.Use(OrgRateLimitMiddleware(limiter, nil))
+		scimGroup.POST("/Users", func(c *gin.Context) { c.Status(http.StatusCreated) })
+
+		var lastCode int
+		for i := 0; i < 4; i++ {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPost, "/scim/v2/Users", nil)
+			req.RemoteAddr = "10.0.0.6:1234"
+			r.ServeHTTP(w, req)
+			lastCode = w.Code
+		}
+
+		if lastCode != http.StatusTooManyRequests {
+			t.Errorf("status of request past burst size = %d, want 429", lastCode)
+		}
+	})
+}

--- a/backend/internal/scm/bitbucket/connector.go
+++ b/backend/internal/scm/bitbucket/connector.go
@@ -6,9 +6,6 @@ package bitbucket
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -428,25 +425,13 @@ func (c *BitbucketDCConnector) ParseDelivery(payloadBytes []byte, httpHeaders ma
 	}, nil
 }
 
-// VerifyDeliverySignature validates webhook authenticity using HMAC-SHA256
+// VerifyDeliverySignature validates webhook authenticity using HMAC-SHA256.
+// BB DC uses the "sha256=<hex>" format. Delegates to the shared
+// scm.VerifyHMACSHA256Signature helper (also used by the GitHub connector) so
+// both connectors apply the same fail-closed empty-secret/empty-header
+// policy.
 func (c *BitbucketDCConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	if signatureHeader == "" || sharedSecret == "" {
-		return false
-	}
-
-	// BB DC uses "sha256=<hex>" format
-	sig, _ := strings.CutPrefix(signatureHeader, "sha256=")
-
-	expectedSig, err := hex.DecodeString(sig)
-	if err != nil {
-		return false
-	}
-
-	mac := hmac.New(sha256.New, []byte(sharedSecret))
-	mac.Write(payloadBytes)
-	computedSig := mac.Sum(nil)
-
-	return hmac.Equal(expectedSig, computedSig)
+	return scm.VerifyHMACSHA256Signature(payloadBytes, signatureHeader, sharedSecret)
 }
 
 // Helper methods

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -6,9 +6,6 @@ package github
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -588,25 +585,12 @@ func (c *GitHubConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[str
 
 // VerifyDeliverySignature validates a GitHub HMAC-SHA256 webhook signature.
 // GitHub sets the X-Hub-Signature-256 header to "sha256=<hex>" where the hex
-// value is HMAC-SHA256(secret, payload).
+// value is HMAC-SHA256(secret, payload). Delegates to the shared
+// scm.VerifyHMACSHA256Signature helper (also used by the Bitbucket Data
+// Center connector) so both connectors apply the same fail-closed
+// empty-secret/empty-header policy.
 func (c *GitHubConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	if sharedSecret == "" {
-		// No secret configured — skip validation.
-		return true
-	}
-	const prefix = "sha256="
-	if !strings.HasPrefix(signatureHeader, prefix) {
-		return false
-	}
-	gotHex := strings.TrimPrefix(signatureHeader, prefix)
-	got, err := hex.DecodeString(gotHex)
-	if err != nil {
-		return false
-	}
-	mac := hmac.New(sha256.New, []byte(sharedSecret))
-	mac.Write(payloadBytes)
-	expected := mac.Sum(nil)
-	return hmac.Equal(got, expected)
+	return scm.VerifyHMACSHA256Signature(payloadBytes, signatureHeader, sharedSecret)
 }
 
 // Helper methods

--- a/backend/internal/scm/github/connector_test.go
+++ b/backend/internal/scm/github/connector_test.go
@@ -559,19 +559,49 @@ func TestVerifyDeliverySignature_WrongSecret(t *testing.T) {
 	}
 }
 
+// TestVerifyDeliverySignature_MissingPrefix asserts that a too-short header
+// value fails verification. This is NOT prefix enforcement: the shared
+// scm.VerifyHMACSHA256Signature helper (issue #667) trims an optional
+// "sha256=" prefix rather than requiring one, so both connectors can share
+// one implementation despite Bitbucket Data Center sending the digest with
+// or without it. This fixture fails only because "734cc62f32841568"
+// hex-decodes to 8 bytes, the wrong length for a SHA-256 digest (32 bytes) —
+// see TestVerifyDeliverySignature_ValidDigestWithoutPrefix_IsAccepted for
+// the case a same-length unprefixed digest IS accepted.
 func TestVerifyDeliverySignature_MissingPrefix(t *testing.T) {
 	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
 	valid := c.VerifyDeliverySignature([]byte("hello"), "734cc62f32841568", "mysecret")
 	if valid {
-		t.Error("expected false when sha256= prefix is missing")
+		t.Error("expected false: decoded digest is the wrong length for a SHA-256 HMAC")
+	}
+}
+
+// TestVerifyDeliverySignature_ValidDigestWithoutPrefix_IsAccepted pins the
+// shared HMAC helper's deliberate behavior (issue #667): a correctly
+// computed digest is accepted whether or not it carries the "sha256="
+// prefix, unlike the old GitHub-only implementation which used
+// strings.HasPrefix and rejected an unprefixed digest outright. GitHub's
+// real webhook deliveries always include the prefix, so this case is not
+// reachable in practice — this test exists so the behavior change is
+// visible and intentional rather than accidental.
+func TestVerifyDeliverySignature_ValidDigestWithoutPrefix_IsAccepted(t *testing.T) {
+	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
+	mac := hmac.New(sha256.New, []byte("mysecret"))
+	mac.Write([]byte("hello"))
+	digest := hex.EncodeToString(mac.Sum(nil))
+
+	if !c.VerifyDeliverySignature([]byte("hello"), digest, "mysecret") {
+		t.Error("expected true: a correct digest is accepted even without the sha256= prefix")
 	}
 }
 
 func TestVerifyDeliverySignature_EmptySecret(t *testing.T) {
-	// When no secret is configured, validation is skipped.
+	// Fail closed: an unconfigured secret means the signature cannot be
+	// verified, so the delivery must be rejected. This unifies GitHub with
+	// the Bitbucket Data Center connector's empty-secret policy (issue #667).
 	c, _ := NewGitHubConnector(&scm.ConnectorSettings{})
-	if !c.VerifyDeliverySignature([]byte("payload"), "sha256=anything", "") {
-		t.Error("expected true when no secret configured")
+	if c.VerifyDeliverySignature([]byte("payload"), "sha256=anything", "") {
+		t.Error("expected false when no secret configured (fail closed)")
 	}
 }
 

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -658,9 +658,15 @@ func (c *GitLabConnector) ParseDelivery(payloadBytes []byte, httpHeaders map[str
 // VerifyDeliverySignature validates a GitLab webhook token.
 // GitLab sends the configured secret token verbatim in the X-Gitlab-Token header.
 // A constant-time comparison is used to prevent timing attacks.
+//
+// Both sharedSecret and signatureHeader are required: an unconfigured secret,
+// or a delivery with no token header, is treated as unverifiable and
+// rejected rather than skipped, matching the fail-closed policy applied to
+// the GitHub/Bitbucket HMAC verification (scm.VerifyHMACSHA256Signature) and
+// this codebase's fail-closed convention for authentication checks.
 func (c *GitLabConnector) VerifyDeliverySignature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
-	if sharedSecret == "" {
-		return true
+	if sharedSecret == "" || signatureHeader == "" {
+		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(signatureHeader), []byte(sharedSecret)) == 1
 }

--- a/backend/internal/scm/gitlab/connector_test.go
+++ b/backend/internal/scm/gitlab/connector_test.go
@@ -535,8 +535,24 @@ func TestVerifyDeliverySignature_Mismatch(t *testing.T) {
 
 func TestVerifyDeliverySignature_EmptySecret(t *testing.T) {
 	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
-	if !c.VerifyDeliverySignature([]byte("payload"), "anytoken", "") {
-		t.Error("expected true when no secret configured")
+	if c.VerifyDeliverySignature([]byte("payload"), "anytoken", "") {
+		t.Error("expected false (fail closed) when no secret configured")
+	}
+}
+
+func TestVerifyDeliverySignature_EmptyHeader(t *testing.T) {
+	c, _ := NewGitLabConnector(&scm.ConnectorSettings{})
+	if c.VerifyDeliverySignature([]byte("payload"), "", "mytoken") {
+		t.Error("expected false (fail closed) when no token header is present")
+	}
+	// The case above (empty header, non-empty secret) already fails closed
+	// under the pre-fix code too, via the length-mismatch in
+	// ConstantTimeCompare, so it does not by itself guard the fail-open
+	// regression this function was fixed for. Also exercise header AND
+	// secret both empty: pre-fix, an empty sharedSecret alone short-circuited
+	// to "true" (fail open) regardless of the header.
+	if c.VerifyDeliverySignature([]byte("payload"), "", "") {
+		t.Error("expected false (fail closed) when neither token header nor secret is present")
 	}
 }
 

--- a/backend/internal/scm/webhooksig.go
+++ b/backend/internal/scm/webhooksig.go
@@ -1,0 +1,40 @@
+// webhooksig.go provides the shared HMAC-SHA256 webhook delivery-signature
+// verification used by SCM connectors that sign payloads with a hex-encoded
+// HMAC-SHA256 digest, optionally prefixed "sha256=" — currently GitHub and
+// Bitbucket Data Center.
+package scm
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// VerifyHMACSHA256Signature validates a webhook delivery signature computed as
+// HMAC-SHA256(sharedSecret, payloadBytes), hex-encoded, and optionally
+// prefixed with "sha256=" (GitHub always sends the prefix; Bitbucket Data
+// Center has been observed sending it with or without depending on
+// configuration).
+//
+// Both sharedSecret and signatureHeader are required: an unconfigured secret,
+// or a delivery with no signature header, is treated as unverifiable and
+// rejected rather than skipped, matching this codebase's fail-closed
+// convention for authentication checks.
+func VerifyHMACSHA256Signature(payloadBytes []byte, signatureHeader, sharedSecret string) bool {
+	if sharedSecret == "" || signatureHeader == "" {
+		return false
+	}
+
+	sig := strings.TrimPrefix(signatureHeader, "sha256=")
+	expected, err := hex.DecodeString(sig)
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, []byte(sharedSecret))
+	mac.Write(payloadBytes)
+	computed := mac.Sum(nil)
+
+	return hmac.Equal(expected, computed)
+}

--- a/backend/internal/scm/webhooksig_test.go
+++ b/backend/internal/scm/webhooksig_test.go
@@ -1,0 +1,77 @@
+package scm
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func computeTestHMAC(payload []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyHMACSHA256Signature_Valid(t *testing.T) {
+	payload := []byte(`{"event":"push"}`)
+	secret := "mysecret"
+	sig := computeTestHMAC(payload, secret)
+
+	if !VerifyHMACSHA256Signature(payload, sig, secret) {
+		t.Error("expected true for a valid signature with matching secret")
+	}
+}
+
+func TestVerifyHMACSHA256Signature_ValidWithoutPrefix(t *testing.T) {
+	payload := []byte(`{"event":"push"}`)
+	secret := "mysecret"
+	sig := computeTestHMAC(payload, secret)
+	sig = sig[len("sha256="):] // strip the prefix; the helper must accept both forms
+
+	if !VerifyHMACSHA256Signature(payload, sig, secret) {
+		t.Error("expected true for a valid signature without the sha256= prefix")
+	}
+}
+
+func TestVerifyHMACSHA256Signature_WrongSecret(t *testing.T) {
+	payload := []byte("hello")
+	sig := computeTestHMAC(payload, "mysecret")
+
+	// Negative test: an attacker without the shared secret cannot forge a
+	// valid signature.
+	if VerifyHMACSHA256Signature(payload, sig, "wrongsecret") {
+		t.Error("expected false when secret does not match")
+	}
+}
+
+func TestVerifyHMACSHA256Signature_TamperedPayload(t *testing.T) {
+	secret := "mysecret"
+	sig := computeTestHMAC([]byte("original"), secret)
+
+	if VerifyHMACSHA256Signature([]byte("tampered"), sig, secret) {
+		t.Error("expected false when payload does not match the signed payload")
+	}
+}
+
+func TestVerifyHMACSHA256Signature_InvalidHex(t *testing.T) {
+	if VerifyHMACSHA256Signature([]byte("payload"), "sha256=not-hex!!", "secret") {
+		t.Error("expected false for a non-hex signature")
+	}
+}
+
+// TestVerifyHMACSHA256Signature_EmptySecretRejected pins the fail-closed
+// policy this helper unifies GitHub and Bitbucket Data Center onto: an
+// unconfigured secret means the signature cannot be verified, so the
+// delivery must be rejected rather than accepted unconditionally.
+func TestVerifyHMACSHA256Signature_EmptySecretRejected(t *testing.T) {
+	if VerifyHMACSHA256Signature([]byte("payload"), "sha256=anything", "") {
+		t.Error("expected false when no secret is configured (fail closed)")
+	}
+}
+
+func TestVerifyHMACSHA256Signature_EmptySignatureRejected(t *testing.T) {
+	if VerifyHMACSHA256Signature([]byte("payload"), "", "secret") {
+		t.Error("expected false when no signature header is present")
+	}
+}

--- a/backend/internal/validation/archive.go
+++ b/backend/internal/validation/archive.go
@@ -12,17 +12,22 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/terraform-registry/terraform-registry/internal/archivelimits"
 )
 
 const (
-	// MaxArchiveSize is the maximum size for a module archive (100MB)
-	MaxArchiveSize = 100 * 1024 * 1024
+	// MaxArchiveSize is the maximum size for a module archive (100MB). Sourced
+	// from archivelimits so this cannot silently drift from the cap
+	// archiver.ExtractTarGz enforces at extraction time.
+	MaxArchiveSize = archivelimits.MaxBytes
 
 	// MaxArchiveEntries bounds the number of tar entries in an archive. Without this,
 	// an archive of millions of zero-byte file entries never trips MaxArchiveSize (which
 	// only tracks decompressed body bytes) while still exhausting inodes/metadata when
-	// later extracted. A ~1MB gzip can encode ~2M such entries.
-	MaxArchiveEntries = 100000
+	// later extracted. A ~1MB gzip can encode ~2M such entries. Sourced from
+	// archivelimits so this cannot silently drift from archiver.ExtractTarGz's cap.
+	MaxArchiveEntries = archivelimits.MaxEntries
 )
 
 // ValidateArchive validates a tar.gz archive


### PR DESCRIPTION
Closes #665
Closes #666
Closes #667
Closes #675
Closes #689
Part of #566 (archive-extraction fuzz coverage)

Batch `f-middleware-dedupe` from the 2026-07-22 blind security audit:

- **#675** — the in-memory OAuth/OIDC state store's `Load` was not single-use (a Load-then-Delete race), so a state value could be replayed. Now atomically consumed.
- **#666** — SCIM 2.0 provisioning routes bypassed the `AuditMiddleware` and rate limiting applied to every other authenticated route; they now go through the same middleware chain.
- **#665** — two independent, byte-for-byte-different implementations of tar.gz path-traversal/decompression-bomb validation are unified behind one guard, so a fix to one can no longer leave the other vulnerable.
- **#667** — duplicated webhook HMAC-SHA256 signature verification across SCM connectors, with inconsistent empty-input handling, consolidated into one implementation.
- **#689** — `context.Background()` replaced with the request context for the synchronous external IdP call inside `CallbackHandler`, so the call is cancelled with the request.
- **#566 regression** — archive fuzzing now exercises the real zip-slip/decompression-bomb extraction guard rather than only the in-memory doc parser.

Verification: adversarial review panel consensus, then rebased cleanly onto current main — `gofmt` clean, `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass.