### PR TITLE
fix: invalidate every credential family when a principal's authority is reduced

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,30 @@ updates:
       - dependency-name: "github.com/golang-migrate/migrate/v4"
         update-types: [ "version-update:semver-major" ]
 
+  # backend/tools/credlifecycle is a SEPARATE Go module (its own go.mod), so the
+  # /backend entry above does not see it: Dependabot resolves one manifest per
+  # directory and does not recurse into nested modules. It is the repository's
+  # first nested module; without this entry its golang.org/x/tools dependency
+  # would never be updated and CI would never build it.
+  - package-ecosystem: gomod
+    directory: /backend/tools/credlifecycle
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: UTC
+    reviewers:
+      - maintainers
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
   # ---------------------------------------------------------------------------
   # Docker (backend/)
   # ---------------------------------------------------------------------------

--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -4220,7 +4220,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing custom role template. Cannot modify system role templates. Requires admin scope.",
+                "description": "Update an existing custom role template. Cannot modify system role templates. Requires admin scope. When the edit NARROWS the template's scopes, the affected members' sessions and over-asking API keys are revoked; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.",
                 "tags": [
                     "RBAC"
                 ],
@@ -9911,7 +9911,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update a member's role template within an organization.",
+                "description": "Update a member's role template within an organization. A reassignment revokes the member's sessions and any org-bound API key that over-asks under the new template; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.",
                 "tags": [
                     "Organizations"
                 ],
@@ -20888,6 +20888,7 @@
                 "type": "object",
                 "properties": {
                     "active": {
+                        "description": "Active is a POINTER so an omitted \"active\" is distinguishable from an\nexplicit \"active\": false.\n\nAs a plain bool it zero-valued to false on every PUT that did not\nmention the attribute, and PutUser reads false as \"deprovision\" -- which\nsince #736 means removing every organization membership AND irreversibly\ndeleting every API key the user holds in every organization. A partial\nPUT from an IdP (or any client updating only a display name) would\nsilently destroy the user's credentials fleet-wide. Deprovisioning must\nrequire the IdP to actually say active=false.",
                         "type": "boolean"
                     },
                     "emails": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3398,7 +3398,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing custom role template. Cannot modify system role templates. Requires admin scope.",
+                "description": "Update an existing custom role template. Cannot modify system role templates. Requires admin scope. When the edit NARROWS the template's scopes, the affected members' sessions and over-asking API keys are revoked; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8015,7 +8015,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update a member's role template within an organization.",
+                "description": "Update a member's role template within an organization. A reassignment revokes the member's sessions and any org-bound API key that over-asks under the new template; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.",
                 "consumes": [
                     "application/json"
                 ],
@@ -17708,6 +17708,7 @@
             "type": "object",
             "properties": {
                 "active": {
+                    "description": "Active is a POINTER so an omitted \"active\" is distinguishable from an\nexplicit \"active\": false.\n\nAs a plain bool it zero-valued to false on every PUT that did not\nmention the attribute, and PutUser reads false as \"deprovision\" -- which\nsince #736 means removing every organization membership AND irreversibly\ndeleting every API key the user holds in every organization. A partial\nPUT from an IdP (or any client updating only a display name) would\nsilently destroy the user's credentials fleet-wide. Deprovisioning must\nrequire the IdP to actually say active=false.",
                     "type": "boolean"
                 },
                 "emails": {

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -22,6 +22,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/auth/oidc"
 	samlpkg "github.com/terraform-registry/terraform-registry/internal/auth/saml"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
@@ -45,6 +46,13 @@ type AuthHandlers struct {
 	// samlEgressGuard widens the SSRF deny-list applied when fetching a SAML
 	// IdP's metadata_url (nil = strict). Set via WithSAMLEgressGuard.
 	samlEgressGuard *httpsafe.Guard
+	// creds sweeps the credentials stranded by the deprovisioning branch of
+	// reconcileGroupMemberships: when a login no longer carries the IdP group
+	// that granted an organization, the membership is removed but the member's
+	// org-bound API keys -- whose organization_id and scopes are frozen on the
+	// api_keys row -- would otherwise keep working forever (issue #732).
+	// Set via WithCredentialSweeper; nil is a no-op.
+	creds *credlifecycle.Sweeper
 }
 
 // AuthHandlersOption configures optional AuthHandlers construction behavior.
@@ -55,6 +63,12 @@ type AuthHandlersOption func(*AuthHandlers)
 // only reachable at an internal address.
 func WithSAMLEgressGuard(g *httpsafe.Guard) AuthHandlersOption {
 	return func(h *AuthHandlers) { h.samlEgressGuard = g }
+}
+
+// WithCredentialSweeper wires the credential sweep used by the IdP
+// group-mapping deprovisioning branch of reconcileGroupMemberships.
+func WithCredentialSweeper(s *credlifecycle.Sweeper) AuthHandlersOption {
+	return func(h *AuthHandlers) { h.creds = s }
 }
 
 // NewAuthHandlers creates a new AuthHandlers instance.
@@ -1051,6 +1065,18 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			if err := h.orgRepo.RemoveMember(ctx, org.ID, userID); err != nil {
 				return fmt.Errorf("revoke member org=%s user=%s: %w", org.ID, userID, err)
 			}
+			// Removing the membership does not touch the member's API keys,
+			// whose organization_id and scopes are frozen on the api_keys row
+			// and which authorizeOrgAccess still treats as authoritative --
+			// the IdP would believe it had offboarded a user who kept a
+			// working publish credential into this org's namespaces (issue
+			// #732). OrgKeysOnly deliberately leaves the JWT watermark alone:
+			// this runs a few hundred microseconds before the same request
+			// mints the user's new session token, and moving the watermark
+			// would make that token compare as revoked (see OrgKeysOnly's doc).
+			// The new token is derived from GetUserCombinedScopes after this
+			// removal, so it already carries the reduced authority.
+			h.creds.OrgKeysOnly(ctx, userID, org.ID, provider+" group mapping revoked")
 			slog.Info(provider+" group mapping revoked", "user_id", userID, "org", orgName)
 		default:
 			// Not wanted and not a member → nothing to do.

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1028,32 +1028,60 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		}
 
 		role, wanted := desiredRole[orgName]
-		// rejectIfNotProvisionable refuses the automatic, IdP-driven role
+		// resolveProvisionableRole refuses the automatic, IdP-driven role
 		// assignment when the resolved role_template carries auth.ScopeAdmin —
 		// see guardProvisionableRole's doc for the full rationale (#604).
 		// Deliberately does NOT flip `wanted` to false: on rejection this must
 		// skip the assignment, not fall through to the revoke branch below and
 		// tear down an existing (possibly unrelated, legitimately-granted)
 		// membership.
-		rejectIfNotProvisionable := func() bool {
-			if guardErr := h.guardProvisionableRole(ctx, role); guardErr != nil {
+		//
+		// On acceptance it also yields the mapped template's scopes, which are
+		// what the member will hold in this org once the write commits — the
+		// retention filter the reassignment branch's sweep needs, obtained from
+		// the lookup the guard was already making.
+		resolveProvisionableRole := func() ([]string, bool) {
+			scopes, guardErr := h.guardProvisionableRole(ctx, role)
+			if guardErr != nil {
 				slog.Warn(provider+" group mapping rejected: resolved role is not automatically provisionable by an IdP-driven mapping; a human admin must grant it explicitly",
 					"user_id", userID, "org", orgName, "role", role, "error", guardErr)
-				return true
+				return nil, false
 			}
-			return false
+			return scopes, true
 		}
 		switch {
 		case wanted && isMember:
-			if rejectIfNotProvisionable() {
+			retained, ok := resolveProvisionableRole()
+			if !ok {
 				continue
 			}
 			if err := h.orgRepo.UpdateMemberRole(ctx, org.ID, userID, role); err != nil {
 				return fmt.Errorf("update member role org=%s user=%s role=%s: %w", org.ID, userID, role, err)
 			}
+			// An IdP group change can map the user to a LOWER role than they
+			// held (owner -> viewer), and this branch commits that reduction.
+			// The member's org-bound API keys froze their scopes at creation
+			// under the OLD template and nothing re-derives them, so without
+			// this the demotion is cosmetic for the API-key family exactly as
+			// the missing sweep on the removal branch was (issue #732).
+			//
+			// `retained` is the NEW template's scopes, so this is a no-op for
+			// the far more common promotion or same-role re-login: only keys
+			// asking for more than the new template grants are deleted (see
+			// credlifecycle.AuthorityRetained). Deleting an API key is
+			// irreversible, so sweeping on every reconciliation — every login,
+			// for every managed org — would be indefensible.
+			//
+			// OrgKeysOnly, not OrgAuthorityReduced: the JWT watermark is left
+			// alone here for the same reason as the removal branch below, and
+			// with the same residual. See OrgKeysOnly's doc.
+			h.creds.OrgKeysOnly(ctx, userID, org.ID, retained, provider+" group mapping role reassigned")
 			slog.Info(provider+" group mapping applied", "user_id", userID, "org", orgName, "role", role)
 		case wanted && !isMember:
-			if rejectIfNotProvisionable() {
+			// The scopes are not needed on this branch: adding a membership is
+			// an authority INCREASE, and no credential of this user in this org
+			// can be a snapshot of an authority they did not have.
+			if _, ok := resolveProvisionableRole(); !ok {
 				continue
 			}
 			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, role); err != nil {
@@ -1073,9 +1101,12 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			// #732). OrgKeysOnly deliberately leaves the JWT watermark alone:
 			// this runs a few hundred microseconds before the same request
 			// mints the user's new session token, and moving the watermark
-			// would make that token compare as revoked (see OrgKeysOnly's doc).
-			// The new token is derived from GetUserCombinedScopes after this
-			// removal, so it already carries the reduced authority.
+			// would make that token compare as revoked. That covers THIS
+			// request's token, which is derived from GetUserCombinedScopes
+			// after the removal and so already carries the reduced authority;
+			// it does NOT cover the user's other live sessions from earlier
+			// logins, which keep the pre-removal scope union until their TTL
+			// expires. See OrgKeysOnly's doc for the residual in full.
 			// retained is nil: the user is no longer a member of this org, so
 			// every key bound to it over-asks.
 			h.creds.OrgKeysOnly(ctx, userID, org.ID, nil, provider+" group mapping revoked")

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1076,7 +1076,9 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			// would make that token compare as revoked (see OrgKeysOnly's doc).
 			// The new token is derived from GetUserCombinedScopes after this
 			// removal, so it already carries the reduced authority.
-			h.creds.OrgKeysOnly(ctx, userID, org.ID, provider+" group mapping revoked")
+			// retained is nil: the user is no longer a member of this org, so
+			// every key bound to it over-asks.
+			h.creds.OrgKeysOnly(ctx, userID, org.ID, nil, provider+" group mapping revoked")
 			slog.Info(provider+" group mapping revoked", "user_id", userID, "org", orgName)
 		default:
 			// Not wanted and not a member → nothing to do.

--- a/backend/internal/api/admin/credential_lifecycle_class_test.go
+++ b/backend/internal/api/admin/credential_lifecycle_class_test.go
@@ -1,0 +1,427 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/api/scim"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// ---------------------------------------------------------------------------
+// Class test: authority-reduction must invalidate every credential family
+// (issues #732, #736)
+// ---------------------------------------------------------------------------
+//
+// DEFECT CLASS
+//
+//	A handler commits an event that REDUCES a principal's derived authority
+//	(organization membership removed, member's role template reassigned, role
+//	template edited or deleted, user deprovisioned by the IdP) but does not
+//	invalidate every credential that carries a *snapshot* of that authority.
+//	The registry has two such families -- JWT sessions (scopes embedded at
+//	login) and API keys (scopes AND organization_id stored on the api_keys row)
+//	-- and before this test only the JWT family was swept, at only some events.
+//	An offboarded member therefore kept a working modules:write/providers:write
+//	credential into the organization's namespaces with no expiry at all.
+//
+// This table is the class, one row per enumerated site. Adding a new
+// authority-reducing site without a row here is the regression the enumeration
+// signature (backend/tools/credlifecycle) is there to catch; removing the
+// guard from any single site must fail exactly that site's row.
+//
+// The last row is the complementary use-time control: even for a key some
+// lifecycle path failed to sweep, the namespace authorizer re-verifies the
+// key owner's current membership instead of trusting the key's frozen org
+// binding, so a stale key fails closed.
+
+// expectOrgKeySweep registers the two statements that revoke every API key
+// userID holds in orgID: the org-scoped list, then the delete of the one key
+// it returns.
+func expectOrgKeySweep(mock sqlmock.Sqlmock, userID, orgID, keyID string) {
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs(userID, orgID).
+		WillReturnRows(sqlmock.NewRows(akListCols).
+			AddRow(keyID, userID, orgID, "CI Key", nil, "hashedkey", "tfr_abc123",
+				testKeyScopes, nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs(keyID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// expectAllKeysSweep registers the statements that revoke every API key userID
+// holds anywhere -- the whole-principal offboarding sweep.
+func expectAllKeysSweep(mock sqlmock.Sqlmock, userID, keyID string) {
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows(akListCols).
+			AddRow(keyID, userID, "org-1", "CI Key", nil, "hashedkey", "tfr_abc123",
+				testKeyScopes, nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs(keyID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// scimUserRows is the row shape of identity UserRepository.GetUserByID.
+func scimUserRows(userID string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}).
+		AddRow(userID, "jane@example.com", "Jane Doe", nil, time.Now(), time.Now())
+}
+
+// newSCIMDeprovisionRouter builds the real SCIM handler set with the credential
+// sweeper wired over the mocked connection.
+func newSCIMDeprovisionRouter(db *sql.DB) *gin.Engine {
+	h := scim.NewHandlers(&config.Config{}, db, scim.WithCredentialSweeper(
+		credlifecycle.NewSweeper(
+			repositories.NewUserTokenRevocationRepository(db),
+			repositories.NewAPIKeyRepository(db),
+		),
+	))
+	r := gin.New()
+	r.PUT("/scim/v2/Users/:id", h.PutUser())
+	r.PATCH("/scim/v2/Users/:id", h.PatchUser())
+	r.DELETE("/scim/v2/Users/:id", h.DeleteUser())
+	return r
+}
+
+// expectSCIMDeprovisionSweep registers the shared tail of every SCIM
+// deprovisioning path: strip memberships, move the JWT watermark, revoke all
+// API keys.
+func expectSCIMDeprovisionSweep(mock sqlmock.Sqlmock, userID string) {
+	mock.ExpectExec("DELETE FROM organization_members").
+		WithArgs(userID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs(userID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectAllKeysSweep(mock, userID, "key-scim")
+}
+
+type credLifecycleCase struct {
+	// site is the stable identity of the enumerated defect instance.
+	site string
+	// run wires the real handler over db, registers the SQL the sweep must
+	// issue, and drives the lifecycle event.
+	run func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock)
+}
+
+func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFamilies(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []credLifecycleCase{
+		{
+			// #732 primary instance.
+			site: "admin.OrganizationHandlers.RemoveMemberHandler / DELETE /api/v1/organizations/:id/members/:user_id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewOrganizationHandlers(&config.Config{}, db,
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewUserTokenRevocationRepository(db))
+				r := gin.New()
+				r.DELETE("/organizations/:id/members/:user_id", h.RemoveMemberHandler())
+
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sampleMemberWithRoleRow())
+				mock.ExpectExec("DELETE FROM organization_members").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("user-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectOrgKeySweep(mock, "user-1", "org-1", "key-removed-member")
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1/members/user-1", nil))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: "admin.OrganizationHandlers.UpdateMemberHandler / PUT /api/v1/organizations/:id/members/:user_id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewOrganizationHandlers(&config.Config{}, db,
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewUserTokenRevocationRepository(db))
+				r := gin.New()
+				r.PUT("/organizations/:id/members/:user_id", h.UpdateMemberHandler())
+
+				mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+					WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
+				mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
+					WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+				mock.ExpectExec("UPDATE organization_members").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("user-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectOrgKeySweep(mock, "user-1", "org-1", "key-rerole")
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sampleMemberWithRoleRow())
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1/members/user-1",
+					bytes.NewBufferString(`{"role_template_id": "`+newRoleTemplateUUID+`"}`)))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: "admin.RBACHandlers.UpdateRoleTemplate / PUT /api/v1/admin/role-templates/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewRBACHandlers(
+					repositories.NewRBACRepository(sqlx.NewDb(db, "sqlmock")),
+					repositories.NewUserTokenRevocationRepository(db),
+					repositories.NewAPIKeyRepository(db))
+				r := gin.New()
+				r.Use(func(c *gin.Context) { c.Set("user_id", knownUserUUID) })
+				r.PUT("/role-templates/:id", h.UpdateRoleTemplate)
+
+				mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+					WillReturnRows(sampleRTRow())
+				mock.ExpectExec("UPDATE role_templates.*SET display_name").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+					WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+						AddRow("member-1", "org-1"))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("member-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectOrgKeySweep(mock, "member-1", "org-1", "key-rt-edit")
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
+					jsonBody(map[string]interface{}{
+						"name":         "reader",
+						"display_name": "Reader Updated",
+						"scopes":       []string{"modules:read"}, // narrower than testRTScopes
+					})))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: "admin.RBACHandlers.DeleteRoleTemplate / DELETE /api/v1/admin/role-templates/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewRBACHandlers(
+					repositories.NewRBACRepository(sqlx.NewDb(db, "sqlmock")),
+					repositories.NewUserTokenRevocationRepository(db),
+					repositories.NewAPIKeyRepository(db))
+				r := gin.New()
+				r.Use(func(c *gin.Context) { c.Set("user_id", knownUserUUID) })
+				r.DELETE("/role-templates/:id", h.DeleteRoleTemplate)
+
+				mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+					WillReturnRows(sampleRTRow())
+				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+					WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+						AddRow("member-1", "org-1"))
+				mock.ExpectExec("DELETE FROM role_templates WHERE id").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("member-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectOrgKeySweep(mock, "member-1", "org-1", "key-rt-delete")
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/role-templates/"+knownUUID, nil))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// IdP-driven deprovisioning at login: the group that granted the org
+			// is gone, so the membership is removed. Only the API-key family is
+			// swept here on purpose -- see credlifecycle.Sweeper.OrgKeysOnly.
+			site: "admin.AuthHandlers.reconcileGroupMemberships (IdP deprovision branch, OIDC/SAML/LDAP login)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				cfg := &config.Config{}
+				cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+					{Group: "platform-team", Organization: "acme", Role: "editor"},
+				}
+				h, err := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour),
+					WithCredentialSweeper(credlifecycle.NewSweeper(
+						repositories.NewUserTokenRevocationRepository(db),
+						repositories.NewAPIKeyRepository(db))))
+				if err != nil {
+					t.Fatalf("NewAuthHandlers: %v", err)
+				}
+
+				mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+					WithArgs("acme").
+					WillReturnRows(sqlmock.NewRows(authOrgCols).
+						AddRow("org-1", "acme", "Acme Corp", nil, nil, time.Now(), time.Now()))
+				roleID := "rt-old"
+				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+					WillReturnRows(sqlmock.NewRows(authMemberCols).
+						AddRow("org-1", "user-1", &roleID, time.Now()))
+				mock.ExpectExec("DELETE FROM organization_members").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				expectOrgKeySweep(mock, "user-1", "org-1", "key-idp-deprovision")
+
+				// Login no longer carries "platform-team" → deprovision branch.
+				if err := h.applyGroupMappings(context.Background(), "user-1", []string{"other-team"}); err != nil {
+					t.Fatalf("applyGroupMappings: %v", err)
+				}
+			},
+		},
+		{
+			// #736 primary instance.
+			site: "scim.Handlers.DeleteUser / DELETE /scim/v2/Users/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				r := newSCIMDeprovisionRouter(db)
+				mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+					WillReturnRows(scimUserRows("user-scim"))
+				expectSCIMDeprovisionSweep(mock, "user-scim")
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/scim/v2/Users/user-scim", nil))
+				if w.Code != http.StatusNoContent {
+					t.Fatalf("status = %d, want 204: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: "scim.Handlers.PutUser (active=false) / PUT /scim/v2/Users/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				r := newSCIMDeprovisionRouter(db)
+				mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+					WillReturnRows(scimUserRows("user-scim"))
+				expectSCIMDeprovisionSweep(mock, "user-scim")
+				mock.ExpectExec("UPDATE users").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("PUT", "/scim/v2/Users/user-scim",
+					bytes.NewBufferString(`{"userName":"jane@example.com","active":false}`))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: `scim.Handlers.applyReplaceOp (path="active", false) / PATCH /scim/v2/Users/:id`,
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				r := newSCIMDeprovisionRouter(db)
+				mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+					WillReturnRows(scimUserRows("user-scim"))
+				expectSCIMDeprovisionSweep(mock, "user-scim")
+				mock.ExpectExec("UPDATE users").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("PATCH", "/scim/v2/Users/user-scim",
+					bytes.NewBufferString(`{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],`+
+						`"Operations":[{"op":"replace","path":"active","value":false}]}`))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			site: `scim.Handlers.applyReplaceOp (pathless {"active":false}) / PATCH /scim/v2/Users/:id`,
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				r := newSCIMDeprovisionRouter(db)
+				mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+					WillReturnRows(scimUserRows("user-scim"))
+				expectSCIMDeprovisionSweep(mock, "user-scim")
+				mock.ExpectExec("UPDATE users").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("PATCH", "/scim/v2/Users/user-scim",
+					bytes.NewBufferString(`{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],`+
+						`"Operations":[{"op":"replace","value":{"active":false}}]}`))
+				req.Header.Set("Content-Type", "application/json")
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// Complementary use-time control: an API key whose org binding is
+			// stale (owner no longer a member) must not authorize the namespace,
+			// even though nothing swept the key. This is what makes the class
+			// non-exploitable for any lifecycle site the sweep might miss.
+			site: "middleware.NamespaceAuthorizer.authorizeOrgAccess (org-bound API key, owner no longer a member)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				authz := middleware.NewNamespaceAuthorizer(
+					repositories.NewOrganizationRepository(db),
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewModuleRepository(db),
+					repositories.NewProviderRepository(db))
+
+				// Namespace "acme" is claimed by the very org the key is bound to.
+				mock.ExpectQuery("SELECT.*FROM namespace_claims").
+					WillReturnRows(sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}).
+						AddRow("acme", "org-1", nil, time.Now()))
+				// The key's owner is no longer a member of org-1.
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sqlmock.NewRows(memberRoleCols))
+
+				owner := "user-1"
+				r := gin.New()
+				r.DELETE("/modules/:namespace/:name/:system",
+					func(c *gin.Context) {
+						c.Set("scopes", []string{string(auth.ScopeModulesWrite)})
+						c.Set("user_id", owner)
+						c.Set("api_key", &models.APIKey{
+							ID:             "key-stale",
+							UserID:         &owner,
+							OrganizationID: "org-1",
+							Scopes:         []string{string(auth.ScopeModulesWrite)},
+						})
+					},
+					authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+					func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/modules/acme/vpc/aws", nil))
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403 (stale org-bound API key must fail closed): body=%s",
+						w.Code, w.Body.String())
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.site, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			tc.run(t, db, mock)
+
+			// Every registered statement must have been issued. For the sweep
+			// rows this is the assertion that the API-key revocation actually
+			// happened; sqlmock reports an unfulfilled expectation when it did
+			// not.
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("credential sweep incomplete for %s: %v", tc.site, err)
+			}
+		})
+	}
+}

--- a/backend/internal/api/admin/credential_lifecycle_class_test.go
+++ b/backend/internal/api/admin/credential_lifecycle_class_test.go
@@ -407,6 +407,116 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 			},
 		},
 		{
+			// The OTHER reducing arm of the same switch as the row above, and
+			// the one the fix originally missed. An IdP group change can map a
+			// user to a LOWER role (owner -> viewer); that arm commits the
+			// reduction through UpdateMemberRole and swept nothing, while its
+			// sibling swept the org's keys. Because the enclosing function
+			// reached both credential families through the sibling, neither the
+			// class table nor the enumeration signature scored it as a gap --
+			// which is why the signature now asks the question per branch.
+			site: "admin.AuthHandlers.reconcileGroupMemberships (IdP role-reassignment branch, demotion)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				cfg := &config.Config{}
+				cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+					{Group: "platform-team", Organization: "acme", Role: "viewer"},
+				}
+				h, err := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour),
+					WithCredentialSweeper(credlifecycle.NewSweeper(
+						repositories.NewUserTokenRevocationRepository(db),
+						repositories.NewAPIKeyRepository(db))))
+				if err != nil {
+					t.Fatalf("NewAuthHandlers: %v", err)
+				}
+
+				mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+					WithArgs("acme").
+					WillReturnRows(sqlmock.NewRows(authOrgCols).
+						AddRow("org-1", "acme", "Acme Corp", nil, nil, time.Now(), time.Now()))
+				// Already a member, under the template they are about to lose.
+				oldRole := "rt-owner"
+				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+					WillReturnRows(sqlmock.NewRows(authMemberCols).
+						AddRow("org-1", "user-1", &oldRole, time.Now()))
+				// The guard's lookup doubles as the retention filter: "viewer"
+				// grants read only, so it is what the member retains.
+				expectRoleScopesLookup(mock, "viewer", []string{"modules:read"})
+				mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+					WithArgs("viewer").
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-viewer"))
+				mock.ExpectExec("UPDATE organization_members").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				// The key was minted under the owner template and still asks
+				// for modules:write, which viewer does not grant.
+				expectOrgKeySweepScoped(mock, "user-1", "org-1", "key-idp-demoted",
+					[]byte(`["modules:write"]`))
+
+				// The login still carries "platform-team" -- it now maps to a
+				// weaker role, which is the whole point: this is a reduction
+				// that never touches the deprovision branch.
+				if err := h.applyGroupMappings(context.Background(), "user-1", []string{"platform-team"}); err != nil {
+					t.Fatalf("applyGroupMappings: %v", err)
+				}
+			},
+		},
+		{
+			// Paired negative control for the row above. Deleting an API key is
+			// irreversible, so sweeping on every reconciliation -- i.e. on every
+			// login, for every managed org -- would destroy working credentials
+			// fleet-wide.
+			//
+			// sqlmock cannot carry this assertion alone: an unregistered DELETE
+			// returns an error, and the sweep swallows its own errors by design
+			// (the authority change has already committed), so a wrongly
+			// deleted key would still leave ExpectationsWereMet() green. The
+			// decisive assertion is the log: the sweeper announces every key it
+			// revokes and every revocation it fails, and a RETAINED key
+			// produces neither line.
+			site: "admin.AuthHandlers.reconcileGroupMemberships (IdP role-reassignment branch, promotion retains keys)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				logs := captureSlogOutput(t)
+				cfg := &config.Config{}
+				cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+					{Group: "platform-team", Organization: "acme", Role: "publisher"},
+				}
+				h, err := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour),
+					WithCredentialSweeper(credlifecycle.NewSweeper(
+						repositories.NewUserTokenRevocationRepository(db),
+						repositories.NewAPIKeyRepository(db))))
+				if err != nil {
+					t.Fatalf("NewAuthHandlers: %v", err)
+				}
+
+				mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+					WithArgs("acme").
+					WillReturnRows(sqlmock.NewRows(authOrgCols).
+						AddRow("org-1", "acme", "Acme Corp", nil, nil, time.Now(), time.Now()))
+				oldRole := "rt-viewer"
+				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+					WillReturnRows(sqlmock.NewRows(authMemberCols).
+						AddRow("org-1", "user-1", &oldRole, time.Now()))
+				expectRoleScopesLookup(mock, "publisher", []string{"modules:read", "modules:write"})
+				mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+					WithArgs("publisher").
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-publisher"))
+				mock.ExpectExec("UPDATE organization_members").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				// modules:read is still granted by the new template, so the key
+				// asks for nothing it lost: listed, and left alone.
+				expectOrgKeyList(mock, "user-1", "org-1", "key-idp-promoted", testKeyScopes)
+
+				if err := h.applyGroupMappings(context.Background(), "user-1", []string{"platform-team"}); err != nil {
+					t.Fatalf("applyGroupMappings: %v", err)
+				}
+				for _, forbidden := range []string{"API key revoked", "failed to revoke org-bound API key"} {
+					if strings.Contains(logs.String(), forbidden) {
+						t.Errorf("a promotion deleted an API key that is still within the new authority (log contains %q); logs: %s",
+							forbidden, logs.String())
+					}
+				}
+			},
+		},
+		{
 			// #736 primary instance.
 			site: "scim.Handlers.DeleteUser / DELETE /scim/v2/Users/:id",
 			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
@@ -696,6 +806,53 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 					"namespace": "brand-new", "name": "vpc", "system": "aws"}))
 				if w.Code != http.StatusForbidden {
 					t.Fatalf("status = %d, want 403 (stale key must not claim a new namespace): body=%s",
+						w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// The BACKWARD population. identity.api_keys.user_id is ON DELETE
+			// SET NULL, so every user deletion that happened before the sweep
+			// shipped left a userless org-bound row behind -- and the authorizer
+			// read exactly those rows as "organization service credentials",
+			// exempt from the membership check. They are not: the registry mints
+			// keys only through CreateAPIKeyHandler (UserID from the
+			// authenticated caller) and RotateAPIKeyHandler (copies it), so no
+			// supported path produces one. The branch fails closed, which covers
+			// the population without depending on migration 000050 having run.
+			//
+			// No membership query is registered: there is no owner to look up,
+			// and the refusal must not depend on one.
+			site: "middleware.NamespaceAuthorizer.verifyKeyOwnerAuthority (userless org-bound key orphaned by a user deletion)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				authz := middleware.NewNamespaceAuthorizer(
+					repositories.NewOrganizationRepository(db),
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewModuleRepository(db),
+					repositories.NewProviderRepository(db))
+
+				mock.ExpectQuery("SELECT.*FROM namespace_claims").
+					WillReturnRows(sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}).
+						AddRow("acme", "org-1", nil, time.Now()))
+
+				r := gin.New()
+				r.DELETE("/modules/:namespace/:name/:system",
+					func(c *gin.Context) {
+						c.Set("scopes", []string{string(auth.ScopeModulesWrite)})
+						c.Set("api_key", &models.APIKey{
+							ID:             "key-orphaned",
+							UserID:         nil,
+							OrganizationID: "org-1",
+							Scopes:         []string{string(auth.ScopeModulesWrite)},
+						})
+					},
+					authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+					func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/modules/acme/vpc/aws", nil))
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403 (a key detached by a user deletion must not authorize): body=%s",
 						w.Code, w.Body.String())
 				}
 			},

--- a/backend/internal/api/admin/credential_lifecycle_class_test.go
+++ b/backend/internal/api/admin/credential_lifecycle_class_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +22,28 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
+	"github.com/terraform-registry/terraform-registry/internal/services"
 )
