### PR TITLE
fix: use the shared single-use state store for the SCM OAuth flow

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -11413,7 +11413,7 @@
                         }
                     },
                     {
-                        "description": "State parameter (userID:providerID)",
+                        "description": "Single-use state nonce issued by /oauth/authorize (64 hex chars)",
                         "name": "state",
                         "in": "query",
                         "required": true,
@@ -11427,7 +11427,7 @@
                         "description": "Redirect to frontend success page"
                     },
                     "400": {
-                        "description": "Invalid provider ID, code, or state",
+                        "description": "Invalid provider ID or code; or state that is unknown, expired, already used, or minted for a different provider",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -9230,7 +9230,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "State parameter (userID:providerID)",
+                        "description": "Single-use state nonce issued by /oauth/authorize (64 hex chars)",
                         "name": "state",
                         "in": "query",
                         "required": true
@@ -9241,7 +9241,7 @@
                         "description": "Redirect to frontend success page"
                     },
                     "400": {
-                        "description": "Invalid provider ID, code, or state",
+                        "description": "Invalid provider ID or code; or state that is unknown, expired, already used, or minted for a different provider",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -7,16 +7,32 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/scm/appcreds"
+)
+
+const (
+	// scmStateProviderType tags a SessionState as belonging to the SCM
+	// connector flow rather than to a login. The two flows share one store, so
+	// each callback must refuse the other's states: an OIDC login state
+	// presented here has no SCMUserID, and an SCM state presented at
+	// /api/v1/auth/callback falls through that handler's switch to
+	// "unknown_provider".
+	scmStateProviderType = "scm"
+	// scmStateTTL bounds how long an SCM authorization flow may stay in-flight,
+	// matching the login flow's 10 minutes (LoginHandler).
+	scmStateTTL = 10 * time.Minute
+	// scmStateMaxAge is the freshness bound re-checked at the callback, matching
+	// CallbackHandler. Belt-and-braces against a store whose TTL did not fire.
+	scmStateMaxAge = 5 * time.Minute
 )
 
 // SCMOAuthHandlers handles SCM OAuth flows
@@ -26,6 +42,7 @@ type SCMOAuthHandlers struct {
 	userRepo    *repositories.UserRepository
 	tokenCipher *crypto.TokenCipher
 	minter      appcreds.SharedMinter
+	stateStore  auth.StateStore
 }
 
 // NewSCMOAuthHandlers creates a new SCM OAuth handlers instance
