### PR TITLE
fix(security): per-org authorization on mirror config and approval routes

### DIFF
--- a/backend/internal/api/mirror_approval_routes_test.go
+++ b/backend/internal/api/mirror_approval_routes_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+const (
+	mirrorCfgID   = "66666666-6666-6666-6666-666666666666"
+	approvalReqID = "77777777-7777-7777-7777-777777777777"
+	foreignOrgID  = "88888888-8888-8888-8888-888888888888"
+	mirrorUserID  = "user-mirror-cross-org"
+)
+
+var memberRoleColsAPI = []string{
+	"organization_id", "user_id", "role_template_id", "joined_at",
+	"name", "email", "role_name", "role_display_name", "role_scopes",
+}
+
+func userRowsFor(userID string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}).
+		AddRow(userID, "mallory@example.com", "Mallory", nil, time.Now(), time.Now())
+}
+
+// crossOrgRouteCase drives one route through the real registerAPIV1Routes with
+// the target row owned by foreignOrgID and the caller not a member of it.
+// Handlers are left nil deliberately: a guarded route rejects in middleware and
+// never reaches one, so gin.Recovery turning the unguarded case into a 500
+// makes the failure legible rather than crashing the binary.
+func crossOrgRouteCase(t *testing.T, method, path string, scopes []string, seed func(sqlmock.Sqlmock)) int {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	token, err := auth.GenerateJWT(mirrorUserID, "mallory@example.com", scopes, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+
+	mock.ExpectQuery("(?s)FROM users WHERE id").WillReturnRows(userRowsFor(mirrorUserID))
+	seed(mock)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsAPI))
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 600, BurstSize: 100, CleanupInterval: time.Minute,
+	})
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	registerAPIV1Routes(r, &apiV1RouteDeps{
+		cfg:                &config.Config{},
+		userRepo:           repositories.NewUserRepository(db),
+		generalRateLimiter: limiter,
+		orgRateLimiter:     limiter,
+		nsAuthz: middleware.NewNamespaceAuthorizer(
+			repositories.NewOrganizationRepository(db),
+			repositories.NewNamespaceClaimRepository(db),
+			repositories.NewModuleRepository(db),
+			repositories.NewProviderRepository(db),
+		),
+		mirrorRepo: repositories.NewMirrorRepository(sqlxDB),
+		rbacRepo:   repositories.NewRBACRepositoryWithIdentity(sqlxDB, sqlxDB),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func seedForeignMirrorConfig(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("FROM mirror_configurations").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "description", "upstream_registry_url", "organization_id",
+			"namespace_filter", "provider_filter", "version_filter", "platform_filter",
+			"enabled", "sync_interval_hours", "requires_approval", "auto_approve_rules",
+			"pull_through_enabled", "pull_through_cache_ttl_hours", "last_sync_at",
+			"last_sync_status", "last_sync_error", "created_at", "updated_at", "created_by",
+		}).AddRow(
+			mirrorCfgID, "upstream", nil, "https://registry.terraform.io", foreignOrgID,
+			nil, nil, nil, nil, true, 24, false, nil, false, 24, nil, nil, nil,
+			time.Now(), time.Now(), nil,
+		))
+}
+
+func seedForeignApprovalRequest(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("FROM mirror_approval_requests").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "mirror_config_id", "organization_id", "requested_by",
+			"provider_namespace", "provider_name", "reason", "status",
+			"reviewed_by", "reviewed_at", "review_notes", "auto_approved",
+			"created_at", "updated_at", "expires_at",
+		}).AddRow(
+			approvalReqID, mirrorCfgID, foreignOrgID, nil,
+			"hashicorp", "aws", "needed upstream", "pending", nil, nil, nil, false,
+			time.Now(), time.Now(), nil,
+		))
+}
+
+// Issue #719: /admin/mirrors/:id operates on org-scoped mirror_configurations
+// rows but was authorized only against the flat org-less scope union.
+func TestMirrorConfigRoutes_CrossOrg_Denied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	scopes := []string{string(auth.ScopeMirrorsRead), string(auth.ScopeMirrorsManage)}
+	for _, tc := range []struct{ name, method, path string }{
+		{"read config", http.MethodGet, "/api/v1/admin/mirrors/" + mirrorCfgID},
+		{"read status", http.MethodGet, "/api/v1/admin/mirrors/" + mirrorCfgID + "/status"},
+		{"list mirrored providers", http.MethodGet, "/api/v1/admin/mirrors/" + mirrorCfgID + "/providers"},
+		{"delete config", http.MethodDelete, "/api/v1/admin/mirrors/" + mirrorCfgID},
+		{"trigger sync", http.MethodPost, "/api/v1/admin/mirrors/" + mirrorCfgID + "/sync"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if code := crossOrgRouteCase(t, tc.method, tc.path, scopes, seedForeignMirrorConfig); code != http.StatusForbidden {
+				t.Errorf("%s %s: status = %d, want 403 (mirror config owned by another organization)",
+					tc.method, tc.path, code)
+			}
+		})
+	}
+}
+
+// Issue #719: POST /admin/approvals/:id/token mints a single-use token whose
+// redemption endpoint is unauthenticated, so minting one for another
+// organization's request hands over a working credential.
+func TestApprovalRoutes_CrossOrg_Denied(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	scopes := []string{string(auth.ScopeMirrorsRead), string(auth.ScopeMirrorsManage)}
+	for _, tc := range []struct{ name, method, path string }{
+		{"read approval", http.MethodGet, "/api/v1/admin/approvals/" + approvalReqID},
+		{"mint approval token", http.MethodPost, "/api/v1/admin/approvals/" + approvalReqID + "/token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if code := crossOrgRouteCase(t, tc.method, tc.path, scopes, seedForeignApprovalRequest); code != http.StatusForbidden {
+				t.Errorf("%s %s: status = %d, want 403 (approval request belongs to another organization)",
+					tc.method, tc.path, code)
+			}
+		})
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -658,6 +658,8 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		auditShipper:                auditShipper,
 		nsAuthz:                     nsAuthz,
 		scmRepo:                     scmRepo,
