### PR TITLE
fix(security): per-org resource guard, enforced across the SCM provider routes

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -657,6 +657,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		auditRepo:                   auditRepo,
 		auditShipper:                auditShipper,
 		nsAuthz:                     nsAuthz,
+		scmRepo:                     scmRepo,
 		scanRepo:                    scanRepo,
 		moduleDocsRepo:              moduleDocsRepo,
 		policyEngine:                policyEngine,

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -9,16 +9,19 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
 	"github.com/terraform-registry/terraform-registry/docs"
@@ -326,6 +329,7 @@ type apiV1RouteDeps struct {
 	auditRepo                   *repositories.AuditRepository
 	auditShipper                audit.Shipper
 	nsAuthz                     *middleware.NamespaceAuthorizer
+	scmRepo                     *repositories.SCMRepository
 	scanRepo                    *repositories.ModuleScanRepository
 	moduleDocsRepo              *repositories.ModuleDocsRepository
 	policyEngine                *policy.PolicyEngine
@@ -826,31 +830,44 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// SCM Provider management
 			scmProvidersGroup := authenticatedGroup.Group("/scm-providers")
 			{
+				// Every /:id route additionally re-derives the caller's scope in
+				// the organization that owns THAT provider (issue #718). The
+				// group-level RequireScope only checks the flat, org-less scope
+				// union from the session JWT (issue #652), so without this a
+				// caller holding scm:manage via membership in one organization
+				// could repoint, re-credential, or delete another
+				// organization's provider — and /repositories would enumerate
+				// the target org's private repos using that org's own shared
+				// app credentials.
+				scmProviderOrg := func(scope auth.Scope) gin.HandlerFunc {
+					return nsAuthz.RequireOrgScopeForResource(scope, scmProviderOrgResolver(d.scmRepo))
+				}
+
 				// Read operations require scm:read
 				scmProvidersGroup.GET("", middleware.RequireScope(auth.ScopeSCMRead), scmProviderHandlers.ListProviders)
-				scmProvidersGroup.GET("/:id", middleware.RequireScope(auth.ScopeSCMRead), scmProviderHandlers.GetProvider)
+				scmProvidersGroup.GET("/:id", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmProviderHandlers.GetProvider)
 
 				// Management operations require scm:manage
 				scmProvidersGroup.POST("", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.CreateProvider)
-				scmProvidersGroup.PUT("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.UpdateProvider)
-				scmProvidersGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.DeleteProvider)
+				scmProvidersGroup.PUT("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmProviderHandlers.UpdateProvider)
+				scmProvidersGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmProviderHandlers.DeleteProvider)
 
 				// Verify shared app credentials by minting a token (app auth modes only)
-				scmProvidersGroup.POST("/:id/verify", middleware.RequireScope(auth.ScopeSCMManage), scmProviderHandlers.VerifyProvider)
+				scmProvidersGroup.POST("/:id/verify", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmProviderHandlers.VerifyProvider)
 
 				// OAuth flow endpoints require scm:manage
-				scmProvidersGroup.GET("/:id/oauth/authorize", middleware.RequireScope(auth.ScopeSCMManage), scmOAuthHandlers.InitiateOAuth)
-				scmProvidersGroup.GET("/:id/oauth/token", middleware.RequireScope(auth.ScopeSCMRead), scmOAuthHandlers.GetTokenStatus)
-				scmProvidersGroup.DELETE("/:id/oauth/token", middleware.RequireScope(auth.ScopeSCMManage), scmOAuthHandlers.RevokeOAuth)
-				scmProvidersGroup.POST("/:id/oauth/refresh", middleware.RequireScope(auth.ScopeSCMManage), scmOAuthHandlers.RefreshToken)
+				scmProvidersGroup.GET("/:id/oauth/authorize", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmOAuthHandlers.InitiateOAuth)
+				scmProvidersGroup.GET("/:id/oauth/token", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmOAuthHandlers.GetTokenStatus)
+				scmProvidersGroup.DELETE("/:id/oauth/token", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmOAuthHandlers.RevokeOAuth)
+				scmProvidersGroup.POST("/:id/oauth/refresh", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmOAuthHandlers.RefreshToken)
 
 				// PAT-based auth (e.g., Bitbucket Data Center)
-				scmProvidersGroup.POST("/:id/token", middleware.RequireScope(auth.ScopeSCMManage), scmOAuthHandlers.SavePATToken)
+				scmProvidersGroup.POST("/:id/token", middleware.RequireScope(auth.ScopeSCMManage), scmProviderOrg(auth.ScopeSCMManage), scmOAuthHandlers.SavePATToken)
 
 				// Repository listing - requires scm:read
-				scmProvidersGroup.GET("/:id/repositories", middleware.RequireScope(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositories)
-				scmProvidersGroup.GET("/:id/repositories/:owner/:repo/tags", middleware.RequireScope(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositoryTags)
-				scmProvidersGroup.GET("/:id/repositories/:owner/:repo/branches", middleware.RequireScope(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositoryBranches)
+				scmProvidersGroup.GET("/:id/repositories", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositories)
+				scmProvidersGroup.GET("/:id/repositories/:owner/:repo/tags", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositoryTags)
+				scmProvidersGroup.GET("/:id/repositories/:owner/:repo/branches", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositoryBranches)
 			}
 
 			// SCM OAuth callback (public endpoint, no auth required)
@@ -1098,5 +1115,36 @@ func registerSCIMRoutes(router *gin.Engine, d *apiV1RouteDeps) {
 		scimGroup.DELETE("/Users/:id", scimHandlers.DeleteUser())
 		scimGroup.GET("/Groups", scimHandlers.ListGroups())
 		scimGroup.GET("/Groups/:id", scimHandlers.GetGroup())
+	}
+}
+
+// scmProviderOrgResolver adapts SCMRepository to middleware.ResourceOrgResolver
+// for the /scm-providers/:id family (issue #718).
+//
+// scm_providers.organization_id is nullable, so a legacy row with no owner
+// resolves to ("", true, nil) — "found, but unowned" — which the guard treats
+// as admin-only rather than open. A nil repository resolves to an error rather
+// than a pass, so a wiring mistake fails closed instead of silently disabling
+// the check.
+func scmProviderOrgResolver(scmRepo *repositories.SCMRepository) middleware.ResourceOrgResolver {
+	return func(ctx context.Context, id string) (string, bool, error) {
+		if scmRepo == nil {
+			return "", false, errors.New("scm repository not configured")
+		}
+		providerID, err := uuid.Parse(id)
+		if err != nil {
+			return "", false, nil
+		}
+		provider, err := scmRepo.GetProvider(ctx, providerID)
+		if err != nil {
+			return "", false, err
+		}
+		if provider == nil {
+			return "", false, nil
+		}
+		if provider.OrganizationID == uuid.Nil {
+			return "", true, nil
+		}
+		return provider.OrganizationID.String(), true, nil
 	}
 }

--- a/backend/internal/api/scm_provider_routes_test.go
+++ b/backend/internal/api/scm_provider_routes_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// Route-wiring regression test for issue #718: every /scm-providers/:id route
+// must re-derive the caller's scope in the organization that owns THAT
+// provider, not trust the flat org-less scope union in the session JWT.
+//
+// Driven through the real registerAPIV1Routes rather than a stand-in engine,
+// for the same reason as module_scm_routes_test.go: the defect was that the
+// guard was absent from the route table, so a middleware-level test would pass
+// while the product stayed vulnerable.
+func TestSCMProviderRoutes_CrossOrg_Denied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	const (
+		providerID = "44444444-4444-4444-4444-444444444444"
+		otherOrgID = "55555555-5555-5555-5555-555555555555"
+		userID     = "user-scm-cross-org"
+	)
+
+	// Mallory holds both SCM scopes — via membership in some OTHER organization.
+	token, err := auth.GenerateJWT(userID, "mallory@example.com",
+		[]string{string(auth.ScopeSCMRead), string(auth.ScopeSCMManage)}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, method, path string
+	}{
+		{"read provider", http.MethodGet, "/api/v1/scm-providers/" + providerID},
+		{"update provider", http.MethodPut, "/api/v1/scm-providers/" + providerID},
+		{"delete provider", http.MethodDelete, "/api/v1/scm-providers/" + providerID},
+		{"verify credentials", http.MethodPost, "/api/v1/scm-providers/" + providerID + "/verify"},
+		{"save PAT", http.MethodPost, "/api/v1/scm-providers/" + providerID + "/token"},
+		{"revoke oauth", http.MethodDelete, "/api/v1/scm-providers/" + providerID + "/oauth/token"},
+		{"list repositories", http.MethodGet, "/api/v1/scm-providers/" + providerID + "/repositories"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			// AuthMiddleware resolves the JWT subject.
+			mock.ExpectQuery("SELECT.*FROM users WHERE id").
+				WillReturnRows(sqlmock.NewRows(
+					[]string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"},
+				).AddRow(userID, "mallory@example.com", "Mallory", nil, time.Now(), time.Now()))
+
+			// The provider belongs to another organization...
+			mock.ExpectQuery("SELECT \\* FROM scm_providers WHERE id").
+				WillReturnRows(sqlmock.NewRows([]string{"id", "organization_id", "provider_type", "name", "base_url", "auth_mode", "created_at", "updated_at"}).
+					AddRow(providerID, otherOrgID, "github", "gh", "https://github.com", "oauth_user", time.Now(), time.Now()))
+			// ...and Mallory is not a member of it.
+			mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+				WillReturnRows(sqlmock.NewRows([]string{
+					"organization_id", "user_id", "role_template_id", "joined_at",
+					"name", "email", "role_name", "role_display_name", "role_scopes",
+				}))
+
+			sqlxDB := sqlx.NewDb(db, "sqlmock")
+			nsAuthz := middleware.NewNamespaceAuthorizer(
+				repositories.NewOrganizationRepository(db),
+				repositories.NewNamespaceClaimRepository(db),
+				repositories.NewModuleRepository(db),
+				repositories.NewProviderRepository(db),
+			)
+
+			limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+				RequestsPerMinute: 600, BurstSize: 100, CleanupInterval: time.Minute,
+			})
+			defer limiter.Stop()
+
+			r := gin.New()
+			// Handlers are left nil: a correctly-guarded route rejects in
+			// middleware and never reaches one. Recovery turns the unguarded
+			// case into a legible 500 instead of crashing the test binary.
+			r.Use(gin.Recovery())
+			registerAPIV1Routes(r, &apiV1RouteDeps{
+				cfg:                &config.Config{},
+				userRepo:           repositories.NewUserRepository(db),
+				generalRateLimiter: limiter,
+				orgRateLimiter:     limiter,
+				nsAuthz:            nsAuthz,
+				scmRepo:            repositories.NewSCMRepository(sqlxDB),
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			// CSRFMiddleware allows Bearer for non-browser origins; no Origin
+			// header is set, so these behave as API clients.
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Errorf("%s %s: status = %d, want 403 (provider owned by another organization); body=%s",
+					tc.method, tc.path, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/middleware/org_resource_authz.go
+++ b/backend/internal/middleware/org_resource_authz.go
@@ -1,0 +1,106 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+// ResourceOrgResolver loads the organization that owns the resource addressed
+// by a path parameter. It returns (orgID, true, nil) when the resource exists,
+// ("", false, nil) when it does not, and a non-nil error only for genuine
+// lookup failures.
+//
+// An existing resource whose organization_id is NULL/empty must return
+// ("", true, nil): "found, but unowned". See RequireOrgScopeForResource for how
+// that case is handled.
+type ResourceOrgResolver func(ctx context.Context, id string) (orgID string, found bool, err error)
+
+// RequireOrgScopeForResource authorizes the caller against the organization
+// that owns the resource named by the ":id" path parameter.
+//
+// This is the resource-keyed counterpart to RequireOrgScopeForPathOrg: that
+// middleware works where ":id" *is* an organization ID, while many route
+// families address an org-scoped row (an SCM provider, a mirror configuration,
+// an approval request) whose owning organization must first be looked up. Both
+// exist because the session JWT carries a flat, org-less union of the caller's
+// scopes across every organization they belong to (issue #652), so
+// RequireScope alone cannot tell "holds scm:manage in org A" apart from
+// "may act on org B's provider" — the cross-tenant gap tracked in #718/#719.
+//
+// It must run in addition to (after) RequireScope, not instead of it, so
+// callers lacking the scope entirely still fail fast without a DB round trip.
+//
+// Authorization itself is delegated to the same authorizeOrgAccess used by the
+// namespace/module/provider guards, so admin-wildcard bypass, org-bound API
+// key precedence, and per-org role-template scope derivation behave
+// identically everywhere. Deliberately not a second implementation: issue #665
+// was filed for exactly that kind of divergence between two copies of one
+// check.
+//
+// Two cases deliberately pass through to the handler rather than being
+// rejected here:
+//   - a malformed (non-UUID) ":id", and
+//   - a resource that does not exist,
+//
+// both so the handler produces its usual 400/404 rather than this middleware
+// inventing one — matching moduleAccessByID's existing behaviour. Note this
+// means a caller can still distinguish "no such resource" from "exists but
+// belongs to another organization"; that is the pre-existing convention in
+// this codebase, and closing it would be a separate, product-wide decision.
+//
+// An existing-but-unowned resource (NULL organization_id — the column is
+// nullable on several of these tables) fails closed for everyone except the
+// admin wildcard: an empty owner cannot be matched against any membership, so
+// only a platform admin may act on such legacy rows.
+func (a *NamespaceAuthorizer) RequireOrgScopeForResource(scope auth.Scope, resolve ResourceOrgResolver) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := uuid.Parse(id); err != nil {
+			// Malformed ID: the handler responds.
+			c.Next()
+			return
+		}
+
+		ownerOrgID, found, err := resolve(c.Request.Context(), id)
+		if err != nil {
+			abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to resolve resource ownership")
+			return
+		}
+		if !found {
+			// Missing resource: the handler responds (404).
+			c.Next()
+			return
+		}
+
+		if ownerOrgID == "" {
+			// Unowned row (nullable organization_id). Handled explicitly rather
+			// than by falling through to the membership lookup: querying
+			// membership for an empty organization is meaningless, and leaving
+			// the outcome to depend on how the driver answers that query is not
+			// a decision worth delegating. Admin only.
+			if scopesVal, exists := c.Get("scopes"); exists {
+				if callerScopes, ok := scopesVal.([]string); ok && auth.HasScope(callerScopes, auth.ScopeAdmin) {
+					c.Set("owner_org_id", "")
+					c.Next()
+					return
+				}
+			}
+			abortNamespaceAuthz(c, http.StatusForbidden, "Resource is not owned by any organization")
+			return
+		}
+
+		if status, msg := a.authorizeOrgAccess(c, ownerOrgID, scope); status != 0 {
+			abortNamespaceAuthz(c, status, msg)
+			return
+		}
+
+		// Expose the resolved owner so handlers never re-derive it.
+		c.Set("owner_org_id", ownerOrgID)
+		c.Next()
+	}
+}

--- a/backend/internal/middleware/org_resource_authz_test.go
+++ b/backend/internal/middleware/org_resource_authz_test.go
@@ -1,0 +1,194 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+const resourceUUID = "33333333-3333-3333-3333-333333333333"
+
+// resolverFor returns a ResourceOrgResolver with fixed behaviour, plus a
+// pointer to a flag recording whether it was called.
+func resolverFor(orgID string, found bool, err error) (ResourceOrgResolver, *bool) {
+	called := false
+	return func(context.Context, string) (string, bool, error) {
+		called = true
+		return orgID, found, err
+	}, &called
+}
+
+// resourceRouter mounts the guard on GET /widgets/:id with a terminal handler
+// that reports 200, so "reached the handler" is observable.
+func resourceRouter(mid gin.HandlerFunc, scopes []string, userID string) *gin.Engine {
+	r := gin.New()
+	r.GET("/widgets/:id",
+		contextSetter(withScopesAndUser(scopes, userID)),
+		mid,
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func TestRequireOrgScopeForResource_CrossOrg_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	// Caller is not a member of the owning org.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW))
+
+	resolve, called := resolverFor(nsOrgB, true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (resource owned by another org): body=%s", w.Code, w.Body.String())
+	}
+	if !*called {
+		t.Error("resolver was not called")
+	}
+}
+
+func TestRequireOrgScopeForResource_SameOrg_Allowed(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-devops", time.Now(),
+			"Dev", "dev@test.com", "devops", "DevOps", []byte(`["scm:manage"]`),
+		))
+
+	resolve, _ := resolverFor(nsOrgA, true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (member of owning org with the scope): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireOrgScopeForResource_MemberWithoutScopeInOwningOrg_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+	// Member of the owning org, but their role there does not grant scm:manage.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			nsOrgA, nsUserID, "role-viewer", time.Now(),
+			"View", "view@test.com", "viewer", "Viewer", []byte(`["scm:read"]`),
+		))
+
+	resolve, _ := resolverFor(nsOrgA, true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (flat scope union must not substitute for the scope in the owning org)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_AdminWildcard_Allowed(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	// No DB expectation: admin must short-circuit before any membership lookup.
+	resolve, _ := resolverFor(nsOrgB, true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeAdmin)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (admin wildcard crosses org boundaries by design)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_UnownedResource_DeniedForNonAdmin(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	// organization_id is nullable on these tables; an unowned row must fail
+	// closed rather than being treated as "belongs to everyone".
+	resolve, _ := resolverFor("", true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (unowned resource is admin-only)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_MissingResource_PassesThroughToHandler(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	resolve, _ := resolverFor("", false, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (missing resource left to the handler's 404)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_NotUUID_PassesThroughWithoutLookup(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	resolve, called := resolverFor(nsOrgB, true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/not-a-uuid")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (malformed ID left to the handler)", w.Code)
+	}
+	if *called {
+		t.Error("resolver must not be called for a malformed ID")
+	}
+}
+
+func TestRequireOrgScopeForResource_ResolverError_FailsClosed(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	resolve, _ := resolverFor("", false, errors.New("db down"))
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeSCMManage)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (lookup failure must not fall open)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_UnownedResource_AllowedForAdmin(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	// Counterpart to the test above: legacy unowned rows stay reachable by a
+	// platform admin, so the fail-closed default is not a lockout.
+	resolve, _ := resolverFor("", true, nil)
+	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		[]string{string(auth.ScopeAdmin)}, nsUserID)
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (admin may act on an unowned resource)", w.Code)
+	}
+}
+
+func TestRequireOrgScopeForResource_NoScopesInContext_Denied(t *testing.T) {
+	_, authz := newNamespaceAuthzTestDeps(t)
+	resolve, _ := resolverFor(nsOrgA, true, nil)
+
+	// Deliberately does NOT go through withScopesAndUser: that helper always
+	// sets the "scopes" key, so passing nil would still exercise the
+	// empty-slice path rather than the absent-key one this test is about.
+	// No sqlmock expectation is registered either — denial must happen before
+	// any database round trip.
+	r := gin.New()
+	r.GET("/widgets/:id",
+		contextSetter(func(c *gin.Context) { c.Set("user_id", nsUserID) }),
+		authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "GET", "/widgets/"+resourceUUID)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (no scopes in context)", w.Code)
+	}
+}


### PR DESCRIPTION
Closes #718 (except the `ListProviders` filtering noted below)

## The gap

Every `/api/v1/scm-providers/:id` route resolved the provider by path ID and never compared its `organization_id` to the caller's memberships. The only gate was `RequireScope(scm:read|scm:manage)` against the **flat, org-less scope union** in the session JWT (#652).

`GetProvider` was, in full: parse `:id` → fetch → return. So a caller holding `scm:manage` via membership in *one* organization could repoint another organization's provider at an attacker-controlled host and overwrite its credentials (supply-chain injection into that org's namespace), and `GET /:id/repositories` — which deliberately uses the *provider's own* shared app credentials — let the lowest-privileged `viewer` role enumerate another org's private repositories.

## The guard

New `RequireOrgScopeForResource(scope, resolver)` in `internal/middleware/org_resource_authz.go`. It is the resource-keyed counterpart to the existing `RequireOrgScopeForPathOrg`: that one works where `:id` *is* an organization, this one looks up the organization owning an arbitrary org-scoped row via an injected `ResourceOrgResolver`.

Authorization is **delegated to the existing `authorizeOrgAccess`**, not reimplemented — so admin-wildcard bypass, org-bound API-key precedence, and per-org role-template scope derivation stay identical to the namespace/module/provider guards. Writing a second copy is precisely the divergence #665 was filed for.

Deliberate behaviours, each with a test:

- **Unowned resource fails closed.** `scm_providers.organization_id` is nullable; a legacy row with no owner is admin-only rather than open to everyone. Handled explicitly rather than by letting a membership lookup against an empty org decide it.
- **Resolver error fails closed** (500), so a database problem can't fall open.
- **A nil repository resolves to an error**, so a future wiring mistake fails closed instead of silently disabling the check.
- **Malformed or missing IDs pass through** to the handler's usual 400/404, matching `moduleAccessByID`. This means "no such resource" is still distinguishable from "exists, other org" — the pre-existing convention here; changing it is a separate product decision, and I did not change it silently.

## Tests

Ten unit tests for the guard, plus `scm_provider_routes_test.go`, which drives the **real** `registerAPIV1Routes` across seven routes (read/update/delete/verify/token/oauth-revoke/repositories). Route-level on purpose: the guard was missing from the route table, so a middleware-only test would have passed while the product was vulnerable — and this repo already had passing `TestRequireModuleAccessByID_CrossOrg_Denied` middleware tests throughout the period the sibling hole in #720 was open.

Both suites were verified to fail with the wiring removed (403s become 500/400) and pass with it, so they genuinely bite.

## Not in this PR

`GET /scm-providers` (the list route) still returns providers across all organizations when no `organization_id` filter is supplied — that is list *filtering* rather than a per-resource check, so it wants its own change and its own test. Tracked in #718.

Verification: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` green.