### PR TITLE
fix: add CSRF-protected POST /auth/logout alongside the GET route

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -7812,6 +7812,37 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.",
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Log out (CSRF-safe)",
+                "responses": {
+                    "200": {
+                        "description": "redirect_url to navigate to",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "CSRF token missing or invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/auth/me": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6335,6 +6335,32 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Log out (CSRF-safe)",
+                "responses": {
+                    "200": {
+                        "description": "redirect_url to navigate to",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "CSRF token missing or invalid",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
             }
         },
         "/api/v1/auth/me": {

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -554,6 +554,38 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 // GET /api/v1/auth/logout
 func (h *AuthHandlers) LogoutHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		c.Redirect(http.StatusFound, h.endSession(c))
+	}
+}
+
+// @Summary      Log out (CSRF-safe)
+// @Description  Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.
+// @Tags         Authentication
+// @Produce      json
+// @Success      200  {object}  map[string]interface{}  "redirect_url to navigate to"
+// @Failure      403  {object}  map[string]interface{}  "CSRF token missing or invalid"
+// @Router       /api/v1/auth/logout [post]
+// LogoutPostHandler is the CSRF-safe counterpart to LogoutHandler (#274 in the
+// state-manager repo; the same GET-only logout exists here). CSRFMiddleware
+// exempts safe methods, and with SameSite the auth cookie still rides a
+// cross-site top-level GET navigation, so an attacker-controlled link can force
+// a logout. Making it a POST brings it under the double-submit check.
+//
+// The GET route is retained for now: the shared terraform-suite-ui AuthProvider
+// drives logout for this app and the sibling state manager, so both backends
+// must accept POST before the frontend can move.
+// POST /api/v1/auth/logout
+func (h *AuthHandlers) LogoutPostHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"redirect_url": h.endSession(c)})
+	}
+}
+
+// endSession performs the teardown both logout routes share — revoke the JWT,
+// clear the auth and CSRF cookies — and returns where the caller should end up.
+// Kept as one function so the two verbs cannot drift apart.
+func (h *AuthHandlers) endSession(c *gin.Context) string {
+	{
 		// Revoke the current JWT if present
 		if claims, exists := c.Get("jwt_claims"); exists {
 			if jwtClaims, ok := claims.(*auth.Claims); ok && jwtClaims.JTI != "" {
@@ -601,14 +633,13 @@ func (h *AuthHandlers) LogoutHandler() gin.HandlerFunc {
 					// security concern of storing raw ID tokens in localStorage.
 					q.Set("client_id", h.cfg.Auth.OIDC.ClientID)
 					logoutURL.RawQuery = q.Encode()
-					c.Redirect(http.StatusFound, logoutURL.String())
-					return
+					return logoutURL.String()
 				}
 			}
 		}
 
-		// No OIDC end_session_endpoint available — redirect to the frontend home page.
-		c.Redirect(http.StatusFound, postLogoutRedirect)
+		// No OIDC end_session_endpoint available — the frontend home page.
+		return postLogoutRedirect
 	}
 }
 

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -24,6 +24,7 @@ import (
 	samlpkg "github.com/terraform-registry/terraform-registry/internal/auth/saml"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
 )
 
 // ---------------------------------------------------------------------------
