### PR TITLE
fix(security): tenant-scope provider/audit list endpoints and reject cross-org SCM binding

### DIFF
--- a/backend/internal/api/admin/audit_logs.go
+++ b/backend/internal/api/admin/audit_logs.go
@@ -4,10 +4,12 @@ package admin
 import (
 	"database/sql"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -15,12 +17,16 @@ import (
 type AuditLogHandlers struct {
 	db        *sql.DB
 	auditRepo *repositories.AuditRepository
+	// orgRepo resolves the caller's memberships so audit reads can be scoped to
+	// the organizations they actually belong to (issue #719).
+	orgRepo *repositories.OrganizationRepository
 }
 
 // NewAuditLogHandlers creates a new AuditLogHandlers instance
 func NewAuditLogHandlers(db *sql.DB) *AuditLogHandlers {
 	return &AuditLogHandlers{
 		db:        db,
+		orgRepo:   repositories.NewOrganizationRepository(db),
 		auditRepo: repositories.NewAuditRepository(db),
 	}
 }
@@ -90,6 +96,61 @@ func (h *AuditLogHandlers) ListAuditLogsHandler() gin.HandlerFunc {
 				return
 			}
 			filters.EndDate = &t
+		}
+
+		// Tenant scoping (issue #719). audit:read is granted per-organization by
+		// the `auditor` role template, but it arrives in the session JWT as part
+		// of a flat, org-less scope union (#652) — so without this an auditor in
+		// one organization read every organization's audit trail.
+		//
+		// Platform admins deliberately still see the whole estate: an audit
+		// trail nobody can review across tenants is not much of an audit trail,
+		// and `admin` is an explicitly-granted platform-wide scope, consistent
+		// with the admin exemption in the per-org guards.
+		//
+		// BEHAVIOUR CHANGE worth calling out in release notes: an existing
+		// non-admin auditor who could previously see all organizations will now
+		// see only their own.
+		if !h.callerIsPlatformAdmin(c) {
+			orgIDs, scopeErr := h.callerOrgIDs(c)
+			if scopeErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve organization memberships"})
+				return
+			}
+			if len(orgIDs) == 0 {
+				// No memberships: nothing is in scope. Fails closed rather than
+				// falling through to an unfiltered query. Returns the same
+				// AuditLogListResponse shape as every other path so clients
+				// don't have to special-case an empty result.
+				c.JSON(http.StatusOK, AuditLogListResponse{
+					Logs: []AuditLogResponse{},
+					Pagination: PaginationMeta{
+						Page:    page,
+						PerPage: perPage,
+						Total:   0,
+					},
+				})
+				return
+			}
+			if requested := c.Query("organization_id"); requested != "" {
+				if !slices.Contains(orgIDs, requested) {
+					c.JSON(http.StatusForbidden, gin.H{"error": "Not a member of the requested organization"})
+					return
+				}
+				filters.OrganizationID = &requested
+			} else if len(orgIDs) == 1 {
+				filters.OrganizationID = &orgIDs[0]
+			} else {
+				// The shared AuditFilters supports a single organization, so a
+				// multi-org caller must name one rather than silently receiving
+				// a partial or unscoped result.
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "organization_id is required for callers belonging to multiple organizations",
+				})
+				return
+			}
+		} else if requested := c.Query("organization_id"); requested != "" {
+			filters.OrganizationID = &requested
 		}
 
 		logs, total, err := h.auditRepo.ListAuditLogs(c.Request.Context(), filters, perPage, offset)
@@ -169,4 +230,44 @@ func (h *AuditLogHandlers) GetAuditLogHandler() gin.HandlerFunc {
 			CreatedAt:      log.CreatedAt,
 		})
 	}
+}
+
+// callerIsPlatformAdmin reports whether the caller holds the platform-wide
+// admin wildcard, which is exempt from per-organization audit scoping.
+func (h *AuditLogHandlers) callerIsPlatformAdmin(c *gin.Context) bool {
+	scopesVal, exists := c.Get("scopes")
+	if !exists {
+		return false
+	}
+	callerScopes, ok := scopesVal.([]string)
+	if !ok {
+		return false
+	}
+	return auth.HasScope(callerScopes, auth.ScopeAdmin)
+}
+
+// callerOrgIDs returns the organizations the caller belongs to. A missing
+// principal yields an empty set (fail closed), while a lookup failure is
+// reported so the handler can 500 rather than silently widening scope.
+func (h *AuditLogHandlers) callerOrgIDs(c *gin.Context) ([]string, error) {
+	userVal, exists := c.Get("user_id")
+	if !exists {
+		return nil, nil
+	}
+	userID, ok := userVal.(string)
+	if !ok || userID == "" {
+		return nil, nil
+	}
+	if h.orgRepo == nil {
+		return nil, nil
+	}
+	memberships, err := h.orgRepo.GetUserMemberships(c.Request.Context(), userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(memberships))
+	for _, m := range memberships {
+		out = append(out, m.OrganizationID)
+	}
+	return out, nil
 }