+		mirrorRepo:                  mirrorRepo,
+		rbacRepo:                    rbacRepo,
 		scanRepo:                    scanRepo,
 		moduleDocsRepo:              moduleDocsRepo,
 		policyEngine:                policyEngine,

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -330,6 +330,8 @@ type apiV1RouteDeps struct {
 	auditShipper                audit.Shipper
 	nsAuthz                     *middleware.NamespaceAuthorizer
 	scmRepo                     *repositories.SCMRepository
+	mirrorRepo                  *repositories.MirrorRepository
+	rbacRepo                    *repositories.RBACRepository
 	scanRepo                    *repositories.ModuleScanRepository
 	moduleDocsRepo              *repositories.ModuleDocsRepository
 	policyEngine                *policy.PolicyEngine
@@ -898,16 +900,24 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			mirrorsGroup := authenticatedGroup.Group("/admin/mirrors")
 			{
 				// Read operations - require mirrors:read (or mirrors:manage or admin)
+				// As with the SCM provider family, every /:id route re-derives
+				// the caller's scope in the organization owning THAT mirror
+				// configuration; the group-level RequireScope only sees the
+				// flat org-less scope union (issues #652/#719).
+				mirrorConfigOrg := func(scope auth.Scope) gin.HandlerFunc {
+					return nsAuthz.RequireOrgScopeForResource(scope, mirrorConfigOrgResolver(d.mirrorRepo))
+				}
+
 				mirrorsGroup.GET("", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorHandlers.ListMirrorConfigs)
-				mirrorsGroup.GET("/:id", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorHandlers.GetMirrorConfig)
-				mirrorsGroup.GET("/:id/status", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorHandlers.GetMirrorStatus)
-				mirrorsGroup.GET("/:id/providers", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorHandlers.ListMirroredProviders)
+				mirrorsGroup.GET("/:id", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorConfigOrg(auth.ScopeMirrorsRead), mirrorHandlers.GetMirrorConfig)
+				mirrorsGroup.GET("/:id/status", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorConfigOrg(auth.ScopeMirrorsRead), mirrorHandlers.GetMirrorStatus)
+				mirrorsGroup.GET("/:id/providers", middleware.RequireScope(auth.ScopeMirrorsRead), mirrorConfigOrg(auth.ScopeMirrorsRead), mirrorHandlers.ListMirroredProviders)
 
 				// Management operations - require mirrors:manage (or admin)
 				mirrorsGroup.POST("", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorHandlers.CreateMirrorConfig)
-				mirrorsGroup.PUT("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorHandlers.UpdateMirrorConfig)
-				mirrorsGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorHandlers.DeleteMirrorConfig)
-				mirrorsGroup.POST("/:id/sync", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorHandlers.TriggerSync)
+				mirrorsGroup.PUT("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorConfigOrg(auth.ScopeMirrorsManage), mirrorHandlers.UpdateMirrorConfig)
+				mirrorsGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorConfigOrg(auth.ScopeMirrorsManage), mirrorHandlers.DeleteMirrorConfig)
+				mirrorsGroup.POST("/:id/sync", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorConfigOrg(auth.ScopeMirrorsManage), mirrorHandlers.TriggerSync)
 			}
 
 			// Terraform Binary Mirror admin endpoints (multi-config)
@@ -950,12 +960,24 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// Mirror Approval Requests
 			approvalsGroup := authenticatedGroup.Group("/admin/approvals")
 			{
+				// Per-org re-derivation for the /:id routes (issue #719). Not
+				// applied to PUT /:id/review, which already requires the
+				// platform-wide admin scope that this guard deliberately
+				// exempts — adding it there would be dead weight, not defence.
+				approvalOrg := func(scope auth.Scope) gin.HandlerFunc {
+					return nsAuthz.RequireOrgScopeForResource(scope, approvalRequestOrgResolver(d.rbacRepo))
+				}
+
 				approvalsGroup.GET("", middleware.RequireScope(auth.ScopeMirrorsRead), rbacHandlers.ListApprovalRequests)
-				approvalsGroup.GET("/:id", middleware.RequireScope(auth.ScopeMirrorsRead), rbacHandlers.GetApprovalRequest)
+				approvalsGroup.GET("/:id", middleware.RequireScope(auth.ScopeMirrorsRead), approvalOrg(auth.ScopeMirrorsRead), rbacHandlers.GetApprovalRequest)
 				approvalsGroup.POST("", middleware.RequireScope(auth.ScopeMirrorsManage), rbacHandlers.CreateApprovalRequest)
 				approvalsGroup.PUT("/:id/review", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.ReviewApproval)
 				// Generate a single-use token that allows out-of-band (email/Slack) approval.
-				approvalsGroup.POST("/:id/token", middleware.RequireScope(auth.ScopeMirrorsManage), rbacHandlers.GenerateApprovalToken)
+				// Guarded per-org: the redemption endpoint
+				// (POST /webhooks/approvals/:token) is unauthenticated, so
+				// minting a token for another organization's request would hand
+				// over a working credential.
+				approvalsGroup.POST("/:id/token", middleware.RequireScope(auth.ScopeMirrorsManage), approvalOrg(auth.ScopeMirrorsManage), rbacHandlers.GenerateApprovalToken)
 			}
 
 			// Version Approvals (provider + terraform mirror version gate)
@@ -1146,5 +1168,63 @@ func scmProviderOrgResolver(scmRepo *repositories.SCMRepository) middleware.Reso
 			return "", true, nil
 		}
 		return provider.OrganizationID.String(), true, nil