@@ -2407,5 +2408,129 @@ func TestApplyLDAPGroupMappings_NothingConfigured(t *testing.T) {
 	if err := h.applyLDAPGroupMappings(context.Background(), "user-1",
 		[]string{"cn=x,ou=groups,dc=example,dc=com"}); err != nil {
 		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LogoutPostHandler — CSRF-safe logout (#274)
+// ---------------------------------------------------------------------------
+
+// POST /auth/logout does the same teardown as the GET route but answers 200
+// with the destination in the body. An XHR cannot usefully follow a
+// cross-origin 302 to the IdP's end_session_endpoint, so the SPA navigates
+// itself using redirect_url.
+func TestLogoutPostHandler_ReturnsRedirectURLNotRedirect(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://app.example.com"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	r := gin.New()
+	r.POST("/auth/logout", h.LogoutPostHandler())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/auth/logout", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("must not redirect; got Location = %q", loc)
+	}
+	if !strings.Contains(w.Body.String(), `"redirect_url":"https://app.example.com/"`) {
+		t.Errorf("body = %s, want redirect_url to the frontend root", w.Body.String())
+	}
+
+	var authCleared, csrfCleared bool
+	for _, ck := range w.Result().Cookies() {
+		if ck.Name == "tfr_auth_token" && ck.MaxAge < 0 {
+			authCleared = true
+		}
+		if ck.Name == "tfr_csrf" && ck.MaxAge < 0 {
+			csrfCleared = true
+		}
+	}
+	if !authCleared || !csrfCleared {
+		t.Errorf("cookies not cleared (auth=%v csrf=%v)", authCleared, csrfCleared)
+	}
+}
+
+// The two verbs must tear the session down identically — POST exists to change
+// the CSRF posture, not the logout semantics.
+func TestLogoutPostMatchesGetTeardown(t *testing.T) {
+	newRec := func(method string) *httptest.ResponseRecorder {
+		db, _, _ := sqlmock.New()
+		t.Cleanup(func() { db.Close() })
+		cfg := &config.Config{}
+		cfg.Server.PublicURL = "https://app.example.com"
+		h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+		r := gin.New()
+		r.GET("/auth/logout", h.LogoutHandler())
+		r.POST("/auth/logout", h.LogoutPostHandler())
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(method, "/auth/logout", nil))
+		return w
+	}
+	get, post := newRec(http.MethodGet), newRec(http.MethodPost)
+
+	cookies := func(w *httptest.ResponseRecorder) map[string]int {
+		out := map[string]int{}
+		for _, ck := range w.Result().Cookies() {
+			out[ck.Name] = ck.MaxAge
+		}
+		return out
+	}
+	gotGet, gotPost := cookies(get), cookies(post)
+	if len(gotGet) != len(gotPost) {
+		t.Fatalf("cookie teardown differs: GET %v vs POST %v", gotGet, gotPost)
+	}
+	for name, age := range gotGet {
+		if gotPost[name] != age {
+			t.Errorf("cookie %q: GET MaxAge=%d, POST MaxAge=%d", name, age, gotPost[name])
+		}
+	}
+	if loc := get.Header().Get("Location"); !strings.Contains(post.Body.String(), loc) {
+		t.Errorf("POST redirect_url does not match GET Location %q: %s", loc, post.Body.String())
+	}
+}
+
+// The POST route is only worth adding if CSRFMiddleware actually covers it —
+// this group is the PUBLIC one and does not inherit the authenticated group's
+// middleware, so the protection is attached per-route in router_routes.go. This
+// asserts the composition, not just the handler: a forged cross-site POST (no
+// X-CSRF-Token) must be rejected, while a proper double-submit succeeds.
+func TestLogoutPost_CSRFMiddlewareRejectsForgedRequest(t *testing.T) {
+	db, _, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://app.example.com"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	r := gin.New()
+	r.POST("/auth/logout", middleware.CSRFMiddleware(cfg), h.LogoutPostHandler())
+
+	// Forged: cookie-authenticated victim; the attacker cannot read the CSRF
+	// cookie cross-origin, so cannot set a matching header.
+	forged := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	forged.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: "v"})
+	forged.AddCookie(&http.Cookie{Name: "tfr_csrf", Value: "secret-token"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, forged)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("forged logout: status = %d, want 403 (%s)", w.Code, w.Body.String())
+	}
+
+	// Legitimate: the SPA echoes the cookie value in the header.
+	ok := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	ok.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: "v"})
+	ok.AddCookie(&http.Cookie{Name: "tfr_csrf", Value: "secret-token"})
+	ok.Header.Set("X-CSRF-Token", "secret-token")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, ok)
+	if w.Code != http.StatusOK {
+		t.Errorf("legitimate logout: status = %d, want 200 (%s)", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -486,6 +486,13 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			authGroup.GET("/login", authHandlers.LoginHandler())
 			authGroup.GET("/callback", authHandlers.CallbackHandler())
 			authGroup.GET("/logout", authHandlers.LogoutHandler())
+			// CSRF-safe logout. This group is the PUBLIC one, so it does not
+			// inherit registerAuthenticatedGroupMiddleware's CSRFMiddleware —
+			// it has to be attached to this route explicitly, otherwise the
+			// POST form would be exactly as forgeable as the GET one it
+			// replaces. GET stays until the shared suite frontend moves over
+			// (the sibling state manager carries the same route).
+			authGroup.POST("/logout", middleware.CSRFMiddleware(cfg), authHandlers.LogoutPostHandler())
 			authGroup.GET("/providers", authHandlers.ProvidersHandler())
 
 			// SAML endpoints


### PR DESCRIPTION
Registry half of a coordinated pair with [terraform-state-manager-backend#328](https://github.com/sethbacon/terraform-state-manager-backend/pull/328). Filed against TSM as #274; this repo carries the identical GET-only logout.

## Summary

`LogoutHandler` revokes the session JWT — a state-changing action — but was mounted only as `GET`. `CSRFMiddleware` exempts safe methods, and the auth cookie still rides a cross-site top-level navigation, so an attacker-controlled link to `/api/v1/auth/logout` forces a victim logout. Impact is limited to session termination (nuisance/availability), hence low severity.

## The part specific to this repo

Unlike the state manager — where `v1.Use(CSRFProtect())` covers the whole group — **the CSRF middleware here is not inherited**. `/auth` is the *public* group (rate limiting only); only `registerAuthenticatedGroupMiddleware` attaches `CSRFMiddleware`. So the POST route takes it explicitly:

```go
authGroup.POST("/logout", middleware.CSRFMiddleware(cfg), authHandlers.LogoutPostHandler())
```

Without that, the new verb would be exactly as forgeable as the GET it replaces — a fix in name only. `TestLogoutPost_CSRFMiddlewareRejectsForgedRequest` asserts the **composition**, not the handler alone: a cookie-authenticated request with no `X-CSRF-Token` gets 403; a proper double-submit gets 200.

## Why 200 and not a redirect

`endSession` ends at the OIDC `end_session_endpoint` when configured. An XHR cannot usefully follow a cross-origin redirect, so a naive "POST then follow the 302" would silently stop terminating the IdP session. POST returns `200 {"redirect_url": ...}` and the SPA navigates itself.

## Why GET stays

The shared `terraform-suite-ui` AuthProvider drives logout for this app *and* the state manager. Flipping the frontend before both backends accept POST breaks logout in whichever repo lagged. So POST ships *alongside* GET; the forced-logout vector remains reachable via GET until the removal follow-up.

## Implementation

Teardown (revoke JWT → clear auth cookie → clear CSRF cookie) moved into a shared `endSession` helper returning the destination, so the two verbs cannot drift — POST exists to change the CSRF posture, not the logout semantics. A test asserts both verbs produce identical cookie teardown and the same destination.

## Verification

- `go test ./internal/...` passes; `go vet` and `gofmt` clean.
- New tests: CSRF composition (403 forged / 200 legitimate), `redirect_url` shape with no `Location` header, and GET/POST teardown parity.
- `swag init` run and `docs/swagger.json` committed.
- **`-race` not run locally** (no gcc in my environment); relying on CI.

## Behavioural note for the frontend work

This middleware 403s an *anonymous* mutation (no CSRF cookie), whereas the state manager's passes it through and returns 200. So a POST logout on an already-expired session answers 403 here and 200 there. The shared AuthProvider should treat both as "session is gone — navigate anyway" rather than surfacing an error.

## Follow-ups

1. `terraform-suite-ui`: AuthProvider → XHR POST with `X-CSRF-Token`, navigate to `redirect_url`.
2. Both backends: remove GET. Only then is the vector actually closed.
