### PR TITLE
fix: remove the forgeable GET /auth/logout route

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -7762,57 +7762,6 @@
             }
         },
         "/api/v1/auth/logout": {
-            "get": {
-                "description": "Revokes the current JWT, clears the auth cookie, and when OIDC is active, redirects the browser to the provider's end_session_endpoint to terminate the SSO session. Falls back to a plain redirect to the frontend login page for non-OIDC setups.",
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "OIDC logout",
-                "parameters": [
-                    {
-                        "description": "URL to redirect to after the provider logs out (defaults to frontend /login)",
-                        "name": "post_logout_redirect_uri",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "302": {
-                        "description": "Redirects to OIDC end_session_endpoint or frontend /login",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized — no valid session",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.",
                 "tags": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -6293,49 +6293,6 @@
             }
         },
         "/api/v1/auth/logout": {
-            "get": {
-                "description": "Revokes the current JWT, clears the auth cookie, and when OIDC is active, redirects the browser to the provider's end_session_endpoint to terminate the SSO session. Falls back to a plain redirect to the frontend login page for non-OIDC setups.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "OIDC logout",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "URL to redirect to after the provider logs out (defaults to frontend /login)",
-                        "name": "post_logout_redirect_uri",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "302": {
-                        "description": "Redirects to OIDC end_session_endpoint or frontend /login",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized — no valid session",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.",
                 "produces": [

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -539,25 +539,6 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 	}
 }
 
-// @Summary      OIDC logout
-// @Description  Revokes the current JWT, clears the auth cookie, and when OIDC is active, redirects the browser to the provider's end_session_endpoint to terminate the SSO session. Falls back to a plain redirect to the frontend login page for non-OIDC setups.
-// @Tags         Authentication
-// @Accept       json
-// @Produce      json
-// @Param        post_logout_redirect_uri  query  string  false  "URL to redirect to after the provider logs out (defaults to frontend /login)"
-// @Success      302  {object}  string  "Redirects to OIDC end_session_endpoint or frontend /login"
-// @Failure      401  {object}  map[string]interface{}  "Unauthorized — no valid session"
-// @Failure      500  {object}  map[string]interface{}  "Internal server error"
-// @Router       /api/v1/auth/logout [get]
-// LogoutHandler revokes the current JWT, clears the auth cookie, and terminates
-// the OIDC SSO session by redirecting to the provider's end_session_endpoint.
-// GET /api/v1/auth/logout
-func (h *AuthHandlers) LogoutHandler() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Redirect(http.StatusFound, h.endSession(c))
-	}
-}
-
 // @Summary      Log out (CSRF-safe)
 // @Description  Revokes the session JWT, clears the auth and CSRF cookies, and returns where the client should navigate next — the OIDC end_session_endpoint when one is configured, otherwise the frontend home page. Unlike GET /auth/logout this is covered by the double-submit CSRF check, so it cannot be triggered by a cross-site navigation. Returns 200 with a redirect_url rather than a 302 because an XHR cannot follow a cross-origin redirect to the IdP.
 // @Tags         Authentication

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -675,10 +675,10 @@ func TestApplyGroupMappings_EmptyGroupsNoDefault(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// LogoutHandler — nil OIDC provider, redirects to frontend home
+// Logout destination resolution (POST is the only logout verb)
 // ---------------------------------------------------------------------------
 
-func TestLogoutHandler_NoOIDC_RedirectsToHome(t *testing.T) {
+func TestLogout_NoOIDC_ReturnsFrontendHome(t *testing.T) {
 	db, _, _ := sqlmock.New()
 	defer db.Close()
 
@@ -687,21 +687,20 @@ func TestLogoutHandler_NoOIDC_RedirectsToHome(t *testing.T) {
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
 	r := gin.New()
-	r.GET("/auth/logout", h.LogoutHandler())
+	r.POST("/auth/logout", h.LogoutPostHandler())
 
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/logout", nil))
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/auth/logout", nil))
 
-	if w.Code != http.StatusFound {
-		t.Errorf("status = %d, want 302", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
 	}
-	loc := w.Header().Get("Location")
-	if loc != "https://app.example.com/" {
-		t.Errorf("Location = %q, want %q", loc, "https://app.example.com/")
+	if !strings.Contains(w.Body.String(), `"redirect_url":"https://app.example.com/"`) {
+		t.Errorf("body = %s, want the frontend root", w.Body.String())
 	}
 }
 
-func TestLogoutHandler_BaseURL_Fallback(t *testing.T) {
+func TestLogout_BaseURL_Fallback(t *testing.T) {
 	db, _, _ := sqlmock.New()
 	defer db.Close()
 
@@ -710,17 +709,16 @@ func TestLogoutHandler_BaseURL_Fallback(t *testing.T) {
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
 	r := gin.New()
-	r.GET("/auth/logout", h.LogoutHandler())
+	r.POST("/auth/logout", h.LogoutPostHandler())
 
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/logout", nil))
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/auth/logout", nil))
 
-	if w.Code != http.StatusFound {
-		t.Errorf("status = %d, want 302", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
 	}
-	loc := w.Header().Get("Location")
-	if loc != "http://localhost:8080/" {
-		t.Errorf("Location = %q, want %q", loc, "http://localhost:8080/")
+	if !strings.Contains(w.Body.String(), `"redirect_url":"http://localhost:8080/"`) {
+		t.Errorf("body = %s, want the base-URL fallback", w.Body.String())
 	}
 }
 
@@ -2454,45 +2452,6 @@ func TestLogoutPostHandler_ReturnsRedirectURLNotRedirect(t *testing.T) {
 	}
 	if !authCleared || !csrfCleared {
 		t.Errorf("cookies not cleared (auth=%v csrf=%v)", authCleared, csrfCleared)
-	}
-}
-
-// The two verbs must tear the session down identically — POST exists to change
-// the CSRF posture, not the logout semantics.
-func TestLogoutPostMatchesGetTeardown(t *testing.T) {
-	newRec := func(method string) *httptest.ResponseRecorder {
-		db, _, _ := sqlmock.New()
-		t.Cleanup(func() { db.Close() })
-		cfg := &config.Config{}
-		cfg.Server.PublicURL = "https://app.example.com"
-		h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
-		r := gin.New()
-		r.GET("/auth/logout", h.LogoutHandler())
-		r.POST("/auth/logout", h.LogoutPostHandler())
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, httptest.NewRequest(method, "/auth/logout", nil))
-		return w
-	}
-	get, post := newRec(http.MethodGet), newRec(http.MethodPost)
-
-	cookies := func(w *httptest.ResponseRecorder) map[string]int {
-		out := map[string]int{}
-		for _, ck := range w.Result().Cookies() {
-			out[ck.Name] = ck.MaxAge
-		}
-		return out
-	}
-	gotGet, gotPost := cookies(get), cookies(post)
-	if len(gotGet) != len(gotPost) {
-		t.Fatalf("cookie teardown differs: GET %v vs POST %v", gotGet, gotPost)
-	}
-	for name, age := range gotGet {
-		if gotPost[name] != age {
-			t.Errorf("cookie %q: GET MaxAge=%d, POST MaxAge=%d", name, age, gotPost[name])
-		}
-	}
-	if loc := get.Header().Get("Location"); !strings.Contains(post.Body.String(), loc) {
-		t.Errorf("POST redirect_url does not match GET Location %q: %s", loc, post.Body.String())
 	}
 }
 

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -485,13 +485,15 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 		{
 			authGroup.GET("/login", authHandlers.LoginHandler())
 			authGroup.GET("/callback", authHandlers.CallbackHandler())
-			authGroup.GET("/logout", authHandlers.LogoutHandler())
-			// CSRF-safe logout. This group is the PUBLIC one, so it does not
-			// inherit registerAuthenticatedGroupMiddleware's CSRFMiddleware —
-			// it has to be attached to this route explicitly, otherwise the
-			// POST form would be exactly as forgeable as the GET one it
-			// replaces. GET stays until the shared suite frontend moves over
-			// (the sibling state manager carries the same route).
+			// Logout is POST-only. A GET logout sits outside the CSRF check
+			// (safe methods are exempt) and the auth cookie rides a cross-site
+			// top-level navigation, so a link could force a victim's session to
+			// be revoked; there is deliberately no GET route.
+			//
+			// This group is the PUBLIC one, so it does not inherit
+			// registerAuthenticatedGroupMiddleware's CSRFMiddleware — it has to
+			// be attached to this route explicitly, otherwise the POST form
+			// would be exactly as forgeable as the GET one it replaced.
 			authGroup.POST("/logout", middleware.CSRFMiddleware(cfg), authHandlers.LogoutPostHandler())
 			authGroup.GET("/providers", authHandlers.ProvidersHandler())
 


### PR DESCRIPTION
Completes the CSRF-safe logout work started in #729. Registry half of closing terraform-state-manager-backend#274.

## Summary

`POST /auth/logout` shipped in #729 and the frontend now calls it ([registry-frontend#664](https://github.com/sethbacon/terraform-registry-frontend/pull/664)), so the GET route can go.

**GET was the vulnerability.** `CSRFMiddleware` exempts safe methods by design, and the auth cookie still rides a cross-site top-level navigation — so an attacker-controlled link to `/api/v1/auth/logout` revoked the victim's session. Adding POST did not close that; it only provided a safe alternative. Deleting the GET route is what actually removes the vector.

## Changes

- `GET /auth/logout` route deleted; `LogoutHandler` deleted (my change made it unused).
- The two GET-route tests are **retargeted onto the POST handler**, keeping their real content — destination resolution from `PublicURL`, and the `BaseURL` fallback.
- The GET-vs-POST teardown parity test is dropped: it existed to prove the two verbs behaved identically *while both were mounted*, and is meaningless with one verb. `TestLogoutPost_CSRFMiddlewareRejectsForgedRequest` still guards the property that matters (403 forged / 200 legitimate).

## ⚠️ Deploy order

**The frontend must be deployed before this backend.** A frontend still issuing the GET redirect will break on logout against a backend that has dropped the route. Safe sequence:

1. Merge + deploy [registry-frontend#664](https://github.com/sethbacon/terraform-registry-frontend/pull/664) — safe, this backend still serves both verbs
2. Merge + deploy this

## Verification

- `go test ./internal/...` passes; `go vet` and `gofmt` clean.
- `swag init` run — the GET entry is gone from `docs/swagger.json`.
- **`-race` not run locally** (no gcc here); relying on CI.
