### PR TITLE
fix(auth): revoke the session JWT on logout

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -579,10 +579,16 @@ func (h *AuthHandlers) LogoutPostHandler() gin.HandlerFunc {
 // endSession performs the teardown both logout routes share — revoke the JWT,
 // clear the auth and CSRF cookies — and returns where the caller should end up.
 // Kept as one function so the two verbs cannot drift apart.
+//
+// The revocation reads the claims the auth middleware resolved for this request,
+// so the route must be mounted under one that publishes them (issue #764): a
+// logout that only clears cookies leaves the JWT usable for the rest of its TTL
+// from anywhere it is still held. See the mount in router_routes.go, which uses
+// optional auth so the no-session and expired-token cases still succeed here.
 func (h *AuthHandlers) endSession(c *gin.Context) string {
 	{
 		// Revoke the current JWT if present
-		if claims, exists := c.Get("jwt_claims"); exists {
+		if claims, exists := c.Get("jwt_claims"); exists && h.tokenRepo != nil {
 			if jwtClaims, ok := claims.(*auth.Claims); ok && jwtClaims.JTI != "" {
 				if jwtClaims.ExpiresAt != nil {
 					_ = h.tokenRepo.RevokeToken(c.Request.Context(),

--- a/backend/internal/api/auth_logout_revocation_test.go
+++ b/backend/internal/api/auth_logout_revocation_test.go
@@ -1,0 +1,269 @@
+package api
+
+import (
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/api/admin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// Issue #764 — POST /api/v1/auth/logout must leave the presented JWT unusable.
+//
+// The invariant under test is "a completed logout ends the session", and the
+// only observable that carries it is the token's fate on the NEXT request. The
+// endpoint has always cleared the auth and CSRF cookies, so a test that asserts
+// cookie-clearing passes whether or not the JWT was revoked — which is exactly
+// why the gap survived: the route was mounted on the public group, nothing
+// populated the claims the handler revokes from, and the revocation branch was
+// unreachable while the endpoint reported success.
+//
+// Driven through the real registerAPIV1Routes rather than a stand-in engine
+// because the defect lived in the wiring: a test that mounts the middleware
+// itself passes while the product still hands back a live token. Same reasoning
+// as module_scm_routes_test.go and scim_routes_test.go.
+
+const (
+	logoutTestUserID = "user-logout-764"
+	logoutTestEmail  = "logout@example.com"
+)
+
+var logoutTestUserCols = []string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}
+
+var logoutTestMembershipCols = []string{
+	"organization_id", "organization_name",
+	"role_template_id", "created_at",
+	"role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+// revocationLedger is the state the revocation store would hold. It records
+// every JTI written by RevokeToken so the later "is this token revoked?" lookup
+// can be answered from what the logout request ACTUALLY persisted, rather than
+// from a hardcoded true. Without that link the replay assertion would pass on a
+// build where nothing is ever revoked.
+type revocationLedger struct {
+	mu   sync.Mutex
+	jtis map[string]struct{}
+}
+
+func newRevocationLedger() *revocationLedger {
+	return &revocationLedger{jtis: map[string]struct{}{}}
+}
+
+// Match implements sqlmock.Argument: it accepts any JTI and records it.
+func (l *revocationLedger) Match(v driver.Value) bool {
+	s, ok := v.(string)
+	if !ok {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.jtis[s] = struct{}{}
+	return true
+}
+
+func (l *revocationLedger) revoked(jti string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, ok := l.jtis[jti]
+	return ok
+}
+
+func logoutTestUserRows() *sqlmock.Rows {
+	return sqlmock.NewRows(logoutTestUserCols).
+		AddRow(logoutTestUserID, logoutTestEmail, "Logout Test", nil, time.Now(), time.Now())
+}
+
+// expectRevocationLookup programs the revoked-tokens probe both auth
+// middlewares make, answering it from the ledger.
+func expectRevocationLookup(mock sqlmock.Sqlmock, ledger *revocationLedger, jti string) {
+	mock.ExpectQuery("SELECT EXISTS.*FROM revoked_tokens WHERE jti").
+		WithArgs(jti).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(ledger.revoked(jti)))
+}
+
+// expectSessionLoad programs the queries an accepted session runs on
+// GET /api/v1/auth/me: AuthMiddleware's user load, then MeHandler's
+// GetUserWithOrgRoles (user + memberships).
+func expectSessionLoad(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT.*FROM users WHERE id").WillReturnRows(logoutTestUserRows())
+	mock.ExpectQuery("SELECT.*FROM users WHERE id").WillReturnRows(logoutTestUserRows())
+	mock.ExpectQuery("FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(logoutTestMembershipCols))
+}
+
+func TestLogout_RevokesPresentedToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// auth.GetJWTSecret panics outside dev mode without this — same rationale
+	// as module_scm_routes_test.go.
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	validToken, err := auth.GenerateJWT(logoutTestUserID, logoutTestEmail, nil, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+	validClaims, err := auth.ValidateJWT(validToken)
+	if err != nil {
+		t.Fatalf("ValidateJWT: %v", err)
+	}
+	expiredToken, err := auth.GenerateJWT(logoutTestUserID, logoutTestEmail, nil, -time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT (expired): %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		// token presented on the logout request; "" means no session cookie.
+		token string
+		// replay: re-present the same token on an authenticated route
+		// afterwards and require it to be rejected.
+		replay bool
+	}{
+		{
+			// The defect: this row is the only one that can see it.
+			name:   "valid session logs out then reuses the token",
+			token:  validToken,
+			replay: true,
+		},
+		{
+			// Logout is reachable without a session (cookie already gone,
+			// second tab, bookmarked POST) and must still tear down.
+			name:  "logout with no token at all",
+			token: "",
+		},
+		{
+			// An expired token cannot be revoked (its claims do not validate);
+			// logout must complete rather than fail the caller.
+			name:  "logout with an expired token",
+			token: expiredToken,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+			// Requests interleave middleware and handler queries; match on
+			// shape, not sequence.
+			mock.MatchExpectationsInOrder(false)
+
+			ledger := newRevocationLedger()
+
+			limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+				RequestsPerMinute: 600, BurstSize: 100, CleanupInterval: time.Minute,
+			})
+			defer limiter.Stop()
+
+			tokenRepo := repositories.NewTokenRepository(db)
+			cfg := &config.Config{}
+			cfg.Server.PublicURL = "https://registry.example.com"
+			authHandlers, err := admin.NewAuthHandlers(cfg, db, nil, tokenRepo,
+				auth.NewMemoryStateStore(time.Hour))
+			if err != nil {
+				t.Fatalf("NewAuthHandlers: %v", err)
+			}
+
+			r := gin.New()
+			r.Use(gin.Recovery())
+			registerAPIV1Routes(r, &apiV1RouteDeps{
+				cfg:                cfg,
+				db:                 db,
+				authHandlers:       authHandlers,
+				userRepo:           repositories.NewUserRepository(db),
+				tokenRepo:          tokenRepo,
+				authRateLimiter:    limiter,
+				generalRateLimiter: limiter,
+				orgRateLimiter:     limiter,
+			})
+
+			// Control: before logging out, the token is a working session.
+			if tc.replay {
+				expectRevocationLookup(mock, ledger, validClaims.JTI)
+				expectSessionLoad(mock)
+				if code, _ := doAuthedMe(r, tc.token); code != http.StatusOK {
+					t.Fatalf("pre-logout GET /api/v1/auth/me: status = %d, want 200 "+
+						"(the replay assertion is meaningless unless the token works first)", code)
+				}
+			}
+
+			// Logout.
+			if tc.token == validToken {
+				expectRevocationLookup(mock, ledger, validClaims.JTI)
+				mock.ExpectQuery("SELECT.*FROM users WHERE id").WillReturnRows(logoutTestUserRows())
+				// The write under test. The ledger argument records the JTI
+				// that reaches the revocation store.
+				mock.ExpectExec("INSERT INTO revoked_tokens").
+					WithArgs(ledger, sqlmock.AnyArg(), sqlmock.AnyArg()).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+			}
+
+			code, body := doLogout(r, tc.token)
+			if code != http.StatusOK {
+				t.Fatalf("POST /api/v1/auth/logout: status = %d, want 200; body=%s", code, body)
+			}
+			if !strings.Contains(body, "redirect_url") {
+				t.Errorf("logout body = %s, want a redirect_url", body)
+			}
+
+			if !tc.replay {
+				return
+			}
+
+			// The assertion that matters: the same token, presented again to
+			// an authenticated route, must be rejected. The revoked-tokens
+			// probe is answered from the ledger, so this can only pass if the
+			// logout request actually wrote the JTI to the store.
+			expectRevocationLookup(mock, ledger, validClaims.JTI)
+			expectSessionLoad(mock)
+
+			code, body = doAuthedMe(r, tc.token)
+			if code != http.StatusUnauthorized {
+				t.Errorf("post-logout GET /api/v1/auth/me: status = %d, want 401 "+
+					"(the JWT survived logout and is still a valid session); body=%s", code, body)
+			}
+			if !strings.Contains(strings.ToLower(body), "revoked") {
+				t.Errorf("post-logout GET /api/v1/auth/me: body = %s, want rejection on revocation", body)
+			}
+			if !ledger.revoked(validClaims.JTI) {
+				t.Errorf("logout did not write the session JTI to the revocation store")
+			}
+		})
+	}
+}
+
+// doLogout POSTs the real logout route with the double-submit CSRF pair the
+// public group requires, optionally carrying a session cookie.
+func doLogout(r *gin.Engine, token string) (int, string) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	const csrf = "csrf-token-value"
+	req.AddCookie(&http.Cookie{Name: middleware.CSRFCookieName, Value: csrf})
+	req.Header.Set(middleware.CSRFHeaderName, csrf)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: token})
+	}
+	r.ServeHTTP(w, req)
+	return w.Code, w.Body.String()
+}
+
+// doAuthedMe presents the token to an authenticated route.
+func doAuthedMe(r *gin.Engine, token string) (int, string) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/me", nil)
+	req.AddCookie(&http.Cookie{Name: "tfr_auth_token", Value: token})
+	r.ServeHTTP(w, req)
+	return w.Code, w.Body.String()
+}

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -499,7 +499,24 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// registerAuthenticatedGroupMiddleware's CSRFMiddleware — it has to
 			// be attached to this route explicitly, otherwise the POST form
 			// would be exactly as forgeable as the GET one it replaced.
-			authGroup.POST("/logout", middleware.CSRFMiddleware(cfg), authHandlers.LogoutPostHandler())
+			//
+			// It does not inherit an auth middleware either, and logout is a
+			// handler that has to act on the caller's own token: the invariant
+			// is that a completed logout leaves the presented JWT unusable, and
+			// endSession can only revoke a JTI the middleware chain resolved for
+			// it (issue #764). Optional — not required — auth, because a logout
+			// with no session, or one whose token already expired, must still
+			// clear cookies and answer 200 rather than 401.
+			//
+			// CSRF runs first, deliberately: it treats an unauthenticated
+			// request as cookie-authenticated and so demands the double-submit
+			// token unconditionally on this route. Establishing auth_method
+			// first would instead route Bearer logouts into CSRFMiddleware's
+			// header-JWT branch, loosening a check this route already passes.
+			authGroup.POST("/logout",
+				middleware.CSRFMiddleware(cfg),
+				middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo),
+				authHandlers.LogoutPostHandler())
 			authGroup.GET("/providers", authHandlers.ProvidersHandler())
 
 			// SAML endpoints

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -358,6 +358,14 @@ func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepos
 					} else {
 						c.Set("auth_method", "jwt")
 					}