+	}
+}
+
+// mirrorConfigOrgResolver adapts MirrorRepository to
+// middleware.ResourceOrgResolver for /admin/mirrors/:id (issue #719).
+// mirror_configurations.organization_id is nullable, so an unowned row
+// resolves to ("", true, nil) and the guard treats it as admin-only.
+func mirrorConfigOrgResolver(mirrorRepo *repositories.MirrorRepository) middleware.ResourceOrgResolver {
+	return func(ctx context.Context, id string) (string, bool, error) {
+		if mirrorRepo == nil {
+			return "", false, errors.New("mirror repository not configured")
+		}
+		configID, err := uuid.Parse(id)
+		if err != nil {
+			return "", false, nil
+		}
+		config, err := mirrorRepo.GetByID(ctx, configID)
+		if err != nil {
+			return "", false, err
+		}
+		if config == nil {
+			return "", false, nil
+		}
+		if config.OrganizationID == nil || *config.OrganizationID == uuid.Nil {
+			return "", true, nil
+		}
+		return config.OrganizationID.String(), true, nil
+	}
+}
+
+// approvalRequestOrgResolver adapts RBACRepository to
+// middleware.ResourceOrgResolver for /admin/approvals/:id (issue #719).
+//
+// This one matters more than a typical read guard: GenerateApprovalToken mints
+// a single-use token whose redemption endpoint
+// (POST /webhooks/approvals/:token) is unauthenticated — possession of the
+// token is the credential — so an unguarded route let a caller mint an
+// approval for another organization's pending mirror request.
+func approvalRequestOrgResolver(rbacRepo *repositories.RBACRepository) middleware.ResourceOrgResolver {
+	return func(ctx context.Context, id string) (string, bool, error) {
+		if rbacRepo == nil {
+			return "", false, errors.New("rbac repository not configured")
+		}
+		requestID, err := uuid.Parse(id)
+		if err != nil {
+			return "", false, nil
+		}
+		req, err := rbacRepo.GetApprovalRequest(ctx, requestID)
+		if err != nil {
+			return "", false, err
+		}
+		if req == nil {
+			return "", false, nil
+		}
+		if req.OrganizationID == nil || *req.OrganizationID == uuid.Nil {
+			return "", true, nil
+		}
+		return req.OrganizationID.String(), true, nil
 	}
 }