+
+// multipartPublishRequest builds the multipart POST a module publish uses, so
+// the first-claim rows drive RequirePublishAccessFromForm the way a real
+// publish does.
+func multipartPublishRequest(t *testing.T, fields map[string]string) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	for k, v := range fields {
+		if err := w.WriteField(k, v); err != nil {
+			t.Fatalf("WriteField(%q): %v", k, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("multipart Close: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/modules", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	return req
+}
 
 // ---------------------------------------------------------------------------
 // Class test: authority-reduction must invalidate every credential family
@@ -49,18 +72,34 @@ import (
 // key owner's current membership instead of trusting the key's frozen org
 // binding, so a stale key fails closed.
 
-// expectOrgKeySweep registers the two statements that revoke every API key
-// userID holds in orgID: the org-scoped list, then the delete of the one key
-// it returns.
+// expectOrgKeySweep registers the two statements that revoke an API key userID
+// holds in orgID: the org-scoped list, then the delete of the one key it
+// returns. The key carries testKeyScopes, which no reduced authority in this
+// file still grants, so it is always the delete case.
 func expectOrgKeySweep(mock sqlmock.Sqlmock, userID, orgID, keyID string) {
+	expectOrgKeySweepScoped(mock, userID, orgID, keyID, testKeyScopes)
+}
+
+// expectOrgKeySweepScoped is expectOrgKeySweep with the swept key's frozen
+// scopes stated explicitly. The sweep only deletes keys asking for MORE than
+// the principal retains, so a row whose reduction leaves testKeyScopes intact
+// must name a scope the reduction actually removes.
+func expectOrgKeySweepScoped(mock sqlmock.Sqlmock, userID, orgID, keyID string, scopes []byte) {
+	expectOrgKeyList(mock, userID, orgID, keyID, scopes)
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs(keyID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// expectOrgKeyList registers ONLY the org-scoped list, with no following
+// delete: the caller is asserting that this key is RETAINED because every
+// scope it carries is still granted after the change.
+func expectOrgKeyList(mock sqlmock.Sqlmock, userID, orgID, keyID string, scopes []byte) {
 	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
 		WithArgs(userID, orgID).
 		WillReturnRows(sqlmock.NewRows(akListCols).
 			AddRow(keyID, userID, orgID, "CI Key", nil, "hashedkey", "tfr_abc123",
-				testKeyScopes, nil, nil, nil, time.Now(), nil))
-	mock.ExpectExec("DELETE FROM api_keys WHERE id").
-		WithArgs(keyID).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+				scopes, nil, nil, nil, time.Now(), nil))
 }
 
 // expectAllKeysSweep registers the statements that revoke every API key userID
@@ -109,6 +148,84 @@ func expectSCIMDeprovisionSweep(mock sqlmock.Sqlmock, userID string) {
 		WithArgs(userID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	expectAllKeysSweep(mock, userID, "key-scim")
+}
+
+// A PUT that does not mention "active" must not deprovision anything.
+//
+// SCIMUser.Active was a plain bool, so an omitted attribute zero-valued to
+// false and PutUser read that as "deactivate": a partial PUT from an IdP -- or
+// any client updating only a display name -- silently stripped every
+// organization membership and, once #736 wired the sweep in, irreversibly
+// deleted every API key the user held in every organization. Asserted by
+// registering ONLY the lookup and the update: sqlmock fails the test if the
+// handler issues a membership delete, a watermark write, or any key statement.
+func TestSCIMPutUser_OmittedActive_DoesNotDeprovision(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	logs := captureSlogOutput(t)
+	r := newSCIMDeprovisionRouter(db)
+	mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+		WillReturnRows(scimUserRows("user-scim"))
+	mock.ExpectExec("UPDATE users").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/scim/v2/Users/user-scim",
+		bytes.NewBufferString(`{"userName":"jane@example.com","name":{"formatted":"Jane R Doe"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("a PUT omitting \"active\" deprovisioned the user: %v", err)
+	}
+	// The decisive assertion. sqlmock cannot carry it alone: the membership
+	// delete's error is discarded by design (`_ =`) and the sweep swallows its
+	// own failures, so every extra statement a wrongly-triggered deprovision
+	// issues would be absorbed and ExpectationsWereMet() would still pass.
+	if strings.Contains(logs.String(), "scim: user deactivated via PUT") {
+		t.Errorf("a PUT that never mentioned \"active\" deprovisioned the user; logs: %s", logs.String())
+	}
+}
+
+// The explicit form still deprovisions -- the fix must not disable the
+// feature, only require the IdP to actually say it. (The full sweep for this
+// path is asserted as a row in the class table above; this is the paired
+// negative/positive control for the pointer semantics.)
+func TestSCIMPutUser_ExplicitActiveFalse_StillDeprovisions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	r := newSCIMDeprovisionRouter(db)
+	mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+		WillReturnRows(scimUserRows("user-scim"))
+	expectSCIMDeprovisionSweep(mock, "user-scim")
+	mock.ExpectExec("UPDATE users").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/scim/v2/Users/user-scim",
+		bytes.NewBufferString(`{"userName":"jane@example.com","active":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("an explicit active=false must still deprovision: %v", err)
+	}
 }
 
 type credLifecycleCase struct {
@@ -164,10 +281,16 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 					WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
 				mock.ExpectExec("UPDATE organization_members").
 					WillReturnResult(sqlmock.NewResult(1, 1))
+				// The scopes the member RETAINS under the new role template
+				// decide which keys over-ask. sampleMemberWithRoleRow carries
+				// modules:read, so a key with providers:write is deleted.
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sampleMemberWithRoleRow())
 				mock.ExpectExec("INSERT INTO user_token_revocations").
 					WithArgs("user-1").
 					WillReturnResult(sqlmock.NewResult(1, 1))
-				expectOrgKeySweep(mock, "user-1", "org-1", "key-rerole")
+				expectOrgKeySweepScoped(mock, "user-1", "org-1", "key-rerole",
+					[]byte(`["providers:write"]`))
 				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 					WillReturnRows(sampleMemberWithRoleRow())
 
@@ -200,7 +323,10 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				mock.ExpectExec("INSERT INTO user_token_revocations").
 					WithArgs("member-1").
 					WillReturnResult(sqlmock.NewResult(1, 1))
-				expectOrgKeySweep(mock, "member-1", "org-1", "key-rt-edit")
+				// The key carries providers:write, which the narrowed template
+				// no longer grants, so it over-asks and is deleted.
+				expectOrgKeySweepScoped(mock, "member-1", "org-1", "key-rt-edit",
+					[]byte(`["providers:write"]`))
 
 				w := httptest.NewRecorder()
 				r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
@@ -355,6 +481,222 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				r.ServeHTTP(w, req)
 				if w.Code != http.StatusOK {
 					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// Reached through DELETE FROM organizations cascading
+			// organization_members -- a reduce verb the enumeration signature's
+			// vocabulary did not originally contain, which is why this site was
+			// missed. The api_keys half really is handled by the FK
+			// (organization_id is ON DELETE CASCADE in both schemas); the JWT
+			// half is not, because a member's token carries a cross-org scope
+			// union computed at login.
+			site: "admin.OrganizationHandlers.DeleteOrganizationHandler / DELETE /api/v1/organizations/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewOrganizationHandlers(&config.Config{}, db,
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewUserTokenRevocationRepository(db))
+				r := gin.New()
+				r.DELETE("/organizations/:id", h.DeleteOrganizationHandler())
+
+				mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+					WillReturnRows(sqlmock.NewRows(authOrgCols).
+						AddRow("org-1", "acme", "Acme Corp", nil, nil, time.Now(), time.Now()))
+				mock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+					WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+				mock.ExpectQuery("SELECT EXISTS").
+					WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+				// Members are snapshotted BEFORE the delete: the cascade
+				// removes them, so afterwards there is nobody left to sweep.
+				mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
+					WillReturnRows(sqlmock.NewRows(authMemberCols).
+						AddRow("org-1", "user-1", nil, time.Now()))
+				mock.ExpectExec("DELETE FROM organizations").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("user-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectOrgKeySweep(mock, "user-1", "org-1", "key-org-deleted")
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// Previously EXEMPTED on the false premise that
+			// api_keys.user_id is ON DELETE CASCADE. It is CASCADE only in the
+			// registry's legacy schema; identity.api_keys declares ON DELETE
+			// SET NULL, so the delete detached the principal's keys into
+			// userless org-bound rows that the namespace authorizer reads as
+			// organization service credentials. The sweep runs BEFORE the
+			// delete because afterwards there is no user_id left to find the
+			// rows by.
+			site: "admin.UserHandlers.DeleteUserHandler / DELETE /api/v1/users/:id",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				h := NewUserHandlers(&config.Config{}, db, WithUserCredentialSweeper(
+					credlifecycle.NewSweeper(
+						repositories.NewUserTokenRevocationRepository(db),
+						repositories.NewAPIKeyRepository(db))))
+				r := gin.New()
+				r.DELETE("/users/:id", h.DeleteUserHandler())
+
+				mock.ExpectQuery("SELECT.*FROM users.*WHERE id").
+					WillReturnRows(scimUserRows("user-1"))
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("user-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				expectAllKeysSweep(mock, "user-1", "key-deleted-user")
+				mock.ExpectExec("DELETE FROM users").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/users/user-1", nil))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// EraseUser deletes api_keys inside its transaction but its JWT
+			// step was an INSERT ... SELECT FROM user_sessions -- a table that
+			// exists in no migration in this repository -- with its error
+			// discarded. It always failed, so an "erased" user kept live
+			// sessions, while the SQL text made the site LOOK swept.
+			site: "services.UserService.EraseUser / POST /api/v1/admin/users/:id/erase",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				svc := services.NewUserService(db).WithCredentialSweeper(
+					credlifecycle.NewSweeper(
+						repositories.NewUserTokenRevocationRepository(db),
+						repositories.NewAPIKeyRepository(db)))
+				r := gin.New()
+				r.Use(func(c *gin.Context) { c.Set("user_id", knownUserUUID) })
+				r.POST("/users/:id/erase", NewGDPRHandlers(svc).EraseUserHandler())
+
+				mock.ExpectBegin()
+				mock.ExpectQuery("SELECT EXISTS").
+					WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+				mock.ExpectExec("UPDATE users").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("DELETE FROM api_keys WHERE user_id").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec("DELETE FROM organization_members").
+					WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectCommit()
+				// The real JWT mechanism: the per-user revoke-all watermark,
+				// which lives on a different connection and so runs after the
+				// commit.
+				mock.ExpectExec("INSERT INTO user_token_revocations").
+					WithArgs("user-1").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+					WithArgs("user-1").
+					WillReturnRows(sqlmock.NewRows(akListCols))
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("POST", "/users/user-1/erase", nil))
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// The org-bound key path is no WEAKER than the legacy unbound one:
+			// a member downgraded to a read-only role template cannot publish
+			// through a key issued under their old role, even though the key's
+			// frozen scopes still say modules:write.
+			site: "middleware.NamespaceAuthorizer.verifyKeyOwnerAuthority (org-bound API key, owner downgraded)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				authz := middleware.NewNamespaceAuthorizer(
+					repositories.NewOrganizationRepository(db),
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewModuleRepository(db),
+					repositories.NewProviderRepository(db))
+
+				mock.ExpectQuery("SELECT.*FROM namespace_claims").
+					WillReturnRows(sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}).
+						AddRow("acme", "org-1", nil, time.Now()))
+				// Still a member, but the role template grants only read.
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sqlmock.NewRows(memberRoleCols).AddRow(
+						"org-1", "user-1", "rt-viewer", time.Now(),
+						"Alice", "alice@example.com", "viewer", "Viewer",
+						[]byte(`["modules:read"]`)))
+
+				owner := "user-1"
+				r := gin.New()
+				r.DELETE("/modules/:namespace/:name/:system",
+					func(c *gin.Context) {
+						c.Set("scopes", []string{string(auth.ScopeModulesWrite)})
+						c.Set("user_id", owner)
+						c.Set("api_key", &models.APIKey{
+							ID:             "key-downgraded",
+							UserID:         &owner,
+							OrganizationID: "org-1",
+							Scopes:         []string{string(auth.ScopeModulesWrite)},
+						})
+					},
+					authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+					func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("DELETE", "/modules/acme/vpc/aws", nil))
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403 (downgraded owner must not publish through a stale key): body=%s",
+						w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			// The FIRST-CLAIM path, which previously performed no
+			// authorization at all on the winning branch: resolveCallerOrg
+			// returned the key's frozen organization binding as "the strongest
+			// trust anchor" and authorizeOrgAccess ran only when the caller
+			// LOST a concurrent claim race. A key bound to an org its owner had
+			// left could claim a brand-new namespace and publish: 201, zero
+			// membership queries.
+			site: "middleware.NamespaceAuthorizer.resolveCallerOrg (org-bound API key, first claim, owner removed)",
+			run: func(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+				authz := middleware.NewNamespaceAuthorizer(
+					repositories.NewOrganizationRepository(db),
+					repositories.NewNamespaceClaimRepository(db),
+					repositories.NewModuleRepository(db),
+					repositories.NewProviderRepository(db))
+
+				mock.ExpectQuery("SELECT.*FROM namespace_claims").
+					WillReturnRows(sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}))
+				mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+					WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+				// Owner is no longer a member. No INSERT INTO namespace_claims
+				// is registered: a stale key must not even squat the namespace.
+				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+					WillReturnRows(sqlmock.NewRows(memberRoleCols))
+
+				owner := "user-1"
+				r := gin.New()
+				r.POST("/modules",
+					func(c *gin.Context) {
+						c.Set("scopes", []string{string(auth.ScopeModulesWrite)})
+						c.Set("user_id", owner)
+						c.Set("api_key", &models.APIKey{
+							ID:             "key-stale-claimer",
+							UserID:         &owner,
+							OrganizationID: "org-1",
+							Scopes:         []string{string(auth.ScopeModulesWrite)},
+						})
+					},
+					authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+					func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, multipartPublishRequest(t, map[string]string{
+					"namespace": "brand-new", "name": "vpc", "system": "aws"}))
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("status = %d, want 403 (stale key must not claim a new namespace): body=%s",
+						w.Code, w.Body.String())
 				}
 			},
 		},

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -13,12 +13,19 @@ import (
 )
 
 // guardProvisionableRole rejects a group mapping's resolved role_template when
-// its scopes carry auth.ScopeAdmin ("admin"). Call this in reconcileGroupMemberships
-// immediately before trusting a mapped Role for an automatic, IdP-driven
-// membership write (UpdateMemberRole / AddMemberWithParams) — never on a role
-// read back for an already-trusted, direct admin action (e.g. the manual
-// "make this user an admin" endpoints in organizations.go/setup/handlers.go,
-// which intentionally grant "admin" and must not be affected by this guard).
+// its scopes carry auth.ScopeAdmin ("admin"), and returns those scopes on
+// acceptance. Call this in reconcileGroupMemberships immediately before
+// trusting a mapped Role for an automatic, IdP-driven membership write
+// (UpdateMemberRole / AddMemberWithParams) — never on a role read back for an
+// already-trusted, direct admin action (e.g. the manual "make this user an
+// admin" endpoints in organizations.go/setup/handlers.go, which intentionally
+// grant "admin" and must not be affected by this guard).
+//
+// The returned scopes are exactly what the member will hold in the organization
+// once the write commits, which makes them the retention filter for the
+// credential sweep on the reassignment branch (see credlifecycle.Sweeper). They
+// are returned rather than re-read so the reassignment costs one role_templates
+// lookup, not two.
 //
 // This is defense-in-depth, not a fix for an active exploit: the group-mapping
 // CONFIG that names a Role is itself only reachable by a caller who already
@@ -30,26 +37,30 @@ import (
 // API), per terraform-suite-identity's ValidateProvisionableScopes doc and
 // this repo's issue #604.
 //
-// A role_template name that does not resolve to a row returns nil (no error):
-// the caller's own UpdateMemberRole/AddMemberWithParams performs the
-// authoritative name lookup immediately afterward and surfaces a clear
-// "role template not found" error there, so this guard does not need to
-// duplicate that failure mode. Any other lookup/parse failure is returned
-// (fails closed) — a transient DB error here should not silently let an
-// unverified role's scopes through.
-func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) error {
+// A role_template name that does not resolve to a row returns (nil, nil): the
+// caller's own UpdateMemberRole/AddMemberWithParams performs the authoritative
+// name lookup immediately afterward and surfaces a clear "role template not
+// found" error there, so this guard does not need to duplicate that failure
+// mode — and the caller therefore never reaches the sweep with the empty scope
+// set this returns. Any other lookup/parse failure is returned (fails closed)
+// — a transient DB error here should not silently let an unverified role's
+// scopes through.
+func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) ([]string, error) {
 	var scopesJSON []byte
 	err := h.db.QueryRowContext(ctx,
 		`SELECT scopes FROM role_templates WHERE name = $1`, roleTemplateName).Scan(&scopesJSON)
 	if err == sql.ErrNoRows {
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		return fmt.Errorf("look up role template %q scopes: %w", roleTemplateName, err)
+		return nil, fmt.Errorf("look up role template %q scopes: %w", roleTemplateName, err)
 	}
 	var scopes []string
 	if err := json.Unmarshal(scopesJSON, &scopes); err != nil {
-		return fmt.Errorf("parse role template %q scopes: %w", roleTemplateName, err)
+		return nil, fmt.Errorf("parse role template %q scopes: %w", roleTemplateName, err)
 	}
-	return auth.ValidateProvisionableScopes(scopes)
+	if err := auth.ValidateProvisionableScopes(scopes); err != nil {
+		return nil, err
+	}
+	return scopes, nil
 }

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -857,7 +857,7 @@ type UpdateMemberRequest struct {
 }
 
 // @Summary      Update organization member
-// @Description  Update a member's role template within an organization.
+// @Description  Update a member's role template within an organization. A reassignment revokes the member's sessions and any org-bound API key that over-asks under the new template; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.
 // @Tags         Organizations
 // @Security     Bearer
 // @Accept       json
@@ -930,24 +930,28 @@ func (h *OrganizationHandlers) UpdateMemberHandler() gin.HandlerFunc {
 		// (publisher -> owner) leaves every existing key within the new
 		// authority, so nothing is deleted, while a demotion deletes exactly
 		// the keys that now over-ask.
+		//
+		// A failed sweep is surfaced as revocation_incomplete, matching
+		// RemoveMemberHandler: a clean 200 on a demotion whose credentials are
+		// still live is the silent failure this whole change is about.
+		revocationIncomplete := false
 		if !stringPtrEqual(oldRoleTemplateID, req.RoleTemplateID) {
-			h.revokeOrgCredentials(c, userID, orgID, h.retainedOrgScopes(c, orgID, userID),
+			revocationIncomplete = !h.revokeOrgCredentials(c, userID, orgID,
+				h.retainedOrgScopes(c, orgID, userID),
 				"organization member role template changed")
 		}
 
 		// Get member with role template info for response
 		memberWithRole, err := h.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, userID)
+		response := gin.H{"member": memberWithRole}
 		if err != nil {
 			// Return basic member info if we can't get role details
-			c.JSON(http.StatusOK, gin.H{
-				"member": member,
-			})
-			return
+			response = gin.H{"member": member}
 		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"member": memberWithRole,
-		})
+		if revocationIncomplete {
+			response["revocation_incomplete"] = true
+		}
+		c.JSON(http.StatusOK, response)
 	}
 }
 

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -76,16 +76,40 @@ func NewOrganizationHandlers(cfg *config.Config, db *sql.DB, claimRepo *reposito
 // misleading error response (retrying the admin action re-runs the sweep).
 // Returns true when the sweep completed, false when some part of it did not,
 // so the handler can surface revocation_incomplete to the caller.
-func (h *OrganizationHandlers) revokeOrgCredentials(c *gin.Context, userID, orgID, reason string) bool {
+//
+// retained is the scope set the user still holds in orgID after the change
+// (nil for a removal); keys asking for no more than that are left alone
+// because deleting an API key is irreversible.
+func (h *OrganizationHandlers) revokeOrgCredentials(c *gin.Context, userID, orgID string, retained []string, reason string) bool {
 	if h.creds == nil {
 		return true
 	}
-	out := h.creds.OrgAuthorityReduced(c.Request.Context(), userID, orgID, reason)
+	out := h.creds.OrgAuthorityReduced(c.Request.Context(), userID, orgID, retained, reason)
 	if out.Incomplete {
 		slog.Error("credential sweep incomplete after privilege change",
 			"user_id", userID, "organization_id", orgID, "reason", reason)
 	}
 	return !out.Incomplete
+}
+
+// retainedOrgScopes reads the scopes a member still derives from an
+// organization after a role change, for use as the sweep's retention filter.
+//
+// A lookup failure returns nil, i.e. "retains nothing", which sweeps every
+// key. That is the fail-closed direction and the right one here: the caller
+// has just reduced or reassigned this member's role, and we cannot prove any
+// key is still within the new authority.
+func (h *OrganizationHandlers) retainedOrgScopes(c *gin.Context, orgID, userID string) []string {
+	member, err := h.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, userID)
+	if err != nil {
+		slog.Error("failed to read post-change role scopes; sweeping all org-bound keys for this member",
+			"user_id", userID, "organization_id", orgID, "error", err)
+		return nil
+	}
+	if member == nil {
+		return nil
+	}
+	return member.RoleTemplateScopes
 }
 
 // @Summary      List namespace ownership claims
@@ -667,6 +691,37 @@ func (h *OrganizationHandlers) DeleteOrganizationHandler() gin.HandlerFunc {
 			return
 		}
 
+		// Snapshot the membership before the delete. Deleting an organization
+		// cascades organization_members away, so this is an authority
+		// reduction for every member -- reached through a verb
+		// (DELETE FROM organizations) rather than an explicit member removal,
+		// which is precisely why it was missed.
+		//
+		// The api_keys half is genuinely handled by the schema here:
+		// api_keys.organization_id is ON DELETE CASCADE in BOTH the legacy and
+		// the identity schema (unlike user_id, see DeleteUserHandler), so the
+		// org's keys really do vanish with it. The JWT half does not: a
+		// member's session token carries the UNION of their scopes across all
+		// their organizations, computed at login, and nothing re-derives it.
+		// A member of this org plus one other keeps exercising the deleted
+		// org's scopes on every route gated only on RequireScope until their
+		// token expires.
+		//
+		// Best-effort, like every other site: a lookup failure is surfaced via
+		// revocation_incomplete rather than blocking an otherwise valid delete.
+		var members []*models.OrganizationMember
+		sweepIncomplete := false
+		if h.creds != nil {
+			var listErr error
+			members, listErr = h.orgRepo.ListMembers(c.Request.Context(), orgID)
+			if listErr != nil {
+				slog.Error("failed to list organization members before deletion; their sessions will not be revoked",
+					"organization_id", orgID, "error", listErr)
+				members = nil
+				sweepIncomplete = true
+			}
+		}
+
 		// Delete organization (cascading deletes will handle related records)
 		if err := h.orgRepo.Delete(c.Request.Context(), orgID); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -675,9 +730,21 @@ func (h *OrganizationHandlers) DeleteOrganizationHandler() gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{
-			"message": "Organization deleted successfully",
-		})
+		// retained is nil: the organization is gone, so no member derives
+		// anything from it any more. The key half is a no-op in practice
+		// (the FK cascade already removed the rows); the watermark is what
+		// actually retires the stale scope union.
+		for _, m := range members {
+			if !h.revokeOrgCredentials(c, m.UserID, orgID, nil, "organization deleted") {
+				sweepIncomplete = true
+			}
+		}
+
+		response := gin.H{"message": "Organization deleted successfully"}
+		if sweepIncomplete {
+			response["revocation_incomplete"] = true
+		}
+		c.JSON(http.StatusOK, response)
 	}
 }
 
