### PR TITLE
docs: record audit-config activation and audit-log scoping as upgrade notes

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -84,6 +84,53 @@ If issues are found after upgrade:
 
 ## Version-Specific Upgrade Notes
 
+### 3.5.x → 3.6.0
+
+The exact version is whatever release first contains PRs #712 and #724 — confirm
+against `CHANGELOG.md`. Both entries below are **behavior changes that activate on
+upgrade with no configuration change**, so review them before deploying.
+
+**Audit configuration becomes active (#659, PR #712):**
+
+`audit.log_read_operations`, `audit.log_failed_requests` and `audit.shippers` were
+previously parsed and validated but **never actually used** — the audit middleware
+was wired with hardcoded `nil`s. That was the bug; those settings are now honored.
+
+If you already have any of them set, upgrading changes runtime behavior immediately:
+
+- `log_read_operations: true` — GET/read-path audit rows begin being written. On a
+  busy registry this can change audit table growth rate sharply; check retention and
+  disk headroom first.
+- `log_failed_requests: true` — failed-request rows begin being written.
+- `shippers: [...]` — a configured external shipper **starts receiving traffic**. The
+  registry begins making outbound calls to an endpoint that has never received them,
+  which may be unexpected volume for a webhook/SIEM target.
+
+**Recommended:** review your `audit.*` block before upgrading and comment out anything
+you did not intend to be live. To keep the previous effective behavior, unset these keys.
+
+**Audit log reads are scoped to the caller's organizations (#719, PR #724):**
+
+`GET /api/v1/admin/audit-logs` previously returned **every organization's** audit trail
+to any holder of `audit:read`. Because `audit:read` is granted per-organization by the
+`auditor` role template but arrives in the session token as part of a flat, org-less
+scope union, that crossed the tenant boundary.
+
+After upgrade:
+
+- Platform admins (the `admin` wildcard scope) still see all organizations.
+- A non-admin auditor sees only the organizations they belong to.
+- A caller belonging to **multiple** organizations must now pass `organization_id`
+  explicitly; without it the request returns `400` rather than a silently partial result.
+
+**Action required** if you have tooling, dashboards, or exports that read this endpoint
+with a non-admin token and expect estate-wide results: either grant that principal the
+`admin` scope deliberately, or update the caller to iterate per organization.
+
+**Migrations:** none for either change.
+
+**Rollback:** both are code-only; rolling back the binary restores the previous behavior.
+
 ### 0.6.x → 0.7.0
 
 **Breaking Changes:**


### PR DESCRIPTION
Closes #717

Adds a `3.5.x → 3.6.0` section to `docs/upgrade-guide.md` covering the two **behaviour changes that activate on upgrade with no configuration change**.

## Why here rather than CHANGELOG.md

`CHANGELOG.md` is generated by release-please from merged PR titles, so a hand-written note there would be overwritten. `docs/upgrade-guide.md` already has a "Version-Specific Upgrade Notes" section in exactly this shape (breaking changes / migrations / rollback), so the note lives where an operator planning an upgrade would actually look.

## What it documents

**1. Audit configuration becomes active (#659, PR #712).** `audit.log_read_operations`, `audit.log_failed_requests` and `audit.shippers` were parsed and validated but never used — the middleware was wired with hardcoded `nil`s. Operators who already set them have been running with them silently inert; on upgrade they go live, which can sharply change audit-table growth and, for `shippers`, start outbound traffic to an endpoint that has never received it.

**2. Audit log reads are org-scoped (#719, PR #724).** A non-admin auditor who previously saw every organization's trail now sees only their own, and a multi-org caller must pass `organization_id` explicitly (400 instead of a silently partial result). Includes the concrete action required for any tooling reading that endpoint with a non-admin token.

Both note "Migrations: none" and that rollback is code-only.

## Two things worth flagging

- The version heading says `3.5.x → 3.6.0` but the body states plainly that the exact version is whichever release first contains #712 and #724, to be confirmed against `CHANGELOG.md` — release-please picks the number, and I would rather the doc admit that than assert something that may not match.
- **The guide is stale independently of this change**: its version-specific notes run only to `0.9.x → 0.10.0` while the product is at 3.5.0, so everything between is undocumented. Out of scope here, but worth its own issue if upgrade notes are meant to be complete.