### PR TITLE
fix: always stop background services on shutdown, even when the drain fails

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -525,7 +525,7 @@ func serve(cfg *config.Config) error {
 	// running) is sent over listenErrCh instead of calling log.Fatalf here
 	// (issue #686): log.Fatalf calls os.Exit(1) directly from this goroutine,
 	// which would terminate the process immediately without running serve()'s
-	// deferred database.Close() or bgServices.Shutdown() below — worst-case
+	// deferred database.Close() or the bgServices.Shutdown() below — worst-case
 	// exactly during a resource-exhaustion incident. Sending the error back to
 	// the main goroutine instead lets the normal shutdown path run.
 	listenErrCh := make(chan error, 1)
@@ -560,18 +560,53 @@ func serve(cfg *config.Config) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := server.Shutdown(ctx); err != nil && listenErr == nil {
-		return fmt.Errorf("server forced to shutdown: %w", err)
-	}
-
-	// Stop background jobs and rate limiter goroutines
-	bgServices.Shutdown()
-
-	if listenErr != nil {
-		return fmt.Errorf("failed to start server: %w", listenErr)
+	if err := shutdownServices(ctx, server, bgServices.Shutdown, listenErr); err != nil {
+		return err
 	}
 
 	log.Println("Server stopped gracefully")
+	return nil
+}
+
+// serverShutdowner is the drain half of *http.Server, narrowed so the shutdown
+// sequence can be unit tested without binding a real listener.
+type serverShutdowner interface {
+	Shutdown(ctx context.Context) error
+}
+
+// shutdownServices drains the HTTP server and then stops background services,
+// returning the error that should end serve().
+//
+// Order matters and is preserved: the server drains first so in-flight requests
+// finish while the services they depend on (audit shipper, rate limiters) are
+// still running, and only then are those services stopped.
+//
+// stopBackground ALWAYS runs, including when the drain itself fails or hits its
+// timeout (issue #716). Previously the drain error returned early and skipped
+// it, so a shutdown that was already degraded — typically the 10s deadline
+// expiring with a slow request still in flight — also silently dropped the
+// audit shipper's buffered batch, losing exactly the records most useful for
+// explaining the slow shutdown. It is also the case where the flush matters
+// most, since the process is about to exit.
+//
+// Extracted from serve() for the same reason as waitForShutdownOrListenError:
+// serve() as a whole needs a live database, this logic does not.
+func shutdownServices(ctx context.Context, srv serverShutdowner, stopBackground func(), listenErr error) error {
+	shutdownErr := srv.Shutdown(ctx)
+
+	// Stop background jobs and rate limiter goroutines.
+	if stopBackground != nil {
+		stopBackground()
+	}
+
+	// A listener startup failure is the more useful error to surface, so it
+	// takes precedence over a drain error on that path (issue #686).
+	if listenErr != nil {
+		return fmt.Errorf("failed to start server: %w", listenErr)
+	}
+	if shutdownErr != nil {
+		return fmt.Errorf("server forced to shutdown: %w", shutdownErr)
+	}
 	return nil
 }
 

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"os"
 	"regexp"
@@ -272,5 +273,76 @@ func TestWaitForShutdownOrListenError_ListenerErrorWinsWhenBothReady(t *testing.
 	err := waitForShutdownOrListenError(quit, listenErrCh)
 	if err == nil {
 		t.Error("waitForShutdownOrListenError() = nil, want the delayed listener error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// shutdownServices (issue #716)
+// ---------------------------------------------------------------------------
+
+// stubShutdowner records that Shutdown ran and returns a fixed error.
+type stubShutdowner struct {
+	err    error
+	called bool
+}
+
+func (s *stubShutdowner) Shutdown(context.Context) error {
+	s.called = true
+	return s.err
+}
+
+// The regression case: a graceful shutdown that itself fails or times out must
+// still stop background services. Before #716 the drain error returned early,
+// skipping bgServices.Shutdown() — and with it the audit shipper's final flush.
+func TestShutdownServices_DrainError_StillStopsBackground(t *testing.T) {
+	srv := &stubShutdowner{err: errors.New("context deadline exceeded")}
+	stopped := false
+
+	err := shutdownServices(context.Background(), srv, func() { stopped = true }, nil)
+
+	if !stopped {
+		t.Error("background services were not stopped after a failed drain (issue #716)")
+	}
+	if err == nil {
+		t.Error("expected the drain error to be returned")
+	}
+}
+
+func TestShutdownServices_CleanShutdown(t *testing.T) {
+	srv := &stubShutdowner{}
+	stopped := false
+
+	if err := shutdownServices(context.Background(), srv, func() { stopped = true }, nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !srv.called {
+		t.Error("server drain was not attempted")
+	}
+	if !stopped {
+		t.Error("background services were not stopped")
+	}
+}
+
+// A listener startup failure must still drain and stop background services, and
+// its error takes precedence over any drain error (issue #686 behaviour, kept).
+func TestShutdownServices_ListenError_TakesPrecedenceAndStopsBackground(t *testing.T) {
+	srv := &stubShutdowner{err: errors.New("drain failed")}
+	stopped := false
+	listenErr := errors.New("bind: address already in use")
+
+	err := shutdownServices(context.Background(), srv, func() { stopped = true }, listenErr)
+
+	if !stopped {
+		t.Error("background services were not stopped on the listener-error path")
+	}
+	if err == nil || !errors.Is(err, listenErr) {
+		t.Errorf("err = %v, want the listener error to take precedence", err)
+	}
+}
+
+func TestShutdownServices_NilStopBackground_DoesNotPanic(t *testing.T) {
+	srv := &stubShutdowner{}
+	if err := shutdownServices(context.Background(), srv, nil, nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #716

## The bug

In `serve()`, a failed or timed-out graceful shutdown returned early and skipped `bgServices.Shutdown()`:

```go
if err := server.Shutdown(ctx); err != nil && listenErr == nil {
    return fmt.Errorf("server forced to shutdown: %w", err)   // <-- returns here
}
bgServices.Shutdown()                                          // <-- never runs
```

That call stops background jobs and rate-limiter goroutines and **flushes the audit shipper's buffered batch**. So a shutdown that was already degraded — typically the 10s deadline expiring with a slow request in flight — also silently dropped the audit records most useful for explaining the slow shutdown. It is the case where the flush matters most, since the process is about to exit.

Telling detail: the comment above the listener goroutine already described *"serve()'s deferred database.Close() or bgServices.Shutdown()"*. The author believed it was deferred. It wasn't — the code didn't match its own documentation. I corrected that comment's wording too.

## The fix

Extracted `shutdownServices(ctx, srv, stopBackground, listenErr)`, which always runs `stopBackground` and then decides what to return.

**Ordering is preserved deliberately**: the server drains first so in-flight requests finish while the services they depend on (audit shipper, rate limiters) are still running; only then are those services stopped. A plain `defer` would also have worked, but an explicit sequence makes that dependency legible rather than incidental.

Listener-error precedence from #686 is unchanged: a startup failure is still the error surfaced.

## Tests

Extracted for testability for the same reason as the neighbouring `waitForShutdownOrListenError` — `serve()` needs a live database, this logic doesn't. A narrow `serverShutdowner` interface lets a stub return a drain error.

Four cases: drain-error still stops background (the regression), clean shutdown, listener-error precedence *and* background still stopped, and a nil `stopBackground` not panicking.

Verified the regression test bites: reverting to the early-return makes it fail with `background services were not stopped after a failed drain (issue #716)`.

Verification: `gofmt` clean, `go build ./...`, `go vet ./...`, full `go test ./...` green.