+					// Same context shape as AuthMiddleware: whenever this
+					// middleware establishes a JWT identity it also publishes
+					// the claims. Handlers that must act on the presented token
+					// itself — logout revoking its JTI (issue #764) — can then
+					// be mounted under either middleware and behave the same.
+					// Without this the claims key is set on required-auth routes
+					// only, so any such handler silently no-ops here.
+					c.Set("jwt_claims", claims)
 					// Use scopes embedded in JWT claims (avoids DB query per request)
 					scopes := claims.Scopes
 					if scopes == nil {


### PR DESCRIPTION
Closes #764.

`POST /auth/logout` cleared cookies, returned success, and left the JWT valid for the remainder of its 24h life. The revocation code existed and was **unreachable**: the route sits on the public `authGroup`, so nothing set `jwt_claims`, so the branch that reads them never ran.

`terraform-state-manager-backend` already got this right (`internal/api/auth.go:519`), which is the useful framing — this is the unfixed half of a class the sibling app closed.

## Three edits, one concern

1. **`router_routes.go`** — logout now mounts `middleware.OptionalAuthMiddleware`. **CSRF stays first in the chain, deliberately**: with `auth_method` unset, `CSRFMiddleware` falls through to the cookie double-submit branch and demands the token unconditionally, as today. Putting auth first would divert Bearer logouts into the header-JWT branch, which is exempt when there is no `Origin` — loosening a check this route currently passes. The comment records that.
2. **`middleware/auth.go`** — `OptionalAuthMiddleware` now sets `jwt_claims` alongside `user`/`user_id`/`auth_method`/`scopes`. **This was the trap**: an optional-auth middleware already existed but published everything *except* the claims, so attaching it alone would have left the revocation exactly as dead while looking fixed.
3. **`admin/auth.go`** — `endSession` gained a `tokenRepo != nil` guard (existing tests build the handler with a nil repo; the branch was unreachable, so nil was previously safe).

**Fail-open, unchanged from existing semantics:** if the revoked-tokens probe errors, optional auth downgrades to unauthenticated and logout returns 200 without revoking — the same DB outage in which the revocation write would fail anyway.

## Class enumeration

Every session-terminating path was checked, not just the reported one. `jwt_claims` has exactly three readers; logout was the only member of the "reads claims its group never sets" class.

- `/auth/refresh` and `/auth/me` — correct, both on `authenticatedGroup` under `AuthMiddleware`
- `GET /auth/logout` — does not exist (removed by #731)
- SAML/OIDC — no back-channel logout or SLO route exists; `end_session_endpoint` is a redirect target computed in `endSession`
- SCIM deactivate/delete, admin user delete, GDPR erase, org-member removal, role-template narrowing, group-mapping revocation — all sweep by **target user ID** via `credlifecycle.Sweeper` / watermark, independent of caller claims. Different class, already handled.

## Tests

`backend/internal/api/auth_logout_revocation_test.go`, table-driven through the **real `registerAPIV1Routes`** — the defect was in the wiring, so a test that mounts middleware itself would pass while the product hands back a live token.

The decisive assertion is the token's fate on a subsequent `GET /api/v1/auth/me`, **never `Set-Cookie`** — asserting cookie-clearing is exactly what let this ship. The `revoked_tokens` probe on replay is answered from a ledger recording what the logout actually wrote (a sqlmock `Argument` matcher on the INSERT), so nothing is hardcoded to "revoked". Each row also asserts a pre-logout control that the token was a working session first.

Rows 2 and 3 confirm **logout still succeeds with no token and with an expired token** — 200 plus a `redirect_url`, neither 401 nor 500.

## Mutation checks — three mutants, all compiling, all red on exactly the intended row

- **A** revocation call removed → `status = 200, want 401 (the JWT survived logout)`
- **B** route reverted to the bare public group → same
- **C** `OptionalAuthMiddleware` stops publishing `jwt_claims` → same

Only `valid session logs out then reuses the token` failed in each; the other two rows stayed green. All reverted.

## Verification

`go build`, `go vet`, `gofmt -l` clean. `go test ./...` — 62 packages ok, zero failures. `golangci-lint run` (v2.12.2, the CI-pinned version) — 0 issues. No swagger regeneration: the existing `@Description` already claimed "Revokes the session JWT" — it is now true rather than aspirational.