--- a/backend/internal/api/admin/audit_logs_test.go
+++ b/backend/internal/api/admin/audit_logs_test.go
@@ -8,6 +8,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 )
 
 // ---------------------------------------------------------------------------
@@ -69,6 +70,14 @@ func newAuditLogRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	h := NewAuditLogHandlers(db)
 
 	r := gin.New()
+	// See the note in scm_providers_test.go: these routes are unreachable
+	// without an authenticated principal in production, so the default test
+	// principal is a platform admin. Non-admin tenant scoping is covered
+	// separately (issue #719).
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", "test-admin")
+	})
 	r.GET("/audit-logs", h.ListAuditLogsHandler())
 	r.GET("/audit-logs/:id", h.GetAuditLogHandler())
 

--- a/backend/internal/api/admin/scm_providers.go
+++ b/backend/internal/api/admin/scm_providers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -304,16 +305,38 @@ func (h *SCMProviderHandlers) ListProviders(c *gin.Context) {
 	var providers []*scm.SCMProviderRecord
 	var err error
 
+	// The per-resource guard on /:id cannot help a list route, so membership is
+	// applied here (issues #718/#719). Previously an omitted organization_id
+	// listed EVERY organization's providers to any holder of the flat scm:read
+	// scope union, and an explicit organization_id was never checked against
+	// the caller's memberships at all — so listing was the enumeration step
+	// that made the per-provider attacks easy to aim.
+	isPlatformAdmin := false
+	if scopesVal, exists := c.Get("scopes"); exists {
+		if callerScopes, ok := scopesVal.([]string); ok {
+			isPlatformAdmin = auth.HasScope(callerScopes, auth.ScopeAdmin)
+		}
+	}
+
 	if orgIDStr != "" {
 		orgID, parseErr := uuid.Parse(orgIDStr)
 		if parseErr != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid organization_id"})
 			return
 		}
+		if !isPlatformAdmin && !h.callerIsMemberOf(c, orgID.String()) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Not a member of the requested organization"})
+			return
+		}
 		providers, err = h.scmRepo.ListProviders(c.Request.Context(), orgID)
-	} else {
-		// Pass uuid.Nil to list all providers
+	} else if isPlatformAdmin {
+		// Platform admins deliberately see every organization.
 		providers, err = h.scmRepo.ListProviders(c.Request.Context(), uuid.Nil)
+	} else {
+		// Everyone else gets the union of their own organizations rather than
+		// the whole estate. Fails closed: an error resolving memberships, or a
+		// caller with none, yields nothing rather than everything.
+		providers, err = h.listProvidersForCallerOrgs(c)
 	}
 
 	if err != nil {
@@ -585,4 +608,55 @@ func (h *SCMProviderHandlers) VerifyProvider(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"ok": true, "expires_at": token.ExpiresAt})
+}
+
+// callerIsMemberOf reports whether the authenticated caller holds any
+// membership in orgID. Fails closed on a missing principal or lookup error.
+func (h *SCMProviderHandlers) callerIsMemberOf(c *gin.Context, orgID string) bool {
+	userVal, exists := c.Get("user_id")
+	if !exists {
+		return false
+	}
+	userID, ok := userVal.(string)
+	if !ok || userID == "" {
+		return false
+	}
+	member, err := h.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, userID)
+	if err != nil || member == nil {
+		return false
+	}
+	return true
+}
+
+// listProvidersForCallerOrgs returns the providers of every organization the
+// caller belongs to. A caller with no memberships gets an empty list, never the
+// full estate.
+func (h *SCMProviderHandlers) listProvidersForCallerOrgs(c *gin.Context) ([]*scm.SCMProviderRecord, error) {
+	userVal, exists := c.Get("user_id")
+	if !exists {
+		return []*scm.SCMProviderRecord{}, nil
+	}
+	userID, ok := userVal.(string)
+	if !ok || userID == "" {
+		return []*scm.SCMProviderRecord{}, nil
+	}
+
+	memberships, err := h.orgRepo.GetUserMemberships(c.Request.Context(), userID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := []*scm.SCMProviderRecord{}
+	for _, m := range memberships {
+		orgID, parseErr := uuid.Parse(m.OrganizationID)
+		if parseErr != nil {
+			continue
+		}
+		providers, listErr := h.scmRepo.ListProviders(c.Request.Context(), orgID)
+		if listErr != nil {
+			return nil, listErr
+		}
+		out = append(out, providers...)
+	}
+	return out, nil
 }

--- a/backend/internal/api/admin/scm_providers_test.go
+++ b/backend/internal/api/admin/scm_providers_test.go
@@ -10,6 +10,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -69,6 +70,15 @@ func newSCMProviderRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	h := NewSCMProviderHandlers(&config.Config{}, scmRepo, orgRepo, cipher)
 
 	r := gin.New()
+	// These routes sit behind AuthMiddleware + RequireScope in production, so an
+	// unauthenticated principal can never reach the handler. Default the test
+	// router to a platform admin: it keeps each existing test exercising the
+	// behaviour it was written for, while tenant scoping for non-admins is
+	// covered separately (issue #719).
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", "test-admin")
+	})
 	r.POST("/scm-providers", h.CreateProvider)
 	r.GET("/scm-providers", h.ListProviders)
 	r.GET("/scm-providers/:id", h.GetProvider)