@@ -42,6 +59,19 @@ func NewSCMOAuthHandlers(cfg *config.Config, scmRepo *repositories.SCMRepository
 // app auth mode (entra_app/github_app). Returns the handler for chaining.
 func (h *SCMOAuthHandlers) WithMinter(minter appcreds.SharedMinter) *SCMOAuthHandlers {
 	h.minter = minter
+	return h
+}
+
+// WithStateStore wires in the session state store used to mint and redeem OAuth
+// state nonces. This is the same store the OIDC/SAML login flows use, so the
+// two OAuth flows share one implementation of "unguessable, server-side,
+// single-use, expiring".
+//
+// Without it both InitiateOAuth and HandleOAuthCallback fail closed: there is no
+// safe fallback, because a state this server cannot verify it issued is not a
+// credential, and the callback has no other binding to a principal.
+func (h *SCMOAuthHandlers) WithStateStore(store auth.StateStore) *SCMOAuthHandlers {
+	h.stateStore = store
 	return h
 }
 
@@ -122,8 +152,34 @@ func (h *SCMOAuthHandlers) InitiateOAuth(c *gin.Context) {
 		return
 	}
 
+	// Mint a single-use state nonce bound server-side to this user and provider.
+	// The callback is unauthenticated, so this nonce is the sole thing tying a
+	// returning authorization code to the principal who started the flow: it has
+	// to be an unguessable credential, not a rendering of ids the caller already
+	// knows. Same generateState() + StateStore the login flow uses.
+	if h.stateStore == nil {
+		slog.Error("SCM OAuth state store not configured; refusing to start flow")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "OAuth state store not configured"})
+		return
+	}
+	state, err := generateState()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate OAuth state"})
+		return
+	}
+	if err := h.stateStore.Save(c.Request.Context(), state, &auth.SessionState{
+		State:         state,
+		CreatedAt:     time.Now(),
+		ProviderType:  scmStateProviderType,
+		SCMUserID:     userID.String(),
+		SCMProviderID: providerID.String(),
+	}, scmStateTTL); err != nil {
+		slog.Error("failed to save SCM OAuth state", "provider_id", providerID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save OAuth state"})
+		return
+	}
+
 	// Generate authorization URL
-	state := fmt.Sprintf("%s:%s", userID, providerID)
 	authURL := connector.AuthorizationEndpoint(state, []string{})
 
 	c.JSON(http.StatusOK, gin.H{
@@ -138,9 +194,9 @@ func (h *SCMOAuthHandlers) InitiateOAuth(c *gin.Context) {
 // @Produce      json
 // @Param        id     path   string  true  "SCM provider ID (UUID)"
 // @Param        code   query  string  true  "Authorization code from SCM provider"
-// @Param        state  query  string  true  "State parameter (userID:providerID)"
+// @Param        state  query  string  true  "Single-use state nonce issued by /oauth/authorize (64 hex chars)"
 // @Success      302    "Redirect to frontend success page"
-// @Failure      400  {object}  map[string]interface{}  "Invalid provider ID, code, or state"
+// @Failure      400  {object}  map[string]interface{}  "Invalid provider ID or code; or state that is unknown, expired, already used, or minted for a different provider"
 // @Failure      404  {object}  map[string]interface{}  "Provider not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/scm-providers/{id}/oauth/callback [get]
@@ -162,15 +218,77 @@ func (h *SCMOAuthHandlers) HandleOAuthCallback(c *gin.Context) {
 		return
 	}
 
-	// Parse state to get user ID (format: "userID:providerID")
-	stateParts := strings.SplitN(state, ":", 2)
-	if len(stateParts) != 2 {
+	// GUARD (scm-oauth-callback): resolve the principal from the server-side
+	// session state, never from the request.
+	//
+	// This route carries no auth middleware, so `state` is the whole credential.
+	// Before this guard existed it was fmt.Sprintf("%s:%s", userID, providerID)
+	// — two UUIDs, guessable, never stored, never single-use — and the handler
+	// parsed the user id straight out of it. That was exploitable in BOTH
+	// directions:
+	//   - attacker → victim: complete OAuth against the attacker's own SCM
+	//     account, submit the code with state=<victim-uuid>:anything, and
+	//     scm_oauth_tokens' ON CONFLICT (user_id, scm_provider_id) DO UPDATE
+	//     replaces the victim's stored token with the attacker's;
+	//   - victim → attacker: lure the victim through an authorize URL carrying
+	//     state=<attacker-uuid>:… and the victim's freshly minted SCM token is
+	//     filed under the attacker's user id.
+	// Either way the connector is a module-publishing source path, so this is a
+	// supply-chain injection route, not just an account-linking nuisance.
+	//
+	// Load is read-consuming in both StateStore backends, so a replay finds
+	// nothing; a state that was never issued finds nothing; the TTL plus the
+	// CreatedAt bound below reject a stale one.
+	if h.stateStore == nil {
+		slog.Error("SCM OAuth state store not configured; refusing callback")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "OAuth state store not configured"})
+		return
+	}
+	if state == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing state parameter"})
+		return
+	}
+	sessionState, err := h.stateStore.Load(c.Request.Context(), state)
+	if err != nil {
+		slog.Error("failed to load SCM OAuth state", "provider_id", providerID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate state parameter"})
+		return
+	}
+	if sessionState == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid, expired, or already-used state parameter"})
+		return
+	}
+	// Belt-and-braces: consume it explicitly in case a future StateStore
+	// implementation is not read-consuming (mirrors CallbackHandler).
+	_ = h.stateStore.Delete(c.Request.Context(), state)
+
+	// A login state must not be redeemable here. Only states minted by
+	// InitiateOAuth carry this provider type — and only those carry an SCMUserID.
+	if sessionState.ProviderType != scmStateProviderType {
+		slog.Warn("SCM OAuth callback presented a non-SCM state",
+			"provider_id", providerID, "state_provider_type", sessionState.ProviderType)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state parameter"})
 		return
 	}
-	userID, err := uuid.Parse(stateParts[0])
+	if time.Since(sessionState.CreatedAt) > scmStateMaxAge {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid, expired, or already-used state parameter"})
+		return
+	}
+	// The state is bound to one provider. A state minted for provider A must not
+	// be redeemable at provider B's callback, which would file a token obtained
+	// from one SCM under a different provider's connection.
+	if sessionState.SCMProviderID != providerID.String() {
+		slog.Warn("SCM OAuth state provider mismatch",
+			"path_provider_id", providerID, "state_provider_id", sessionState.SCMProviderID)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "state parameter does not match this provider"})
+		return
+	}
+	// The principal. Taken from the stored record this server wrote at authorize
+	// time, never from the request.
+	userID, err := uuid.Parse(sessionState.SCMUserID)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID in state"})
+		slog.Error("SCM OAuth state carries an unparseable user id", "provider_id", providerID)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state parameter"})
 		return
 	}
 

--- a/backend/internal/api/admin/scm_oauth_test.go
+++ b/backend/internal/api/admin/scm_oauth_test.go
@@ -3,9 +3,9 @@ package admin
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -44,7 +45,8 @@ func newSCMOAuthRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	t.Cleanup(func() { db.Close() })
 
 	scmRepo := repositories.NewSCMRepository(sqlx.NewDb(db, "sqlmock"))
-	h := NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil)
+	h := NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil).
+		WithStateStore(newOAuthTestStateStore(t))
 
 	r := gin.New()
 	r.GET("/scm-providers/:id/oauth/authorize", h.InitiateOAuth)