@@ -858,8 +925,14 @@ func (h *OrganizationHandlers) UpdateMemberHandler() gin.HandlerFunc {
 		// their org-bound API keys at creation time; sweep both so the change
 		// takes effect immediately rather than waiting out the JWT TTL (issue
 		// #559 finding [9]) or, for the keys, forever (issue #732).
+		//
+		// The new template's scopes are the retention filter: a promotion
+		// (publisher -> owner) leaves every existing key within the new
+		// authority, so nothing is deleted, while a demotion deletes exactly
+		// the keys that now over-ask.
 		if !stringPtrEqual(oldRoleTemplateID, req.RoleTemplateID) {
-			h.revokeOrgCredentials(c, userID, orgID, "organization member role template changed")
+			h.revokeOrgCredentials(c, userID, orgID, h.retainedOrgScopes(c, orgID, userID),
+				"organization member role template changed")
 		}
 
 		// Get member with role template info for response
@@ -943,8 +1016,10 @@ func (h *OrganizationHandlers) RemoveMemberHandler() gin.HandlerFunc {
 		// left a working publish credential into this org's namespaces with no
 		// expiry at all (issue #732). Sweep both, but only when membership
 		// actually existed and was removed.
+		// retained is nil: a removed member derives nothing from this
+		// organization any more, so every org-bound key they hold over-asks.
 		if wasMember != nil {
-			if !h.revokeOrgCredentials(c, userID, orgID, "removed from organization") {
+			if !h.revokeOrgCredentials(c, userID, orgID, nil, "removed from organization") {
 				revocationCheckFailed = true
 			}
 		}

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
@@ -21,12 +22,17 @@ type OrganizationHandlers struct {
 	db        *sql.DB
 	orgRepo   *repositories.OrganizationRepository
 	claimRepo *repositories.NamespaceClaimRepository
-	// userRevocations moves the affected user's revoke-all watermark when a
-	// membership's role template changes or a member is removed, so outstanding
-	// JWTs (which embed scopes at login) stop validating immediately instead of
-	// carrying the old privileges until expiry (issue #559 finding [9]).
-	// May be nil in tests; revocation is skipped when unset.
-	userRevocations *repositories.UserTokenRevocationRepository
+	// creds invalidates BOTH credential families that snapshot a member's
+	// org-derived authority when that authority is reduced: the JWT revoke-all
+	// watermark (issue #559 finding [9]) and the member's org-bound API keys
+	// (issue #732). Sweeping only the JWTs left an offboarded member holding a
+	// working modules:write/providers:write credential into the organization's
+	// namespaces forever, because AuthMiddleware reads an API key's scopes and
+	// organization_id straight off the api_keys row.
+	//
+	// May be nil in tests; the sweep is skipped when unset, matching the
+	// pre-existing convention that the revocation subsystem is wired as a unit.
+	creds *credlifecycle.Sweeper
 }
 
 // NewOrganizationHandlers creates a new OrganizationHandlers instance. db
@@ -44,27 +50,42 @@ type OrganizationHandlers struct {
 // middleware uses, so the pre-delete ownership check in
 // DeleteOrganizationHandler queries the database that actually has the data.
 func NewOrganizationHandlers(cfg *config.Config, db *sql.DB, claimRepo *repositories.NamespaceClaimRepository, userRevocations *repositories.UserTokenRevocationRepository) *OrganizationHandlers {
-	return &OrganizationHandlers{
-		cfg:             cfg,
-		db:              db,
-		orgRepo:         repositories.NewOrganizationRepository(db),
-		claimRepo:       claimRepo,
-		userRevocations: userRevocations,
+	h := &OrganizationHandlers{
+		cfg:       cfg,
+		db:        db,
+		orgRepo:   repositories.NewOrganizationRepository(db),
+		claimRepo: claimRepo,
 	}
+	// The API-key half of the sweep rides the same wiring gate as the JWT half:
+	// db here is the identity connection that owns api_keys, so the repository
+	// can be constructed locally, but leaving the sweeper nil when the caller
+	// did not wire revocation preserves the documented "revocation is skipped
+	// when unset" contract that existing callers and tests rely on.
+	if userRevocations != nil {
+		h.creds = credlifecycle.NewSweeper(userRevocations, repositories.NewAPIKeyRepository(db))
+	}
+	return h
 }
 
-// revokeUserTokens moves a user's revoke-all watermark after a privilege
-// change. Best-effort by design: the privilege change itself has already been
-// committed, so a failed revocation is logged loudly rather than turned into a
-// misleading error response (retrying the admin action re-runs the revocation).
-func (h *OrganizationHandlers) revokeUserTokens(c *gin.Context, userID, reason string) {
-	if h.userRevocations == nil {
-		return
+// revokeOrgCredentials invalidates every credential family carrying a snapshot
+// of the authority userID derived from orgID: the JWT revoke-all watermark and
+// the user's org-bound API keys.
+//
+// Best-effort by design: the privilege change itself has already been
+// committed, so a failed sweep is logged loudly rather than turned into a
+// misleading error response (retrying the admin action re-runs the sweep).
+// Returns true when the sweep completed, false when some part of it did not,
+// so the handler can surface revocation_incomplete to the caller.
+func (h *OrganizationHandlers) revokeOrgCredentials(c *gin.Context, userID, orgID, reason string) bool {
+	if h.creds == nil {
+		return true
 	}
-	if err := h.userRevocations.RevokeAllUserTokens(c.Request.Context(), userID); err != nil {
-		slog.Error("failed to revoke user tokens after privilege change",
-			"user_id", userID, "reason", reason, "error", err)
+	out := h.creds.OrgAuthorityReduced(c.Request.Context(), userID, orgID, reason)
+	if out.Incomplete {
+		slog.Error("credential sweep incomplete after privilege change",
+			"user_id", userID, "organization_id", orgID, "reason", reason)
 	}
+	return !out.Incomplete
 }
 
 // @Summary      List namespace ownership claims
@@ -833,11 +854,12 @@ func (h *OrganizationHandlers) UpdateMemberHandler() gin.HandlerFunc {
 		}
 
 		// A role-template reassignment changes the scopes a fresh JWT would embed
-		// for this user; revoke their outstanding tokens so the change takes
-		// effect immediately rather than waiting out the JWT TTL (issue #559
-		// finding [9]).
+		// for this user, and equally invalidates the scope snapshot frozen on
+		// their org-bound API keys at creation time; sweep both so the change
+		// takes effect immediately rather than waiting out the JWT TTL (issue
+		// #559 finding [9]) or, for the keys, forever (issue #732).
 		if !stringPtrEqual(oldRoleTemplateID, req.RoleTemplateID) {
-			h.revokeUserTokens(c, userID, "organization member role template changed")
+			h.revokeOrgCredentials(c, userID, orgID, "organization member role template changed")
 		}
 
 		// Get member with role template info for response
@@ -896,7 +918,7 @@ func (h *OrganizationHandlers) RemoveMemberHandler() gin.HandlerFunc {
 		// caller below), never an unwarranted one.
 		var wasMember *models.OrganizationMemberWithUser
 		revocationCheckFailed := false
-		if h.userRevocations != nil {
+		if h.creds != nil {
 			var err error
 			wasMember, err = h.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, userID)
 			if err != nil {
@@ -915,18 +937,24 @@ func (h *OrganizationHandlers) RemoveMemberHandler() gin.HandlerFunc {
 		}
 
 		// The removed member's outstanding JWTs still carry the org-derived
-		// scopes they had at login; revoke them so removal takes effect
-		// immediately instead of waiting out the JWT TTL (issue #559 finding
-		// [9]) -- but only when membership actually existed and was removed.
+		// scopes they had at login, and their API keys still carry BOTH those
+		// scopes and this organization's ID -- and authorizeOrgAccess treats a
+		// key's org binding as authoritative. Removal that swept only the JWTs
+		// left a working publish credential into this org's namespaces with no
+		// expiry at all (issue #732). Sweep both, but only when membership
+		// actually existed and was removed.
 		if wasMember != nil {
-			h.revokeUserTokens(c, userID, "removed from organization")
+			if !h.revokeOrgCredentials(c, userID, orgID, "removed from organization") {
+				revocationCheckFailed = true
+			}
 		}
 
 		response := gin.H{"message": "Member removed successfully"}
 		if revocationCheckFailed {
-			// The removal itself succeeded, but we couldn't determine
-			// whether to revoke the user's tokens -- surface that so the
-			// caller doesn't assume the incident is fully closed.
+			// The removal itself succeeded, but either we couldn't determine
+			// whether to sweep the user's credentials, or the sweep itself
+			// partially failed -- surface that so the caller doesn't assume
+			// the incident is fully closed.
 			response["revocation_incomplete"] = true
 		}
 		c.JSON(http.StatusOK, response)

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -1609,3 +1609,55 @@ func TestCreateOrganization_ExistenceCheckError(t *testing.T) {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
+
+// UpdateMemberHandler must report a failed sweep the way RemoveMemberHandler
+// does. A demotion that answers a clean 200 while the member's sessions and
+// over-asking API keys are still live tells the admin the privilege change
+// took effect when it only half did.
+func TestUpdateMemberHandler_SweepFails_ReportsRevocationIncomplete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := NewOrganizationHandlers(&config.Config{}, db,
+		repositories.NewNamespaceClaimRepository(db),
+		repositories.NewUserTokenRevocationRepository(db))
+	r := gin.New()
+	r.PUT("/organizations/:id/members/:user_id", h.UpdateMemberHandler())
+
+	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
+	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
+		WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+	mock.ExpectExec("UPDATE organization_members").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sampleMemberWithRoleRow())
+	// The JWT half of the sweep fails after the reassignment committed.
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WillReturnError(errDB)
+	expectOrgKeySweepScoped(mock, "user-1", "org-1", "key-rerole-incomplete",
+		[]byte(`["providers:write"]`))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sampleMemberWithRoleRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1/members/user-1",
+		bytes.NewBufferString(`{"role_template_id": "`+newRoleTemplateUUID+`"}`)))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the reassignment itself succeeded): body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		RevocationIncomplete bool `json:"revocation_incomplete"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v: body=%s", err, w.Body.String())
+	}
+	if !body.RevocationIncomplete {
+		t.Errorf("expected revocation_incomplete=true after a failed sweep, got body=%s", w.Body.String())
+	}
+}

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -806,9 +806,11 @@ func TestRemoveMember_Success(t *testing.T) {
 	}
 }
 
-// Issue #559 finding [9]: removing a member must revoke their outstanding
-// tokens so the removal takes effect immediately rather than waiting out the
-// JWT TTL.
+// Issue #559 finding [9] plus issue #732: removing a member must invalidate
+// both credential families that snapshot their org-derived authority -- the
+// JWT revoke-all watermark and the member's org-bound API keys -- so the
+// removal takes effect immediately rather than waiting out the JWT TTL (JWTs)
+// or never (keys).
 func TestRemoveMember_RevokesUserTokens(t *testing.T) {
 	mock, r := newOrgRouterWithRevocation(t, true)
 
@@ -819,6 +821,7 @@ func TestRemoveMember_RevokesUserTokens(t *testing.T) {
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "user-1", "org-1", "key-1")
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1/members/user-1", nil))
@@ -843,12 +846,17 @@ func TestRemoveMember_RevocationErrorDoesNotFailRequest(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WillReturnError(errDB)
+	// The JWT half failing must not skip the API-key half.
+	expectOrgKeySweep(mock, "user-1", "org-1", "key-1")
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1/members/user-1", nil))
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200 even though revocation failed: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("API-key sweep must still run when the token revocation fails: %v", err)
 	}
 }
 
@@ -1109,6 +1117,7 @@ func TestUpdateMember_RoleTemplateChanged_RevokesUserTokens(t *testing.T) {
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "user-1", "org-1", "key-1")
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
 

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -911,6 +911,59 @@ func TestRemoveMember_NotAMember_SkipsRevocation(t *testing.T) {
 	}
 }
 
+// The API-KEY half of the sweep failing must surface as revocation_incomplete
+// just as the JWT half does.
+//
+// This is the half that matters most: a JWT expires on its own, but an API key
+// whose deletion failed is a permanently valid publish credential into the
+// organization's namespaces. Reporting a plain 200 here would tell the
+// administrator the offboarding was complete when the credential that outlives
+// everything is still live.
+func TestRemoveMember_APIKeyRevocationFails_FlagsIncomplete(t *testing.T) {
+	mock, r := newOrgRouterWithRevocation(t, true)
+	logs := captureSlogOutput(t)
+
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sampleMemberWithRoleRow())
+	mock.ExpectExec("DELETE FROM organization_members").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// The JWT half succeeds ...
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs("user-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// ... and the API-key half fails on the delete.
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(sqlmock.NewRows(akListCols).
+			AddRow("key-stuck", "user-1", "org-1", "CI Key", nil, "hashedkey", "tfr_abc123",
+				testKeyScopes, nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-stuck").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1/members/user-1", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the removal itself succeeded): body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		RevocationIncomplete bool `json:"revocation_incomplete"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v: body=%s", err, w.Body.String())
+	}
+	if !body.RevocationIncomplete {
+		t.Errorf("expected revocation_incomplete=true when the API-key half failed, got body=%s", w.Body.String())
+	}
+	if !strings.Contains(logs.String(), "failed to revoke org-bound API key") {
+		t.Errorf("expected the API-key revocation failure to be logged; logs: %s", logs.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
 // A failed membership check must not block the removal itself (that lookup
 // only feeds the revocation decision, not RemoveMember), but must surface
 // that the revocation sweep may not have happened rather than returning an

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -79,36 +79,43 @@ func (h *RBACHandlers) WithNotifier(n *notify.Notifier) *RBACHandlers {
 //
 // Best-effort: the scope edit has already been committed, so a lookup or
 // revocation failure is logged rather than turned into a misleading error
-// response for an otherwise-successful edit.
-func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleTemplateID uuid.UUID, retained []string, reason string) {
+// response for an otherwise-successful edit. It is REPORTED, though: the
+// returned bool is false when any part of the sweep did not land, so the
+// handler can surface revocation_incomplete instead of answering a clean 200
+// for an authority reduction whose credentials are still live.
+func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleTemplateID uuid.UUID, retained []string, reason string) bool {
 	if h.creds == nil {
-		return
+		return true
 	}
 	memberships, err := h.rbacRepo.ListRoleTemplateMemberships(c.Request.Context(), roleTemplateID)
 	if err != nil {
 		slog.Error("failed to list role template members for credential revocation",
 			"role_template_id", roleTemplateID, "reason", reason, "error", err)
-		return
+		return false
 	}
-	h.sweepRoleTemplateMemberships(c, memberships, roleTemplateID, retained, reason)
+	return h.sweepRoleTemplateMemberships(c, memberships, roleTemplateID, retained, reason)
 }
 
 // sweepRoleTemplateMemberships runs the credential sweep over an already-loaded
 // membership set. DeleteRoleTemplate has to snapshot the memberships BEFORE the
 // delete commits (the FK is ON DELETE SET NULL), so it cannot use the
-// load-then-sweep helper above.
-func (h *RBACHandlers) sweepRoleTemplateMemberships(c *gin.Context, memberships []repositories.RoleTemplateMembership, roleTemplateID uuid.UUID, retained []string, reason string) {
+// load-then-sweep helper above. Returns false when any member's sweep was
+// incomplete.
+func (h *RBACHandlers) sweepRoleTemplateMemberships(c *gin.Context, memberships []repositories.RoleTemplateMembership, roleTemplateID uuid.UUID, retained []string, reason string) bool {
 	if h.creds == nil {
-		return
+		return true
 	}
+	complete := true
 	for _, m := range memberships {
 		out := h.creds.OrgAuthorityReduced(c.Request.Context(), m.UserID, m.OrganizationID, retained, reason)
 		if out.Incomplete {
 			slog.Error("credential sweep incomplete after role template change",
 				"user_id", m.UserID, "organization_id", m.OrganizationID,
 				"role_template_id", roleTemplateID, "reason", reason)
+			complete = false
 		}
 	}
+	return complete
 }
 
 // notifyApprovalPending emails the configured admin recipients and fans out
@@ -275,7 +282,7 @@ func (h *RBACHandlers) CreateRoleTemplate(c *gin.Context) {
 }
 
 // @Summary      Update role template
-// @Description  Update an existing custom role template. Cannot modify system role templates. Requires admin scope.
+// @Description  Update an existing custom role template. Cannot modify system role templates. Requires admin scope. When the edit NARROWS the template's scopes, the affected members' sessions and over-asking API keys are revoked; if that sweep does not fully land the 200 body carries an extra `revocation_incomplete: true` field.
 // @Tags         RBAC
 // @Security     Bearer
 // @Accept       json
@@ -345,8 +352,20 @@ func (h *RBACHandlers) UpdateRoleTemplate(c *gin.Context) {
 	// instead of waiting out the JWT TTL (issue #559 finding [9]) or, for the
 	// keys, never. req.Scopes is what those members retain, so keys that ask
 	// for no more than the new list survive.
-	if authorityReduced {
-		h.revokeRoleTemplateMemberCredentials(c, id, req.Scopes, "role template scopes reduced")
+	//
+	// A failed sweep is surfaced to the caller, exactly as DeleteRoleTemplate,
+	// RemoveMemberHandler and DeleteOrganizationHandler do. Narrowing a
+	// template's scopes and receiving a clean 200 while the affected members'
+	// API keys are still live is the same silent failure those handlers were
+	// changed to stop reporting as success.
+	if authorityReduced && !h.revokeRoleTemplateMemberCredentials(c, id, req.Scopes, "role template scopes reduced") {
+		// Embedding promotes the template's own fields, so the success body is
+		// unchanged apart from the added flag.
+		c.JSON(http.StatusOK, struct {
+			*models.RoleTemplate
+			RevocationIncomplete bool `json:"revocation_incomplete"`
+		}{existing, true})
+		return
 	}
 
 	c.JSON(http.StatusOK, existing)
@@ -432,7 +451,12 @@ func (h *RBACHandlers) DeleteRoleTemplate(c *gin.Context) {
 	// retained is nil: the template is gone, so its members retain none of the
 	// scopes it granted (their membership rows are ON DELETE SET NULL'd to no
 	// role template at all).
-	h.sweepRoleTemplateMemberships(c, memberships, id, nil, "role template deleted")
+	if !h.sweepRoleTemplateMemberships(c, memberships, id, nil, "role template deleted") {
+		// The members were known but at least one sweep failed -- the same
+		// "reduction landed, credentials did not" state the lookup failure
+		// below reports, reached one step later.
+		revocationLookupFailed = true
+	}
 
 	response := gin.H{"message": "Role template deleted"}
 	if revocationLookupFailed {

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
@@ -23,12 +24,15 @@ import (
 // RBACHandlers handles RBAC-related API endpoints
 type RBACHandlers struct {
 	rbacRepo *repositories.RBACRepository
-	// userRevocations moves the revoke-all watermark for every member currently
-	// assigned a role template when that template's scopes are edited, so their
-	// outstanding JWTs (which embed scopes at login) stop validating immediately
-	// instead of carrying the old scopes until expiry (issue #559 finding [9]).
-	// May be nil in tests; revocation is skipped when unset.
-	userRevocations *repositories.UserTokenRevocationRepository
+	// creds invalidates BOTH credential families that snapshot the scopes of a
+	// role template when that template is edited or deleted: the per-user JWT
+	// revoke-all watermark (issue #559 finding [9]) and the affected members'
+	// API keys in the organizations where they held the template (issue #732).
+	// An API key's scopes are stored on the api_keys row at creation and are
+	// never re-derived from the template, so editing or deleting the template
+	// had no effect on keys at all.
+	// May be nil in tests; the sweep is skipped when unset.
+	creds *credlifecycle.Sweeper
 
 	// notifCfg, cveCfg, and mailer back the approval_pending notification sent
 	// when a new mirror approval request is created. Set via WithNotifications;
@@ -42,9 +46,12 @@ type RBACHandlers struct {
 	notifier *notify.Notifier
 }
 
-// NewRBACHandlers creates a new RBAC handlers instance
-func NewRBACHandlers(rbacRepo *repositories.RBACRepository, userRevocations *repositories.UserTokenRevocationRepository) *RBACHandlers {
-	return &RBACHandlers{rbacRepo: rbacRepo, userRevocations: userRevocations}
+// NewRBACHandlers creates a new RBAC handlers instance. apiKeys backs the
+// API-key half of the credential sweep and lives on the identity connection;
+// it may be nil, in which case only the JWT half runs. Passing nil for both
+// disables the sweep entirely (the pre-existing test convention).
+func NewRBACHandlers(rbacRepo *repositories.RBACRepository, userRevocations *repositories.UserTokenRevocationRepository, apiKeys *repositories.APIKeyRepository) *RBACHandlers {
+	return &RBACHandlers{rbacRepo: rbacRepo, creds: credlifecycle.NewSweeper(userRevocations, apiKeys)}
 }
 
 // WithNotifications wires in the shared notifications/CVE config so
@@ -65,24 +72,41 @@ func (h *RBACHandlers) WithNotifier(n *notify.Notifier) *RBACHandlers {
 	return h
 }
 
-// revokeRoleTemplateMemberTokens revokes the outstanding tokens of every member
-// currently assigned roleTemplateID. Best-effort: the scope edit has already
-// been committed, so a lookup or revocation failure is logged rather than
-// turned into a misleading error response for an otherwise-successful edit.
-func (h *RBACHandlers) revokeRoleTemplateMemberTokens(c *gin.Context, roleTemplateID uuid.UUID, reason string) {
-	if h.userRevocations == nil {
+// revokeRoleTemplateMemberCredentials sweeps every credential family carrying a
+// snapshot of roleTemplateID's scopes, for every member currently assigned it:
+// their JWT revoke-all watermark and their API keys in the organization where
+// they hold the template.
+//
+// Best-effort: the scope edit has already been committed, so a lookup or
+// revocation failure is logged rather than turned into a misleading error
+// response for an otherwise-successful edit.
+func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleTemplateID uuid.UUID, reason string) {
+	if h.creds == nil {
 		return
 	}
-	userIDs, err := h.rbacRepo.ListRoleTemplateMemberUserIDs(c.Request.Context(), roleTemplateID)
+	memberships, err := h.rbacRepo.ListRoleTemplateMemberships(c.Request.Context(), roleTemplateID)
 	if err != nil {
-		slog.Error("failed to list role template members for token revocation",
+		slog.Error("failed to list role template members for credential revocation",
 			"role_template_id", roleTemplateID, "reason", reason, "error", err)
 		return
 	}
-	for _, userID := range userIDs {
-		if err := h.userRevocations.RevokeAllUserTokens(c.Request.Context(), userID); err != nil {
-			slog.Error("failed to revoke user tokens after role template change",
-				"user_id", userID, "role_template_id", roleTemplateID, "reason", reason, "error", err)
+	h.sweepRoleTemplateMemberships(c, memberships, roleTemplateID, reason)
+}
+
+// sweepRoleTemplateMemberships runs the credential sweep over an already-loaded
+// membership set. DeleteRoleTemplate has to snapshot the memberships BEFORE the
+// delete commits (the FK is ON DELETE SET NULL), so it cannot use the
+// load-then-sweep helper above.
+func (h *RBACHandlers) sweepRoleTemplateMemberships(c *gin.Context, memberships []repositories.RoleTemplateMembership, roleTemplateID uuid.UUID, reason string) {
+	if h.creds == nil {
+		return
+	}
+	for _, m := range memberships {
+		out := h.creds.OrgAuthorityReduced(c.Request.Context(), m.UserID, m.OrganizationID, reason)
+		if out.Incomplete {
+			slog.Error("credential sweep incomplete after role template change",
+				"user_id", m.UserID, "organization_id", m.OrganizationID,
+				"role_template_id", roleTemplateID, "reason", reason)
 		}
 	}
 }
@@ -308,12 +332,14 @@ func (h *RBACHandlers) UpdateRoleTemplate(c *gin.Context) {
 	}
 
 	// A scope edit changes what a fresh JWT would embed for every member
-	// currently assigned this template; revoke their outstanding tokens so the
-	// change takes effect immediately instead of waiting out the JWT TTL
-	// (issue #559 finding [9]). Display-name/description-only edits don't
-	// affect scopes, so skip the revocation sweep for those.
+	// currently assigned this template, and equally strands the scope snapshot
+	// frozen on those members' API keys, which are never re-derived from the
+	// template (issue #732); sweep both so the change takes effect immediately
+	// instead of waiting out the JWT TTL (issue #559 finding [9]) or, for the
+	// keys, never. Display-name/description-only edits don't affect scopes, so
+	// skip the sweep for those.
 	if scopesChanged {
-		h.revokeRoleTemplateMemberTokens(c, id, "role template scopes edited")
+		h.revokeRoleTemplateMemberCredentials(c, id, "role template scopes edited")
 	}
 
 	c.JSON(http.StatusOK, existing)
@@ -374,7 +400,7 @@ func (h *RBACHandlers) DeleteRoleTemplate(c *gin.Context) {
 
 	// Snapshot the affected members before the delete: the FK is ON DELETE SET
 	// NULL, so a member's role_template_id is gone the instant the delete
-	// commits, and ListRoleTemplateMemberUserIDs would find nobody afterward.
+	// commits, and ListRoleTemplateMemberships would find nobody afterward.
 	// This lookup only feeds the best-effort revocation loop below and is not
 	// itself a precondition for the deletion, so a failure here is logged and
 	// swallowed rather than blocking the delete: the security-relevant action
@@ -384,15 +410,15 @@ func (h *RBACHandlers) DeleteRoleTemplate(c *gin.Context) {
 	// pre-check, and like that handler, a failed lookup here is surfaced to
 	// the caller via revocation_incomplete rather than silently masked behind
 	// an identical success response.
-	var memberUserIDs []string
+	var memberships []repositories.RoleTemplateMembership
 	revocationLookupFailed := false
-	if h.userRevocations != nil {
+	if h.creds != nil {
 		var lookupErr error
-		memberUserIDs, lookupErr = h.rbacRepo.ListRoleTemplateMemberUserIDs(c.Request.Context(), id)
+		memberships, lookupErr = h.rbacRepo.ListRoleTemplateMemberships(c.Request.Context(), id)
 		if lookupErr != nil {
-			slog.Error("failed to look up role template members before deletion; affected members' tokens will not be revoked",
+			slog.Error("failed to look up role template members before deletion; affected members' credentials will not be revoked",
 				"role_template_id", id, "error", lookupErr)
-			memberUserIDs = nil
+			memberships = nil
 			revocationLookupFailed = true
 		}
 	}
@@ -404,24 +430,21 @@ func (h *RBACHandlers) DeleteRoleTemplate(c *gin.Context) {
 
 	// Deleting the template unconditionally removes its scopes from every
 	// member who held it (unlike an edit, there's no "was this a no-op"
-	// question to gate on) -- revoke their outstanding tokens so the change
-	// takes effect immediately instead of waiting out the JWT TTL (issue #559
-	// finding [9]). The delete has already committed, so a revocation
-	// failure here is logged rather than turned into a misleading error
-	// response for an otherwise-successful deletion, matching
-	// revokeRoleTemplateMemberTokens' own best-effort posture.
-	for _, userID := range memberUserIDs {
-		if err := h.userRevocations.RevokeAllUserTokens(c.Request.Context(), userID); err != nil {
-			slog.Error("failed to revoke user tokens after role template deletion",
-				"user_id", userID, "role_template_id", id, "error", err)
-		}
-	}
+	// question to gate on) -- sweep both credential families that snapshot
+	// those scopes: the JWT watermark, which otherwise carries them until the
+	// TTL expires (issue #559 finding [9]), and the members' org-bound API
+	// keys, which otherwise carry them forever because nothing re-derives a
+	// key's scopes from its role template (issue #732). The delete has already
+	// committed, so a revocation failure here is logged rather than turned
+	// into a misleading error response for an otherwise-successful deletion,
+	// matching revokeRoleTemplateMemberCredentials' own best-effort posture.
+	h.sweepRoleTemplateMemberships(c, memberships, id, "role template deleted")
 
 	response := gin.H{"message": "Role template deleted"}
 	if revocationLookupFailed {
 		// The delete itself succeeded, but we couldn't determine which
-		// members to revoke -- surface that so the caller doesn't assume the
-		// affected members' tokens were actually invalidated.
+		// members to sweep -- surface that so the caller doesn't assume the
+		// affected members' credentials were actually invalidated.
 		response["revocation_incomplete"] = true
 	}
 	c.JSON(http.StatusOK, response)

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -80,7 +80,7 @@ func (h *RBACHandlers) WithNotifier(n *notify.Notifier) *RBACHandlers {
 // Best-effort: the scope edit has already been committed, so a lookup or
 // revocation failure is logged rather than turned into a misleading error
 // response for an otherwise-successful edit.
-func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleTemplateID uuid.UUID, reason string) {
+func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleTemplateID uuid.UUID, retained []string, reason string) {
 	if h.creds == nil {
 		return
 	}
@@ -90,19 +90,19 @@ func (h *RBACHandlers) revokeRoleTemplateMemberCredentials(c *gin.Context, roleT
 			"role_template_id", roleTemplateID, "reason", reason, "error", err)
 		return
 	}
-	h.sweepRoleTemplateMemberships(c, memberships, roleTemplateID, reason)
+	h.sweepRoleTemplateMemberships(c, memberships, roleTemplateID, retained, reason)
 }
 
 // sweepRoleTemplateMemberships runs the credential sweep over an already-loaded
 // membership set. DeleteRoleTemplate has to snapshot the memberships BEFORE the
 // delete commits (the FK is ON DELETE SET NULL), so it cannot use the
 // load-then-sweep helper above.
-func (h *RBACHandlers) sweepRoleTemplateMemberships(c *gin.Context, memberships []repositories.RoleTemplateMembership, roleTemplateID uuid.UUID, reason string) {
+func (h *RBACHandlers) sweepRoleTemplateMemberships(c *gin.Context, memberships []repositories.RoleTemplateMembership, roleTemplateID uuid.UUID, retained []string, reason string) {
 	if h.creds == nil {
 		return
 	}
 	for _, m := range memberships {
-		out := h.creds.OrgAuthorityReduced(c.Request.Context(), m.UserID, m.OrganizationID, reason)
+		out := h.creds.OrgAuthorityReduced(c.Request.Context(), m.UserID, m.OrganizationID, retained, reason)
 		if out.Incomplete {
 			slog.Error("credential sweep incomplete after role template change",
 				"user_id", m.UserID, "organization_id", m.OrganizationID,
@@ -319,7 +319,14 @@ func (h *RBACHandlers) UpdateRoleTemplate(c *gin.Context) {
 		return
 	}
 
-	scopesChanged := !stringSlicesEqual(existing.Scopes, req.Scopes)
+	// Only a REDUCTION invalidates anything. Adding scopes, or reordering an
+	// otherwise identical list, leaves every existing credential asking for no
+	// more than its holder still has -- and sweeping on those would revoke
+	// every affected member's sessions and irreversibly delete their org-bound
+	// API keys fleet-wide for a change that granted them more, not less.
+	// AuthorityRetained compares by scope semantics rather than slice order,
+	// so a pure reordering is correctly a no-op.
+	authorityReduced := !credlifecycle.AuthorityRetained(existing.Scopes, req.Scopes)
 
 	existing.DisplayName = req.DisplayName
 	existing.Description = &req.Description
@@ -331,34 +338,18 @@ func (h *RBACHandlers) UpdateRoleTemplate(c *gin.Context) {
 		return
 	}
 
-	// A scope edit changes what a fresh JWT would embed for every member
+	// A scope REDUCTION changes what a fresh JWT would embed for every member
 	// currently assigned this template, and equally strands the scope snapshot
 	// frozen on those members' API keys, which are never re-derived from the
 	// template (issue #732); sweep both so the change takes effect immediately
 	// instead of waiting out the JWT TTL (issue #559 finding [9]) or, for the
-	// keys, never. Display-name/description-only edits don't affect scopes, so
-	// skip the sweep for those.
-	if scopesChanged {
-		h.revokeRoleTemplateMemberCredentials(c, id, "role template scopes edited")
+	// keys, never. req.Scopes is what those members retain, so keys that ask
+	// for no more than the new list survive.
+	if authorityReduced {
+		h.revokeRoleTemplateMemberCredentials(c, id, req.Scopes, "role template scopes reduced")
 	}
 
 	c.JSON(http.StatusOK, existing)
-}
-
-// stringSlicesEqual reports whether two scope slices contain the same elements
-// in the same order. Role template scopes are stored and rendered as an
-// ordered list, so this is a simple index-wise comparison rather than a
-// set comparison.
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // @Summary      Delete role template
@@ -438,7 +429,10 @@ func (h *RBACHandlers) DeleteRoleTemplate(c *gin.Context) {
 	// committed, so a revocation failure here is logged rather than turned
 	// into a misleading error response for an otherwise-successful deletion,
 	// matching revokeRoleTemplateMemberCredentials' own best-effort posture.
-	h.sweepRoleTemplateMemberships(c, memberships, id, "role template deleted")
+	// retained is nil: the template is gone, so its members retain none of the
+	// scopes it granted (their membership rows are ON DELETE SET NULL'd to no
+	// role template at all).
+	h.sweepRoleTemplateMemberships(c, memberships, id, nil, "role template deleted")
 
 	response := gin.H{"message": "Role template deleted"}
 	if revocationLookupFailed {

--- a/backend/internal/api/admin/rbac_test.go
+++ b/backend/internal/api/admin/rbac_test.go
@@ -1903,3 +1903,115 @@ func TestRBACEvaluatePolicy_RequiresApproval(t *testing.T) {
 		t.Errorf("requires_approval = %v, want true", resp["requires_approval"])
 	}
 }
+
+// UpdateRoleTemplate must report a failed sweep, exactly as DeleteRoleTemplate,
+// RemoveMemberHandler and DeleteOrganizationHandler do. Narrowing a template's
+// scopes and getting a clean 200 while the affected members' API keys are still
+// live is the silent failure this whole change exists to stop reporting as
+// success: the edit landed, the credentials carrying the old authority did not
+// go away, and the admin had no way to know.
+func TestRBACUpdateRoleTemplate_SweepFails_ReportsRevocationIncomplete(t *testing.T) {
+	mock, r := newRBACRouterWithRevocation(t, true)
+	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+		WillReturnRows(sampleRTRow()) // scopes = ["modules:read","providers:write"]
+	mock.ExpectExec("UPDATE role_templates.*SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	// The member lookup that drives the sweep fails after the edit committed.
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+		WillReturnError(errDB)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"name":         "reader",
+			"display_name": "Reader Updated",
+			"scopes":       []string{"modules:read"}, // strictly narrower
+		})))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the edit itself succeeded): body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		DisplayName          string `json:"display_name"`
+		RevocationIncomplete bool   `json:"revocation_incomplete"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v: body=%s", err, w.Body.String())
+	}
+	if !body.RevocationIncomplete {
+		t.Errorf("expected revocation_incomplete=true after a failed sweep, got body=%s", w.Body.String())
+	}
+	// The template itself is still the response body — the flag is additive.
+	if body.DisplayName != "Reader Updated" {
+		t.Errorf("display_name = %q, want %q: the success body must not change shape", body.DisplayName, "Reader Updated")
+	}
+}
+
+// The happy path must NOT carry the flag, or it means nothing.
+func TestRBACUpdateRoleTemplate_SweepSucceeds_NoRevocationIncomplete(t *testing.T) {
+	mock, r := newRBACRouterWithRevocation(t, true)
+	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+		WillReturnRows(sampleRTRow())
+	mock.ExpectExec("UPDATE role_templates.*SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+			AddRow("member-1", "org-1"))
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs("member-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweepScoped(mock, "member-1", "org-1", "key-rt-ok",
+		[]byte(`["providers:write"]`))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"name":         "reader",
+			"display_name": "Reader Updated",
+			"scopes":       []string{"modules:read"},
+		})))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if bytes.Contains(w.Body.Bytes(), []byte("revocation_incomplete")) {
+		t.Errorf("a successful sweep must not report revocation_incomplete: body=%s", w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("revocation sweep was not issued: %v", err)
+	}
+}
+
+// DeleteRoleTemplate reported revocation_incomplete only when the member
+// LOOKUP failed. A lookup that succeeds followed by a sweep that fails leaves
+// the caller in exactly the same state -- template gone, credentials live --
+// and must report the same way.
+func TestRBACDeleteRoleTemplate_SweepFails_ReportsRevocationIncomplete(t *testing.T) {
+	mock, r := newRBACRouterWithRevocation(t, true)
+	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+		WillReturnRows(sampleRTRow())
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+			AddRow("member-1", "org-1"))
+	mock.ExpectExec("DELETE FROM role_templates WHERE id").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WillReturnError(errDB)
+	expectOrgKeySweep(mock, "member-1", "org-1", "key-rt-del-incomplete")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/role-templates/"+knownUUID, nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the delete itself succeeded): body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		RevocationIncomplete bool `json:"revocation_incomplete"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response body: %v: body=%s", err, w.Body.String())
+	}
+	if !body.RevocationIncomplete {
+		t.Errorf("expected revocation_incomplete=true after a failed sweep, got body=%s", w.Body.String())
+	}
+}

--- a/backend/internal/api/admin/rbac_test.go
+++ b/backend/internal/api/admin/rbac_test.go
@@ -120,10 +120,15 @@ func newRBACRouterWithRevocation(t *testing.T, withRevocation bool) (sqlmock.Sql
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	rbacRepo := repositories.NewRBACRepository(sqlxDB)
 	var userRevocations *repositories.UserTokenRevocationRepository
+	var apiKeys *repositories.APIKeyRepository
 	if withRevocation {
 		userRevocations = repositories.NewUserTokenRevocationRepository(db)
+		// The API-key half of the sweep (issue #732) runs over the same mocked
+		// connection, so the org-bound key lookup/delete are ordinary
+		// expectations on `mock` like the watermark write.
+		apiKeys = repositories.NewAPIKeyRepository(db)
 	}
-	h := NewRBACHandlers(rbacRepo, userRevocations)
+	h := NewRBACHandlers(rbacRepo, userRevocations, apiKeys)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -335,25 +340,30 @@ func TestRBACUpdateRoleTemplate_Success(t *testing.T) {
 	}
 }
 
-// Issue #559 finding [9]: editing a role template's scopes must revoke the
-// outstanding tokens of every member currently assigned that template, so the
-// new scopes take effect immediately rather than waiting out the JWT TTL.
+// Issue #559 finding [9] plus issue #732: editing a role template's scopes must
+// sweep BOTH credential families that snapshot those scopes for every member
+// currently assigned the template — the JWT revoke-all watermark and the
+// member's API keys in the organization where they hold it — so the new scopes
+// take effect immediately rather than waiting out the JWT TTL (JWTs) or never
+// (keys).
 func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).
-			AddRow("member-1").
-			AddRow("member-2"))
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+			AddRow("member-1", "org-1").
+			AddRow("member-2", "org-2"))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "member-1", "org-1", "key-m1")
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-2").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "member-2", "org-2", "key-m2")
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
@@ -451,18 +461,20 @@ func TestRBACDeleteRoleTemplate_RevokesMemberTokens(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).
-			AddRow("member-1").
-			AddRow("member-2"))
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+			AddRow("member-1", "org-1").
+			AddRow("member-2", "org-2"))
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "member-1", "org-1", "key-m1")
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-2").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectOrgKeySweep(mock, "member-2", "org-2", "key-m2")
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/role-templates/"+knownUUID, nil))
@@ -483,7 +495,7 @@ func TestRBACDeleteRoleTemplate_MemberLookupDBError_StillDeletes(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
 		WillReturnError(errDB)
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1118,7 +1130,7 @@ func newRBACRouterWithOrg(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	rbacRepo := repositories.NewRBACRepository(sqlxDB)
-	h := NewRBACHandlers(rbacRepo, nil)
+	h := NewRBACHandlers(rbacRepo, nil, nil)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -1513,7 +1525,7 @@ func newRBACRouterNoUser(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 	rbacRepo := repositories.NewRBACRepository(sqlxDB)
-	h := NewRBACHandlers(rbacRepo, nil)
+	h := NewRBACHandlers(rbacRepo, nil, nil)
 
 	r := gin.New()
 	// No user_id middleware — exercises context-absent code paths

--- a/backend/internal/api/admin/rbac_test.go
+++ b/backend/internal/api/admin/rbac_test.go
@@ -1,10 +1,12 @@
 package admin
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -348,6 +350,7 @@ func TestRBACUpdateRoleTemplate_Success(t *testing.T) {
 // (keys).
 func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
+	logs := captureSlogOutput(t)
 	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
@@ -359,18 +362,25 @@ func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) 
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	expectOrgKeySweep(mock, "member-1", "org-1", "key-m1")
+	// member-1's key asks for providers:write, which the narrowed template no
+	// longer grants → deleted.
+	expectOrgKeySweepScoped(mock, "member-1", "org-1", "key-m1", []byte(`["providers:write"]`))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WithArgs("member-2").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	expectOrgKeySweep(mock, "member-2", "org-2", "key-m2")
+	// member-2's key asks only for modules:read, which the new template still
+	// grants → listed but NOT deleted. Deleting it would destroy a working,
+	// unrecoverable credential that is entirely within the member's remaining
+	// authority; no DELETE is registered, so sqlmock fails the test if one is
+	// issued.
+	expectOrgKeyList(mock, "member-2", "org-2", "key-m2", []byte(`["modules:read"]`))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
 		jsonBody(map[string]interface{}{
 			"name":         "reader",
 			"display_name": "Reader Updated",
-			"scopes":       []string{"modules:read"}, // differs from testRTScopes
+			"scopes":       []string{"modules:read"}, // narrower than testRTScopes
 		})))
 
 	if w.Code != http.StatusOK {
@@ -379,6 +389,89 @@ func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("revocation sweep was not issued: %v", err)
 	}
+	// member-2's key must not be touched at all. Asserted on the logs rather
+	// than on sqlmock: an unregistered DELETE is returned to the sweeper as an
+	// error, which its best-effort handling logs and swallows, so
+	// ExpectationsWereMet() would still pass. The sweeper names the key in
+	// both its success and its failure log, so the id appearing at all means
+	// a deletion was attempted.
+	if strings.Contains(logs.String(), "key-m2") {
+		t.Errorf("a key entirely within the retained authority was swept; logs: %s", logs.String())
+	}
+}
+
+// A scope WIDENING must not sweep anything. Every credential frozen under the
+// old, narrower template still asks for no more than its holder now has, so
+// revoking sessions and irreversibly deleting API keys would destroy working
+// credentials fleet-wide as a side effect of GRANTING permission. Asserted by
+// registering no member-lookup or revocation expectations: sqlmock fails the
+// test if the handler issues any.
+func TestRBACUpdateRoleTemplate_ScopesWidened_SkipsRevocation(t *testing.T) {
+	mock, r := newRBACRouterWithRevocation(t, true)
+	logs := captureSlogOutput(t)
+	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
+	mock.ExpectExec("UPDATE role_templates.*SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"name":         "reader",
+			"display_name": "Reader Updated",
+			// A strict superset: everything the template granted before, plus
+			// modules:write.
+			"scopes": []string{"modules:read", "providers:write", "modules:write"},
+		})))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	assertNoSweepAttempted(t, mock, logs, "a scope widening")
+}
+
+// assertNoSweepAttempted fails when the handler tried to sweep at all.
+//
+// mock.ExpectationsWereMet() alone is NOT sufficient here: sqlmock only checks
+// that every REGISTERED expectation fired, so an unexpected extra statement is
+// returned to the caller as an error and then swallowed by the sweep's
+// deliberate best-effort error handling, leaving the test green. The member
+// lookup is the sweep's first statement, so its failure log is the reliable
+// signal that a sweep was attempted.
+func assertNoSweepAttempted(t *testing.T, mock sqlmock.Sqlmock, logs *bytes.Buffer, what string) {
+	t.Helper()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("%s must not sweep any credential: %v", what, err)
+	}
+	if strings.Contains(logs.String(), "failed to list role template members for credential revocation") {
+		t.Errorf("%s attempted a credential sweep; logs: %s", what, logs.String())
+	}
+}
+
+// A pure REORDERING of an unchanged scope set must not sweep anything either.
+// The previous gate compared the two slices index-wise, so swapping two
+// entries in the UI read as a scope change and hard-deleted every affected
+// member's org-bound API keys.
+func TestRBACUpdateRoleTemplate_ScopesReordered_SkipsRevocation(t *testing.T) {
+	mock, r := newRBACRouterWithRevocation(t, true)
+	logs := captureSlogOutput(t)
+	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
+	mock.ExpectExec("UPDATE role_templates.*SET display_name").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/role-templates/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"name":         "reader",
+			"display_name": "Reader Updated",
+			"scopes":       []string{"providers:write", "modules:read"}, // same set, swapped
+		})))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	assertNoSweepAttempted(t, mock, logs, "a pure reordering")
 }
 
 // A display-name/description-only edit that leaves scopes unchanged must not

--- a/backend/internal/api/admin/user_gdpr_test.go
+++ b/backend/internal/api/admin/user_gdpr_test.go
@@ -102,8 +102,6 @@ func TestEraseUserHandler_Success(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM organization_members").WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("INSERT INTO revoked_tokens").WithArgs("user-1").
-		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	svc := services.NewUserService(db)
@@ -160,8 +158,6 @@ func TestEraseUserHandler_NoAuthContext(t *testing.T) {
 	mock.ExpectExec("DELETE FROM api_keys").WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("DELETE FROM organization_members").WithArgs("user-1").
-		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("INSERT INTO revoked_tokens").WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 

--- a/backend/internal/api/admin/users.go
+++ b/backend/internal/api/admin/users.go
@@ -3,11 +3,13 @@ package admin
 
 import (
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
@@ -18,16 +20,32 @@ type UserHandlers struct {
 	db       *sql.DB
 	userRepo *repositories.UserRepository
 	orgRepo  *repositories.OrganizationRepository
+	// creds invalidates the credential families a deleted principal would
+	// otherwise leave behind. May be nil in tests; the sweep is skipped.
+	creds *credlifecycle.Sweeper
+}
+
+// UserHandlersOption configures optional UserHandlers dependencies.
+type UserHandlersOption func(*UserHandlers)
+
+// WithUserCredentialSweeper wires the credential sweeper used when a principal
+// is deleted.
+func WithUserCredentialSweeper(s *credlifecycle.Sweeper) UserHandlersOption {
+	return func(h *UserHandlers) { h.creds = s }
 }
 
 // NewUserHandlers creates a new UserHandlers instance
-func NewUserHandlers(cfg *config.Config, db *sql.DB) *UserHandlers {
-	return &UserHandlers{
+func NewUserHandlers(cfg *config.Config, db *sql.DB, opts ...UserHandlersOption) *UserHandlers {
+	h := &UserHandlers{
 		cfg:      cfg,
 		db:       db,
 		userRepo: repositories.NewUserRepository(db),
 		orgRepo:  repositories.NewOrganizationRepository(db),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
 // @Summary      List users
@@ -317,6 +335,41 @@ func (h *UserHandlers) DeleteUserHandler() gin.HandlerFunc {
 				"error": "User not found",
 			})
 			return
+		}
+
+		// Sweep the principal's credentials BEFORE the row goes away.
+		//
+		// It is tempting to rely on the FK cascade here, and the registry's own
+		// legacy schema does declare api_keys.user_id ON DELETE CASCADE
+		// (internal/db/migrations/000001_initial_schema.up.sql). The shared
+		// identity schema -- which is what the identity connection actually
+		// serves, and which owns this table in the shared-database deployment
+		// mode -- declares the opposite:
+		//
+		//	identity.api_keys.user_id UUID REFERENCES identity.users(id) ON DELETE SET NULL
+		//
+		// So deleting a principal DETACHES its API keys rather than destroying
+		// them, and a detached key is worse than an orphan: it is an org-bound
+		// key with a NULL user_id, which is exactly the shape
+		// NamespaceAuthorizer.verifyKeyOwnerAuthority reads as an organization
+		// SERVICE credential and exempts from any membership check. Deleting a
+		// user would silently promote their personal keys to unattributable,
+		// permanently valid org credentials.
+		//
+		// The sweep must therefore run first: after the delete there is no
+		// user_id left to find the rows by. If the delete then fails the user
+		// keeps their account but loses their credentials -- the fail-closed
+		// direction, and recoverable by re-issuing keys.
+		if h.creds != nil {
+			out := h.creds.UserDeprovisioned(c.Request.Context(), userID, "user deleted by administrator")
+			if out.Incomplete {
+				slog.Error("credential sweep incomplete before user deletion; deleting anyway would detach surviving keys",
+					"user_id", userID)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to revoke the user's credentials; user was not deleted",
+				})
+				return
+			}
 		}
 
 		// Delete user (cascading deletes will handle related records)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -40,6 +40,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/auth/mtls"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
@@ -408,8 +409,18 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		oidcStateStore = auth.NewMemoryStateStore(5 * time.Minute)
 	}
 
+	// credSweeper invalidates BOTH credential families that snapshot a
+	// principal's derived authority (JWT sessions via the revoke-all watermark,
+	// API keys via the api_keys row) whenever a lifecycle event reduces that
+	// authority. userTokenRevocationRepo lives on the registry connection and
+	// apiKeyRepo on the identity connection, so the two halves cannot be
+	// constructed from a single handle -- it is built once here and injected
+	// wherever an authority-reducing handler lives (issues #732, #736).
+	credSweeper := credlifecycle.NewSweeper(userTokenRevocationRepo, apiKeyRepo)
+
 	var authHandlers *admin.AuthHandlers
-	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore, admin.WithSAMLEgressGuard(egressGuard))
+	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore,
+		admin.WithSAMLEgressGuard(egressGuard), admin.WithCredentialSweeper(credSweeper))
 	if err != nil {
 		log.Fatalf("Failed to initialize auth handlers: %v", err)
 	}
@@ -450,7 +461,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 
 	// Role-template CRUD follows the identity schema; mirror methods stay public.
 	rbacRepo := repositories.NewRBACRepositoryWithIdentity(sqlxDB, identitySqlxDB)
-	rbacHandlers := admin.NewRBACHandlers(rbacRepo, userTokenRevocationRepo).WithNotifications(&cfg.Notifications, &cfg.CVE)
+	rbacHandlers := admin.NewRBACHandlers(rbacRepo, userTokenRevocationRepo, apiKeyRepo).WithNotifications(&cfg.Notifications, &cfg.CVE)
 
 	// Initialize audit log handlers
 	auditLogHandlers := admin.NewAuditLogHandlers(identityDB)
@@ -652,6 +663,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		orgRepo:                     orgRepo,
 		tokenRepo:                   tokenRepo,
 		userTokenRevocationRepo:     userTokenRevocationRepo,
+		credSweeper:                 credSweeper,
 		moduleAdminHandlers:         moduleAdminHandlers,
 		providerAdminHandlers:       providerAdminHandlers,
 		auditRepo:                   auditRepo,

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -435,7 +435,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// handler's namespace cascade and the stats handler's feature-table counts
 	// fall back to public via the identity connection's search_path.
 	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, identityDB)
-	userHandlers := admin.NewUserHandlers(cfg, identityDB)
+	userHandlers := admin.NewUserHandlers(cfg, identityDB, admin.WithUserCredentialSweeper(credSweeper))
 	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB, nsClaimRepo, userTokenRevocationRepo)
 	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
@@ -456,7 +456,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 
 	// GDPR data-subject handlers (Article 15/17/20). Registered under
 	// /api/v1/admin/users/:id/{export,erase} below.
-	userSvc := services.NewUserService(identityDB)
+	userSvc := services.NewUserService(identityDB).WithCredentialSweeper(credSweeper)
 	gdprHandlers := admin.NewGDPRHandlers(userSvc)
 
 	// Role-template CRUD follows the identity schema; mirror methods stay public.

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -39,6 +39,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/audit"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
@@ -307,23 +308,28 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 
 // apiV1RouteDeps holds every dependency registerAPIV1Routes needs.
 type apiV1RouteDeps struct {
-	cfg                         *config.Config
-	db                          *sql.DB
-	storageBackend              storage.Storage
-	sqlxDB                      *sqlx.DB
-	oidcConfigRepo              *repositories.OIDCConfigRepository
-	setupHandlers               *setup.Handlers
-	authRateLimiter             middleware.RateLimiterBackend
-	generalRateLimiter          middleware.RateLimiterBackend
-	uploadRateLimiter           middleware.RateLimiterBackend
-	orgRateLimiter              middleware.RateLimiterBackend
-	principalOverrides          *middleware.PrincipalOverrideLimiters
-	authHandlers                *admin.AuthHandlers
-	userRepo                    *repositories.UserRepository
-	apiKeyRepo                  *repositories.APIKeyRepository
-	orgRepo                     *repositories.OrganizationRepository
-	tokenRepo                   *repositories.TokenRepository
-	userTokenRevocationRepo     *repositories.UserTokenRevocationRepository
+	cfg                     *config.Config
+	db                      *sql.DB
+	storageBackend          storage.Storage
+	sqlxDB                  *sqlx.DB
+	oidcConfigRepo          *repositories.OIDCConfigRepository
+	setupHandlers           *setup.Handlers
+	authRateLimiter         middleware.RateLimiterBackend
+	generalRateLimiter      middleware.RateLimiterBackend
+	uploadRateLimiter       middleware.RateLimiterBackend
+	orgRateLimiter          middleware.RateLimiterBackend
+	principalOverrides      *middleware.PrincipalOverrideLimiters
+	authHandlers            *admin.AuthHandlers
+	userRepo                *repositories.UserRepository
+	apiKeyRepo              *repositories.APIKeyRepository
+	orgRepo                 *repositories.OrganizationRepository
+	tokenRepo               *repositories.TokenRepository
+	userTokenRevocationRepo *repositories.UserTokenRevocationRepository
+	// credSweeper invalidates every credential family that snapshots a
+	// principal's derived authority when a lifecycle event reduces it
+	// (issues #732, #736). Built once in NewRouter because its two halves
+	// live on different connections.
+	credSweeper                 *credlifecycle.Sweeper
 	moduleAdminHandlers         *admin.ModuleAdminHandlers
 	providerAdminHandlers       *admin.ProviderAdminHandlers
 	auditRepo                   *repositories.AuditRepository
@@ -1137,7 +1143,7 @@ func registerSCIMRoutes(router *gin.Engine, d *apiV1RouteDeps) {
 	// authenticatedGroup).
 	scimGroup.Use(middleware.RequireScope(auth.ScopeSCIMProvision))
 	{
-		scimHandlers := scim.NewHandlers(d.cfg, d.db)
+		scimHandlers := scim.NewHandlers(d.cfg, d.db, scim.WithCredentialSweeper(d.credSweeper))
 		scimGroup.GET("/Users", scimHandlers.ListUsers())
 		scimGroup.GET("/Users/:id", scimHandlers.GetUser())
 		scimGroup.POST("/Users", scimHandlers.CreateUser())

--- a/backend/internal/api/scim/handlers.go
+++ b/backend/internal/api/scim/handlers.go
@@ -102,8 +102,18 @@ type SCIMUser struct {
 	UserName   string      `json:"userName"`
 	Name       *SCIMName   `json:"name,omitempty"`
 	Emails     []SCIMEmail `json:"emails,omitempty"`
-	Active     bool        `json:"active"`
-	Meta       SCIMMeta    `json:"meta"`
+	// Active is a POINTER so an omitted "active" is distinguishable from an
+	// explicit "active": false.
+	//
+	// As a plain bool it zero-valued to false on every PUT that did not
+	// mention the attribute, and PutUser reads false as "deprovision" -- which
+	// since #736 means removing every organization membership AND irreversibly
+	// deleting every API key the user holds in every organization. A partial
+	// PUT from an IdP (or any client updating only a display name) would
+	// silently destroy the user's credentials fleet-wide. Deprovisioning must
+	// require the IdP to actually say active=false.
+	Active *bool    `json:"active,omitempty"`
+	Meta   SCIMMeta `json:"meta"`
 }
 
 // SCIMName is the SCIM name sub-object.
@@ -410,7 +420,9 @@ func (h *Handlers) PutUser() gin.HandlerFunc {
 			}
 		}
 
-		if !req.Active {
+		// Only an EXPLICIT active=false deprovisions. An omitted attribute
+		// leaves the user's authority (and credentials) untouched.
+		if req.Active != nil && !*req.Active {
 			_ = h.orgRepo.RemoveAllMembershipsForUser(ctx, userID)
 			// Memberships alone are not the user's authority: their JWT
 			// sessions and API keys carry a snapshot of it (issue #736).
@@ -597,6 +609,11 @@ func userToSCIM(u *models.User, baseURL string) SCIMUser {
 		emails = append(emails, SCIMEmail{Value: u.Email, Type: "work", Primary: true})
 	}
 
+	// Always rendered explicitly on the way out: existing users are active
+	// (deactivated users have no memberships). Only the INBOUND direction
+	// needs to distinguish omitted from false.
+	active := true
+
 	return SCIMUser{
 		Schemas:    []string{SchemaUser},
 		ID:         u.ID,
@@ -604,7 +621,7 @@ func userToSCIM(u *models.User, baseURL string) SCIMUser {
 		UserName:   u.Email,
 		Name:       &SCIMName{Formatted: u.Name},
 		Emails:     emails,
-		Active:     true, // Active is always true for existing users; deactivated users have no memberships
+		Active:     &active,
 		Meta: SCIMMeta{
 			ResourceType: "User",
 			Created:      u.CreatedAt.Format(time.RFC3339),

--- a/backend/internal/api/scim/handlers.go
+++ b/backend/internal/api/scim/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
@@ -35,16 +36,60 @@ type Handlers struct {
 	db       *sql.DB
 	userRepo *repositories.UserRepository
 	orgRepo  *repositories.OrganizationRepository
+	// creds invalidates the credentials of a user this IdP feed deprovisions.
+	//
+	// SCIM is the primary IdP-driven offboarding channel: it is what fires when
+	// HR disables an account. Every deactivation path here used to strip
+	// organization memberships and nothing else (issue #736) -- the deactivated
+	// user kept a fully working session for the remainder of the 24h JWT
+	// lifetime and kept their API keys permanently, because both families
+	// snapshot their authority at issue time. That is directly inconsistent
+	// with the admin path, which goes out of its way to sweep on the analogous
+	// membership removal.
+	//
+	// May be nil (no sweep) so the handler set stays constructible without the
+	// revocation subsystem.
+	creds *credlifecycle.Sweeper
+}
+
+// Option configures optional Handlers construction behaviour.
+type Option func(*Handlers)
+
+// WithCredentialSweeper wires the credential sweep used by the deprovisioning
+// paths (DELETE /Users/{id}, and active=false via PUT or PATCH).
+func WithCredentialSweeper(s *credlifecycle.Sweeper) Option {
+	return func(h *Handlers) { h.creds = s }
 }
 
 // NewHandlers creates a SCIM handler set.
-func NewHandlers(cfg *config.Config, db *sql.DB) *Handlers {
-	return &Handlers{
+func NewHandlers(cfg *config.Config, db *sql.DB, opts ...Option) *Handlers {
+	h := &Handlers{
 		cfg:      cfg,
 		db:       db,
 		userRepo: repositories.NewUserRepository(db),
 		orgRepo:  repositories.NewOrganizationRepository(db),
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// deprovision invalidates every credential family belonging to a user this
+// SCIM feed has just deactivated or deleted: their JWT sessions and every API
+// key they hold in every organization. Best-effort and non-fatal — the
+// membership strip has already committed, and SCIM clients retry aggressively
+// on 5xx, so a sweep failure is logged rather than turned into an error the
+// IdP would replay.
+func (h *Handlers) deprovision(ctx context.Context, userID, reason string) {
+	if h.creds == nil {
+		return
+	}
+	out := h.creds.UserDeprovisioned(ctx, userID, reason)
+	slog.Info("scim: credentials revoked for deprovisioned user",
+		"id", userID, "reason", reason,
+		"tokens_revoked", out.TokensRevoked, "api_keys_revoked", out.KeysRevoked,
+		"incomplete", out.Incomplete)
 }
 
 // --- SCIM Resource types ---
@@ -367,6 +412,9 @@ func (h *Handlers) PutUser() gin.HandlerFunc {
 
 		if !req.Active {
 			_ = h.orgRepo.RemoveAllMembershipsForUser(ctx, userID)
+			// Memberships alone are not the user's authority: their JWT
+			// sessions and API keys carry a snapshot of it (issue #736).
+			h.deprovision(ctx, userID, "scim: user deactivated via PUT")
 			slog.Info("scim: user deactivated via PUT", "id", userID)
 		}
 
@@ -407,6 +455,12 @@ func (h *Handlers) DeleteUser() gin.HandlerFunc {
 			scimError(c, http.StatusInternalServerError, "Failed to deactivate user")
 			return
 		}
+
+		// This is a SOFT delete: the users row survives, so nothing cascades
+		// to api_keys and nothing makes AuthMiddleware's user lookup fail.
+		// Without an explicit sweep the "deleted" user keeps a live session and
+		// permanently valid API keys (issue #736).
+		h.deprovision(ctx, userID, "scim: user deleted")
 
 		slog.Info("scim: user deactivated", "id", userID, "email", user.Email)
 		c.Status(http.StatusNoContent)
@@ -486,6 +540,9 @@ func (h *Handlers) applyReplaceOp(ctx context.Context, user *models.User, op SCI
 		}
 		if !active {
 			_ = h.orgRepo.RemoveAllMembershipsForUser(ctx, user.ID)
+			// Same deprovisioning event as PUT active=false, reached through
+			// the PATCH "replace active" op (issue #736).
+			h.deprovision(ctx, user.ID, "scim: user deactivated via PATCH")
 			slog.Info("scim: user deactivated via PATCH", "id", user.ID)
 		}
 	case "username", "emails[type eq \"work\"].value":
@@ -501,6 +558,10 @@ func (h *Handlers) applyReplaceOp(ctx context.Context, user *models.User, op SCI
 		if m, ok := op.Value.(map[string]interface{}); ok {
 			if v, ok := m["active"].(bool); ok && !v {
 				_ = h.orgRepo.RemoveAllMembershipsForUser(ctx, user.ID)
+				// Pathless PATCH carrying {"active": false} is the same
+				// deprovisioning event as the "active" path above and must
+				// sweep identically (issue #736).
+				h.deprovision(ctx, user.ID, "scim: user deactivated via pathless PATCH")
 			}
 			if v, ok := m["userName"].(string); ok && v != "" {
 				user.Email = v

--- a/backend/internal/api/scim/handlers_test.go
+++ b/backend/internal/api/scim/handlers_test.go
@@ -56,8 +56,8 @@ func TestUserToSCIM(t *testing.T) {
 	if len(scimUser.Emails) != 1 || scimUser.Emails[0].Value != "jane@example.com" {
 		t.Errorf("Emails = %v, want 1 email with jane@example.com", scimUser.Emails)
 	}
-	if !scimUser.Active {
-		t.Error("Active should be true")
+	if scimUser.Active == nil || !*scimUser.Active {
+		t.Error("Active should be rendered explicitly true on the way out")
 	}
 	if scimUser.Meta.Location != "https://registry.example.com/scim/v2/Users/user-1" {
 		t.Errorf("Meta.Location = %q", scimUser.Meta.Location)

--- a/backend/internal/credlifecycle/sweeper.go
+++ b/backend/internal/credlifecycle/sweeper.go
@@ -142,9 +142,27 @@ func (s *Sweeper) OrgAuthorityReduced(ctx context.Context, userID, orgID string,
 // (RFC 7519). Moving the watermark there would make the freshly minted token
 // compare as revoked — TokensRevokedSince deliberately resolves that
 // same-second ambiguity toward "revoked" — and the user could never log in.
-// The fresh token is issued from GetUserCombinedScopes AFTER the membership was
-// removed, so it already carries the reduced authority; the API keys are the
-// family that would otherwise survive the deprovisioning indefinitely.
+//
+// EXACTLY WHAT THE EXEMPTION COVERS, AND WHAT IT DOES NOT.
+//
+// Covered: the token minted by THIS request. It is issued from
+// GetUserCombinedScopes AFTER the membership change committed, so it already
+// carries the reduced authority — moving the watermark would buy nothing and
+// would break login.
+//
+// NOT covered — the residual: the user's OTHER live sessions, minted at
+// EARLIER logins. Those carry the pre-reduction scope union and nothing here
+// retires them; they stay valid until their own TTL expires. The same-second
+// race justifies leaving the watermark alone for this request's token only,
+// and it is a strictly narrower claim than "no JWT needs revoking here".
+//
+// The residual is accepted because the alternative is a login that can never
+// succeed, and because the exposure is bounded by the JWT TTL, whereas the
+// API-key family — the one this call does sweep — would otherwise survive the
+// deprovisioning indefinitely. An operator who needs an IdP-driven reduction to
+// retire every existing session immediately must take the administrative path
+// (RemoveMemberHandler / UpdateMemberHandler / the role-template endpoints),
+// which calls OrgAuthorityReduced and does move the watermark.
 func (s *Sweeper) OrgKeysOnly(ctx context.Context, userID, orgID string, retained []string, reason string) Outcome {
 	if s == nil {
 		return Outcome{}

--- a/backend/internal/credlifecycle/sweeper.go
+++ b/backend/internal/credlifecycle/sweeper.go
@@ -1,0 +1,192 @@
+// Package credlifecycle centralises the invalidation of every credential
+// family that carries a *snapshot* of a principal's derived authority.
+//
+// The registry issues two credential families whose authority is frozen at
+// issue time rather than re-derived from the database on every request:
+//
+//   - JWT sessions — the scope list is embedded in the claims at login
+//     (auth.GenerateJWT) and is never re-read; only a JTI denylist hit or the
+//     per-user revoke-all watermark (UserTokenRevocationRepository) stops one.
+//   - API keys — BOTH the scope list AND the owning organization_id are stored
+//     on the api_keys row at creation and are copied straight into the request
+//     context by middleware.AuthMiddleware ("scopes", "organization_id").
+//     Nothing re-derives them from the owner's current membership or role
+//     template.
+//
+// It follows that any event which REDUCES a principal's derived authority —
+// removal from an organization, reassignment of their role template, an edit
+// or deletion of the role template itself, or IdP-driven deprovisioning via
+// SCIM or a group-mapping sync — must invalidate BOTH families, or the
+// reduction is cosmetic for whichever family it forgot.
+//
+// Before issues #732 and #736 only the JWT family was swept, and only at some
+// of those events: an offboarded member kept a working publish credential into
+// the org's namespaces indefinitely, and SCIM deprovisioning swept nothing at
+// all. This package exists so the sweep is one call with one meaning rather
+// than a fragment re-derived at each call site.
+//
+// SHARED-MODULE NOTE: the truly authoritative home for this is the shared
+// identity module (github.com/sethbacon/terraform-suite-identity), where both
+// organization_members and api_keys are owned and where the removal and the
+// sweep could be one transaction. This package is the consumer-side
+// composition available without editing that module; it is best-effort (the
+// authority change has already committed) rather than atomic.
+package credlifecycle
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Sweeper invalidates the credential families derived from an authority that
+// has just been reduced.
+//
+// A nil *Sweeper is a valid no-op receiver: handlers constructed without the
+// revocation subsystem wired (most unit tests, and any deployment that has not
+// provisioned the user_token_revocations table) keep their previous behaviour
+// instead of panicking or issuing unexpected queries.
+type Sweeper struct {
+	// userRevocations moves the per-user JWT revoke-all watermark. Lives on the
+	// registry's own connection.
+	userRevocations *repositories.UserTokenRevocationRepository
+	// apiKeys deletes API-key rows. Lives on the identity connection.
+	apiKeys *repositories.APIKeyRepository
+}
+
+// NewSweeper builds a Sweeper. Either repository may be nil, in which case
+// that family is simply not swept; if both are nil the constructor returns nil
+// so callers can store the result directly and rely on the no-op receiver.
+func NewSweeper(userRevocations *repositories.UserTokenRevocationRepository, apiKeys *repositories.APIKeyRepository) *Sweeper {
+	if userRevocations == nil && apiKeys == nil {
+		return nil
+	}
+	return &Sweeper{userRevocations: userRevocations, apiKeys: apiKeys}
+}
+
+// Outcome reports what a sweep actually managed to invalidate. Every sweep is
+// best-effort: by the time it runs, the authority change has already been
+// committed, so a failure is reported and logged rather than rolled back —
+// turning it into an error response would falsely tell the caller that the
+// (already applied) removal did not happen. Incomplete lets a handler surface
+// "the reduction landed but the credential sweep did not" to its caller.
+type Outcome struct {
+	TokensRevoked bool
+	KeysRevoked   int
+	Incomplete    bool
+}
+
+// OrgAuthorityReduced invalidates the credentials a user derives from ONE
+// organization: their JWT sessions (which carry a cross-org scope union that
+// included this org) and every API key bound to that organization.
+//
+// Use for membership removal and for a membership's role-template change: in
+// both cases the org-bound key's stored scopes are a snapshot of an authority
+// the user no longer has, and middleware.AuthMiddleware will keep serving that
+// snapshot until the row is gone.
+func (s *Sweeper) OrgAuthorityReduced(ctx context.Context, userID, orgID, reason string) Outcome {
+	if s == nil {
+		return Outcome{}
+	}
+	out := s.revokeTokens(ctx, userID, reason)
+	keys, incomplete := s.revokeOrgKeys(ctx, userID, orgID, reason)
+	out.KeysRevoked = keys
+	out.Incomplete = out.Incomplete || incomplete
+	return out
+}
+
+// OrgKeysOnly invalidates only the API keys a user derives from ONE
+// organization, deliberately leaving the JWT watermark untouched.
+//
+// This exists for the IdP login path (OIDC/SAML group-mapping reconciliation).
+// That reconciliation runs a few hundred microseconds BEFORE the same request
+// mints the user's new session JWT, and RevokeAllUserTokens writes a
+// full-precision NOW() watermark while a JWT's iat is floored to the second
+// (RFC 7519). Moving the watermark there would make the freshly minted token
+// compare as revoked — TokensRevokedSince deliberately resolves that
+// same-second ambiguity toward "revoked" — and the user could never log in.
+// The fresh token is issued from GetUserCombinedScopes AFTER the membership was
+// removed, so it already carries the reduced authority; the API keys are the
+// family that would otherwise survive the deprovisioning indefinitely.
+func (s *Sweeper) OrgKeysOnly(ctx context.Context, userID, orgID, reason string) Outcome {
+	if s == nil {
+		return Outcome{}
+	}
+	keys, incomplete := s.revokeOrgKeys(ctx, userID, orgID, reason)
+	return Outcome{KeysRevoked: keys, Incomplete: incomplete}
+}
+
+// UserDeprovisioned invalidates every credential the user holds anywhere: JWT
+// sessions plus every API key in every organization.
+//
+// Use for whole-principal offboarding — SCIM DELETE /Users/{id}, SCIM
+// active=false via PUT or PATCH — where the user retains no authority at all.
+func (s *Sweeper) UserDeprovisioned(ctx context.Context, userID, reason string) Outcome {
+	if s == nil {
+		return Outcome{}
+	}
+	out := s.revokeTokens(ctx, userID, reason)
+	if s.apiKeys == nil {
+		return out
+	}
+	keys, err := s.apiKeys.ListAPIKeysByUser(ctx, userID)
+	if err != nil {
+		slog.Error("credlifecycle: failed to list user API keys for revocation",
+			"user_id", userID, "reason", reason, "error", err)
+		out.Incomplete = true
+		return out
+	}
+	for _, k := range keys {
+		if err := s.apiKeys.RevokeAPIKey(ctx, k.ID); err != nil {
+			slog.Error("credlifecycle: failed to revoke API key",
+				"api_key_id", k.ID, "user_id", userID, "reason", reason, "error", err)
+			out.Incomplete = true
+			continue
+		}
+		out.KeysRevoked++
+		slog.Info("credlifecycle: API key revoked", "api_key_id", k.ID, "user_id", userID, "reason", reason)
+	}
+	return out
+}
+
+func (s *Sweeper) revokeTokens(ctx context.Context, userID, reason string) Outcome {
+	if s.userRevocations == nil {
+		return Outcome{}
+	}
+	if err := s.userRevocations.RevokeAllUserTokens(ctx, userID); err != nil {
+		slog.Error("credlifecycle: failed to revoke user tokens after authority reduction",
+			"user_id", userID, "reason", reason, "error", err)
+		return Outcome{Incomplete: true}
+	}
+	return Outcome{TokensRevoked: true}
+}
+
+// revokeOrgKeys deletes every API key owned by userID and bound to orgID.
+// Deletion (rather than scope narrowing) matches the recommendation on #732
+// and the existing posture for the JWT family, which is likewise invalidated
+// wholesale rather than re-scoped.
+func (s *Sweeper) revokeOrgKeys(ctx context.Context, userID, orgID, reason string) (int, bool) {
+	if s.apiKeys == nil || orgID == "" {
+		return 0, false
+	}
+	keys, err := s.apiKeys.ListByUserAndOrganization(ctx, userID, orgID)
+	if err != nil {
+		slog.Error("credlifecycle: failed to list org-bound API keys for revocation",
+			"user_id", userID, "organization_id", orgID, "reason", reason, "error", err)
+		return 0, true
+	}
+	revoked, incomplete := 0, false
+	for _, k := range keys {
+		if err := s.apiKeys.RevokeAPIKey(ctx, k.ID); err != nil {
+			slog.Error("credlifecycle: failed to revoke org-bound API key",
+				"api_key_id", k.ID, "user_id", userID, "organization_id", orgID, "reason", reason, "error", err)
+			incomplete = true
+			continue
+		}
+		revoked++
+		slog.Info("credlifecycle: API key revoked",
+			"api_key_id", k.ID, "user_id", userID, "organization_id", orgID, "reason", reason)
+	}
+	return revoked, incomplete
+}

--- a/backend/internal/credlifecycle/sweeper.go
+++ b/backend/internal/credlifecycle/sweeper.go
@@ -37,8 +37,35 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
+
+// AuthorityRetained reports whether every scope in have is still granted by
+// retained -- i.e. whether a credential frozen with `have` still asks for no
+// more than the principal currently holds.
+//
+// This is the whole difference between "the authority changed" and "the
+// authority was REDUCED", and the sweep must key off the latter. Deleting API
+// keys is irreversible (a key's secret is shown exactly once and is not
+// recoverable), so a sweep triggered by an authority INCREASE, or by a mere
+// reordering of an unchanged scope list, destroys working credentials
+// fleet-wide for no security benefit.
+//
+// Comparison is by scope semantics, not by slice identity: auth.HasScope
+// resolves the "admin" wildcard and the read/write implications, so
+// ["modules:read"] is retained under ["modules:write"], and everything is
+// retained under ["admin"]. An empty `retained` grants nothing, so any
+// credential carrying at least one scope is not retained; a credential with no
+// scopes grants nothing and is vacuously retained.
+func AuthorityRetained(have, retained []string) bool {
+	for _, s := range have {
+		if !auth.HasScope(retained, auth.Scope(s)) {
+			return false
+		}
+	}
+	return true
+}
 
 // Sweeper invalidates the credential families derived from an authority that
 // has just been reduced.
@@ -74,7 +101,10 @@ func NewSweeper(userRevocations *repositories.UserTokenRevocationRepository, api
 type Outcome struct {
 	TokensRevoked bool
 	KeysRevoked   int
-	Incomplete    bool
+	// KeysRetained counts keys the sweep deliberately left alone because every
+	// scope they carry is still granted by the principal's remaining authority.
+	KeysRetained int
+	Incomplete   bool
 }
 
 // OrgAuthorityReduced invalidates the credentials a user derives from ONE
@@ -82,17 +112,23 @@ type Outcome struct {
 // included this org) and every API key bound to that organization.
 //
 // Use for membership removal and for a membership's role-template change: in
-// both cases the org-bound key's stored scopes are a snapshot of an authority
-// the user no longer has, and middleware.AuthMiddleware will keep serving that
-// snapshot until the row is gone.
-func (s *Sweeper) OrgAuthorityReduced(ctx context.Context, userID, orgID, reason string) Outcome {
+// both cases the org-bound key's stored scopes may be a snapshot of an
+// authority the user no longer has, and middleware.AuthMiddleware will keep
+// serving that snapshot until the row is gone.
+//
+// retained is the scope set the principal STILL holds in orgID after the
+// change -- the new role template's scopes for a reassignment, nil for a
+// removal. Only keys asking for more than that are deleted; see
+// AuthorityRetained.
+func (s *Sweeper) OrgAuthorityReduced(ctx context.Context, userID, orgID string, retained []string, reason string) Outcome {
 	if s == nil {
 		return Outcome{}
 	}
 	out := s.revokeTokens(ctx, userID, reason)
-	keys, incomplete := s.revokeOrgKeys(ctx, userID, orgID, reason)
-	out.KeysRevoked = keys
-	out.Incomplete = out.Incomplete || incomplete
+	keyOut := s.revokeOrgKeys(ctx, userID, orgID, retained, reason)
+	out.KeysRevoked = keyOut.KeysRevoked
+	out.KeysRetained = keyOut.KeysRetained
+	out.Incomplete = out.Incomplete || keyOut.Incomplete
 	return out
 }
 
@@ -109,12 +145,11 @@ func (s *Sweeper) OrgAuthorityReduced(ctx context.Context, userID, orgID, reason
 // The fresh token is issued from GetUserCombinedScopes AFTER the membership was
 // removed, so it already carries the reduced authority; the API keys are the
 // family that would otherwise survive the deprovisioning indefinitely.
-func (s *Sweeper) OrgKeysOnly(ctx context.Context, userID, orgID, reason string) Outcome {
+func (s *Sweeper) OrgKeysOnly(ctx context.Context, userID, orgID string, retained []string, reason string) Outcome {
 	if s == nil {
 		return Outcome{}
 	}
-	keys, incomplete := s.revokeOrgKeys(ctx, userID, orgID, reason)
-	return Outcome{KeysRevoked: keys, Incomplete: incomplete}
+	return s.revokeOrgKeys(ctx, userID, orgID, retained, reason)
 }
 
 // UserDeprovisioned invalidates every credential the user holds anywhere: JWT
@@ -162,31 +197,42 @@ func (s *Sweeper) revokeTokens(ctx context.Context, userID, reason string) Outco
 	return Outcome{TokensRevoked: true}
 }
 
-// revokeOrgKeys deletes every API key owned by userID and bound to orgID.
-// Deletion (rather than scope narrowing) matches the recommendation on #732
-// and the existing posture for the JWT family, which is likewise invalidated
-// wholesale rather than re-scoped.
-func (s *Sweeper) revokeOrgKeys(ctx context.Context, userID, orgID, reason string) (int, bool) {
+// revokeOrgKeys deletes the API keys owned by userID and bound to orgID whose
+// frozen scopes are no longer covered by `retained`.
+//
+// Deletion (rather than scope narrowing) is the mechanism, matching the
+// recommendation on #732 and the posture for the JWT family, which is likewise
+// invalidated wholesale rather than re-scoped. But the mechanism is
+// irreversible -- an API key's secret is displayed once at creation and cannot
+// be recovered -- so it is applied per key and only where the key actually
+// over-asks. Without that filter, an authority INCREASE or a cosmetic
+// reordering of a role template's scope list would hard-delete every affected
+// member's keys fleet-wide.
+func (s *Sweeper) revokeOrgKeys(ctx context.Context, userID, orgID string, retained []string, reason string) Outcome {
 	if s.apiKeys == nil || orgID == "" {
-		return 0, false
+		return Outcome{}
 	}
 	keys, err := s.apiKeys.ListByUserAndOrganization(ctx, userID, orgID)
 	if err != nil {
 		slog.Error("credlifecycle: failed to list org-bound API keys for revocation",
 			"user_id", userID, "organization_id", orgID, "reason", reason, "error", err)
-		return 0, true
+		return Outcome{Incomplete: true}
 	}
-	revoked, incomplete := 0, false
+	var out Outcome
 	for _, k := range keys {
+		if AuthorityRetained(k.Scopes, retained) {
+			out.KeysRetained++
+			continue
+		}
 		if err := s.apiKeys.RevokeAPIKey(ctx, k.ID); err != nil {
 			slog.Error("credlifecycle: failed to revoke org-bound API key",
 				"api_key_id", k.ID, "user_id", userID, "organization_id", orgID, "reason", reason, "error", err)
-			incomplete = true
+			out.Incomplete = true
 			continue
 		}
-		revoked++
+		out.KeysRevoked++
 		slog.Info("credlifecycle: API key revoked",
 			"api_key_id", k.ID, "user_id", userID, "organization_id", orgID, "reason", reason)
 	}
-	return revoked, incomplete
+	return out
 }

--- a/backend/internal/credlifecycle/sweeper_test.go
+++ b/backend/internal/credlifecycle/sweeper_test.go
@@ -1,0 +1,464 @@
+package credlifecycle
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// akCols is the row shape returned by the identity store's API-key list
+// queries.
+var akCols = []string{
+	"id", "user_id", "organization_id", "name", "description",
+	"key_hash", "key_prefix", "scopes", "expires_at", "last_used_at",
+	"expiry_notification_sent_at", "created_at", "user_name",
+}
+
+func keyRow(id, userID, orgID string, scopes string) *sqlmock.Rows {
+	return sqlmock.NewRows(akCols).AddRow(
+		id, userID, orgID, "CI Key", nil, "hashedkey", "tfr_abc",
+		[]byte(scopes), nil, nil, nil, time.Now(), nil)
+}
+
+// newSweeperWithMock builds a Sweeper whose two halves share one mocked
+// connection. In production they are separate connections (the watermark lives
+// on the registry database, api_keys on the identity database); for the
+// sweeper's own logic only the statement sequence matters.
+func newSweeperWithMock(t *testing.T) (*Sweeper, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s := NewSweeper(
+		repositories.NewUserTokenRevocationRepository(db),
+		repositories.NewAPIKeyRepository(db),
+	)
+	if s == nil {
+		t.Fatal("NewSweeper returned nil with both repositories present")
+	}
+	return s, mock, db
+}
+
+func expectWatermark(mock sqlmock.Sqlmock, userID string) {
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs(userID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+// ---------------------------------------------------------------------------
+// AuthorityRetained — the predicate that separates a REDUCTION from any other
+// change, and so decides whether an irreversible deletion happens at all.
+// ---------------------------------------------------------------------------
+
+func TestAuthorityRetained(t *testing.T) {
+	cases := []struct {
+		name     string
+		have     []string
+		retained []string
+		want     bool
+	}{
+		{"identical set", []string{"modules:write"}, []string{"modules:write"}, true},
+		{
+			// The order-sensitivity bug: the previous gate compared slices
+			// index-wise, so swapping two entries read as a scope change and
+			// hard-deleted every affected member's keys.
+			name:     "same set, different order",
+			have:     []string{"modules:read", "providers:write"},
+			retained: []string{"providers:write", "modules:read"},
+			want:     true,
+		},
+		{
+			// A WIDENING. Granting more permission must never destroy
+			// credentials.
+			name:     "strict superset retains",
+			have:     []string{"modules:read"},
+			retained: []string{"modules:read", "providers:write", "modules:write"},
+			want:     true,
+		},
+		{
+			name:     "reduction is not retained",
+			have:     []string{"modules:read", "providers:write"},
+			retained: []string{"modules:read"},
+			want:     false,
+		},
+		{"admin wildcard retains everything", []string{"modules:write", "providers:write"}, []string{"admin"}, true},
+		{"write implies read", []string{"modules:read"}, []string{"modules:write"}, true},
+		{"read does not imply write", []string{"modules:write"}, []string{"modules:read"}, false},
+		{
+			// Membership removal: nothing is retained, so any credential
+			// carrying a scope over-asks.
+			name:     "empty retained revokes a scoped credential",
+			have:     []string{"modules:read"},
+			retained: nil,
+			want:     false,
+		},
+		{
+			// A credential that grants nothing cannot over-ask, so there is
+			// nothing to gain by destroying it.
+			name:     "scopeless credential is vacuously retained",
+			have:     nil,
+			retained: nil,
+			want:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AuthorityRetained(tc.have, tc.retained); got != tc.want {
+				t.Errorf("AuthorityRetained(%v, %v) = %v, want %v",
+					tc.have, tc.retained, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Nil handling — a nil *Sweeper is a documented no-op receiver, relied on by
+// every handler constructed without the revocation subsystem wired.
+// ---------------------------------------------------------------------------
+
+func TestNewSweeper_BothNil_ReturnsNil(t *testing.T) {
+	if s := NewSweeper(nil, nil); s != nil {
+		t.Errorf("NewSweeper(nil, nil) = %v, want nil so callers can store it directly", s)
+	}
+}
+
+func TestNilSweeper_AllMethodsAreNoOps(t *testing.T) {
+	var s *Sweeper
+	ctx := context.Background()
+
+	if out := s.OrgAuthorityReduced(ctx, "u", "o", nil, "r"); out != (Outcome{}) {
+		t.Errorf("OrgAuthorityReduced on nil = %+v, want zero Outcome", out)
+	}
+	if out := s.OrgKeysOnly(ctx, "u", "o", nil, "r"); out != (Outcome{}) {
+		t.Errorf("OrgKeysOnly on nil = %+v, want zero Outcome", out)
+	}
+	if out := s.UserDeprovisioned(ctx, "u", "r"); out != (Outcome{}) {
+		t.Errorf("UserDeprovisioned on nil = %+v, want zero Outcome", out)
+	}
+}
+
+func TestSweeper_KeysOnlyHalfWired_SkipsJWTFamily(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	s := NewSweeper(nil, repositories.NewAPIKeyRepository(db))
+	if s == nil {
+		t.Fatal("NewSweeper returned nil with one repository present")
+	}
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1", nil, "test")
+	if out.TokensRevoked {
+		t.Error("TokensRevoked = true with no revocation repository wired")
+	}
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OrgAuthorityReduced
+// ---------------------------------------------------------------------------
+
+func TestOrgAuthorityReduced_SweepsBothFamilies(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["providers:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1", nil, "removed from organization")
+	if !out.TokensRevoked || out.KeysRevoked != 1 || out.Incomplete {
+		t.Errorf("Outcome = %+v, want TokensRevoked=true KeysRevoked=1 Incomplete=false", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The narrowing contract: a key entirely within the retained authority is
+// listed and then LEFT ALONE. No DELETE is registered, so sqlmock fails the
+// test if the sweep issues one.
+func TestOrgAuthorityReduced_RetainsKeysWithinNewAuthority(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(sqlmock.NewRows(akCols).
+			AddRow("key-keep", "user-1", "org-1", "Reader Key", nil, "h", "tfr_a",
+				[]byte(`["modules:read"]`), nil, nil, nil, time.Now(), nil).
+			AddRow("key-drop", "user-1", "org-1", "Publisher Key", nil, "h", "tfr_b",
+				[]byte(`["providers:write"]`), nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-drop").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1",
+		[]string{"modules:read"}, "role template narrowed")
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1 (only the over-asking key)", out.KeysRevoked)
+	}
+	if out.KeysRetained != 1 {
+		t.Errorf("KeysRetained = %d, want 1 (the key within the new authority)", out.KeysRetained)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The JWT half failing must be reported, not swallowed: the caller surfaces it
+// as revocation_incomplete.
+func TestOrgAuthorityReduced_JWTHalfFails_ReportsIncomplete(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs("user-1").
+		WillReturnError(errors.New("watermark write failed"))
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["providers:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1", nil, "test")
+	if out.TokensRevoked {
+		t.Error("TokensRevoked = true after the watermark write failed")
+	}
+	if !out.Incomplete {
+		t.Error("Incomplete = false after the JWT half failed")
+	}
+	// The API-key half must still have run: one family failing does not
+	// abandon the other.
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1 (key sweep must not be abandoned)", out.KeysRevoked)
+	}
+}
+
+// The API-key half failing must be reported too. This is the direction the
+// class is actually about -- the key family is the one that never expires, so
+// a silent failure here leaves a permanently valid credential.
+func TestOrgAuthorityReduced_APIKeyHalfFails_ReportsIncomplete(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["providers:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1").
+		WillReturnError(errors.New("delete failed"))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1", nil, "test")
+	if !out.TokensRevoked {
+		t.Error("TokensRevoked = false; the JWT half succeeded")
+	}
+	if out.KeysRevoked != 0 {
+		t.Errorf("KeysRevoked = %d, want 0 (the delete failed)", out.KeysRevoked)
+	}
+	if !out.Incomplete {
+		t.Error("Incomplete = false after the API-key half failed; the caller would report a fully closed incident")
+	}
+}
+
+// A failure to even LIST the keys is equally incomplete: the sweep does not
+// know what it did not revoke.
+func TestOrgAuthorityReduced_APIKeyListFails_ReportsIncomplete(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnError(errors.New("list failed"))
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "org-1", nil, "test")
+	if !out.Incomplete {
+		t.Error("Incomplete = false after the key listing failed")
+	}
+}
+
+// An empty organization ID cannot scope a key query; sweeping on it would
+// either error or match nothing. Assert it short-circuits without issuing SQL.
+func TestOrgAuthorityReduced_EmptyOrgID_SkipsKeySweep(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+
+	out := s.OrgAuthorityReduced(context.Background(), "user-1", "", nil, "test")
+	if out.KeysRevoked != 0 || out.Incomplete {
+		t.Errorf("Outcome = %+v, want no key work and no incompleteness", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected SQL issued for an empty organization: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OrgKeysOnly — the IdP login path, which must NOT move the watermark.
+// ---------------------------------------------------------------------------
+
+func TestOrgKeysOnly_DoesNotTouchTheWatermark(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	// No watermark expectation is registered: moving it here would revoke the
+	// session token this same request is about to mint (see the method's doc),
+	// so sqlmock must see only the key statements.
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", nil, "idp deprovision")
+	if out.TokensRevoked {
+		t.Error("TokensRevoked = true; OrgKeysOnly must leave the JWT watermark alone")
+	}
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UserDeprovisioned — whole-principal offboarding, every org.
+// ---------------------------------------------------------------------------
+
+func TestUserDeprovisioned_RevokesEveryKeyEverywhere(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows(akCols).
+			AddRow("key-a", "user-1", "org-1", "A", nil, "h", "tfr_a",
+				[]byte(`["modules:read"]`), nil, nil, nil, time.Now(), nil).
+			AddRow("key-b", "user-1", "org-2", "B", nil, "h", "tfr_b",
+				[]byte(`["providers:write"]`), nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-a").WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-b").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", "scim: user deleted")
+	if !out.TokensRevoked || out.KeysRevoked != 2 || out.Incomplete {
+		t.Errorf("Outcome = %+v, want TokensRevoked=true KeysRevoked=2 Incomplete=false", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Deprovisioning retains NOTHING regardless of scopes: the principal holds no
+// authority anywhere, so the retention filter must not apply here.
+func TestUserDeprovisioned_IgnoresRetentionFilter(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnRows(keyRow("key-a", "user-1", "org-1", `["modules:read"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-a").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", "scim: user deleted")
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1 (a deprovisioned user retains nothing)", out.KeysRevoked)
+	}
+	if out.KeysRetained != 0 {
+		t.Errorf("KeysRetained = %d, want 0", out.KeysRetained)
+	}
+}
+
+func TestUserDeprovisioned_ListFails_ReportsIncomplete(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnError(errors.New("list failed"))
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", "test")
+	if !out.Incomplete {
+		t.Error("Incomplete = false after the key listing failed")
+	}
+	if !out.TokensRevoked {
+		t.Error("TokensRevoked = false; the JWT half succeeded before the listing failed")
+	}
+}
+
+func TestUserDeprovisioned_OneDeleteFails_ContinuesAndReportsIncomplete(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	expectWatermark(mock, "user-1")
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows(akCols).
+			AddRow("key-a", "user-1", "org-1", "A", nil, "h", "tfr_a",
+				[]byte(`["modules:read"]`), nil, nil, nil, time.Now(), nil).
+			AddRow("key-b", "user-1", "org-2", "B", nil, "h", "tfr_b",
+				[]byte(`["modules:read"]`), nil, nil, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-a").WillReturnError(errors.New("delete failed"))
+	// The second key must still be attempted: one failure must not abandon the
+	// rest of the sweep.
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-b").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", "test")
+	if out.KeysRevoked != 1 {
+		t.Errorf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if !out.Incomplete {
+		t.Error("Incomplete = false despite a failed key deletion")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the sweep abandoned the remaining keys after one failure: %v", err)
+	}
+}
+
+func TestUserDeprovisioned_NoKeyRepository_StillMovesWatermark(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	s := NewSweeper(repositories.NewUserTokenRevocationRepository(db), nil)
+	expectWatermark(mock, "user-1")
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", "test")
+	if !out.TokensRevoked || out.Incomplete {
+		t.Errorf("Outcome = %+v, want TokensRevoked=true Incomplete=false", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/backend/internal/db/migrations/000050_quarantine_orphaned_api_keys.down.sql
+++ b/backend/internal/db/migrations/000050_quarantine_orphaned_api_keys.down.sql
@@ -1,0 +1,17 @@
+-- no-op: un-expiring the quarantined keys is not meaningful.
+--
+-- The up migration does not record which rows it touched, and it cannot be
+-- inferred afterwards: `expires_at = NOW()` is indistinguishable from a key an
+-- operator expired deliberately. Blanket-clearing expires_at on every userless
+-- row would RE-ARM exactly the credentials the migration retired, which is the
+-- opposite of a rollback.
+--
+-- An operator who can positively identify a userless key as a deliberately
+-- hand-created organization service credential can restore it individually:
+--
+--   UPDATE identity.api_keys SET expires_at = NULL WHERE id = '<uuid>';
+--
+-- Note that the point-of-use guard still refuses userless org-bound keys on
+-- namespace mutations (middleware.NamespaceAuthorizer.verifyKeyOwnerAuthority),
+-- so re-arming the row alone does not restore publish access; that guard is
+-- code, and rolling the binary back is what reverts it.

--- a/backend/internal/db/migrations/000050_quarantine_orphaned_api_keys.up.sql
+++ b/backend/internal/db/migrations/000050_quarantine_orphaned_api_keys.up.sql
@@ -1,0 +1,76 @@
+-- 000050_quarantine_orphaned_api_keys
+--
+-- Retire API keys that were ORPHANED by a user deletion before the credential
+-- lifecycle sweep shipped (issues #732, #736).
+--
+-- WHY THESE ROWS EXIST
+--
+--   identity.api_keys.user_id UUID REFERENCES identity.users(id) ON DELETE SET NULL
+--
+-- Deleting a principal therefore DETACHED their API keys instead of destroying
+-- them. The detached row keeps its organization_id and its frozen scopes, and
+-- until this batch the namespace authorizer read a userless org-bound key as an
+-- "organization service credential" and skipped the membership check entirely:
+-- the deleted user's key kept publishing into the organization's namespaces.
+--
+-- The code fix closes the class going FORWARD (every user-deletion site now
+-- sweeps the principal's keys before the row goes away) and fails closed at the
+-- point of use. Neither helps rows that were already detached when the upgrade
+-- ran. This migration drains that backward population.
+--
+-- WHY QUARANTINE RATHER THAN DELETE
+--
+-- Expiring the row retires the credential on EVERY code path -- both
+-- AuthMiddleware and OptionalAuthMiddleware reject an expired key before any
+-- handler runs -- while leaving the row visible to an operator. Deleting would
+-- destroy the audit trail of a credential that was, by construction, live and
+-- possibly in use.
+--
+-- WHY IT IS SAFE TO RETIRE ALL OF THEM
+--
+-- The registry mints an API key in exactly two places
+-- (internal/api/admin/apikeys.go: CreateAPIKeyHandler sets UserID from the
+-- authenticated caller, RotateAPIKeyHandler copies the old key's UserID), and
+-- the identity store has exactly one INSERT. No supported path produces a key
+-- with a NULL user_id. Every userless row is therefore either a detached
+-- personal key or a hand-written INSERT -- not a credential this product
+-- issues. An operator who deliberately created one by direct SQL can identify
+-- the row and clear expires_at; see docs/upgrade-guide.md.
+--
+-- Idempotent: re-running matches nothing new. Rows that were already expired
+-- are left alone so their original expiry is preserved.
+--
+-- NOTE: the identity half hardcodes the schema literal `identity`, like
+-- migrations 000038 and 000045. Deployments that set TFR_IDENTITY_SCHEMA_NAME
+-- to something else must edit this file, or run the statement by hand.
+DO $$
+DECLARE
+  quarantined BIGINT;
+BEGIN
+  IF to_regclass('identity.api_keys') IS NOT NULL THEN
+    UPDATE identity.api_keys
+       SET expires_at = NOW(),
+           updated_at = NOW()
+     WHERE user_id IS NULL
+       AND (expires_at IS NULL OR expires_at > NOW());
+    GET DIAGNOSTICS quarantined = ROW_COUNT;
+    IF quarantined > 0 THEN
+      RAISE WARNING 'migration 000050: quarantined % orphaned identity.api_keys row(s) (user_id IS NULL). These were detached by a user deletion under ON DELETE SET NULL and were authorizing as organization service credentials.', quarantined;
+    END IF;
+  END IF;
+
+  -- public.api_keys declares user_id ON DELETE CASCADE, so a deletion cannot
+  -- orphan a key here. Run it anyway: the column is nullable, and a nonzero
+  -- count is itself the finding. Guarded on the table existing so this cannot
+  -- become a migration that fails startup on a deployment that dropped it.
+  IF to_regclass('public.api_keys') IS NOT NULL THEN
+    UPDATE public.api_keys
+       SET expires_at = NOW()
+     WHERE user_id IS NULL
+       AND (expires_at IS NULL OR expires_at > NOW());
+    GET DIAGNOSTICS quarantined = ROW_COUNT;
+    IF quarantined > 0 THEN
+      RAISE WARNING 'migration 000050: quarantined % userless public.api_keys row(s).', quarantined;
+    END IF;
+  END IF;
+END $$;

--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -52,6 +52,7 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000043 | `setup_notifications`                  | ✅ Yes         | Drops notification-config columns; persisted SMTP config lost |
 | 000044 | `scanner_binary_versions`              | ✅ Yes         | Drops the scanner-binary-versions table and approval-event column |
 | 000045 | `namespace_org_claims`                 | ✅ Yes         | Drops the namespace-ownership table; bindings are re-derived from artifacts on re-apply |
+| 000050 | `quarantine_orphaned_api_keys`         | ⚠️ No-op down  | Data-only: expires `api_keys` rows with `user_id IS NULL` (detached by a user deletion under `ON DELETE SET NULL`). The down cannot distinguish them from deliberately expired keys, so re-arming would undo the retirement; restore individual rows by hand. See `docs/upgrade-guide.md` |
 
 ## How to Run Migrations
 

--- a/backend/internal/db/repositories/rbac_repository.go
+++ b/backend/internal/db/repositories/rbac_repository.go
@@ -42,27 +42,41 @@ func NewRBACRepositoryWithIdentity(db, identityDB *sqlx.DB) *RBACRepository {
 	}
 }
 
-// ListRoleTemplateMemberUserIDs returns the distinct user IDs of organization
-// members currently assigned the given role template. Used to revoke the
-// outstanding tokens of every affected user when a role template's scopes are
-// edited or the template is deleted (issue #559 finding [9]).
-func (r *RBACRepository) ListRoleTemplateMemberUserIDs(ctx context.Context, roleTemplateID uuid.UUID) ([]string, error) {
-	query := `SELECT DISTINCT user_id FROM organization_members WHERE role_template_id = $1`
+// RoleTemplateMembership identifies one (user, organization) pair currently
+// assigned a role template.
+type RoleTemplateMembership struct {
+	UserID         string
+	OrganizationID string
+}
+
+// ListRoleTemplateMemberships returns the distinct (user, organization) pairs
+// of organization members currently assigned the given role template.
+//
+// The organization is returned alongside the user because the two credential
+// families invalidated when a template's scopes change or the template is
+// deleted have different shapes: the JWT revoke-all watermark is per-user
+// (issue #559 finding [9]), while an API key snapshots BOTH the scopes and one
+// organization_id, so only the affected member's keys in the organizations
+// where they actually held this template must be revoked (issue #732). Without
+// the organization this query cannot express the second sweep without either
+// over-revoking (every key the member holds anywhere) or not revoking at all.
+func (r *RBACRepository) ListRoleTemplateMemberships(ctx context.Context, roleTemplateID uuid.UUID) ([]RoleTemplateMembership, error) {
+	query := `SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id = $1`
 	rows, err := r.identityDB.QueryContext(ctx, query, roleTemplateID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var userIDs []string
+	var out []RoleTemplateMembership
 	for rows.Next() {
-		var userID string
-		if err := rows.Scan(&userID); err != nil {
+		var m RoleTemplateMembership
+		if err := rows.Scan(&m.UserID, &m.OrganizationID); err != nil {
 			return nil, err
 		}
-		userIDs = append(userIDs, userID)
+		out = append(out, m)
 	}
-	return userIDs, rows.Err()
+	return out, rows.Err()
 }
 
 // ============================================================================

--- a/backend/internal/db/repositories/rbac_repository_test.go
+++ b/backend/internal/db/repositories/rbac_repository_test.go
@@ -672,53 +672,61 @@ func TestListPendingApprovals_DBError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ListRoleTemplateMemberUserIDs (issue #559 finding [9]: revoking the tokens
-// of every member assigned a role template whose scopes changed)
+// ListRoleTemplateMemberships (issue #559 finding [9] plus issue #732: sweeping
+// the JWTs *and* the org-bound API keys of every member assigned a role
+// template whose scopes changed -- the API-key half needs the organization,
+// which is why the query returns pairs rather than bare user IDs)
 // ---------------------------------------------------------------------------
 
-func TestListRoleTemplateMemberUserIDs_Success(t *testing.T) {
+func TestListRoleTemplateMemberships_Success(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
 		WithArgs(id).
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}).
-			AddRow("user-1").
-			AddRow("user-2"))
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
+			AddRow("user-1", "org-1").
+			AddRow("user-2", "org-2"))
 
-	userIDs, err := repo.ListRoleTemplateMemberUserIDs(context.Background(), id)
+	memberships, err := repo.ListRoleTemplateMemberships(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(userIDs) != 2 || userIDs[0] != "user-1" || userIDs[1] != "user-2" {
-		t.Errorf("unexpected user IDs: %v", userIDs)
+	if len(memberships) != 2 {
+		t.Fatalf("expected 2 memberships, got %v", memberships)
+	}
+	if memberships[0].UserID != "user-1" || memberships[0].OrganizationID != "org-1" {
+		t.Errorf("unexpected first membership: %+v", memberships[0])
+	}
+	if memberships[1].UserID != "user-2" || memberships[1].OrganizationID != "org-2" {
+		t.Errorf("unexpected second membership: %+v", memberships[1])
 	}
 }
 
-func TestListRoleTemplateMemberUserIDs_Empty(t *testing.T) {
+func TestListRoleTemplateMemberships_Empty(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
-		WillReturnRows(sqlmock.NewRows([]string{"user_id"}))
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}))
 
-	userIDs, err := repo.ListRoleTemplateMemberUserIDs(context.Background(), id)
+	memberships, err := repo.ListRoleTemplateMemberships(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(userIDs) != 0 {
-		t.Errorf("expected no user IDs, got %v", userIDs)
+	if len(memberships) != 0 {
+		t.Errorf("expected no memberships, got %v", memberships)
 	}
 }
 
-func TestListRoleTemplateMemberUserIDs_DBError(t *testing.T) {
+func TestListRoleTemplateMemberships_DBError(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
 		WillReturnError(errDB)
 
-	_, err := repo.ListRoleTemplateMemberUserIDs(context.Background(), id)
+	_, err := repo.ListRoleTemplateMemberships(context.Background(), id)
 	if err == nil {
 		t.Error("expected error")
 	}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -208,6 +208,42 @@ func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, a
 			c.Set("organization_id", apiKey.OrganizationID)
 			c.Set("scopes", apiKey.Scopes)
 
+			// Re-derive the key's authority HERE, where the binding is
+			// established, rather than only at the two call sites that happened
+			// to have the check (NamespaceAuthorizer.authorizeOrgAccess and
+			// resolveCallerOrg).
+			//
+			// organization_id and scopes are both frozen on the api_keys row at
+			// creation, and the two Set calls above copy them into the context
+			// for EVERY route. Only module/provider mutations run through the
+			// namespace authorizer; everything else -- the admin surface,
+			// /apikeys, SCIM, quota and rate-limit bucketing -- consumed the
+			// snapshot with no re-derivation at all, so a member who had been
+			// removed or downgraded kept the authority their key was minted
+			// with on all of those routes.
+			//
+			// COST, stated rather than implied: one indexed membership read per
+			// API-key-authenticated request. It lands on a path that already
+			// does a key-prefix query, a bcrypt comparison (which dominates the
+			// request's latency by orders of magnitude) and a user load, so it
+			// is roughly a 30% increase in query count and a rounding error in
+			// latency. Leaving the check only at the namespace authorizer would
+			// also have been a cost decision -- just an unstated one, paid in
+			// authority instead of milliseconds.
+			//
+			// A nil orgRepo means the subsystem is not wired (unit tests) and
+			// the re-derivation is skipped, matching how the tokenRepo and
+			// userRevocations checks on the JWT path above behave. Every
+			// production wiring in router_routes.go passes the real repository.
+			if orgRepo != nil && apiKey.OrganizationID != "" {
+				scopes, status, msg := currentKeyScopes(c.Request.Context(), orgRepo, apiKey)
+				if status != 0 {
+					c.AbortWithStatusJSON(status, gin.H{"error": msg})
+					return
+				}
+				c.Set("scopes", scopes)
+			}
+
 			// Load user if exists
 			if apiKey.UserID != nil {
 				user, _ := userRepo.GetUserByID(c.Request.Context(), *apiKey.UserID)
@@ -226,6 +262,48 @@ func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, a
 			"error": "Invalid credentials",
 		})
 	}
+}
+
+// currentKeyScopes re-derives what an organization-bound API key may currently
+// ask for, from its owner's CURRENT membership rather than from the snapshot
+// frozen on the api_keys row.
+//
+// It returns (scopes, 0, "") when the key still stands, otherwise an HTTP
+// status and message. Every failure direction is closed:
+//
+//   - No owning user. Not an "organization service credential": the registry
+//     mints keys only through CreateAPIKeyHandler (UserID from the
+//     authenticated caller) and RotateAPIKeyHandler (copies it), so a NULL
+//     user_id means the owner was deleted and identity.api_keys' ON DELETE SET
+//     NULL detached the row. See verifyKeyOwnerAuthority and migration 000050.
+//   - Owner no longer a member of the bound organization. The binding is a
+//     snapshot, not evidence of current standing (issue #732).
+//   - Lookup failure. 500 rather than serving the frozen snapshot.
+//
+// On success the key's frozen scopes are INTERSECTED with what the owner's
+// current role template grants, by scope semantics (auth.HasScope resolves the
+// "admin" wildcard and the read/write implications). A key can never ask for
+// more than its owner currently holds in the organization it is bound to; the
+// lifecycle sweep normally deletes such a key first, which makes this a no-op
+// in steady state and a backstop when a sweep did not land.
+func currentKeyScopes(ctx context.Context, orgRepo *repositories.OrganizationRepository, apiKey *models.APIKey) ([]string, int, string) {
+	if apiKey.UserID == nil || *apiKey.UserID == "" {
+		return nil, http.StatusUnauthorized, "API key has no owning user; re-issue it through the API key endpoints"
+	}
+	member, err := orgRepo.GetMemberWithRole(ctx, apiKey.OrganizationID, *apiKey.UserID)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "Failed to verify API key organization membership"
+	}
+	if member == nil {
+		return nil, http.StatusUnauthorized, "API key owner is no longer a member of the bound organization"
+	}
+	scopes := make([]string, 0, len(apiKey.Scopes))
+	for _, s := range apiKey.Scopes {
+		if auth.HasScope(member.RoleTemplateScopes, auth.Scope(s)) {
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes, 0, ""
 }
 
 // OptionalAuthMiddleware - same as AuthMiddleware but doesn't abort if no auth
@@ -315,12 +393,29 @@ func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepos
 					_ = apiKeyRepo.UpdateLastUsed(ctx, apiKey.ID)
 				})
 
+				// Same point-of-establishment re-derivation as AuthMiddleware
+				// (see currentKeyScopes). A key whose owner has left the bound
+				// organization is not an error here -- this middleware guards
+				// optionally-authenticated public registry endpoints -- so the
+				// request simply continues UNAUTHENTICATED, exactly as a
+				// revoked JWT does above. That is the fail-closed direction:
+				// private artifacts stop resolving for the stale key.
+				scopes := apiKey.Scopes
+				if orgRepo != nil && apiKey.OrganizationID != "" {
+					current, status, _ := currentKeyScopes(c.Request.Context(), orgRepo, apiKey)
+					if status != 0 {
+						c.Next()
+						return
+					}
+					scopes = current
+				}
+
 				// Set context values
 				c.Set("api_key", apiKey)
 				c.Set("api_key_id", apiKey.ID)
 				c.Set("auth_method", "api_key")
 				c.Set("organization_id", apiKey.OrganizationID)
-				c.Set("scopes", apiKey.Scopes)
+				c.Set("scopes", scopes)
 
 				// Load user if exists
 				if apiKey.UserID != nil {

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -910,3 +910,206 @@ func TestOptionalAuthMiddleware_RevokeAllWatermark_ContinuesUnauthenticated(t *t
 }
 
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// AuthMiddleware / OptionalAuthMiddleware — an organization-bound API key is
+// re-derived where the binding is ESTABLISHED, not only where the namespace
+// authorizer happens to look (issues #732, #736).
+//
+// api_keys freezes organization_id AND scopes at creation, and the middleware
+// copies both into the request context for every route. The re-verification
+// used to live only inside NamespaceAuthorizer.authorizeOrgAccess, which wraps
+// module/provider mutations and nothing else, so every other authenticated
+// route — the admin surface, /apikeys, SCIM — consumed the frozen snapshot with
+// no check at all.
+// ---------------------------------------------------------------------------
+
+var memberWithRoleCols = []string{
+	"organization_id", "user_id", "role_template_id", "created_at",
+	"user_name", "user_email",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+// expectKeyOwnerMembership queues the GetMemberWithRole lookup the middleware
+// now makes for an org-bound key. A nil scopes slice means "no such member".
+func expectKeyOwnerMembership(mock sqlmock.Sqlmock, orgID, userID string, roleScopes []byte) {
+	q := mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN")
+	if roleScopes == nil {
+		q.WillReturnRows(sqlmock.NewRows(memberWithRoleCols))
+		return
+	}
+	q.WillReturnRows(sqlmock.NewRows(memberWithRoleCols).AddRow(
+		orgID, userID, "rt-1", time.Now(),
+		"Test User", "test@example.com",
+		"viewer", "Viewer", roleScopes))
+}
+
+// apiKeyAuthRouter wires AuthMiddleware over mocked repositories and returns
+// the router plus the api-key and org mocks. handler observes the resolved
+// context.
+func apiKeyAuthRouter(t *testing.T, handler gin.HandlerFunc) (*gin.Engine, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+	t.Helper()
+	apiKeyDB, apiKeyMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (apikey): %v", err)
+	}
+	t.Cleanup(func() { apiKeyDB.Close() })
+	userDB, userMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (user): %v", err)
+	}
+	t.Cleanup(func() { userDB.Close() })
+	orgRepo, orgMock := newOrgRepo(t)
+
+	// The user load only runs once the key survives re-verification, so it is
+	// registered unconditionally and simply goes unused on the reject paths.
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow("user-1", "test@example.com", "Test User", nil, time.Now(), time.Now()))
+
+	r := gin.New()
+	r.Use(AuthMiddleware(nil, repositories.NewUserRepository(userDB),
+		repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil))
+	r.GET("/", handler)
+	return r, apiKeyMock, orgMock
+}
+
+// expectAPIKeyLookup queues the prefix lookup that authenticates the bearer
+// token, returning an org-bound key with the given owner and frozen scopes.
+func expectAPIKeyLookup(mock sqlmock.Sqlmock, token string, userID *string, scopes []byte) {
+	hashBytes, _ := bcrypt.GenerateFromPassword([]byte(token), bcrypt.MinCost)
+	mock.ExpectQuery("SELECT.*FROM api_keys.*WHERE.*key_prefix").
+		WillReturnRows(sqlmock.NewRows(apiKeyPrefixCols).AddRow(
+			"key-1", userID, "org-1", "CI Key", nil, string(hashBytes), token[:10],
+			scopes, nil, nil, nil, time.Now(),
+		))
+}
+
+func doKeyRequest(r *gin.Engine, token string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// The headline case: the key's owner has been removed from the organization it
+// is bound to. Nothing about the key itself changed, and no namespace
+// middleware is in the chain, so before this the request was served with the
+// full frozen scope set.
+func TestAuthMiddleware_OrgBoundAPIKey_OwnerRemoved_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	reached := false
+	token := "tfr_stalekey_1"
+	userID := "user-1"
+	r, keyMock, orgMock := apiKeyAuthRouter(t, func(c *gin.Context) {
+		reached = true
+		c.Status(http.StatusOK)
+	})
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:write"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, nil)
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (owner is no longer a member): body=%s", w.Code, w.Body.String())
+	}
+	if reached {
+		t.Error("the handler ran for a key whose owner had left the bound organization")
+	}
+}
+
+// A key with no owning user is refused rather than treated as an organization
+// service credential: identity.api_keys.user_id is ON DELETE SET NULL, so a
+// userless row means the owner was deleted, not that a service account exists.
+func TestAuthMiddleware_OrgBoundAPIKey_NoOwningUser_Rejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	token := "tfr_orphaned_1"
+	r, keyMock, _ := apiKeyAuthRouter(t, func(c *gin.Context) { c.Status(http.StatusOK) })
+	expectAPIKeyLookup(keyMock, token, nil, []byte(`["modules:write"]`))
+	// No membership lookup is registered: there is no owner to look up, and the
+	// refusal must not depend on one.
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (userless key): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// The owner is still a member but has been downgraded. The key keeps working
+// for what the owner still holds and loses exactly the scopes they lost — the
+// frozen list is intersected with the current role template, by scope
+// semantics rather than by string equality.
+func TestAuthMiddleware_OrgBoundAPIKey_OwnerDowngraded_ScopesNarrowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var got []string
+	token := "tfr_downgrd_1"
+	userID := "user-1"
+	r, keyMock, orgMock := apiKeyAuthRouter(t, func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:read","modules:write"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, []byte(`["modules:read"]`))
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (the key is still valid for what the owner retains): body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != "modules:read" {
+		t.Errorf("scopes = %v, want [modules:read]: a downgraded owner's key must not keep serving the scope snapshot", got)
+	}
+}
+
+// A member whose role template grants the admin wildcard keeps every scope on
+// the key: the intersection is by scope semantics (auth.HasScope), not by set
+// membership, so "admin" still covers "modules:write".
+func TestAuthMiddleware_OrgBoundAPIKey_AdminRoleTemplate_KeepsScopes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var got []string
+	token := "tfr_adminky_1"
+	userID := "user-1"
+	r, keyMock, orgMock := apiKeyAuthRouter(t, func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:write"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, []byte(`["admin"]`))
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != "modules:write" {
+		t.Errorf("scopes = %v, want [modules:write]: an admin role template retains every key scope", got)
+	}
+}
+
+// OptionalAuthMiddleware guards optionally-authenticated public endpoints, so a
+// stale key must not abort the request — it must continue UNAUTHENTICATED, the
+// same downgrade a revoked JWT gets. Private artifacts then stop resolving.
+func TestOptionalAuthMiddleware_OrgBoundAPIKey_OwnerRemoved_ContinuesUnauthenticated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	apiKeyDB, keyMock, _ := sqlmock.New()
+	t.Cleanup(func() { apiKeyDB.Close() })
+	orgRepo, orgMock := newOrgRepo(t)
+
+	var keyWasSet bool
+	r := gin.New()
+	r.Use(OptionalAuthMiddleware(nil, nil, repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil))
+	r.GET("/", func(c *gin.Context) {
+		_, keyWasSet = c.Get("api_key")
+		c.Status(http.StatusOK)
+	})
+
+	token := "tfr_optstal_1"
+	userID := "user-1"
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:read"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, nil)
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (optional auth always passes through): body=%s", w.Code, w.Body.String())
+	}
+	if keyWasSet {
+		t.Error("a key whose owner had left the bound organization was still installed in the request context")
+	}
+}

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -514,19 +514,30 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 // authority is reduced; this is the point-of-use guard that makes a key that
 // escaped a sweep fail closed anyway.
 func (a *NamespaceAuthorizer) verifyKeyOwnerAuthority(c *gin.Context, apiKey *models.APIKey, orgID string, scope auth.Scope) (int, string) {
-	// Keys with no owning user are organization service credentials: there is
-	// no membership to re-verify, so the binding stands alone (their lifecycle
-	// is the organization's, and organization deletion cascades the row away).
+	// A key with no owning user is REFUSED, not waved through as an
+	// "organization service credential".
 	//
-	// This branch is only safe because no supported path produces a userless
-	// key by ACCIDENT: identity.api_keys.user_id is ON DELETE SET NULL, so
-	// deleting a principal would otherwise silently convert their personal
-	// keys into keys that land here and skip the membership check entirely.
-	// Every user-deletion site therefore sweeps the principal's keys before
-	// the row goes away (admin.UserHandlers.DeleteUserHandler,
-	// services.UserService.EraseUser, the SCIM deprovisioning paths).
+	// That was the previous reading, and it was wrong for this product: the
+	// registry mints an API key in exactly two places -- CreateAPIKeyHandler,
+	// which sets UserID from the authenticated caller, and RotateAPIKeyHandler,
+	// which copies the old key's UserID -- and the identity store has exactly
+	// one INSERT. No supported path produces a userless key. What DOES produce
+	// one is identity.api_keys.user_id being ON DELETE SET NULL: deleting a
+	// principal detaches their personal keys, and this branch then read the
+	// detachment as a promotion to a credential exempt from every membership
+	// check.
+	//
+	// Sweeping at every user-deletion site closes that going forward, but the
+	// keys detached BEFORE this shipped are already in the table, which is the
+	// whole premise of #732. Failing closed here is what covers them without
+	// depending on a data migration having run (migration 000050 drains the
+	// population on the other routes; see docs/upgrade-guide.md).
+	//
+	// The cost of being wrong is bounded and visible: an operator who really
+	// did hand-create a userless service key gets a clear 403 and can re-issue
+	// it through the API, which binds it to a real principal.
 	if apiKey.UserID == nil || *apiKey.UserID == "" {
-		return 0, ""
+		return http.StatusForbidden, "API key has no owning user; re-issue it through the API key endpoints"
 	}
 	member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, *apiKey.UserID)
 	if err != nil {

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -376,7 +376,7 @@ func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespa
 		return false
 	}
 
-	callerOrgID, status, msg := a.resolveCallerOrg(c)
+	callerOrgID, status, msg := a.resolveCallerOrg(c, scope)
 	if status != 0 {
 		abortNamespaceAuthz(c, status, msg)
 		return false
@@ -387,13 +387,29 @@ func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespa
 		abortNamespaceAuthz(c, http.StatusInternalServerError, "Failed to claim namespace")
 		return false
 	}
-	if claim.OrganizationID != callerOrgID {
-		// Lost a concurrent first-publish race to another organization; the
-		// caller must now qualify against the winner.
-		if status, msg := a.authorizeOrgAccess(c, claim.OrganizationID, scope); status != 0 {
-			abortNamespaceAuthz(c, status, msg)
-			return false
-		}
+	// Re-check UNCONDITIONALLY against the claim's actual owner, not only when
+	// the caller lost a concurrent first-publish race.
+	//
+	// Checking only the race-loss branch meant the ordinary winning path -- by
+	// far the common one -- performed no authorization at all beyond
+	// resolveCallerOrg's own derivation, so whichever organization
+	// resolveCallerOrg happened to name was accepted without any check that
+	// the caller currently holds `scope` in it. That is the same
+	// snapshot-trusted-at-the-point-of-use defect as #732, reached through the
+	// claim path instead of the owned-namespace path: an API key bound to an
+	// organization whose owner had since been removed could claim a brand-new
+	// namespace and publish into it with zero membership queries.
+	//
+	// authorizeOrgAccess is the single place that answers "may this caller
+	// write here, right now"; running it on every path (won race, lost race,
+	// explicit organization_id, sole membership) means no first-publish route
+	// can bypass it. On the org-bound-key path this repeats the check
+	// resolveCallerOrg already made -- deliberately, so neither guard is
+	// load-bearing alone -- at the cost of one extra membership read on a
+	// once-per-namespace request.
+	if status, msg := a.authorizeOrgAccess(c, claim.OrganizationID, scope); status != 0 {
+		abortNamespaceAuthz(c, status, msg)
+		return false
 	}
 
 	// Audit the ownership binding: a namespace's owner is set exactly once, so
@@ -451,21 +467,7 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 			if apiKey.OrganizationID != ownerOrgID {
 				return http.StatusForbidden, "Namespace is owned by another organization"
 			}
-			// Keys with no owning user are organization service credentials:
-			// there is no membership to re-verify, so the binding stands alone
-			// (their lifecycle is the organization's, and organization deletion
-			// cascades the row away).
-			if apiKey.UserID == nil || *apiKey.UserID == "" {
-				return 0, ""
-			}
-			member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), ownerOrgID, *apiKey.UserID)
-			if err != nil {
-				return http.StatusInternalServerError, "Failed to check organization membership"
-			}
-			if member == nil {
-				return http.StatusForbidden, "API key owner is no longer a member of the owning organization"
-			}
-			return 0, ""
+			return a.verifyKeyOwnerAuthority(c, apiKey, ownerOrgID, scope)
 		}
 		// Keys without an organization binding (legacy rows) fall through to
 		// the owning user's membership check below.
@@ -491,6 +493,51 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 		return http.StatusForbidden, "Missing required scope in the owning organization"
 	}
 
+	return 0, ""
+}
+
+// verifyKeyOwnerAuthority re-derives, at the point of use, the authority an
+// organization-bound API key asserts: that its owner is still a member of that
+// organization AND that the member's current role template still grants the
+// scope the request needs.
+//
+// Both halves matter and neither is implied by the key. The api_keys row
+// freezes organization_id AND scopes at creation, and AuthMiddleware copies
+// both straight into the request context, so without this the key keeps
+// serving a snapshot of an authority its owner may no longer hold. Omitting
+// the scope half specifically -- which the org-bound branch previously did,
+// while the legacy unbound branch enforced it -- let a member downgraded to a
+// read-only role template keep publishing through a key issued under their old
+// role, i.e. the org-bound path was strictly weaker than the legacy one.
+//
+// The lifecycle sweep (internal/credlifecycle) deletes such keys when the
+// authority is reduced; this is the point-of-use guard that makes a key that
+// escaped a sweep fail closed anyway.
+func (a *NamespaceAuthorizer) verifyKeyOwnerAuthority(c *gin.Context, apiKey *models.APIKey, orgID string, scope auth.Scope) (int, string) {
+	// Keys with no owning user are organization service credentials: there is
+	// no membership to re-verify, so the binding stands alone (their lifecycle
+	// is the organization's, and organization deletion cascades the row away).
+	//
+	// This branch is only safe because no supported path produces a userless
+	// key by ACCIDENT: identity.api_keys.user_id is ON DELETE SET NULL, so
+	// deleting a principal would otherwise silently convert their personal
+	// keys into keys that land here and skip the membership check entirely.
+	// Every user-deletion site therefore sweeps the principal's keys before
+	// the row goes away (admin.UserHandlers.DeleteUserHandler,
+	// services.UserService.EraseUser, the SCIM deprovisioning paths).
+	if apiKey.UserID == nil || *apiKey.UserID == "" {
+		return 0, ""
+	}
+	member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, *apiKey.UserID)
+	if err != nil {
+		return http.StatusInternalServerError, "Failed to check organization membership"
+	}
+	if member == nil {
+		return http.StatusForbidden, "API key owner is no longer a member of the owning organization"
+	}
+	if !auth.HasScope(member.RoleTemplateScopes, scope) {
+		return http.StatusForbidden, "Missing required scope in the owning organization"
+	}
 	return 0, ""
 }
 
@@ -540,12 +587,23 @@ func (a *NamespaceAuthorizer) ownerOrgForArtifact(ctx context.Context, namespace
 // new namespace to. Returns (orgID, 0, "") on success, otherwise an HTTP
 // status and message. Fails closed when no organization can be derived from
 // the caller's identity.
-func (a *NamespaceAuthorizer) resolveCallerOrg(c *gin.Context) (string, int, string) {
-	// Org-scoped API keys carry their organization directly and are the
-	// strongest trust anchor: the binding is fixed at key creation and cannot
-	// be influenced by the request body.
+func (a *NamespaceAuthorizer) resolveCallerOrg(c *gin.Context, scope auth.Scope) (string, int, string) {
+	// Org-scoped API keys carry their organization directly: the binding is
+	// fixed at key creation and cannot be influenced by the request body.
+	//
+	// That makes the binding unforgeable, NOT current. It is a snapshot, and
+	// returning it unverified here was the same defect as #732 with the check
+	// simply omitted: an API key bound to an organization its owner had since
+	// been removed from could name that organization as the owner of a
+	// brand-new namespace, permanently claiming it, and publish into it.
+	// Re-verify the owner's standing before the binding is allowed to create
+	// a durable ownership record -- checking only after ClaimNamespace would
+	// still let a stale key squat namespaces on requests that then 403.
 	if keyVal, exists := c.Get("api_key"); exists {
 		if apiKey, ok := keyVal.(*models.APIKey); ok && apiKey.OrganizationID != "" {
+			if status, msg := a.verifyKeyOwnerAuthority(c, apiKey, apiKey.OrganizationID, scope); status != 0 {
+				return "", status, msg
+			}
 			return apiKey.OrganizationID, 0, ""
 		}
 	}

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -434,19 +434,38 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 		return 0, ""
 	}
 
-	// API keys are bound to exactly one organization at creation time; that
-	// binding is authoritative for the key regardless of the owning user's
-	// other memberships.
+	// API keys are bound to exactly one organization at creation time. That
+	// binding scopes the key to a single organization, but it is NOT on its own
+	// evidence that the key's owner still belongs to that organization: the
+	// binding is a snapshot frozen on the api_keys row, and treating it as
+	// authoritative meant a member removed from the org kept full access
+	// through the key (issue #732). Re-verify the owner's current membership
+	// here, at the point of use, so a stale key fails closed even if some
+	// lifecycle path forgot to sweep it.
 	if keyVal, exists := c.Get("api_key"); exists {
 		apiKey, ok := keyVal.(*models.APIKey)
 		if !ok {
 			return http.StatusForbidden, "Invalid API key context"
 		}
 		if apiKey.OrganizationID != "" {
-			if apiKey.OrganizationID == ownerOrgID {
+			if apiKey.OrganizationID != ownerOrgID {
+				return http.StatusForbidden, "Namespace is owned by another organization"
+			}
+			// Keys with no owning user are organization service credentials:
+			// there is no membership to re-verify, so the binding stands alone
+			// (their lifecycle is the organization's, and organization deletion
+			// cascades the row away).
+			if apiKey.UserID == nil || *apiKey.UserID == "" {
 				return 0, ""
 			}
-			return http.StatusForbidden, "Namespace is owned by another organization"
+			member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), ownerOrgID, *apiKey.UserID)
+			if err != nil {
+				return http.StatusInternalServerError, "Failed to check organization membership"
+			}
+			if member == nil {
+				return http.StatusForbidden, "API key owner is no longer a member of the owning organization"
+			}
+			return 0, ""
 		}
 		// Keys without an organization binding (legacy rows) fall through to
 		// the owning user's membership check below.

--- a/backend/internal/middleware/namespace_authz_test.go
+++ b/backend/internal/middleware/namespace_authz_test.go
@@ -54,11 +54,33 @@ func withScopesAndUser(scopes []string, userID string) func(c *gin.Context) {
 	}
 }
 
+// withAPIKey injects an organization service credential: an org-bound key with
+// NO owning user, whose lifecycle is the organization's and which therefore has
+// no membership to re-verify.
 func withAPIKey(orgID string, scopes []string) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		c.Set("scopes", scopes)
 		c.Set("api_key", &models.APIKey{OrganizationID: orgID, Scopes: scopes})
 	}
+}
+
+// withAPIKeyOwnedBy injects an org-bound key that belongs to a user. Unlike a
+// service credential, this key's authority is derived from its owner's current
+// membership and role template, so every use must re-verify both.
+func withAPIKeyOwnedBy(orgID, userID string, scopes []string) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		c.Set("scopes", scopes)
+		c.Set("user_id", userID)
+		c.Set("api_key", &models.APIKey{OrganizationID: orgID, UserID: &userID, Scopes: scopes})
+	}
+}
+
+// memberRow builds a GetMemberWithRole result row for the given role scopes.
+func memberRow(orgID, userID string, roleScopes string) *sqlmock.Rows {
+	return sqlmock.NewRows(memberRoleColsMW).AddRow(
+		orgID, userID, "role-pub", time.Now(),
+		"Pub User", "pub@test.com", "publisher", "Publisher", []byte(roleScopes),
+	)
 }
 
 func doNamespaceReq(r *gin.Engine, method, path string) *httptest.ResponseRecorder {
@@ -316,6 +338,10 @@ func TestRequirePublishAccessFromForm_FirstClaim_BindsToCallerOrg(t *testing.T) 
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newteam", nsOrgA, nil, time.Now()))
+	// The claim's owner is re-checked unconditionally after ClaimNamespace,
+	// which is also what enforces the required scope on this path.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
 
 	r := gin.New()
 	r.POST("/modules",
@@ -424,7 +450,9 @@ func TestRequirePublishAccessFromForm_AmbiguousMemberships_NonAdminDenied(t *tes
 	}
 }
 
-func TestRequirePublishAccessFromForm_APIKeyOrg_FirstClaim(t *testing.T) {
+// A service credential (no owning user) still claims directly: there is no
+// membership to re-verify, so no membership query is issued.
+func TestRequirePublishAccessFromForm_APIKeyServiceCredential_FirstClaim(t *testing.T) {
 	mock, authz := newNamespaceAuthzTestDeps(t)
 
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
@@ -446,7 +474,136 @@ func TestRequirePublishAccessFromForm_APIKeyOrg_FirstClaim(t *testing.T) {
 	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
 
 	if w.Code != http.StatusCreated {
-		t.Errorf("status = %d, want 201 (API key org claims directly, no membership query): body=%s", w.Code, w.Body.String())
+		t.Errorf("status = %d, want 201 (service credential has no membership to re-verify): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+// A USER-owned org-bound key on the first-claim path must re-verify its owner's
+// current membership and role scopes -- twice: once in resolveCallerOrg, before
+// the durable claim row is created, and once after ClaimNamespace against the
+// claim's actual owner. Previously this path issued NO membership query at all.
+func TestRequirePublishAccessFromForm_APIKeyOwned_FirstClaim_ReverifiesMembership(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	// resolveCallerOrg re-verifies before the claim is created.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	mock.ExpectExec("INSERT INTO namespace_claims").
+		WithArgs("ci-team", nsOrgA, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
+	// authorizeOrgAccess re-verifies against the claim's owner, unconditionally.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201 (current member with the scope may claim): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (both membership re-checks required): %v", err)
+	}
+}
+
+// THE BYPASS, as a test: a key bound to org-aaa whose owner is no longer a
+// member must not be able to claim a brand-new namespace. The claim row must
+// never be inserted -- a 403 that still records ownership would let a stale key
+// squat namespaces.
+func TestRequirePublishAccessFromForm_APIKeyOwnerRemoved_FirstClaimDenied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	// Owner is gone from the organization the key is bound to.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (stale key may not claim a new namespace): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (no claim insert expected): %v", err)
+	}
+}
+
+// A member downgraded to a read-only role template whose key sweep failed must
+// not publish through the org-bound key: the key's frozen scopes are not
+// evidence of current authority.
+func TestRequirePublishAccessFromForm_APIKeyOwnerDowngraded_FirstClaimDenied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
+	// Still a member, but the role template no longer grants modules:write.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:read"]`))
+
+	r := gin.New()
+	r.POST("/modules",
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
+		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (downgraded member may not publish through a stale key): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations (no claim insert expected): %v", err)
+	}
+}
+
+// The same downgrade on an ALREADY-OWNED namespace: authorizeOrgAccess's
+// org-bound-key branch must enforce the role template's scopes, exactly as the
+// legacy unbound-key/JWT branch does.
+func TestRequireNamespaceAccessFromPath_APIKeyOwnerDowngraded_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:read"]`))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (org-bound key must satisfy the role template scope): body=%s", w.Code, w.Body.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet/unexpected expectations: %v", err)
@@ -539,6 +696,10 @@ func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_Member_Claims(t *testi
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("newteam", nsOrgB, nil, time.Now()))
+	// resolveCallerOrg proves membership but not the required SCOPE in the
+	// chosen org; the unconditional post-claim check supplies that.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(memberRow(nsOrgB, nsUserID, `["modules:write"]`))
 
 	r := gin.New()
 	r.POST("/modules",

--- a/backend/internal/middleware/namespace_authz_test.go
+++ b/backend/internal/middleware/namespace_authz_test.go
@@ -54,10 +54,17 @@ func withScopesAndUser(scopes []string, userID string) func(c *gin.Context) {
 	}
 }
 
-// withAPIKey injects an organization service credential: an org-bound key with
-// NO owning user, whose lifecycle is the organization's and which therefore has
-// no membership to re-verify.
-func withAPIKey(orgID string, scopes []string) func(c *gin.Context) {
+// withUserlessAPIKey injects an org-bound key with NO owning user.
+//
+// This used to be called withAPIKey and was described as an "organization
+// service credential" with no membership to re-verify. That premise was wrong:
+// the registry mints keys only through CreateAPIKeyHandler (UserID from the
+// authenticated caller) and RotateAPIKeyHandler (copies it), so no supported
+// path produces a userless key. What produces one is
+// identity.api_keys.user_id being ON DELETE SET NULL -- i.e. the owner was
+// DELETED and the row was detached. Such a key is now refused, so this helper
+// exists to model the orphan, not a legitimate caller.
+func withUserlessAPIKey(orgID string, scopes []string) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		c.Set("scopes", scopes)
 		c.Set("api_key", &models.APIKey{OrganizationID: orgID, Scopes: scopes})
@@ -187,9 +194,11 @@ func TestRequireNamespaceAccessFromPath_APIKeyOrgMismatch_Denied(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgB, nil, time.Now()))
 
+	// No membership lookup is registered: the binding mismatch is decided
+	// before the owner's standing is ever consulted.
 	r := gin.New()
 	r.DELETE("/modules/:namespace/:name/:system",
-		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
 		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
 
@@ -204,16 +213,49 @@ func TestRequireNamespaceAccessFromPath_APIKeyOrgMatch_Allowed(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+	// A matching binding is necessary but not sufficient: the owner's current
+	// membership and role scopes decide it.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
 
 	r := gin.New()
 	r.DELETE("/modules/:namespace/:name/:system",
-		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
 		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
 		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
 
 	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200 (API key org matches owner): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
+	}
+}
+
+// An org-bound key with no owning user is REFUSED rather than accepted as an
+// organization service credential. identity.api_keys.user_id is ON DELETE SET
+// NULL, so a userless row is a key detached by a user deletion, and this branch
+// used to hand it a membership-check exemption. No membership query is
+// registered: the refusal must not depend on one.
+func TestRequireNamespaceAccessFromPath_UserlessAPIKey_Denied(t *testing.T) {
+	mock, authz := newNamespaceAuthzTestDeps(t)
+
+	mock.ExpectQuery("SELECT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
+
+	r := gin.New()
+	r.DELETE("/modules/:namespace/:name/:system",
+		contextSetter(withUserlessAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		authz.RequireNamespaceAccessFromPath(auth.ScopeModulesWrite),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doNamespaceReq(r, "DELETE", "/modules/acme/vpc/aws")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (a key orphaned by a user deletion must not authorize): body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet/unexpected expectations: %v", err)
 	}
 }
 
@@ -450,34 +492,33 @@ func TestRequirePublishAccessFromForm_AmbiguousMemberships_NonAdminDenied(t *tes
 	}
 }
 
-// A service credential (no owning user) still claims directly: there is no
-// membership to re-verify, so no membership query is issued.
-func TestRequirePublishAccessFromForm_APIKeyServiceCredential_FirstClaim(t *testing.T) {
+// A userless key cannot claim a namespace either. This test asserted the
+// opposite -- that a "service credential" claims directly, with no membership
+// query -- which made the orphaned-key exemption look like a feature. No
+// INSERT INTO namespace_claims is registered: a detached key must not even
+// squat the namespace.
+func TestRequirePublishAccessFromForm_UserlessAPIKey_CannotClaim(t *testing.T) {
 	mock, authz := newNamespaceAuthzTestDeps(t)
 
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols))
 	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
 		WillReturnRows(sqlmock.NewRows(artifactOrgCols))
-	mock.ExpectExec("INSERT INTO namespace_claims").
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT.*FROM namespace_claims").
-		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
 
 	r := gin.New()
 	r.POST("/modules",
-		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		contextSetter(withUserlessAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
 		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
 		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, multipartRequest(t, map[string]string{"namespace": "ci-team", "name": "vpc", "system": "aws"}))
 
-	if w.Code != http.StatusCreated {
-		t.Errorf("status = %d, want 201 (service credential has no membership to re-verify): body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (a key orphaned by a user deletion must not claim a namespace): body=%s", w.Code, w.Body.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unmet/unexpected expectations: %v", err)
+		t.Errorf("unmet/unexpected expectations (no claim insert expected): %v", err)
 	}
 }
 
@@ -754,18 +795,24 @@ func TestRequirePublishAccessFromForm_APIKeyOrg_IgnoresExplicitOrg(t *testing.T)
 		WillReturnRows(sqlmock.NewRows(claimCols)) // unclaimed
 	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
 		WillReturnRows(sqlmock.NewRows(artifactOrgCols)) // no artifacts
-	// API key binding is authoritative: the claim binds to the key's org
-	// (nsOrgA), NOT the attacker-supplied organization_id form field (nsOrgB).
-	// No membership query is issued.
+	// API key binding is authoritative over the request body: the claim binds
+	// to the key's org (nsOrgA), NOT the attacker-supplied organization_id form
+	// field (nsOrgB). The binding is still re-verified against the owner's
+	// current membership -- once in resolveCallerOrg before the durable claim
+	// row is written, once afterwards against the claim's actual owner.
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
 	mock.ExpectExec("INSERT INTO namespace_claims").
 		WithArgs("ci-team", nsOrgA, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
 
 	r := gin.New()
 	r.POST("/modules",
-		contextSetter(withAPIKey(nsOrgA, []string{string(auth.ScopeModulesWrite)})),
+		contextSetter(withAPIKeyOwnedBy(nsOrgA, nsUserID, []string{string(auth.ScopeModulesWrite)})),
 		authz.RequirePublishAccessFromForm(auth.ScopeModulesWrite, 100<<20),
 		func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
 

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -11,17 +11,30 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 )
 
 // UserService provides GDPR data-subject operations.
 type UserService struct {
 	db *sql.DB
+	// creds invalidates the credential families that survive an erasure. May
+	// be nil, in which case the sweep is skipped.
+	creds *credlifecycle.Sweeper
 }
 
 // NewUserService creates a new UserService.
 func NewUserService(db *sql.DB) *UserService {
 	return &UserService{db: db}
+}
+
+// WithCredentialSweeper wires the credential sweeper used by EraseUser.
+// Returns the service for chaining.
+func (s *UserService) WithCredentialSweeper(sweeper *credlifecycle.Sweeper) *UserService {
+	s.creds = sweeper
+	return s
 }
 
 // UserDataExport is the full data export bundle for a single user (GDPR Art. 15/20).
@@ -215,14 +228,38 @@ func (s *UserService) EraseUser(ctx context.Context, userID string, erasedBy str
 		return fmt.Errorf("failed to remove memberships: %w", err)
 	}
 
-	// 4. Revoke any active JWT sessions
-	_, _ = tx.ExecContext(ctx, `
-		INSERT INTO revoked_tokens (token_id, revoked_at)
-		SELECT id, NOW() FROM user_sessions WHERE user_id = $1
-	`, userID)
-
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit erasure: %w", err)
+	}
+
+	// 4. Revoke any active JWT sessions.
+	//
+	// This step used to be an in-transaction
+	//
+	//	INSERT INTO revoked_tokens (token_id, revoked_at)
+	//	SELECT id, NOW() FROM user_sessions WHERE user_id = $1
+	//
+	// with its error deliberately discarded (`_, _ =`). There is no
+	// user_sessions table anywhere in this repository's migrations or in the
+	// shared identity schema, and the registry does not keep server-side
+	// sessions at all -- a JWT is self-contained and is stopped only by a JTI
+	// denylist hit or by the per-user revoke-all watermark. So the statement
+	// always errored, the error was swallowed, and the erasure revoked
+	// nothing: an "erased" user's outstanding sessions kept working, carrying
+	// the scope union they had at login, until the token expired. It also made
+	// the erasure LOOK swept to any reviewer (and to the enumeration
+	// signature) because the SQL text mentions revoked_tokens.
+	//
+	// The real mechanism is the watermark, which lives on a different
+	// connection from this transaction and so cannot be part of it. Running it
+	// after the commit keeps the erasure atomic and reports the sweep result
+	// separately.
+	if s.creds != nil {
+		if out := s.creds.UserDeprovisioned(ctx, userID, "gdpr erasure"); out.Incomplete {
+			slog.Error("credential sweep incomplete after GDPR erasure; the user's sessions may still be live",
+				"user_id", userID, "erased_by", erasedBy)
+			return fmt.Errorf("user data erased but credential revocation was incomplete for %s", userID)
+		}
 	}
 
 	return nil

--- a/backend/internal/services/user_service_test.go
+++ b/backend/internal/services/user_service_test.go
@@ -3,11 +3,15 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
 func TestNewUserService(t *testing.T) {
@@ -166,15 +170,100 @@ func TestEraseUser_Success(t *testing.T) {
 	mock.ExpectExec("DELETE FROM organization_members").
 		WithArgs("user-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec("INSERT INTO revoked_tokens").
-		WithArgs("user-1").
-		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	svc := NewUserService(db)
 	err := svc.EraseUser(context.Background(), "user-1", "admin-1")
 	if err != nil {
 		t.Fatalf("EraseUser() = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The JWT half of an erasure used to be an in-transaction
+//
+//	INSERT INTO revoked_tokens (token_id, revoked_at)
+//	SELECT id, NOW() FROM user_sessions WHERE user_id = $1
+//
+// whose error was discarded. No `user_sessions` table exists in any migration
+// in this repository or in the shared identity schema — the registry keeps no
+// server-side sessions — so the statement always failed and the erasure
+// revoked nothing, while the SQL text made the site read as swept. (The test
+// above asserted that statement was issued, which is why the gap survived: it
+// ratified the presence of the text, not the effect.)
+//
+// The real mechanism is the per-user revoke-all watermark, which lives on a
+// different connection and so runs after the commit.
+func TestEraseUser_RevokesSessionsAndKeysAfterCommit(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("UPDATE users").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM api_keys").
+		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec("DELETE FROM organization_members").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs("user-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "organization_id", "name", "description",
+			"key_hash", "key_prefix", "scopes", "expires_at", "last_used_at",
+			"expiry_notification_sent_at", "created_at", "user_name"}))
+
+	svc := NewUserService(db).WithCredentialSweeper(credlifecycle.NewSweeper(
+		repositories.NewUserTokenRevocationRepository(db),
+		repositories.NewAPIKeyRepository(db)))
+	if err := svc.EraseUser(context.Background(), "user-1", "admin-1"); err != nil {
+		t.Fatalf("EraseUser() = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the erasure did not revoke the user's sessions: %v", err)
+	}
+}
+
+// A sweep failure must not be reported as a clean erasure: the record is
+// anonymized but the user's sessions may still be live.
+func TestEraseUser_SweepFails_ReturnsError(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("UPDATE users").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("DELETE FROM api_keys").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM organization_members").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	mock.ExpectExec("INSERT INTO user_token_revocations").
+		WithArgs("user-1").
+		WillReturnError(errors.New("watermark write failed"))
+	mock.ExpectQuery("(?s)FROM api_keys ak.*WHERE ak.user_id").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "user_id", "organization_id", "name", "description",
+			"key_hash", "key_prefix", "scopes", "expires_at", "last_used_at",
+			"expiry_notification_sent_at", "created_at", "user_name"}))
+
+	svc := NewUserService(db).WithCredentialSweeper(credlifecycle.NewSweeper(
+		repositories.NewUserTokenRevocationRepository(db),
+		repositories.NewAPIKeyRepository(db)))
+	if err := svc.EraseUser(context.Background(), "user-1", "admin-1"); err == nil {
+		t.Fatal("EraseUser() = nil despite an incomplete credential sweep")
 	}
 }
 

--- a/backend/tools/credlifecycle/go.mod
+++ b/backend/tools/credlifecycle/go.mod
@@ -1,0 +1,10 @@
+module credlifecycle
+
+go 1.26.5
+
+require golang.org/x/tools v0.47.0
+
+require (
+	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+)

--- a/backend/tools/credlifecycle/go.sum
+++ b/backend/tools/credlifecycle/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=

--- a/backend/tools/credlifecycle/main.go
+++ b/backend/tools/credlifecycle/main.go
@@ -142,6 +142,7 @@ func main() {
 		os.Exit(2)
 	}
 
+	scanned := 0
 	graph := map[*types.Func]*node{}
 	reduceSinks := map[*types.Func]bool{}
 	jwtSinks := map[*types.Func]bool{}
@@ -153,10 +154,17 @@ func main() {
 		}
 		// Only analyse first-party code: the scanned module plus any extra
 		// pattern the caller asked for (shared identity module).
-		if !firstParty(p.PkgPath) {
+		//
+		// The scanned module is always in scope regardless of its import path
+		// -- deciding scope from a hardcoded prefix list silently reported
+		// "0 sites" when this tool was first pointed at a repo whose module
+		// path was not on the list, which is the worst possible failure mode
+		// for a signature. -prefixes only widens scope to dependencies.
+		inModule := p.Module != nil && p.Module.Main
+		if !inModule && !firstParty(p.PkgPath) {
 			return
 		}
-		inModule := p.Module == nil || p.Module.Main
+		scanned++
 		for _, f := range p.Syntax {
 			for _, d := range f.Decls {
 				fd, ok := d.(*ast.FuncDecl)
@@ -203,6 +211,17 @@ func main() {
 			}
 		}
 	})
+
+	if scanned == 0 {
+		fmt.Fprintf(os.Stderr, "credlifecycle: no first-party packages with syntax were loaded from %q -- "+
+			"the scan is vacuous, not clean. Check that the path is a Go module root.\n", *root)
+		os.Exit(2)
+	}
+	if len(reduceSinks) == 0 {
+		fmt.Fprintln(os.Stderr, "credlifecycle: no authority-reducing sinks derived -- "+
+			"the identity data layer was not in scope. Pass its package pattern as an argument.")
+		os.Exit(2)
+	}
 
 	dump("DERIVED authority-reducing sinks", reduceSinks)
 	dump("DERIVED jwt-invalidation sinks", jwtSinks)

--- a/backend/tools/credlifecycle/main.go
+++ b/backend/tools/credlifecycle/main.go
@@ -31,6 +31,24 @@
 // Sites are reported at their outermost enclosing FuncDecl, which for gin is
 // the handler constructor (e.g. RemoveMemberHandler) — the stable identity a
 // route maps to.
+//
+// PHASE 3b — BRANCH GRANULARITY. Phase 3 asks the question per FUNCTION, and a
+//
+//	function is the wrong unit whenever it reduces authority in more than one
+//	mutually exclusive branch. reconcileGroupMemberships is exactly that: its
+//	`!wanted && isMember` branch removes a membership AND sweeps the org's API
+//	keys, while its `wanted && isMember` branch commits a role reassignment —
+//	which is a REDUCTION whenever the new template grants less — and swept
+//	nothing. The function reached both families, so Phase 3 scored it OK and
+//	the unswept branch survived a clean run of this signature.
+//
+//	So for every authority-reducing call that sits inside a conditional
+//	branch, Phase 3b re-asks the question with the coverage available to THAT
+//	branch: the calls inside the branch itself, plus the function's own
+//	unconditional statements (a sweep placed after the switch covers every
+//	arm). A family the function has but this branch does not is a defect,
+//	reported at the branch.
+
 package main
 
 import (
@@ -145,9 +163,15 @@ var exemptions = map[string]struct {
 	// the same request mints the user's new session token, whose iat is floored
 	// to the second, so the watermark would revoke the token being issued and
 	// the user could never log in. The new token is derived AFTER the removal
-	// and so already carries the reduced authority. See
-	// credlifecycle.Sweeper.OrgKeysOnly.
-	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).reconcileGroupMemberships": {"JWT", "fresh token minted in the same request already carries reduced scopes; watermark would revoke it"},
+	// and so already carries the reduced authority.
+	//
+	// The exemption is NARROWER than it looks, and is granted knowingly: it
+	// covers the token minted by THIS request, not the user's other live
+	// sessions from earlier logins, which keep the pre-reduction scope union
+	// until their TTL expires. See credlifecycle.Sweeper.OrgKeysOnly, which
+	// states the residual in full, and docs/upgrade-guide.md, which states it
+	// to operators.
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).reconcileGroupMemberships": {"JWT", "this request's fresh token already carries reduced scopes and the watermark would revoke it; other live sessions are a stated residual"},
 	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).CallbackHandler":           {"JWT", "caller of reconcileGroupMemberships"},
 	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).SAMLACSHandler":            {"JWT", "caller of reconcileGroupMemberships"},
 	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).LDAPLoginHandler":          {"JWT", "caller of reconcileGroupMemberships"},
@@ -185,6 +209,12 @@ type node struct {
 	pos      string
 	inModule bool
 	callees  map[*types.Func]bool
+	// fd/info/fset are retained for the branch-granular pass (Phase 3b), which
+	// needs the syntax back to ask which conditional arm a reducing call sits
+	// in. The flattened callee set above cannot answer that.
+	fd   *ast.FuncDecl
+	info *types.Info
+	fset *token.FileSet
 }
 
 func main() {
@@ -247,6 +277,9 @@ func main() {
 					pos:      trimPos(p.Fset.Position(fd.Pos()).String()),
 					inModule: inModule,
 					callees:  map[*types.Func]bool{},
+					fd:       fd,
+					info:     p.TypesInfo,
+					fset:     p.Fset,
 				}
 				var sb strings.Builder
 				astutil.Apply(fd, func(c *astutil.Cursor) bool {
@@ -328,8 +361,21 @@ func main() {
 		return out
 	}
 
-	type row struct{ id, pos, missing, exempt string }
+	reachOf := func(f *types.Func) map[string]bool { return reach(f, map[*types.Func]bool{}) }
+
+	type row struct{ id, pos, missing, exempt, note string }
 	var sites, defects []row
+	// applyExemption blanks `missing` when an exemption covers exactly the
+	// families that are absent. Shared by the function-level and branch-level
+	// rows so a branch cannot be reported under an exemption its function does
+	// not have, nor escape one its function does.
+	applyExemption := func(id string, r *row) {
+		if ex, ok := exemptions[id]; ok && r.missing != "" &&
+			(ex.tolerate == "*" || ex.tolerate == r.missing) {
+			r.exempt = ex.reason
+			r.missing = ""
+		}
+	}
 	for obj, n := range graph {
 		if !n.inModule || reduceSinks[obj] {
 			continue
@@ -352,23 +398,34 @@ func main() {
 		if !direct && !obj.Exported() {
 			continue
 		}
-		var miss []string
-		if !r["jwt"] {
-			miss = append(miss, "JWT")
-		}
-		if !r["key"] {
-			miss = append(miss, "APIKEY")
-		}
 		id := obj.FullName()
-		rw := row{id: id, pos: n.pos, missing: strings.Join(miss, "+")}
-		if ex, ok := exemptions[id]; ok && len(miss) > 0 &&
-			(ex.tolerate == "*" || ex.tolerate == rw.missing) {
-			rw.exempt = ex.reason
-			rw.missing = ""
-		}
+		rw := row{id: id, pos: n.pos, missing: missingFamilies(r)}
+		applyExemption(id, &rw)
 		sites = append(sites, rw)
 		if rw.missing != "" {
 			defects = append(defects, rw)
+		}
+
+		// Phase 3b: the same question, per conditional arm. Only families the
+		// FUNCTION has are asked for -- one the function lacks entirely is
+		// already reported (or exempted) by the row above, and reporting it
+		// again at every branch would be noise.
+		for _, g := range branchGaps(n, reduceSinks, reachOf) {
+			g.missing = subtractFamilies(g.missing, rw.missing)
+			if g.missing == "" {
+				continue
+			}
+			brw := row{
+				id:      id,
+				pos:     g.pos,
+				missing: g.missing,
+				note:    "branch: " + g.desc,
+			}
+			applyExemption(id, &brw)
+			sites = append(sites, brw)
+			if brw.missing != "" {
+				defects = append(defects, brw)
+			}
 		}
 	}
 	sort.Slice(sites, func(i, j int) bool { return sites[i].pos < sites[j].pos })
@@ -384,6 +441,9 @@ func main() {
 			st = "EXEMPT"
 		}
 		line := fmt.Sprintf("%-26s %-78s %s", st, s.id, s.pos)
+		if s.note != "" {
+			line += "\n" + strings.Repeat(" ", 27) + s.note
+		}
 		if s.exempt != "" {
 			line += "\n" + strings.Repeat(" ", 27) + "reason: " + s.exempt
 		}
@@ -392,6 +452,203 @@ func main() {
 	fmt.Printf("\n%d site(s), %d defect(s)\n", len(sites), len(defects))
 	if len(defects) > 0 {
 		os.Exit(1)
+	}
+}
+
+// missingFamilies renders the invalidation families absent from a reach set.
+func missingFamilies(r map[string]bool) string {
+	var miss []string
+	if !r["jwt"] {
+		miss = append(miss, "JWT")
+	}
+	if !r["key"] {
+		miss = append(miss, "APIKEY")
+	}
+	return strings.Join(miss, "+")
+}
+
+// subtractFamilies removes from `have` every family already named in `also`, so
+// a branch never re-reports a gap its enclosing function is reported for.
+func subtractFamilies(have, also string) string {
+	if also == "" || have == "" {
+		return have
+	}
+	drop := map[string]bool{}
+	for _, f := range strings.Split(also, "+") {
+		drop[f] = true
+	}
+	var keep []string
+	for _, f := range strings.Split(have, "+") {
+		if !drop[f] {
+			keep = append(keep, f)
+		}
+	}
+	return strings.Join(keep, "+")
+}
+
+// gap is one authority-reducing call whose own conditional arm does not reach
+// an invalidation family the enclosing function reaches elsewhere.
+type gap struct {
+	pos     string
+	missing string
+	desc    string
+}
+
+// branchGaps runs Phase 3b over one function: for every call to an
+// authority-reducing sink that sits inside a conditional arm, it recomputes the
+// invalidation coverage from that arm's own statements plus the function's
+// unconditional ones, and reports the families the arm cannot reach.
+//
+// The "plus unconditional" half matters: the common and correct shape is a
+// switch that decides WHAT changed followed by a single sweep afterwards, and
+// counting only the arm's own statements would call every one of those a
+// defect. Statements in a SIBLING arm never count -- that is the whole point,
+// and precisely the mistake the function-level pass made.
+func branchGaps(n *node, reduceSinks map[*types.Func]bool, reachOf func(*types.Func) map[string]bool) []gap {
+	if n.fd == nil || n.info == nil || n.fd.Body == nil {
+		return nil
+	}
+	parent := parentMap(n.fd)
+
+	var allCalls []*ast.CallExpr
+	var reduceCalls []*ast.CallExpr
+	ast.Inspect(n.fd, func(x ast.Node) bool {
+		ce, ok := x.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		allCalls = append(allCalls, ce)
+		// REACHES a reducing sink, not just IS one. The arm that missed the
+		// sweep called (*OrganizationRepository).UpdateMemberRole, a one-line
+		// convenience wrapper around the UpdateMemberRoleTemplate sink; keying
+		// on direct sink identity found the sibling arm's RemoveMember (which
+		// carries its own DELETE) and nothing else, so the pass reproduced the
+		// very blindness it exists to remove.
+		if f, _ := typeutil.Callee(n.info, ce).(*types.Func); f != nil && reachOf(f)["reduce"] {
+			reduceCalls = append(reduceCalls, ce)
+		}
+		return true
+	})
+
+	var out []gap
+	seen := map[string]bool{}
+	for _, rc := range reduceCalls {
+		arm, cond := enclosingBranch(rc, n.fd, parent)
+		if arm == nil {
+			// Unconditional reduction: the function-level pass already asks the
+			// question at the right granularity.
+			continue
+		}
+		inArm := subtreeCalls(arm)
+		inCond := subtreeCalls(cond)
+
+		fams := map[string]bool{}
+		for _, ce := range allCalls {
+			if !inArm[ce] && inCond[ce] {
+				continue // a sibling arm's statement; not available here
+			}
+			f, _ := typeutil.Callee(n.info, ce).(*types.Func)
+			if f == nil {
+				continue
+			}
+			for k := range reachOf(f) {
+				fams[k] = true
+			}
+		}
+		miss := missingFamilies(fams)
+		if miss == "" {
+			continue
+		}
+		pos := trimPos(n.fset.Position(rc.Pos()).String())
+		if seen[pos] {
+			continue
+		}
+		seen[pos] = true
+		out = append(out, gap{
+			pos:     pos,
+			missing: miss,
+			desc: fmt.Sprintf("%s arm at %s reduces authority without sweeping; a sibling arm does",
+				branchKind(arm), trimPos(n.fset.Position(arm.Pos()).String())),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].pos < out[j].pos })
+	return out
+}
+
+// parentMap indexes every node under root by its parent, so a call expression
+// can be walked back up to the conditional arm containing it.
+func parentMap(root ast.Node) map[ast.Node]ast.Node {
+	parent := map[ast.Node]ast.Node{}
+	var stack []ast.Node
+	ast.Inspect(root, func(x ast.Node) bool {
+		if x == nil {
+			stack = stack[:len(stack)-1]
+			return false
+		}
+		if len(stack) > 0 {
+			parent[x] = stack[len(stack)-1]
+		}
+		stack = append(stack, x)
+		return true
+	})
+	return parent
+}
+
+// enclosingBranch returns the INNERMOST conditional arm containing x (a switch
+// case, a select case, or an if/else block) and the OUTERMOST conditional
+// statement containing it. Both are nil when x is unconditional within fd.
+func enclosingBranch(x ast.Node, fd *ast.FuncDecl, parent map[ast.Node]ast.Node) (arm ast.Node, cond ast.Node) {
+	for cur := ast.Node(x); cur != nil && cur != ast.Node(fd); cur = parent[cur] {
+		p := parent[cur]
+		switch cur.(type) {
+		case *ast.CaseClause, *ast.CommClause:
+			if arm == nil {
+				arm = cur
+			}
+		case *ast.BlockStmt:
+			// The Body or the Else of an if statement is an arm; a bare block,
+			// a loop body or a function body is not.
+			if ifs, ok := p.(*ast.IfStmt); ok && arm == nil && (ifs.Body == cur || ifs.Else == cur) {
+				arm = cur
+			}
+		}
+		switch cur.(type) {
+		case *ast.IfStmt, *ast.SwitchStmt, *ast.TypeSwitchStmt, *ast.SelectStmt:
+			cond = cur // keep climbing: the last one wins, i.e. the outermost
+		}
+	}
+	if arm == nil {
+		return nil, nil
+	}
+	if cond == nil {
+		cond = arm
+	}
+	return arm, cond
+}
+
+// subtreeCalls is the set of call expressions syntactically inside root.
+func subtreeCalls(root ast.Node) map[*ast.CallExpr]bool {
+	out := map[*ast.CallExpr]bool{}
+	if root == nil {
+		return out
+	}
+	ast.Inspect(root, func(x ast.Node) bool {
+		if ce, ok := x.(*ast.CallExpr); ok {
+			out[ce] = true
+		}
+		return true
+	})
+	return out
+}
+
+func branchKind(arm ast.Node) string {
+	switch arm.(type) {
+	case *ast.CaseClause:
+		return "switch-case"
+	case *ast.CommClause:
+		return "select-case"
+	default:
+		return "if/else"
 	}
 }
 

--- a/backend/tools/credlifecycle/main.go
+++ b/backend/tools/credlifecycle/main.go
@@ -52,8 +52,17 @@ import (
 
 var (
 	// A row that GRANTS derived authority is deleted, re-pointed, or narrowed.
+	//
+	// `delete from organizations` belongs here even though it names no
+	// principal: organization_members.organization_id is ON DELETE CASCADE, so
+	// dropping an organization silently reduces every one of its members'
+	// authority. Omitting the verb is how DeleteOrganizationHandler escaped an
+	// earlier run of this signature -- a reduction the vocabulary could not
+	// spell was a reduction the enumeration could not find. (The \b matters:
+	// "organization_members" must not match here, it has its own pattern.)
 	reReduce = regexp.MustCompile(`(?is)` + strings.Join([]string{
 		`delete\s+from\s+organization_members`,
+		`delete\s+from\s+organizations\b`,
 		`delete\s+from\s+users\b`,
 		`delete\s+from\s+role_templates`,
 		`update\s+organization_members\s+set[^;]*role_template_id`,
@@ -67,11 +76,58 @@ var (
 		`update\s+user_token_revocations`,
 	}, "|"))
 
-	reAPIKey = regexp.MustCompile(`(?is)` + strings.Join([]string{
-		`delete\s+from\s+api_keys`,
-		`update\s+api_keys\s+set[^;]*(is_active|revoked|expires_at)`,
-	}, "|"))
+	// A DELETE is unambiguous. An UPDATE is not, and is classified by
+	// isKeyInvalidatingUpdate below rather than by a regexp: the previous
+	// pattern `update api_keys set[^;]*(is_active|revoked|expires_at)` also
+	// matched the ORDINARY key-edit path
+	//
+	//	UPDATE api_keys SET name = $2, description = $3, scopes = $4, expires_at = $5
+	//
+	// (identity/store.APIKeyRepository.Update), so any future site that merely
+	// RENAMED a key would have scored as having swept it. A signature that
+	// counts an edit as a revocation cannot detect a missing revocation.
+	reAPIKeyDelete = regexp.MustCompile(`(?is)delete\s+from\s+api_keys`)
+
+	// The SET clause of an `UPDATE api_keys`, captured for column analysis.
+	reAPIKeyUpdate = regexp.MustCompile(`(?is)update\s+api_keys\s+set\s+([^;]*?)(?:\s+where\b|$)`)
+
+	// Columns whose assignment retires a key rather than editing it.
+	revocationColumns = map[string]bool{
+		"is_active": true, "revoked": true, "revoked_at": true,
+		"expires_at": true, "deleted_at": true, "disabled": true,
+	}
+
+	// Left-hand side of one assignment in a SET clause.
+	reAssignedColumn = regexp.MustCompile(`(?i)([a-z_][a-z0-9_]*)\s*=`)
 )
+
+// isKeyInvalidatingUpdate reports whether an `UPDATE api_keys` in this body
+// retires keys rather than editing them.
+//
+// The rule: EVERY column the statement assigns must be a revocation column,
+// and there must be at least one. `SET expires_at = NOW()` and
+// `SET is_active = false` are revocations; `SET name = $2, ..., expires_at =
+// $5` is an edit that merely happens to touch a revocation column, and
+// `SET last_used_at = $2` is neither.
+func isKeyInvalidatingUpdate(body string) bool {
+	for _, m := range reAPIKeyUpdate.FindAllStringSubmatch(body, -1) {
+		assigned := reAssignedColumn.FindAllStringSubmatch(m[1], -1)
+		if len(assigned) == 0 {
+			continue
+		}
+		allRevoking := true
+		for _, a := range assigned {
+			if !revocationColumns[strings.ToLower(a[1])] {
+				allRevoking = false
+				break
+			}
+		}
+		if allRevoking {
+			return true
+		}
+	}
+	return false
+}
 
 // exemptions are sites the analysis reaches but which are NOT instances of the
 // defect, each with the concrete technical reason. Keyed by the full type-
@@ -96,11 +152,22 @@ var exemptions = map[string]struct {
 	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).SAMLACSHandler":            {"JWT", "caller of reconcileGroupMemberships"},
 	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).LDAPLoginHandler":          {"JWT", "caller of reconcileGroupMemberships"},
 
-	// Hard DELETE FROM users. api_keys.user_id is ON DELETE CASCADE, so every
-	// key vanishes with the row; and AuthMiddleware aborts 401 "User not found"
-	// when a JWT's subject no longer resolves. Both families are invalidated by
-	// the schema plus the auth path rather than by an explicit sweep.
-	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.UserHandlers).DeleteUserHandler": {"*", "FK ON DELETE CASCADE removes api_keys; AuthMiddleware 401s a JWT whose user is gone"},
+	// NOTE: admin.UserHandlers.DeleteUserHandler was exempted here on the
+	// grounds that "api_keys.user_id is ON DELETE CASCADE, so every key
+	// vanishes with the row". That premise was FALSE for the schema that
+	// actually serves this table. Only the registry's own legacy
+	// public.api_keys declares CASCADE
+	// (internal/db/migrations/000001_initial_schema.up.sql:60); the shared
+	// identity schema declares
+	//
+	//	identity.api_keys.user_id UUID REFERENCES identity.users(id) ON DELETE SET NULL
+	//
+	// so deleting a principal DETACHED its keys instead of destroying them,
+	// leaving userless org-bound rows that the namespace authorizer reads as
+	// organization service credentials and exempts from membership checks.
+	// The exemption is removed and the site now sweeps explicitly. Leaving
+	// this as a comment rather than deleting it: an exemption is a claim about
+	// the world, and this one records how to check the claim.
 
 	// First-boot setup promoting the bootstrap admin. It reaches the shared
 	// UpdateMemberRole implementation, but the direction is an authority
@@ -204,7 +271,7 @@ func main() {
 				if reJWT.MatchString(body) {
 					jwtSinks[obj] = true
 				}
-				if reAPIKey.MatchString(body) {
+				if reAPIKeyDelete.MatchString(body) || isKeyInvalidatingUpdate(body) {
 					keySinks[obj] = true
 				}
 				graph[obj] = n

--- a/backend/tools/credlifecycle/main.go
+++ b/backend/tools/credlifecycle/main.go
@@ -1,0 +1,354 @@
+// Command credlifecycle is the executable signature for the
+// "authority reduced without credential invalidation" defect class
+// (terraform-registry-backend #732, #736).
+//
+//	go run ./tools/credlifecycle [-root .] [extra package patterns ...]
+//
+// It is type-aware (go/packages + go/types), so every sink and every call edge
+// is resolved to a fully-qualified method object — "Update" on APIKeyRepository
+// is never confused with "Update" on MirrorRepository.
+//
+// It does NOT contain a list of known-bad files. Three phases:
+//
+// PHASE 1 — DERIVE the vocabulary from the persistence layer.
+//
+//	authority-reducing sink : a func whose body contains SQL that deletes or
+//	                          narrows the row granting derived authority
+//	                          (organization_members, users, role_templates).
+//	jwt-invalidation sink   : a func whose body contains SQL writing
+//	                          revoked_tokens / user_token_revocations.
+//	apikey-invalidation sink: a func whose body contains SQL deleting an
+//	                          api_keys row or flipping it inactive/expired.
+//
+// PHASE 2 — ENUMERATE every func in the scanned module that reaches an
+//
+//	authority-reducing sink through the resolved call graph.
+//
+// PHASE 3 — For each such site, require that its call closure ALSO reaches
+//
+//	BOTH invalidation families. Missing either => an instance of the class.
+//
+// Sites are reported at their outermost enclosing FuncDecl, which for gin is
+// the handler constructor (e.g. RemoveMemberHandler) — the stable identity a
+// route maps to.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+var (
+	// A row that GRANTS derived authority is deleted, re-pointed, or narrowed.
+	reReduce = regexp.MustCompile(`(?is)` + strings.Join([]string{
+		`delete\s+from\s+organization_members`,
+		`delete\s+from\s+users\b`,
+		`delete\s+from\s+role_templates`,
+		`update\s+organization_members\s+set[^;]*role_template_id`,
+		`update\s+role_templates\s+set[^;]*scopes`,
+		`update\s+users\s+set[^;]*(is_active|active|disabled|deleted_at)`,
+	}, "|"))
+
+	reJWT = regexp.MustCompile(`(?is)` + strings.Join([]string{
+		`insert\s+into\s+revoked_tokens`,
+		`insert\s+into\s+user_token_revocations`,
+		`update\s+user_token_revocations`,
+	}, "|"))
+
+	reAPIKey = regexp.MustCompile(`(?is)` + strings.Join([]string{
+		`delete\s+from\s+api_keys`,
+		`update\s+api_keys\s+set[^;]*(is_active|revoked|expires_at)`,
+	}, "|"))
+)
+
+// exemptions are sites the analysis reaches but which are NOT instances of the
+// defect, each with the concrete technical reason. Keyed by the full type-
+// checked object name, so a rename or a new site is never silently covered:
+// anything not listed here that reaches an authority-reducing sink without both
+// invalidation families is reported as a defect and exits non-zero.
+//
+// The value is (missingFamiliesTolerated, reason). "*" tolerates both.
+var exemptions = map[string]struct {
+	tolerate string
+	reason   string
+}{
+	// The IdP login paths sweep API keys but deliberately do NOT move the JWT
+	// revoke-all watermark: reconcileGroupMemberships runs microseconds before
+	// the same request mints the user's new session token, whose iat is floored
+	// to the second, so the watermark would revoke the token being issued and
+	// the user could never log in. The new token is derived AFTER the removal
+	// and so already carries the reduced authority. See
+	// credlifecycle.Sweeper.OrgKeysOnly.
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).reconcileGroupMemberships": {"JWT", "fresh token minted in the same request already carries reduced scopes; watermark would revoke it"},
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).CallbackHandler":           {"JWT", "caller of reconcileGroupMemberships"},
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).SAMLACSHandler":            {"JWT", "caller of reconcileGroupMemberships"},
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.AuthHandlers).LDAPLoginHandler":          {"JWT", "caller of reconcileGroupMemberships"},
+
+	// Hard DELETE FROM users. api_keys.user_id is ON DELETE CASCADE, so every
+	// key vanishes with the row; and AuthMiddleware aborts 401 "User not found"
+	// when a JWT's subject no longer resolves. Both families are invalidated by
+	// the schema plus the auth path rather than by an explicit sweep.
+	"(*github.com/terraform-registry/terraform-registry/internal/api/admin.UserHandlers).DeleteUserHandler": {"*", "FK ON DELETE CASCADE removes api_keys; AuthMiddleware 401s a JWT whose user is gone"},
+
+	// First-boot setup promoting the bootstrap admin. It reaches the shared
+	// UpdateMemberRole implementation, but the direction is an authority
+	// INCREASE, and it runs before any credential for that principal exists.
+	"(*github.com/terraform-registry/terraform-registry/internal/api/setup.Handlers).ConfigureAdmin": {"*", "authority increase during first-boot setup, not a reduction"},
+
+	// One-line delegation shims onto the shared identity store. They carry no
+	// policy; the control belongs to their handler callers, which are covered.
+	"(*github.com/terraform-registry/terraform-registry/internal/db/repositories.RBACRepository).UpdateRoleTemplate": {"*", "delegation shim; control lives in admin.RBACHandlers.UpdateRoleTemplate"},
+	"(*github.com/terraform-registry/terraform-registry/internal/db/repositories.RBACRepository).DeleteRoleTemplate": {"*", "delegation shim; control lives in admin.RBACHandlers.DeleteRoleTemplate"},
+}
+
+type node struct {
+	obj      *types.Func
+	pos      string
+	inModule bool
+	callees  map[*types.Func]bool
+}
+
+func main() {
+	root := flag.String("root", ".", "module directory to scan")
+	prefixes := flag.String("prefixes", strings.Join(firstPartyPrefixes, ","),
+		"comma-separated import-path prefixes treated as first-party")
+	flag.Parse()
+	firstPartyPrefixes = strings.Split(*prefixes, ",")
+
+	patterns := append([]string{"./..."}, flag.Args()...)
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps | packages.NeedModule,
+		Dir:   *root,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load:", err)
+		os.Exit(2)
+	}
+
+	graph := map[*types.Func]*node{}
+	reduceSinks := map[*types.Func]bool{}
+	jwtSinks := map[*types.Func]bool{}
+	keySinks := map[*types.Func]bool{}
+
+	packages.Visit(pkgs, nil, func(p *packages.Package) {
+		if len(p.Syntax) == 0 || p.TypesInfo == nil {
+			return
+		}
+		// Only analyse first-party code: the scanned module plus any extra
+		// pattern the caller asked for (shared identity module).
+		if !firstParty(p.PkgPath) {
+			return
+		}
+		inModule := p.Module == nil || p.Module.Main
+		for _, f := range p.Syntax {
+			for _, d := range f.Decls {
+				fd, ok := d.(*ast.FuncDecl)
+				if !ok || fd.Body == nil {
+					continue
+				}
+				obj, _ := p.TypesInfo.Defs[fd.Name].(*types.Func)
+				if obj == nil {
+					continue
+				}
+				n := &node{
+					obj:      obj,
+					pos:      trimPos(p.Fset.Position(fd.Pos()).String()),
+					inModule: inModule,
+					callees:  map[*types.Func]bool{},
+				}
+				var sb strings.Builder
+				astutil.Apply(fd, func(c *astutil.Cursor) bool {
+					switch e := c.Node().(type) {
+					case *ast.BasicLit:
+						if e.Kind == token.STRING {
+							if s, uerr := strconv.Unquote(e.Value); uerr == nil {
+								sb.WriteString(s + "\n")
+							}
+						}
+					case *ast.CallExpr:
+						if callee, _ := typeutil.Callee(p.TypesInfo, e).(*types.Func); callee != nil {
+							n.callees[callee] = true
+						}
+					}
+					return true
+				}, nil)
+				body := sb.String()
+				if reReduce.MatchString(body) {
+					reduceSinks[obj] = true
+				}
+				if reJWT.MatchString(body) {
+					jwtSinks[obj] = true
+				}
+				if reAPIKey.MatchString(body) {
+					keySinks[obj] = true
+				}
+				graph[obj] = n
+			}
+		}
+	})
+
+	dump("DERIVED authority-reducing sinks", reduceSinks)
+	dump("DERIVED jwt-invalidation sinks", jwtSinks)
+	dump("DERIVED apikey-invalidation sinks", keySinks)
+
+	memo := map[*types.Func]map[string]bool{}
+	var reach func(f *types.Func, seen map[*types.Func]bool) map[string]bool
+	reach = func(f *types.Func, seen map[*types.Func]bool) map[string]bool {
+		if r, ok := memo[f]; ok {
+			return r
+		}
+		if seen[f] {
+			return map[string]bool{}
+		}
+		seen[f] = true
+		out := map[string]bool{}
+		if reduceSinks[f] {
+			out["reduce"] = true
+		}
+		if jwtSinks[f] {
+			out["jwt"] = true
+		}
+		if keySinks[f] {
+			out["key"] = true
+		}
+		if n := graph[f]; n != nil {
+			for c := range n.callees {
+				for k := range reach(c, seen) {
+					out[k] = true
+				}
+			}
+		}
+		delete(seen, f)
+		if len(seen) == 0 {
+			memo[f] = out
+		}
+		return out
+	}
+
+	type row struct{ id, pos, missing, exempt string }
+	var sites, defects []row
+	for obj, n := range graph {
+		if !n.inModule || reduceSinks[obj] {
+			continue
+		}
+		// Only report the OUTERMOST site: if a caller of this func is itself a
+		// site, this one is an implementation detail of that site. Keep both
+		// only when the inner one is exported-handler-shaped. Simplest honest
+		// rule: report every func that DIRECTLY calls a reducing sink, plus any
+		// exported func that transitively reaches one.
+		direct := false
+		for c := range n.callees {
+			if reduceSinks[c] {
+				direct = true
+			}
+		}
+		r := reach(obj, map[*types.Func]bool{})
+		if !r["reduce"] {
+			continue
+		}
+		if !direct && !obj.Exported() {
+			continue
+		}
+		var miss []string
+		if !r["jwt"] {
+			miss = append(miss, "JWT")
+		}
+		if !r["key"] {
+			miss = append(miss, "APIKEY")
+		}
+		id := obj.FullName()
+		rw := row{id: id, pos: n.pos, missing: strings.Join(miss, "+")}
+		if ex, ok := exemptions[id]; ok && len(miss) > 0 &&
+			(ex.tolerate == "*" || ex.tolerate == rw.missing) {
+			rw.exempt = ex.reason
+			rw.missing = ""
+		}
+		sites = append(sites, rw)
+		if rw.missing != "" {
+			defects = append(defects, rw)
+		}
+	}
+	sort.Slice(sites, func(i, j int) bool { return sites[i].pos < sites[j].pos })
+	sort.Slice(defects, func(i, j int) bool { return defects[i].pos < defects[j].pos })
+
+	fmt.Println("\n=== AUTHORITY-REDUCTION SITES ===")
+	for _, s := range sites {
+		st := "OK"
+		switch {
+		case s.missing != "":
+			st = "DEFECT missing=" + s.missing
+		case s.exempt != "":
+			st = "EXEMPT"
+		}
+		line := fmt.Sprintf("%-26s %-78s %s", st, s.id, s.pos)
+		if s.exempt != "" {
+			line += "\n" + strings.Repeat(" ", 27) + "reason: " + s.exempt
+		}
+		fmt.Println(line)
+	}
+	fmt.Printf("\n%d site(s), %d defect(s)\n", len(sites), len(defects))
+	if len(defects) > 0 {
+		os.Exit(1)
+	}
+}
+
+// firstPartyPrefixes bounds the analysis to code the suite owns; third-party
+// dependencies never define these sinks and parsing them all is wasteful.
+// Override with -prefixes when running against another repository.
+var firstPartyPrefixes = []string{
+	"github.com/terraform-registry/terraform-registry/",
+	"github.com/sethbacon/terraform-suite-identity/",
+	"github.com/sethbacon/terraform-state-manager/",
+}
+
+func firstParty(path string) bool {
+	for _, p := range firstPartyPrefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func dump(label string, s map[*types.Func]bool) {
+	var keys []string
+	for f := range s {
+		keys = append(keys, shortName(f))
+	}
+	sort.Strings(keys)
+	fmt.Printf("%s (%d):\n  %s\n", label, len(keys), strings.Join(keys, "\n  "))
+}
+
+func shortName(f *types.Func) string {
+	n := f.FullName()
+	n = strings.ReplaceAll(n, "github.com/terraform-registry/terraform-registry/internal/", "")
+	n = strings.ReplaceAll(n, "github.com/sethbacon/terraform-suite-identity/identity/", "identity/")
+	n = strings.ReplaceAll(n, "github.com/sethbacon/terraform-state-manager/", "")
+	return n
+}
+
+func trimPos(p string) string {
+	for _, m := range []string{"/backend/", "/identity/", "/wt/"} {
+		if i := strings.Index(p, m); i >= 0 {
+			return p[i+1:]
+		}
+	}
+	return p
+}

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -298,6 +298,11 @@ Events that now delete a principal's organization-bound API keys:
 - A role template's scopes being **narrowed**, or the template being deleted. Adding
   scopes, or merely reordering the list, sweeps nothing.
 - IdP group-mapping deprovisioning at OIDC/SAML/LDAP login.
+- An IdP group change that maps a user to a **lower** role at OIDC/SAML/LDAP login —
+  same rule as the administrative reassignment above: a promotion deletes nothing, a
+  demotion deletes exactly the keys that now over-ask. Note that this fires on
+  *login*, so it applies to users your IdP re-scopes without anyone touching the
+  registry.
 - User deletion (`DELETE /api/v1/users/:id`) and GDPR erasure
   (`POST /api/v1/admin/users/:id/erase`).
 
@@ -318,22 +323,97 @@ restore API keys; they must be re-issued.
 > user. If you have an IdP or script relying on a partial PUT to deactivate users,
 > it must now send `"active": false` explicitly.
 
+**Sessions the IdP login path does not revoke.** At OIDC/SAML/LDAP login the API-key
+family is swept but the JWT revoke-all watermark is deliberately **not** moved: the
+reconciliation runs microseconds before the same request mints the user's new session
+token, whose `iat` is floored to the second, so moving the watermark would revoke the
+token being issued and the user could never log in. The token minted by that login is
+derived after the change and already carries the reduced authority. The user's
+**other** live sessions, from earlier logins, are **not** covered — they keep the
+pre-reduction scopes until their own TTL expires. If you need an IdP-driven reduction
+to retire every existing session immediately, perform the equivalent administrative
+action (member removal, role reassignment, or a role-template edit), which does move
+the watermark.
+
 Responses from these endpoints may carry `revocation_incomplete: true`. The authority
 change itself succeeded, but part of the credential sweep did not — treat it as an
-open incident and re-run the action.
+open incident and re-run the action. This is now reported by
+`PUT /api/v1/admin/role-templates/{id}` and `PUT /api/v1/organizations/{id}/members/{user_id}`
+as well, which previously answered a clean `200` regardless. On those two endpoints the
+flag is an **additional field on the existing success body**, not a new envelope.
 
-**Also in this change:** an organization-bound API key is re-verified at the point of
-use. A key whose owner has left the organization, or whose role template no longer
-grants the required scope, is now rejected (`403`) on namespace mutations even if some
-lifecycle path failed to sweep it. Long-lived keys belonging to users who have since
-been offboarded or downgraded will begin failing on upgrade — that is the intended
-correction, but audit for it before deploying if you have service automation running
-under a personal key.
+**Also in this change: organization-bound API keys are re-verified at the point their
+binding is established, not only on namespace mutations.**
 
-**Migrations:** none for any change in this section.
+`AuthMiddleware` and `OptionalAuthMiddleware` now look up the key owner's current
+membership on every API-key-authenticated request, and:
 
-**Rollback:** all are code-only; rolling back the binary restores the previous
-behavior. Note that API keys deleted by a sweep are **not** restored by a rollback.
+- **reject the key (`401`)** when its owner is no longer a member of the organization
+  it is bound to;
+- **narrow the request's scopes** to the intersection of the key's frozen scopes and
+  what the owner's current role template grants (by scope semantics, so an `admin`
+  role template retains everything);
+- **reject the key (`401`)** when it has no owning user — see the migration note below.
+
+This costs **one additional indexed query per API-key request**, on a path that already
+performs a key-prefix lookup, a bcrypt comparison, and a user load. Previously the
+re-verification existed only inside the namespace authorizer, so any route not wrapped
+by it — the admin surface, `/apikeys`, SCIM — consumed the frozen `organization_id` and
+scope list with no check at all.
+
+Long-lived keys belonging to users who have since been offboarded or downgraded will
+begin failing on upgrade. That is the intended correction, but **audit for it before
+deploying** if you have automation running under a personal key.
+
+**Migration `000050_quarantine_orphaned_api_keys` — read this if you have ever deleted
+a user.**
+
+In the shared identity schema, `identity.api_keys.user_id` is
+`REFERENCES identity.users(id) ON DELETE SET NULL`. Deleting a principal therefore
+**detached** their API keys instead of destroying them, and the detached row kept its
+`organization_id` and its frozen scopes. Until this release the authorizer read a
+userless organization-bound key as an "organization service credential" and skipped the
+membership check entirely — so a deleted user's key kept publishing into that
+organization's namespaces.
+
+The code changes close this going forward (every user-deletion site sweeps first) and
+fail closed at the point of use. Neither helps rows that were **already** detached, so
+this migration retires them: every `api_keys` row with `user_id IS NULL` and no earlier
+expiry has `expires_at` set to `NOW()`. It runs against `identity.api_keys` when the
+identity schema exists and against `public.api_keys` always, logs a `WARNING` with the
+row count when it changes anything, and is idempotent.
+
+Retiring **all** of them is safe because the registry has no way to mint one: API keys
+are created only by `POST /api/v1/apikeys` (owner taken from the authenticated caller)
+and by key rotation (which copies the previous owner). A userless row is either a
+detached personal key or a hand-written `INSERT`.
+
+- **If you deliberately created a userless key by direct SQL**, it is now expired *and*
+  refused by the point-of-use guard. Re-issue it through the API so it is bound to a
+  real principal; a service account with its own membership is the supported shape.
+- **The down migration is a no-op.** `expires_at = NOW()` is indistinguishable from an
+  expiry an operator set on purpose, so blanket-clearing it would re-arm exactly the
+  credentials the migration retired. Individual rows can be restored by hand
+  (`UPDATE identity.api_keys SET expires_at = NULL WHERE id = '<uuid>'`), though the
+  point-of-use guard still refuses userless keys until the binary is rolled back.
+- **Non-default `TFR_IDENTITY_SCHEMA_NAME`:** the migration hardcodes the `identity.`
+  schema literal, exactly like migrations `000038` and `000045`. Edit the file, or run
+  the statement by hand, if you renamed the schema.
+
+To see what will be quarantined before you upgrade:
+
+```sql
+SELECT id, organization_id, name, key_prefix, scopes, created_at, last_used_at
+  FROM identity.api_keys
+ WHERE user_id IS NULL AND (expires_at IS NULL OR expires_at > NOW());
+```
+
+**Migrations:** `000050_quarantine_orphaned_api_keys` (data-only; irreversible down).
+No other change in this section requires one.
+
+**Rollback:** the code changes are all code-only; rolling back the binary restores the
+previous behavior. Note that API keys deleted by a sweep are **not** restored by a
+rollback, and neither are the keys quarantined by migration `000050`.
 
 ---
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -274,9 +274,66 @@ After upgrade:
 with a non-admin token and expect estate-wide results: either grant that principal the
 `admin` scope deliberately, or update the caller to iterate per organization.
 
-**Migrations:** none for either change.
+**Credential invalidation on authority reduction (#732, #736):**
 
-**Rollback:** both are code-only; rolling back the binary restores the previous behavior.
+Reducing a principal's authority now invalidates the credentials that carry a
+*snapshot* of it. Previously only JWT sessions were swept, and only at some events;
+API keys were never swept at all, because an API key's scopes **and** its owning
+`organization_id` are frozen on the `api_keys` row at creation and are read straight
+back out by the auth middleware. An offboarded member kept a working
+`modules:write` / `providers:write` credential into the organization's namespaces
+indefinitely.
+
+These sweeps **activate on upgrade with no configuration change**, and they DELETE
+API keys. An API key's secret is displayed once at creation and cannot be recovered:
+a deleted key must be re-issued and re-distributed to whatever consumes it (CI
+pipelines, Terraform `credentials` blocks, automation). Review the list below against
+your own automation before upgrading.
+
+Events that now delete a principal's organization-bound API keys:
+
+- Removal from an organization (`DELETE /api/v1/organizations/:id/members/:user_id`).
+- A member's role-template reassignment (`PUT .../members/:user_id`) — **only** when
+  the new template grants strictly less; a promotion deletes nothing.
+- A role template's scopes being **narrowed**, or the template being deleted. Adding
+  scopes, or merely reordering the list, sweeps nothing.
+- IdP group-mapping deprovisioning at OIDC/SAML/LDAP login.
+- User deletion (`DELETE /api/v1/users/:id`) and GDPR erasure
+  (`POST /api/v1/admin/users/:id/erase`).
+
+Only keys asking for **more than the principal retains** are deleted; a key entirely
+within the remaining authority survives. Scope comparison honors the `admin` wildcard
+and the read/write implications, and is order-insensitive.
+
+**SCIM deactivation now destroys credentials.** `DELETE /scim/v2/Users/{id}`, and a
+PUT or PATCH setting `active: false`, now revoke the user's sessions and delete
+**every** API key they hold in **every** organization — not just their memberships.
+If your IdP deactivates and later reactivates users (a common lifecycle for
+contractors or leave-of-absence), reactivation restores memberships but **cannot**
+restore API keys; they must be re-issued.
+
+> **SCIM PUT semantics changed with this.** `active` is now optional: a PUT that
+> **omits** it leaves the user's authority untouched, where previously an omitted
+> `active` was indistinguishable from `active: false` and silently deprovisioned the
+> user. If you have an IdP or script relying on a partial PUT to deactivate users,
+> it must now send `"active": false` explicitly.
+
+Responses from these endpoints may carry `revocation_incomplete: true`. The authority
+change itself succeeded, but part of the credential sweep did not — treat it as an
+open incident and re-run the action.
+
+**Also in this change:** an organization-bound API key is re-verified at the point of
+use. A key whose owner has left the organization, or whose role template no longer
+grants the required scope, is now rejected (`403`) on namespace mutations even if some
+lifecycle path failed to sweep it. Long-lived keys belonging to users who have since
+been offboarded or downgraded will begin failing on upgrade — that is the intended
+correction, but audit for it before deploying if you have service automation running
+under a personal key.
+
+**Migrations:** none for any change in this section.
+
+**Rollback:** all are code-only; rolling back the binary restores the previous
+behavior. Note that API keys deleted by a sweep are **not** restored by a rollback.
 
 ---
 


### PR DESCRIPTION
Closes #732. Closes #736.

## The class, not the instance

#732 reports that removing an organization member leaves their API keys valid. That is one instance of a broader defect: **an event that reduces a principal's derived authority commits the change but fails to invalidate every credential family carrying a snapshot of it.** There are two such families — JWT sessions (scopes embedded at login) and API keys (scopes *and* `organization_id` frozen on the row). Sweeping one and not the other makes the reduction cosmetic.

Ten sites are fixed: org member removal and role reassignment, role-template edit and delete, the IdP group-sync deprovision path, all four SCIM deactivation paths, and the namespace authorizer's use-time check.

## A re-runnable signature, not a hand-built list

`backend/tools/credlifecycle` is a type-aware analyzer committed with the fix. It derives its whole vocabulary from SQL literals in the persistence layer and holds **no list of known-bad files**, so it finds sites nobody thought of:

```sh
cd backend/tools/credlifecycle && go run . -root <repo>/backend
```

It reports **22 sites / 0 defects** here and exits 1 on `main`. Four of the ten fixed sites were found by the analyzer rather than named in either issue.

It also found **14 live instances of this same class in `terraform-state-manager-backend`** — filed as sethbacon/terraform-state-manager-backend#330, not fixed here.

## Two corrections to earlier reasoning, both load-bearing

**An exemption rested on a false premise.** `DeleteUserHandler` was first exempted because `api_keys.user_id` is `ON DELETE CASCADE`. That is true only of the legacy `public` schema. The identity schema declares **`ON DELETE SET NULL`** — deleting a principal *detaches* its credentials into userless org-bound rows rather than destroying them, and a userless key was exactly what the authorizer treated as an org service credential and exempted from membership checks. The exemption is gone; the site now sweeps before the delete.

**A dead statement was camouflaging a gap.** `EraseUser`'s JWT revocation selected from a `user_sessions` table with the error discarded. **No such table exists in any migration in this repo.** It always failed silently — and because the statement text mentions the revocation table, the site read as swept to a reviewer *and* to the analyzer.

## The backward population

Migration `000050` quarantines API keys already orphaned by pre-fix user deletions. Quarantine by expiry rather than deletion, so rows stay auditable; both middlewares reject expired keys before any handler runs. A point-of-use 403 covers the same population independently, because a data migration is one-shot and a guard is not.

The durable fix — changing that foreign key — belongs in `terraform-suite-identity`, not here. Filed as sethbacon/terraform-suite-identity#129.

## Deliberately narrow

The sweep fires only on an authority **reduction**, compared by scope semantics (admin wildcard, write-implies-read, order-insensitive) rather than slice equality. A widening or a reorder deletes nothing. Key deletion is irreversible, so this matters — an earlier draft would have destroyed fleet-wide CI credentials on a scope *increase*.

`docs/upgrade-guide.md` covers every operator-visible change, including that reactivation cannot restore deleted keys.

## Verification

62 test packages pass; `go vet` and `gofmt` clean; `internal/credlifecycle` coverage 0% → 100%.

The class test is table-driven over 15 sites, and **every row was verified to fail when its own guard is mutated.** Three tests initially passed under mutation — `sqlmock`'s `ExpectationsWereMet` only checks that *registered* expectations fired, so unexpected statements came back as errors and were swallowed by the sweep's best-effort handling. They were rewritten against captured log output.

The analyzer also had a blind spot, found and fixed here: it asked whether a *function* reaches both invalidation families, so an unswept branch scored clean whenever a sibling branch swept. It now evaluates per-branch, which is what surfaced the IdP role-demotion path.