--- a/backend/internal/api/admin/tenant_scoping_test.go
+++ b/backend/internal/api/admin/tenant_scoping_test.go
@@ -1,0 +1,185 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Tenant-scoping tests for the two list endpoints that a per-resource guard
+// cannot protect (issue #719). Both were previously authorized only by the
+// flat, org-less scope union in the session JWT (#652), so a caller holding
+// scm:read or audit:read via membership in ONE organization could read across
+// every organization.
+
+const (
+	scopeUserID = "user-scoped"
+	orgAlpha    = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	orgBeta     = "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+)
+
+// Column shape of identity models.UserMembership, which GetUserMemberships
+// returns — deliberately different from GetMemberWithRole's row shape.
+// GetUserMemberships' row shape. Note the column ORDER differs from the field
+// order of identity models.UserMembership: created_at is scanned at index 3,
+// before the role-template columns. Verified against the real repository call.
+var membershipCols = []string{
+	"organization_id", "organization_name", "role_template_id", "created_at",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+func newNonAdminSCMRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewSCMProviderHandlers(
+		&config.Config{},
+		repositories.NewSCMRepository(sqlx.NewDb(db, "sqlmock")),
+		repositories.NewOrganizationRepository(db),
+		testTokenCipher(t),
+	)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeSCMRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/scm-providers", h.ListProviders)
+	return mock, r
+}
+
+func TestSCMList_NonAdmin_ForeignOrgFilter_Denied(t *testing.T) {
+	mock, r := newNonAdminSCMRouter(t)
+	// Not a member of the requested organization (GetMemberWithRole shape).
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/scm-providers?organization_id="+orgBeta, nil))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (not a member of the requested org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMList_NonAdmin_OwnOrgFilter_Allowed(t *testing.T) {
+	mock, r := newNonAdminSCMRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(memberRoleCols).AddRow(
+			orgAlpha, scopeUserID, "role-viewer", time.Now(),
+			"Scoped", "scoped@test.com", "viewer", "Viewer", []byte(`["scm:read"]`),
+		))
+	mock.ExpectQuery("(?s)FROM scm_providers").WillReturnRows(sqlmock.NewRows(scmProvCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/scm-providers?organization_id="+orgAlpha, nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (member of the requested org): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSCMList_NonAdmin_Unfiltered_ScopedToOwnOrgs(t *testing.T) {
+	mock, r := newNonAdminSCMRouter(t)
+	// With no organization_id the caller must get their OWN orgs' providers,
+	// not the whole estate: one membership lookup, then one per-org list.
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "role-viewer", time.Now(), "viewer", "Viewer", []byte(`["scm:read"]`),
+		))
+	mock.ExpectQuery("(?s)FROM scm_providers WHERE organization_id").
+		WillReturnRows(sqlmock.NewRows(scmProvCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/scm-providers", nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	// The per-org query having been consumed is the assertion that matters: a
+	// regression to the old behaviour would issue the unfiltered list instead.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected a per-organization provider query, got: %v", err)
+	}
+}
+
+func newNonAdminAuditRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewAuditLogHandlers(db)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAuditRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/audit-logs", h.ListAuditLogsHandler())
+	return mock, r
+}
+
+func TestListAuditLogs_NonAdmin_NoMemberships_ReturnsEmpty(t *testing.T) {
+	mock, r := newNonAdminAuditRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	// Must fail closed: no audit rows queried at all, rather than an unfiltered
+	// query returning every organization's trail.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected queries beyond the membership lookup: %v", err)
+	}
+}
+
+func TestListAuditLogs_NonAdmin_ForeignOrgFilter_Denied(t *testing.T) {
+	mock, r := newNonAdminAuditRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "role-auditor", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`),
+		))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs?organization_id="+orgBeta, nil))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (audit trail of an organization the caller does not belong to)", w.Code)
+	}
+}
+
+func TestListAuditLogs_NonAdmin_MultiOrg_RequiresExplicitOrg(t *testing.T) {
+	mock, r := newNonAdminAuditRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).
+			AddRow(orgAlpha, "Alpha", "r1", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`)).
+			AddRow(orgBeta, "Beta", "r2", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`)))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs", nil))
+
+	// A multi-org caller must name one rather than silently receiving a
+	// partial — or worse, unscoped — result.
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (multi-org caller must specify organization_id)", w.Code)
+	}
+}

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -181,6 +181,32 @@ func (h *SCMLinkingHandler) LinkModuleToSCM(c *gin.Context) {
 		return
 	}
 
+	// The route's RequireModuleAccessByID guard authorized the caller against
+	// the MODULE's owning organization and published it as owner_org_id; the
+	// provider side was previously unchecked, so a caller authorized for their
+	// own module could bind it to another organization's SCM provider (issue
+	// #719). That link is durable and credential-bearing: syncs would then run
+	// against the other organization's provider credentials.
+	//
+	// Rejected for every caller including platform admins, deliberately
+	// departing from this codebase's usual admin-bypass convention: this is not
+	// "act on one organization's resource" (which admin may do) but "create a
+	// persistent cross-tenant credential path", which nothing in the product
+	// needs and which would be invisible after the fact.
+	if ownerOrgVal, exists := c.Get("owner_org_id"); exists {
+		ownerOrgID, _ := ownerOrgVal.(string)
+		providerOrgID := ""
+		if provider.OrganizationID != uuid.Nil {
+			providerOrgID = provider.OrganizationID.String()
+		}
+		if ownerOrgID != "" && providerOrgID != "" && ownerOrgID != providerOrgID {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "SCM provider belongs to a different organization than the module",
+			})
+			return
+		}
+	}
+
 	// Check if module is already linked
 	existing, err := h.scmRepo.GetModuleSourceRepo(c.Request.Context(), moduleID)
 	if err != nil {


### PR DESCRIPTION
Closes #719
Closes #718

Finishes the cross-tenant work. The per-resource guard from #721 covers `/:id` routes; these are the cases it structurally cannot reach — two **list** endpoints and one **binding** decision.

## 1. `LinkModuleToSCM` — cross-org provider binding

The route's `RequireModuleAccessByID` guard authorized the caller against the *module's* org, but the provider side was never checked: the handler fetched the provider and only tested for existence. A caller legitimately authorized for their own module could bind it to **another organization's SCM provider**, after which syncs run against that org's credentials.

Now compared against `owner_org_id` (published by the guard) and rejected on mismatch.

**Deliberate departure from convention, flagged for review:** this is rejected for *platform admins too*, unlike every other guard in the codebase. The reasoning: this is not "act on one org's resource" (which admin legitimately does) but "create a persistent, credential-bearing cross-tenant link" — nothing in the product needs it, and it would be invisible afterwards. Easy to relax if you disagree.

## 2. `ListProviders` — the enumeration step

Two gaps: an omitted `organization_id` listed **every** organization's providers, and an explicit `organization_id` was never checked against the caller's memberships. This is what made the per-provider attacks in #718 easy to aim.

Now: platform admins see everything; everyone else gets the union of their own organizations, and an explicit org they don't belong to is a 403. Fails closed — no memberships yields nothing, not everything.

## 3. `GET /admin/audit-logs` — tenant scoping

`audit:read` is granted per-organization by the `auditor` role template but arrives as part of the flat scope union, so any auditor read every organization's trail.

Now scoped by membership. `AuditFilters` already had an `OrganizationID` field, so no change to the shared identity module was needed.

**⚠️ Behaviour change for release notes:** a non-admin auditor who previously saw all organizations now sees only their own. Platform admins still see the whole estate — an audit trail nobody can review across tenants isn't much of an audit trail. A caller in multiple organizations must now pass `organization_id` explicitly rather than silently receiving a partial result (`AuditFilters` holds one org).

## Tests

Six new tests in `tenant_scoping_test.go` covering: foreign-org filter denied, own-org allowed, unfiltered scoped to own orgs, no-memberships returns empty without querying audit rows, and multi-org requiring an explicit org.

Three pre-existing tests changed and it is worth being explicit that this is **not** weakening them: their routers mounted the handlers with *no authenticated principal*, which in production cannot reach these routes (they sit behind `AuthMiddleware` + `RequireScope`). They now run as a platform admin, which preserves exactly what each was testing (DB-error → 500, org filter → 200) while the new non-admin behaviour is covered separately.

Verification: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` green.