@@ -368,7 +370,45 @@ func TestGetTokenStatus_DBError(t *testing.T) {
 // InitiateOAuth — provider DB paths
 // ---------------------------------------------------------------------------
 
+// mintSCMOAuthState saves a state the way InitiateOAuth does and returns the
+// plaintext nonce. createdAt lets a test age the state past the callback's
+// freshness bound.
+func mintSCMOAuthState(t *testing.T, store auth.StateStore, userID, providerID string, createdAt time.Time) string {
+	t.Helper()
+	state, err := generateState()
+	if err != nil {
+		t.Fatalf("generateState: %v", err)
+	}
+	if err := store.Save(t.Context(), state, &auth.SessionState{
+		State:         state,
+		CreatedAt:     createdAt,
+		ProviderType:  scmStateProviderType,
+		SCMUserID:     userID,
+		SCMProviderID: providerID,
+	}, scmStateTTL); err != nil {
+		t.Fatalf("state store Save: %v", err)
+	}
+	return state
+}
+
+// newOAuthTestStateStore returns an in-memory session state store for SCM OAuth
+// tests. The SCM connector flow shares the login flow's StateStore, so handlers
+// under test need one wired or they fail closed.
+func newOAuthTestStateStore(t *testing.T) auth.StateStore {
+	t.Helper()
+	s := auth.NewMemoryStateStore(time.Minute)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
 func newSCMOAuthRouterWithUser(t *testing.T, userUUID string) (sqlmock.Sqlmock, *gin.Engine) {
+	mock, r, _ := newSCMOAuthRouterWithState(t, userUUID)
+	return mock, r
+}
+
+// newSCMOAuthRouterWithState is newSCMOAuthRouterWithUser plus a handle on the
+// state store, for tests that need to mint or inspect an OAuth state.
+func newSCMOAuthRouterWithState(t *testing.T, userUUID string) (sqlmock.Sqlmock, *gin.Engine, auth.StateStore) {
 	t.Helper()
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -376,8 +416,9 @@ func newSCMOAuthRouterWithUser(t *testing.T, userUUID string) (sqlmock.Sqlmock, 
 	}
 	t.Cleanup(func() { db.Close() })
 
+	store := newOAuthTestStateStore(t)
 	scmRepo := repositories.NewSCMRepository(sqlx.NewDb(db, "sqlmock"))
-	h := NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil)
+	h := NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil).WithStateStore(store)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -387,7 +428,7 @@ func newSCMOAuthRouterWithUser(t *testing.T, userUUID string) (sqlmock.Sqlmock, 
 	r.GET("/scm-providers/:id/oauth/authorize", h.InitiateOAuth)
 	r.GET("/scm-providers/:id/oauth/callback", h.HandleOAuthCallback)
 	r.POST("/scm-providers/:id/token", h.SavePATToken)
-	return mock, r
+	return mock, r, store
 }
 
 const oauthUserUUID = "00000000-0000-0000-0000-000000000002"
@@ -438,8 +479,10 @@ func TestInitiateOAuth_PATBasedProvider(t *testing.T) {
 // HandleOAuthCallback — additional paths
 // ---------------------------------------------------------------------------
 
+// TestHandleOAuthCallback_InvalidUserIDInState pins that a self-describing,
+// colon-separated pseudo-state — the shape the handler used to parse a principal
+// out of — is now simply an unknown state and is refused.
 func TestHandleOAuthCallback_InvalidUserIDInState(t *testing.T) {
-	// State has ":" but first part is not a UUID.
 	_, r := newSCMOAuthRouterWithUser(t, oauthUserUUID)
 
 	w := httptest.NewRecorder()
@@ -452,8 +495,11 @@ func TestHandleOAuthCallback_InvalidUserIDInState(t *testing.T) {
 }
 
 func TestHandleOAuthCallback_ProviderNotFound(t *testing.T) {
-	mock, r := newSCMOAuthRouterWithUser(t, oauthUserUUID)
-	state := oauthUserUUID + ":" + oauthProviderID
+	mock, r, store := newSCMOAuthRouterWithState(t, oauthUserUUID)
+
+	// A legitimately minted state, so the flow gets past the state guard and
+	// reaches the provider lookup this test is about.
+	state := mintSCMOAuthState(t, store, oauthUserUUID, oauthProviderID, time.Now())
 
 	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
 		WillReturnRows(sqlmock.NewRows(scmProvCols))
@@ -614,7 +660,7 @@ func newSCMOAuthRouterWithCipher(t *testing.T, userUUID string, tc *crypto.Token
 			BaseURL: "http://localhost:8080",
 		},
 	}
-	h := NewSCMOAuthHandlers(cfg, scmRepo, nil, tc)
+	h := NewSCMOAuthHandlers(cfg, scmRepo, nil, tc).WithStateStore(newOAuthTestStateStore(t))
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -962,13 +1008,31 @@ func TestInitiateOAuth_OAuthProviderSuccess(t *testing.T) {
 	if !ok || authURL == "" {
 		t.Errorf("authorization_url missing or empty in response: %v", resp)
 	}
-	if _, ok := resp["state"].(string); !ok {
+	state, ok := resp["state"].(string)
+	if !ok || state == "" {
 		t.Errorf("state missing in response: %v", resp)
 	}
-	// Verify the state format is "userID:providerID"
-	expectedState := fmt.Sprintf("%s:%s", oauthUserUUID, oauthProviderID)
-	if resp["state"] != expectedState {
-		t.Errorf("state = %q, want %q", resp["state"], expectedState)
+	// The state must be an opaque random nonce, NOT a rendering of ids the
+	// caller already knows. This assertion used to require exactly the opposite
+	// — state == fmt.Sprintf("%s:%s", oauthUserUUID, oauthProviderID) — which is
+	// the vulnerability: the callback is unauthenticated and parsed its
+	// principal straight out of that string.
+	if strings.Contains(state, oauthUserUUID) || strings.Contains(state, oauthProviderID) {
+		t.Errorf("state %q leaks a principal-derived value; want an opaque nonce", state)
+	}
+	if strings.Contains(state, ":") {
+		t.Errorf("state %q is structured; want an opaque nonce", state)
+	}
+	if len(state) < 32 {
+		t.Errorf("state %q is only %d chars; want >= 32 chars of encoded entropy", state, len(state))
+	}
+	// The same nonce must be what the user is actually redirected with.
+	parsed, parseErr := url.Parse(authURL)
+	if parseErr != nil {
+		t.Fatalf("url.Parse(authorization_url): %v", parseErr)
+	}
+	if got := parsed.Query().Get("state"); got != state {
+		t.Errorf("authorization_url state = %q, want the minted %q", got, state)
 	}
 }
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -493,7 +493,12 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 
 	// Initialize SCM handlers with the already-created repositories and token cipher
 	scmProviderHandlers := admin.NewSCMProviderHandlers(cfg, scmRepo, orgRepo, tokenCipher).WithMinter(sharedMinter).WithEgressGuard(egressGuard)
-	scmOAuthHandlers := admin.NewSCMOAuthHandlers(cfg, scmRepo, userRepo, tokenCipher).WithMinter(sharedMinter)
+	// The SCM connector flow shares the login flow's state store: its callback is
+	// unauthenticated, so its `state` must be an unguessable, server-side,
+	// single-use nonce exactly like the OIDC login state.
+	scmOAuthHandlers := admin.NewSCMOAuthHandlers(cfg, scmRepo, userRepo, tokenCipher).
+		WithMinter(sharedMinter).
+		WithStateStore(oidcStateStore)
 	scmLinkingHandler := modules.NewSCMLinkingHandler(scmRepo, moduleRepo, tokenCipher, cfg.Server.BaseURL, scmPublisher).WithMinter(sharedMinter)
 
 	// Initialize storage configuration handlers

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -896,8 +896,18 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				scmProvidersGroup.GET("/:id/repositories/:owner/:repo/branches", middleware.RequireScope(auth.ScopeSCMRead), scmProviderOrg(auth.ScopeSCMRead), scmOAuthHandlers.ListRepositoryBranches)
 			}
 
-			// SCM OAuth callback (public endpoint, no auth required)
-			apiV1.GET("/scm-providers/:id/oauth/callback", scmOAuthHandlers.HandleOAuthCallback)
+			// SCM OAuth callback (public endpoint, no auth required).
+			//
+			// The caller is anonymous, so possession of the single-use state
+			// nonce minted by /oauth/authorize is the whole credential — see
+			// HandleOAuthCallback's GUARD (scm-oauth-callback). It is rate
+			// limited on the same authRateLimiter as /api/v1/auth/*, the other
+			// family of unauthenticated credential-redeeming routes: without a
+			// limiter an anonymous caller may grind state guesses (and drive
+			// upstream token-endpoint exchanges) at will.
+			apiV1.GET("/scm-providers/:id/oauth/callback",
+				middleware.RateLimitMiddleware(authRateLimiter),
+				scmOAuthHandlers.HandleOAuthCallback)
 
 			// Module SCM linking endpoints. Every route requires namespace-org
 			// authorization for the target module (issue #555): the reads are

--- a/backend/internal/api/unauth_principal_class_test.go
+++ b/backend/internal/api/unauth_principal_class_test.go
@@ -1,0 +1,515 @@
+// unauth_principal_class_test.go is the class test for the defect class
+//
+//	"an unauthenticated endpoint derives a principal from a caller-supplied
+//	 value that is not a credential"
+//
+// The live instance was GET /api/v1/scm-providers/:id/oauth/callback: registered
+// bare on apiV1 with no auth middleware and no rate limiter, its only binding to
+// a principal was an OAuth `state` of fmt.Sprintf("%s:%s", userID, providerID) —
+// two UUIDs, not random, not stored server-side, not single-use, no expiry, and
+// with the provider half never compared to anything. The handler parsed the user
+// id out of the request and wrote scm_oauth_tokens, whose
+// ON CONFLICT (user_id, scm_provider_id) DO UPDATE overwrote the victim's row.
+//
+// The class invariant this file pins, for EVERY unauthenticated route that
+// resolves a principal:
+//
+//	the principal must come from a server-side row looked up by an unguessable
+//	secret, and that lookup must reject a value that was never issued, has
+//	expired, has already been redeemed, or was minted for a different resource —
+//	before any identity-keyed write happens.
+//
+// The table below carries one row per enumerated site. Sites are enumerated by
+// the signature described in the batch-C fix report: every route whose gin
+// middleware chain contains no auth middleware, intersected with those whose
+// handler resolves a principal. Scenarios that do not apply to a site are
+// recorded explicitly rather than silently omitted.
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/api/admin"
+	"github.com/terraform-registry/terraform-registry/internal/api/webhooks"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// ---------------------------------------------------------------------------
+// Scenarios — the four ways a non-credential must be refused.
+// ---------------------------------------------------------------------------
+
+type classScenario string
+
+const (
+	scenNeverIssued      classScenario = "never-issued state rejected before any token write"
+	scenReplayed         classScenario = "replayed state rejected the second time"
+	scenExpired          classScenario = "expired state rejected"
+	scenResourceMismatch classScenario = "state whose stored resource id does not match the path rejected"
+)
+
+// classSite is one enumerated unauthenticated principal-resolving route.
+type classSite struct {
+	// name is the site's stable identifier, also used by the mutation matrix.
+	name string
+	// route is the production registration this site stands for.
+	route string
+	// guardLine is the single line of source that refuses the non-credential.
+	// Mutating it must make this site's rows fail — that is what proves the
+	// rows test the guard rather than incidental behaviour.
+	guardLine string
+	// wantStatus is the status the GUARD produces. It is asserted exactly, not
+	// as ">= 400": a mutated guard typically still errors out further down the
+	// handler (provider-not-found, decrypt failure) and a loose ">= 400" check
+	// would call that a pass. The specific code is what distinguishes "the
+	// non-credential was refused" from "the attack proceeded and then tripped
+	// over something else".
+	wantStatus int
+	// wantBodyContains, when set, additionally pins that the rejection came
+	// from the state/secret check rather than from some later failure.
+	wantBodyContains string
+	// wantBody overrides wantBodyContains per scenario. This is load-bearing,
+	// not decoration: mutation testing showed that for oidc-auth-callback a
+	// removed guard still yields 400 (the flow runs on and fails at
+	// "provider_not_configured"), so status alone scored a removed guard as a
+	// pass. Pinning the guard's own message is what makes the row fail.
+	wantBody map[classScenario]string
+	// exercise runs one scenario. It returns the response and a bool reporting
+	// whether the scenario applies to this site; false means "not applicable",
+	// with the reason recorded in naReason.
+	exercise func(t *testing.T, scen classScenario) (*httptest.ResponseRecorder, bool)
+	// naReason explains, per scenario, why an inapplicable scenario is absent.
+	naReason map[classScenario]string
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+func classRandomHex64(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
+
+// classRandomState mints a state in the same encoding the login and SCM flows
+// use (32 bytes crypto/rand, base64url).
+func classRandomState(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func classHash(plain string) string {
+	sum := sha256.Sum256([]byte(plain))
+	return hex.EncodeToString(sum[:])
+}
+
+func classSQLMock(t *testing.T) (*sqlx.DB, *sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlx.NewDb(db, "sqlmock"), db, mock
+}
+
+var classModuleSourceRepoCols = []string{
+	"id", "module_id", "scm_provider_id",
+	"repository_owner", "repository_name", "repository_url",
+	"default_branch", "module_path", "tag_pattern",
+	"auto_publish", "webhook_id", "webhook_url",
+	"webhook_enabled", "last_sync_at", "last_sync_commit",
+	"created_at", "updated_at",
+}
+
+// ---------------------------------------------------------------------------
+// Site 1 — GET /api/v1/scm-providers/:id/oauth/callback   (THE FIXED INSTANCE)
+// ---------------------------------------------------------------------------
+
+func exerciseSCMOAuthCallback(t *testing.T, scen classScenario) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	sqlxDB, _, mock := classSQLMock(t)
+
+	store := auth.NewMemoryStateStore(time.Minute)
+	t.Cleanup(func() { _ = store.Close() })
+
+	scmRepo := repositories.NewSCMRepository(sqlxDB)
+	h := admin.NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil).WithStateStore(store)
+
+	r := gin.New()
+	r.GET("/api/v1/scm-providers/:id/oauth/callback", h.HandleOAuthCallback)
+
+	ctx := t.Context()
+	pathProviderID := uuid.New()
+	victimUserID := uuid.New()
+	state := classRandomState(t)
+
+	mint := func(providerID uuid.UUID, createdAt time.Time) {
+		if err := store.Save(ctx, state, &auth.SessionState{
+			State:         state,
+			CreatedAt:     createdAt,
+			ProviderType:  "scm",
+			SCMUserID:     victimUserID.String(),
+			SCMProviderID: providerID.String(),
+		}, 10*time.Minute); err != nil {
+			t.Fatalf("state store Save: %v", err)
+		}
+	}
+
+	switch scen {
+	case scenNeverIssued:
+		// Nothing minted — the attacker invented the state, exactly as they
+		// could when it was just "<victim-uuid>:<provider-uuid>".
+
+	case scenReplayed:
+		mint(pathProviderID, time.Now())
+		// Load is read-consuming, so a legitimate first redemption burns it.
+		if _, err := store.Load(ctx, state); err != nil {
+			t.Fatalf("first Load: %v", err)
+		}
+
+	case scenExpired:
+		mint(pathProviderID, time.Now().Add(-30*time.Minute))
+
+	case scenResourceMismatch:
+		// A state legitimately minted for a DIFFERENT provider, replayed at
+		// this provider's callback path.
+		mint(uuid.New(), time.Now())
+	}
+
+	// Deliberately program NO db expectations. Any provider lookup or any write
+	// to scm_oauth_tokens would be an unexpected call — the guard must reject
+	// before the handler reaches the database at all, which is the "rejected
+	// BEFORE any token write" half of the assertion.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+		"/api/v1/scm-providers/"+pathProviderID.String()+
+			"/oauth/callback?code=attacker-code&state="+url.QueryEscape(state), nil))
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("db expectations: %v", err)
+	}
+	return w, true
+}
+
+// ---------------------------------------------------------------------------
+// Site 2 — POST /webhooks/approvals/:token   (the pattern site 1 now mirrors)
+// ---------------------------------------------------------------------------
+
+func exerciseApprovalRedeem(t *testing.T, scen classScenario) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	if scen == scenResourceMismatch {
+		return nil, false
+	}
+	sqlxDB, _, mock := classSQLMock(t)
+
+	h := webhooks.NewApprovalHandler(repositories.NewRBACRepository(sqlxDB))
+	r := gin.New()
+	r.POST("/webhooks/approvals/:token", h.RedeemApprovalToken)
+
+	token := classRandomHex64(t)
+	cols := []string{"approval_request_id", "expires_at", "used_at"}
+	sel := mock.ExpectQuery("SELECT approval_request_id").WithArgs(classHash(token))
+
+	switch scen {
+	case scenNeverIssued:
+		sel.WillReturnError(sql.ErrNoRows)
+	case scenReplayed:
+		sel.WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			uuid.New(), time.Now().Add(time.Hour), time.Now()))
+	case scenExpired:
+		sel.WillReturnRows(sqlmock.NewRows(cols).AddRow(
+			uuid.New(), time.Now().Add(-time.Hour), nil))
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/webhooks/approvals/"+token, nil))
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("db expectations: %v", err)
+	}
+	return w, true
+}
+
+// ---------------------------------------------------------------------------
+// Site 3 — GET /api/v1/auth/callback   (OIDC login, StateStore-backed)
+// ---------------------------------------------------------------------------
+
+func exerciseOIDCCallback(t *testing.T, scen classScenario) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	if scen == scenResourceMismatch {
+		return nil, false
+	}
+	_, rawDB, _ := classSQLMock(t)
+
+	store := auth.NewMemoryStateStore(time.Minute)
+	t.Cleanup(func() { _ = store.Close() })
+
+	h, err := admin.NewAuthHandlers(&config.Config{}, rawDB, nil, nil, store)
+	if err != nil {
+		t.Fatalf("NewAuthHandlers: %v", err)
+	}
+	r := gin.New()
+	r.GET("/api/v1/auth/callback", h.CallbackHandler())
+
+	state := classRandomHex64(t)
+	ctx := t.Context()
+
+	switch scen {
+	case scenNeverIssued:
+		// Nothing saved: the caller invented the state.
+	case scenReplayed:
+		if err := store.Save(ctx, state, &auth.SessionState{
+			State: state, CreatedAt: time.Now(), ProviderType: "oidc",
+		}, 10*time.Minute); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		// Load is consuming, so the first redemption burns it.
+		if _, err := store.Load(ctx, state); err != nil {
+			t.Fatalf("first Load: %v", err)
+		}
+	case scenExpired:
+		// Present in the store but older than the handler's 5-minute bound.
+		if err := store.Save(ctx, state, &auth.SessionState{
+			State: state, CreatedAt: time.Now().Add(-10 * time.Minute), ProviderType: "oidc",
+		}, 10*time.Minute); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+		"/api/v1/auth/callback?code=attacker-code&state="+state, nil))
+	return w, true
+}
+
+// ---------------------------------------------------------------------------
+// Site 4 — POST /webhooks/scm/:module_source_repo_id/:secret
+// ---------------------------------------------------------------------------
+
+func exerciseSCMWebhook(t *testing.T, scen classScenario) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	// A webhook secret is a long-lived shared credential by design: it is
+	// re-presented on every delivery, so single-use and expiry are not part of
+	// its contract. Only the never-issued scenario applies.
+	if scen != scenNeverIssued {
+		return nil, false
+	}
+	sqlxDB, _, mock := classSQLMock(t)
+
+	cipher, err := crypto.NewTokenCipher([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	h := webhooks.NewSCMWebhookHandler(repositories.NewSCMRepository(sqlxDB), nil, cipher)
+	r := gin.New()
+	r.POST("/webhooks/scm/:module_source_repo_id/:secret", h.HandleWebhook)
+
+	linkID := uuid.New()
+	providerID := uuid.New()
+	storedURL := "https://registry.example.com/webhooks/scm/" + linkID.String() + "/" + classRandomHex64(t)
+
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
+		WithArgs(linkID).
+		WillReturnRows(sqlmock.NewRows(classModuleSourceRepoCols).AddRow(
+			linkID, uuid.New(), providerID,
+			"my-org", "my-repo", nil,
+			"main", "", "v*",
+			false, nil, storedURL,
+			false, nil, nil,
+			time.Now(), time.Now(),
+		))
+	// No provider lookup is programmed: the secret must be refused first.
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		"/webhooks/scm/"+linkID.String()+"/"+classRandomHex64(t), nil))
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("db expectations: %v", err)
+	}
+	return w, true
+}
+
+// ---------------------------------------------------------------------------
+// The class table
+// ---------------------------------------------------------------------------
+
+func classSites() []classSite {
+	return []classSite{
+		{
+			name:       "scm-oauth-callback",
+			route:      "GET /api/v1/scm-providers/:id/oauth/callback",
+			guardLine:  "internal/api/admin/scm_oauth.go — GUARD (scm-oauth-callback): stateStore.Load nil-check + ProviderType check + CreatedAt bound + sessionState.SCMProviderID != providerID; principal from sessionState.SCMUserID",
+			exercise:   exerciseSCMOAuthCallback,
+			wantStatus: http.StatusBadRequest,
+			wantBody: map[classScenario]string{
+				scenNeverIssued:      "invalid, expired, or already-used state parameter",
+				scenReplayed:         "invalid, expired, or already-used state parameter",
+				scenExpired:          "invalid, expired, or already-used state parameter",
+				scenResourceMismatch: "state parameter does not match this provider",
+			},
+		},
+		{
+			name:             "webhook-approval-redeem",
+			route:            "POST /webhooks/approvals/:token",
+			guardLine:        "internal/db/repositories/rbac_repository.go — RedeemApprovalToken: used_at/expires_at checks + UPDATE ... WHERE used_at IS NULL",
+			exercise:         exerciseApprovalRedeem,
+			wantStatus:       http.StatusNotFound,
+			wantBodyContains: "Token not found, already used, or expired",
+			naReason: map[classScenario]string{
+				scenResourceMismatch: "the token is FK-bound to exactly one approval_request_id and the route carries no second resource id to cross-check",
+			},
+		},
+		{
+			name:       "oidc-auth-callback",
+			route:      "GET /api/v1/auth/callback",
+			guardLine:  "internal/api/admin/auth.go — CallbackHandler: stateStore.Load(state) nil-check + time.Since(sessionState.CreatedAt) > 5*time.Minute",
+			exercise:   exerciseOIDCCallback,
+			wantStatus: http.StatusBadRequest,
+			wantBody: map[classScenario]string{
+				scenNeverIssued: "Invalid state parameter",
+				scenReplayed:    "Invalid state parameter",
+				scenExpired:     "Login session expired",
+			},
+			naReason: map[classScenario]string{
+				scenResourceMismatch: "the route has no resource path parameter; the provider is read from the stored session state itself",
+			},
+		},
+		{
+			name:             "scm-webhook",
+			route:            "POST /webhooks/scm/:module_source_repo_id/:secret",
+			guardLine:        "internal/api/webhooks/scm_webhook.go — subtle.ConstantTimeCompare(storedSecret, requestSecret) != 1",
+			exercise:         exerciseSCMWebhook,
+			wantStatus:       http.StatusUnauthorized,
+			wantBodyContains: "invalid webhook secret",
+			naReason: map[classScenario]string{
+				scenReplayed:         "a webhook secret is long-lived and re-presented on every delivery; single-use is not its contract",
+				scenExpired:          "a webhook secret has no expiry by design; it is rotated by relinking the module",
+				scenResourceMismatch: "the secret is stored on the very row the path id selects, so the binding is the lookup itself",
+			},
+		},
+	}
+}
+
+// TestUnauthenticatedPrincipalDerivation_Class asserts the class invariant at
+// every enumerated site: a caller-supplied value that is not a credential must
+// be refused, and refused before any identity-keyed write.
+func TestUnauthenticatedPrincipalDerivation_Class(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	scenarios := []classScenario{
+		scenNeverIssued, scenReplayed, scenExpired, scenResourceMismatch,
+	}
+
+	for _, site := range classSites() {
+		for _, scen := range scenarios {
+			t.Run(site.name+"/"+string(scen), func(t *testing.T) {
+				w, applies := site.exercise(t, scen)
+				if !applies {
+					reason := site.naReason[scen]
+					if reason == "" {
+						t.Fatalf("site %s reported scenario %q inapplicable with no recorded reason",
+							site.name, scen)
+					}
+					t.Skipf("not applicable: %s", reason)
+					return
+				}
+				// Asserted exactly, not as ">= 400". A mutated guard usually
+				// still errors further down the handler (provider-not-found,
+				// decrypt failure, unexpected-DB-call), and a loose check would
+				// score that as a pass. The exact code is what distinguishes
+				// "the non-credential was refused by the guard" from "the
+				// attack proceeded and then tripped over something else".
+				if w.Code != site.wantStatus {
+					t.Fatalf("site %s scenario %q: status = %d, want %d — "+
+						"the guard did not refuse this non-credential.\nguard: %s\nroute: %s\nbody: %s",
+						site.name, scen, w.Code, site.wantStatus,
+						site.guardLine, site.route, w.Body.String())
+				}
+				want := site.wantBodyContains
+				if s, ok := site.wantBody[scen]; ok {
+					want = s
+				}
+				if want == "" {
+					t.Fatalf("site %s scenario %q has no expected guard message; "+
+						"without one a removed guard that still 4xxs further down "+
+						"the handler would score as a pass", site.name, scen)
+				}
+				if !strings.Contains(w.Body.String(), want) {
+					t.Fatalf("site %s scenario %q: body %q does not contain %q — "+
+						"the rejection did not come from the guard.\nguard: %s",
+						site.name, scen, w.Body.String(), want, site.guardLine)
+				}
+			})
+		}
+	}
+}
+
+// TestUnauthenticatedPrincipalDerivation_NoConstructedState is the signature
+// half of the class test: it fails if any handler ever again renders a principal
+// into a state/nonce value instead of minting one from crypto/rand. The original
+// defect was exactly one line — state := fmt.Sprintf("%s:%s", userID, providerID).
+func TestUnauthenticatedPrincipalDerivation_NoConstructedState(t *testing.T) {
+	// InitiateOAuth must produce a 64-hex-char random state, never a rendering
+	// of ids the caller already knows.
+	sqlxDB, _, mock := classSQLMock(t)
+	scmRepo := repositories.NewSCMRepository(sqlxDB)
+	h := admin.NewSCMOAuthHandlers(&config.Config{}, scmRepo, nil, nil)
+
+	providerID := uuid.New()
+	userID := uuid.New()
+
+	r := gin.New()
+	r.GET("/scm-providers/:id/oauth/authorize", func(c *gin.Context) {
+		c.Set("user_id", userID.String())
+		h.InitiateOAuth(c)
+	})
+
+	// Provider lookup fails, so the handler returns before minting — but that is
+	// enough to pin that no state is derivable from the request either.
+	mock.ExpectQuery("SELECT").WillReturnError(sql.ErrNoRows)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+		"/scm-providers/"+providerID.String()+"/oauth/authorize", nil))
+
+	if body := w.Body.String(); containsAny(body, userID.String(), providerID.String()+":") {
+		t.Errorf("authorize response echoes a principal-derived state: %s", body)
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		for i := 0; i+len(n) <= len(haystack); i++ {
+			if haystack[i:i+len(n)] == n {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/backend/internal/auth/statestore.go
+++ b/backend/internal/auth/statestore.go
@@ -30,6 +30,17 @@ type SessionState struct {
 	// SAML login. It is echoed back by the IdP as InResponseTo and validated
 	// at the ACS to bind the assertion to a request this SP actually made.
 	SAMLRequestID string `json:"saml_request_id,omitempty"`
+	// SCMUserID is the already-authenticated user who started an SCM connector
+	// authorization flow (GET /api/v1/scm-providers/:id/oauth/authorize). That
+	// flow's callback carries no auth middleware, so this stored value — not
+	// anything in the callback request — is the only legitimate source of the
+	// principal whose scm_oauth_tokens row the callback writes. Set only when
+	// ProviderType is "scm".
+	SCMUserID string `json:"scm_user_id,omitempty"`
+	// SCMProviderID is the SCM provider the state was minted for. The callback
+	// rejects a state whose provider does not match its :id path parameter, so
+	// a state issued for one provider cannot file a token under another.
+	SCMProviderID string `json:"scm_provider_id,omitempty"`
 }
 
 // StateStore is the interface for OIDC session state persistence.


### PR DESCRIPTION
Aligns the SCM connector's OAuth flow with the login flow's state handling.

## Background

This repository has two OAuth flows. The login flow (`GET /api/v1/auth/callback`) uses `internal/auth.StateStore`: `state` is 32 bytes from `crypto/rand`, saved server-side with a TTL, and `Load` is read-consuming in both the Redis and in-memory backends, so a value is usable exactly once.

The SCM connector flow did not use that store. It built its `state` as a formatted string from values it already had, and the callback read the acting user back out of that string.

## Change

The SCM flow now uses the same `StateStore` as the login flow:

- `InitiateOAuth` mints `state` with the existing `generateState()` helper and saves it with a short TTL, alongside the initiating user and the provider the authorization was started for.
- `HandleOAuthCallback` looks the state up, and rejects when it is unknown, already consumed, stale, or was issued for a different provider than the one in the path.
- The acting user is taken from the **stored record**, never from the request.
- The route gets `RateLimitMiddleware`, which it previously lacked.

`auth.SessionState` gains two optional fields so one store serves both flows. A second nonce table and migration were prototyped and then discarded — there was no property `StateStore` did not already provide, and a third mechanism would have left the two flows divergent, which is the thing being fixed.

## Scope

A sweep of every route in this repository, `terraform-state-manager-backend` and `terraform-suite-identity` that reaches a handler without an authenticating middleware found no other flow deriving an actor from a request-supplied value. The login callback, SAML ACS, both setup wizards, both webhook receivers and the state-manager's run callbacks each resolve their principal from a server-issued secret verified before any effect. This change is a one-off alignment, not a pattern rollout.

Two follow-ups are recorded and deliberately not in this PR:

- `terraform-suite-identity`'s `oidc.Provider.BeginAuth(state)` accepts an opaque caller-supplied state and offers no verification counterpart. A store-and-consume helper there would make the whole shape unrepresentable in both apps.
- `internal/api/admin/mirror.go`'s `MirrorHandler.RegisterRoutes` registers eight routes with no middleware. It currently has **no callers**, so it is not live — but it is worth removing or gating before anyone wires it up.

## Verification

61 test packages pass; `go build`, `go vet` and `gofmt` clean.

`backend/internal/api/unauth_principal_class_test.go` is table-driven over four routes × four scenarios — unknown state, replayed state, stale state, and a state issued for a different resource — with rows that do not apply recorded as such with a reason, and a runner that fails if a row claims not-applicable without one.

Every row was verified to fail when its own guard is mutated. The first mutation run **failed honestly**: three rows passed with the guard removed, because under a bare test config the callback returns the same status either way, so asserting on status alone scored a removed guard as a pass. Each scenario now pins the specific message its guard emits, and a row with no expected message is a hard failure. All seven mutations detected on re-run.