### PR DESCRIPTION
Part of #719 (items 2 and 3) · builds on the guard added in #721

## The gap

Two more route families operating on org-scoped rows while authorized only against the flat, org-less scope union from the session JWT (#652):

- **`/admin/mirrors/:id`** (read, status, providers, update, delete, sync) over `mirror_configurations`.
- **`/admin/approvals/:id`** (read, and `POST /:id/token`) over `mirror_approval_requests`.

The approval token route is the sharper of the two: `GenerateApprovalToken` mints a single-use token whose redemption endpoint, `POST /webhooks/approvals/:token`, is **unauthenticated** — possession of the token is the credential. So a caller holding `mirrors:manage` in any one organization could mint a working approval for another organization's pending mirror request.

## The fix

Two `ResourceOrgResolver`s (`mirrorConfigOrgResolver`, `approvalRequestOrgResolver`) wired through the `RequireOrgScopeForResource` guard from #721 — no new authorization logic. Both org columns are nullable, so an unowned legacy row resolves to "found, but unowned" and is admin-only, consistent with the SCM provider family.

`PUT /:id/review` is deliberately **not** guarded: it already requires the platform-wide `admin` scope, which this guard exempts by design, so adding it would be dead weight rather than defence.

## Tests

`mirror_approval_routes_test.go` drives the real `registerAPIV1Routes` across all seven routes, with the target row owned by another organization and the caller not a member. Verified to fail with the wiring removed (403 → 500) and pass with it.

Two fixture details worth knowing for anyone writing similar tests: `mirror_configurations.pull_through_cache_ttl_hours` and `mirror_approval_requests.reason` are **non-pointer** fields, so a `nil` in the sqlmock row fails the scan. The guard fails closed on a resolver error (500, never a pass), which is correct — but it means a fixture bug and a logic bug look alike at first glance.

Verification: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` green; re-verified after rebasing onto the merged #721.