### PR TITLE
fix(mirrors)!: require platform admin to mutate the shared Terraform binary mirror

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -5304,7 +5304,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Creates a new named Terraform binary mirror configuration. Requires mirrors:manage scope.",
+                "description": "Creates a new named Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -5512,7 +5512,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Updates a Terraform binary mirror configuration. Requires mirrors:manage scope.",
+                "description": "Updates a Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -5613,7 +5613,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.",
+                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -5831,7 +5831,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Enqueues a manual sync for the specified mirror config. Requires mirrors:manage scope.",
+                "description": "Enqueues a manual sync for the specified mirror config. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -6080,7 +6080,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.",
+                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -6159,7 +6159,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires mirrors:manage scope.",
+                "description": "Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],
@@ -6237,7 +6237,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires mirrors:manage scope.",
+                "description": "Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "tags": [
                     "Terraform Mirror"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4277,7 +4277,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Creates a new named Terraform binary mirror configuration. Requires mirrors:manage scope.",
+                "description": "Creates a new named Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4443,7 +4443,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Updates a Terraform binary mirror configuration. Requires mirrors:manage scope.",
+                "description": "Updates a Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "consumes": [
                     "application/json"
                 ],
@@ -4522,7 +4522,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.",
+                "description": "Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "produces": [
                     "application/json"
                 ],
@@ -4693,7 +4693,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Enqueues a manual sync for the specified mirror config. Requires mirrors:manage scope.",
+                "description": "Enqueues a manual sync for the specified mirror config. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "produces": [
                     "application/json"
                 ],
@@ -4887,7 +4887,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.",
+                "description": "Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "produces": [
                     "application/json"
                 ],
@@ -4949,7 +4949,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires mirrors:manage scope.",
+                "description": "Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "produces": [
                     "application/json"
                 ],
@@ -5010,7 +5010,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires mirrors:manage scope.",
+                "description": "Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.",
                 "produces": [
                     "application/json"
                 ],

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -2,7 +2,13 @@
 // The multi-config design mirrors the provider mirror feature: full CRUD for configs,
 // per-config sync triggering, and per-config version/platform/history inspection.
 //
-// All endpoints are secured with mirrors:read / mirrors:manage scopes.
+// SCOPES. Reads are secured with mirrors:read; every mutation requires the
+// platform-wide admin scope (issue #734). terraform_mirror_configs has no
+// organization_id column — one config is the binary supply chain for every
+// tenant — so mirrors:manage, which the seeded devops/org_owner role templates
+// grant through membership in a single organization, is not sufficient
+// authority to change it. See the route registration in
+// internal/api/router_routes.go for the full rationale.
 package admin
 
 import (
@@ -31,10 +37,12 @@ type TerraformMirrorHandler struct {
 	repo           *repositories.TerraformMirrorRepository
 	syncJob        TerraformMirrorSyncJobInterface
 	storageBackend storage.Storage
-	// egress is consulted when validating upstream_url on create/update so a
-	// non-admin "devops"-scoped caller cannot point the binary mirror at a
-	// private or cloud-metadata address; nil enforces the strict default
-	// deny-list.
+	// egress is consulted when validating upstream_url on create/update so the
+	// binary mirror cannot be pointed at a private or cloud-metadata address;
+	// nil enforces the strict default deny-list. Retained as defence in depth
+	// now that create/update require the platform admin scope (issue #734) —
+	// SSRF into the deployment's own network is not something an operator
+	// should be able to configure by accident either.
 	egress *httpsafe.Guard
 }
 
@@ -88,7 +96,7 @@ func (h *TerraformMirrorHandler) deleteVersionArtifacts(ctx context.Context, v *
 // ---- POST /api/v1/admin/terraform-mirrors ----------------------------------
 
 // @Summary      Create Terraform mirror configuration
-// @Description  Creates a new named Terraform binary mirror configuration. Requires mirrors:manage scope.
+// @Description  Creates a new named Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Accept       json
@@ -294,7 +302,7 @@ func (h *TerraformMirrorHandler) GetStatus(c *gin.Context) {
 // ---- PUT /api/v1/admin/terraform-mirrors/:id --------------------------------
 
 // @Summary      Update Terraform mirror configuration
-// @Description  Updates a Terraform binary mirror configuration. Requires mirrors:manage scope.
+// @Description  Updates a Terraform binary mirror configuration. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Accept       json
@@ -401,7 +409,7 @@ func (h *TerraformMirrorHandler) UpdateConfig(c *gin.Context) {
 // ---- DELETE /api/v1/admin/terraform-mirrors/:id -----------------------------
 
 // @Summary      Delete Terraform mirror configuration
-// @Description  Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires mirrors:manage scope.
+// @Description  Deletes a Terraform binary mirror config, all its associated versions/history, and the stored binaries for every version (each platform package plus per-version SHA256SUMS and detached signatures) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -450,7 +458,7 @@ func (h *TerraformMirrorHandler) DeleteConfig(c *gin.Context) {
 // ---- POST /api/v1/admin/terraform-mirrors/:id/sync -------------------------
 
 // @Summary      Trigger Terraform mirror sync
-// @Description  Enqueues a manual sync for the specified mirror config. Requires mirrors:manage scope.
+// @Description  Enqueues a manual sync for the specified mirror config. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -606,7 +614,7 @@ func (h *TerraformMirrorHandler) GetVersion(c *gin.Context) {
 // ---- DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version ----------
 
 // @Summary      Delete a mirrored Terraform version
-// @Description  Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires mirrors:manage scope.
+// @Description  Removes a version, its platform records, and the stored binaries (each platform package plus the version's SHA256SUMS and detached signature) from object storage. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -649,7 +657,7 @@ func (h *TerraformMirrorHandler) DeleteVersion(c *gin.Context) {
 // ---- POST /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate --
 
 // @Summary      Deprecate a mirrored Terraform version
-// @Description  Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires mirrors:manage scope.
+// @Description  Mark a mirrored Terraform/OpenTofu version as deprecated. Deprecated versions are skipped by the sync job (no further binary downloads), but already-mirrored artifacts remain available so existing pulls keep working. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json
@@ -689,7 +697,7 @@ func (h *TerraformMirrorHandler) DeprecateVersion(c *gin.Context) {
 // ---- DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate
 
 // @Summary      Undeprecate a mirrored Terraform version
-// @Description  Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires mirrors:manage scope.
+// @Description  Clear the deprecated flag on a mirrored Terraform/OpenTofu version, restoring normal sync behavior on subsequent runs. Requires the platform-wide admin scope: this mirror is not owned by any organization, it is the binary supply chain for every tenant.
 // @Tags         Terraform Mirror
 // @Security     Bearer
 // @Produce      json

--- a/backend/internal/api/platform_mirror_routes_test.go
+++ b/backend/internal/api/platform_mirror_routes_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/api/admin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// tfMirrorCfgID is an arbitrary well-formed UUID: the routes under test must
+// decide on the caller's authority before the row is ever looked up, so no
+// mirror config needs to exist for the gate to be observable.
+const tfMirrorCfgID = "5b0f2c9a-6d3e-4a1b-9c8d-2e7f4a6b1c30"
+
+// platformRouteCase drives one route through the real registerAPIV1Routes
+// wiring with a principal holding exactly scopes, and returns the status code.
+//
+// Handlers are left nil deliberately, the same way crossOrgRouteCase does it:
+// a route whose gate rejects the caller aborts in middleware and never reaches
+// one, so a caller who IS authorized falls through to a nil handler and
+// gin.Recovery turns that into a 500 (or the handler's own 400 when it binds
+// JSON before touching its repository). Either way the pass/fail signal is
+// "403 or not", which is exactly the authority decision under test.
+func platformRouteCase(t *testing.T, method, path string, scopes []string) int {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	token, err := auth.GenerateJWT(mirrorUserID, "mallory@example.com", scopes, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+
+	mock.ExpectQuery("(?s)FROM users WHERE id").WillReturnRows(userRowsFor(mirrorUserID))
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 600, BurstSize: 100, CleanupInterval: time.Minute,
+	})
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	registerAPIV1Routes(r, &apiV1RouteDeps{
+		cfg:                &config.Config{},
+		userRepo:           repositories.NewUserRepository(db),
+		generalRateLimiter: limiter,
+		orgRateLimiter:     limiter,
+		nsAuthz: middleware.NewNamespaceAuthorizer(
+			repositories.NewOrganizationRepository(db),
+			repositories.NewNamespaceClaimRepository(db),
+			repositories.NewModuleRepository(db),
+			repositories.NewProviderRepository(db),
+		),
+		mirrorRepo:       repositories.NewMirrorRepository(sqlxDB),
+		rbacRepo:         repositories.NewRBACRepositoryWithIdentity(sqlxDB, sqlxDB),
+		auditLogHandlers: admin.NewAuditLogHandlers(db),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// platformMirrorRoute is one row of the /admin/terraform-mirrors route table.
+type platformMirrorRoute struct {
+	name    string
+	method  string
+	path    string
+	mutates bool
+}
+
+// platformMirrorRoutes is the complete /admin/terraform-mirrors family. Every
+// table it reaches — terraform_mirror_configs, terraform_versions,
+// terraform_version_platforms, terraform_sync_history, releases_gpg_keys — is
+// platform-global: none of them has an organization_id column, so no per-org
+// guard can apply and the authority has to come from the scope itself.
+var platformMirrorRoutes = []platformMirrorRoute{
+	// Mutations: repointing the upstream, lowering gpg_verify /
+	// verify_github_attestation / requires_approval, triggering a sync, and
+	// deleting or deprecating configs and versions all change what binaries
+	// EVERY tenant receives from /terraform/binaries (issue #734).
+	{"create config", http.MethodPost, "/api/v1/admin/terraform-mirrors", true},
+	{"update config", http.MethodPut, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID, true},
+	{"delete config", http.MethodDelete, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID, true},
+	{"trigger sync", http.MethodPost, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/sync", true},
+	{"delete version", http.MethodDelete, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions/1.9.5", true},
+	{"deprecate version", http.MethodPost, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions/1.9.5/deprecate", true},
+	{"undeprecate version", http.MethodDelete, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions/1.9.5/deprecate", true},
+
+	// Reads: deliberately left on mirrors:read. These tables hold no tenant
+	// data and no credentials, and the binary mirror is a shared service whose
+	// catalogue and health tenant operators legitimately need to see.
+	{"releases gpg keys", http.MethodGet, "/api/v1/admin/terraform-mirrors/releases-gpg-keys", false},
+	{"list configs", http.MethodGet, "/api/v1/admin/terraform-mirrors", false},
+	{"get config", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID, false},
+	{"get status", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/status", false},
+	{"list versions", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions", false},
+	{"get version", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions/1.9.5", false},
+	{"list platforms", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/versions/1.9.5/platforms", false},
+	{"sync history", http.MethodGet, "/api/v1/admin/terraform-mirrors/" + tfMirrorCfgID + "/history", false},
+}
+
+// Issue #734: terraform_mirror_configs has no organization_id column — one
+// config is the Terraform/OpenTofu binary supply chain for every tenant — yet
+// the whole family was gated on mirrors:manage, which the seeded devops and
+// org_owner role templates grant through membership in a SINGLE organization.
+//
+// The table runs each route against three principal classes so a regression
+// that denies EVERYONE is as visible as one that allows everyone: the org-level
+// principals must be refused on the mutations, and the platform admin must
+// still get through.
+func TestPlatformTerraformMirrorRoutes_Authority(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	principals := []struct {
+		name   string
+		scopes []string
+		// allowedOnMutations is the authority claim under test.
+		allowedOnMutations bool
+		// allowedOnReads records the deliberate read/write split.
+		allowedOnReads bool
+	}{
+		{
+			// The seeded "devops" / "org_owner" principal: mirrors:manage (which
+			// implies mirrors:read) held via membership in one organization.
+			name:               "org user with mirrors:manage",
+			scopes:             []string{string(auth.ScopeMirrorsRead), string(auth.ScopeMirrorsManage)},
+			allowedOnMutations: false,
+			allowedOnReads:     true,
+		},
+		{
+			// The seeded "viewer" principal: no mirror management at all.
+			name:               "org user without mirrors:manage",
+			scopes:             []string{string(auth.ScopeModulesRead), string(auth.ScopeProvidersRead)},
+			allowedOnMutations: false,
+			allowedOnReads:     false,
+		},
+		{
+			name:               "platform admin",
+			scopes:             []string{string(auth.ScopeAdmin)},
+			allowedOnMutations: true,
+			allowedOnReads:     true,
+		},
+	}
+
+	for _, p := range principals {
+		for _, rt := range platformMirrorRoutes {
+			wantAllowed := p.allowedOnReads
+			if rt.mutates {
+				wantAllowed = p.allowedOnMutations
+			}
+
+			t.Run(p.name+"/"+rt.name, func(t *testing.T) {
+				code := platformRouteCase(t, rt.method, rt.path, p.scopes)
+
+				if code == http.StatusNotFound {
+					t.Fatalf("%s %s: 404 — route not registered, the table is stale", rt.method, rt.path)
+				}
+
+				gotAllowed := code != http.StatusForbidden
+				if gotAllowed != wantAllowed {
+					verb := "allowed"
+					if !wantAllowed {
+						verb = "denied"
+					}
+					t.Errorf("%s %s as %s: status = %d, want %s (mutates=%t; terraform mirror config is platform-global, issue #734)",
+						rt.method, rt.path, p.name, code, verb, rt.mutates)
+				}
+			})
+		}
+	}
+}

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -971,8 +971,40 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				mirrorsGroup.POST("/:id/sync", middleware.RequireScope(auth.ScopeMirrorsManage), mirrorConfigOrg(auth.ScopeMirrorsManage), mirrorHandlers.TriggerSync)
 			}
 
-			// Terraform Binary Mirror admin endpoints (multi-config)
-			// Read operations require mirrors:read scope; management requires mirrors:manage
+			// Terraform Binary Mirror admin endpoints (multi-config).
+			//
+			// PLATFORM-GLOBAL, unlike the /admin/mirrors family above.
+			// terraform_mirror_configs has no organization_id column at all
+			// (migration 000004): a single row is the Terraform/OpenTofu binary
+			// supply chain for EVERY tenant, and the versions, platforms and
+			// sync-history tables hanging off it inherit that. There is no
+			// owning organization for a per-resource guard to re-derive, so the
+			// #719 mirrorConfigOrg(...) treatment does not apply here.
+			//
+			// The absence of a tenancy axis is not "no guard needed" — it means
+			// platform-wide authority is required. That is already the settled
+			// contract for org-less rows everywhere else in this codebase:
+			// tenantscope.Permits admits an unowned row to a platform admin
+			// only, and middleware.RequireOrgScopeForResource does the same for
+			// the ":id" axes. mirrors:manage does NOT carry that authority — the
+			// seeded devops and org_owner role templates grant it through
+			// membership in a SINGLE organization (migrations 000001/000049),
+			// which is the whole gap (issue #734).
+			//
+			// Every mutation is therefore gated on the platform-wide admin
+			// scope: repointing upstream_url, lowering the verification
+			// settings (gpg_verify, verify_github_attestation) or the
+			// requires_approval gate, triggering a sync, and deleting or
+			// deprecating configs/versions all change what binaries every
+			// tenant receives from /terraform/binaries.
+			//
+			// Reads deliberately stay on mirrors:read. These tables carry no
+			// tenant data and no credentials — names, upstream URLs, filters,
+			// verification flags, version catalogues, sync status and cached
+			// PUBLIC release-signing keys — and the mirror is a shared service
+			// whose catalogue and health tenant operators legitimately need to
+			// see. This is the same read/write split the /admin/policies and
+			// /admin/version-approvals groups above already use.
 			tfMirrorGroup := authenticatedGroup.Group("/admin/terraform-mirrors")
 			{
 				// Release-signing GPG key cache + expiry state (read-only).
@@ -980,19 +1012,19 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				tfMirrorGroup.GET("/releases-gpg-keys", middleware.RequireScope(auth.ScopeMirrorsRead), releasesGPGKeysAdminHandler.GetReleasesGPGKeys)
 				// Config CRUD
 				tfMirrorGroup.GET("", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListConfigs)
-				tfMirrorGroup.POST("", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.CreateConfig)
+				tfMirrorGroup.POST("", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.CreateConfig)
 				tfMirrorGroup.GET("/:id", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetConfig)
 				tfMirrorGroup.GET("/:id/status", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetStatus)
-				tfMirrorGroup.PUT("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.UpdateConfig)
-				tfMirrorGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.DeleteConfig)
+				tfMirrorGroup.PUT("/:id", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.UpdateConfig)
+				tfMirrorGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.DeleteConfig)
 				// Sync trigger
-				tfMirrorGroup.POST("/:id/sync", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.TriggerSync)
+				tfMirrorGroup.POST("/:id/sync", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.TriggerSync)
 				// Versions
 				tfMirrorGroup.GET("/:id/versions", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListVersions)
 				tfMirrorGroup.GET("/:id/versions/:version", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetVersion)
-				tfMirrorGroup.DELETE("/:id/versions/:version", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.DeleteVersion)
-				tfMirrorGroup.POST("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.DeprecateVersion)
-				tfMirrorGroup.DELETE("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeMirrorsManage), tfMirrorAdminHandler.UndeprecateVersion)
+				tfMirrorGroup.DELETE("/:id/versions/:version", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.DeleteVersion)
+				tfMirrorGroup.POST("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.DeprecateVersion)
+				tfMirrorGroup.DELETE("/:id/versions/:version/deprecate", middleware.RequireScope(auth.ScopeAdmin), tfMirrorAdminHandler.UndeprecateVersion)
 				tfMirrorGroup.GET("/:id/versions/:version/platforms", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.ListPlatforms)
 				// Sync history
 				tfMirrorGroup.GET("/:id/history", middleware.RequireScope(auth.ScopeMirrorsRead), tfMirrorAdminHandler.GetSyncHistory)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,7 +108,7 @@ These endpoints implement the HashiCorp protocols that `terraform init` and `ter
 | API Keys | `/api/v1/apikeys` | `admin:apikeys` |
 | RBAC / Role Templates | `/api/v1/admin/roles` | `admin:roles` |
 | Mirror Configuration | `/api/v1/admin/mirrors` | `mirrors:manage` |
-| Terraform Binary Mirror Configs | `/api/v1/admin/terraform-mirrors` | `mirrors:read` / `mirrors:manage` |
+| Terraform Binary Mirror Configs | `/api/v1/admin/terraform-mirrors` | `mirrors:read` (view) / `admin` (create, update, delete, sync, deprecate) |
 | Version Approvals | `/api/v1/admin/version-approvals` | `mirrors:read` (view) / `admin` (approve, reject) |
 | SCM Providers | `/api/v1/admin/scm-providers` | `admin:scm` |
 | SCM OAuth Flows | `/api/v1/admin/scm-oauth` | `admin:scm` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,8 +168,14 @@ Key scopes and their write-implies-read relationship:
 | `providers:read` | Read provider metadata and download providers |
 | `providers:write` | Upload and manage providers (implies `providers:read`) |
 | `mirrors:read` | View mirror configurations and sync history |
-| `mirrors:manage` | Create/update/delete mirrors and trigger syncs (implies `mirrors:read`) |
+| `mirrors:manage` | Create/update/delete **provider** mirrors and trigger their syncs (implies `mirrors:read`) |
 | `admin:*` | Full administrative access (implies all scopes) |
+
+`mirrors:manage` is granted per organization and governs the org-owned provider
+mirrors (`mirror_configurations`) only. The Terraform/OpenTofu **binary** mirror
+(`terraform_mirror_configs`) has no owning organization — one configuration
+serves every tenant — so mutating it requires the platform-wide `admin` scope
+(issue #734). Its read endpoints remain on `mirrors:read`.
 
 ### Shared identity module
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -433,7 +433,9 @@ configuration change**. The common thread: routes that read, list, create or
 delete rows of an organization-owned table now bind the row's owning
 organization to one the caller is a verified member of. Previously several did
 not, so a principal scoped to one organization could see or act on another's
-rows.
+rows. Item 9 is the same principle from the other side: a table with **no**
+organization column is a platform-wide resource, so changing it requires
+platform-wide authority rather than an organization-grantable scope.
 
 > **REQUIRES A SHARED-MODULE BUMP.** The audit-log half of this work lives in
 > `terraform-suite-identity` (`identity/store`), where the three audit read
@@ -571,6 +573,47 @@ credential, a leaver will now be deprovisioned only from the organizations that
 credential covers — a **partial** deprovision that previously appeared total.
 Give the IdP connector an `admin`-scoped credential to preserve estate-wide
 deprovisioning, which is the intended configuration for a SCIM connector.
+
+**9. Changing the Terraform binary mirror now requires the `admin` scope, not
+`mirrors:manage`.**
+
+`terraform_mirror_configs` has no `organization_id` column: one configuration is
+the Terraform/OpenTofu binary supply chain for **every** tenant, and the versions,
+platforms and sync-history rows hanging off it inherit that. `mirrors:manage`
+does not carry platform-wide authority — the seeded `devops` and `org_owner` role
+templates grant it through membership in a single organization — so the following
+routes moved to the platform-wide `admin` scope (issue #734), applying to
+org-less rows the same rule item 5 above already states:
+
+| Route | Previously | Now |
+| --- | --- | --- |
+| `POST /api/v1/admin/terraform-mirrors` | `mirrors:manage` | `admin` |
+| `PUT /api/v1/admin/terraform-mirrors/:id` | `mirrors:manage` | `admin` |
+| `DELETE /api/v1/admin/terraform-mirrors/:id` | `mirrors:manage` | `admin` |
+| `POST /api/v1/admin/terraform-mirrors/:id/sync` | `mirrors:manage` | `admin` |
+| `DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version` | `mirrors:manage` | `admin` |
+| `POST /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate` | `mirrors:manage` | `admin` |
+| `DELETE /api/v1/admin/terraform-mirrors/:id/versions/:version/deprecate` | `mirrors:manage` | `admin` |
+
+This covers the verification settings specifically: `gpg_verify`,
+`verify_github_attestation` and `requires_approval` are all set through
+`PUT /:id`, and weakening any of them changes what every tenant's Terraform CLI
+accepts. Repointing `upstream_url` is in the same request body.
+
+The **read** routes are unchanged and stay on `mirrors:read`: the whole family's
+`GET`s (`/releases-gpg-keys`, list/get config, status, versions, platforms and
+history). These tables carry no tenant data and no credentials, and the binary
+mirror is a shared service whose catalogue and health tenant operators
+legitimately need to see.
+
+*Action:* an operator who managed the binary mirror with a `devops` or
+`org_owner` role loses the ability to create, edit, sync, delete or deprecate it
+and receives `403`; the admin UI's Terraform Mirrors page stays viewable but its
+actions fail for them. Move that work to an `admin`-scoped credential. Any CI
+job that calls `POST /:id/sync` on a `mirrors:manage` token needs its token
+re-issued with `admin`. Nothing about the mirror's runtime behaviour changes —
+already-synced binaries keep serving from `/terraform/binaries`, and the
+scheduled sync job is unaffected.
 
 **Shared module:** this release requires a `terraform-suite-identity` version
 newer than `v0.20.3`. `AuditRepository.ListAuditLogs`, `.GetAuditLog` and


### PR DESCRIPTION
Closes #734.

The Terraform binary mirror is a **single instance-wide resource** — `terraform_mirror_configs` has no `organization_id` at all — yet every mutating route was gated only on `mirrors:manage`, a scope the seeded `devops` and `org_owner` templates grant through membership in **one** organization.

## The invariant

**Authority over a resource must be at least as wide as the resource.** A table with no tenancy axis is platform-wide, so changing it needs platform-wide authority.

The codebase had already settled this for org-less *rows* — `tenantscope.Permits` admits an unowned row to a platform admin only, and `RequireOrgScopeForResource` does the same on the `:id` axes. #719 gave the provider-mirror family `mirrorConfigOrg(...)` because those rows **are** org-owned. The terraform-mirror family was skipped because it has no org column, and that absence was read as "no guard needed" when it actually means "needs a wider one."

## Class enumeration

Every `CREATE TABLE` / `ALTER … ADD COLUMN organization_id` across the migrations — **50 tables, 12 org-owned, 38 not** — then every route in `router_routes.go` walked to its handler's accessors and back to the tables.

Most of the 38 are **transitively** org-owned through a parent FK (`module_versions`→`modules`, `mirrored_providers`→`mirror_configurations`, `scm_oauth_tokens`→`scm_providers`, …) and already covered by the #555/#718/#719 guards. Of the genuinely platform-global tables, everything else was **already correct**: role templates, notification channels, OIDC/system/UI config, storage, scanner binaries and CVE advisories all require `admin`; version-approval *writes* already did too.

**Exactly one family had mutations of a platform-global table reachable from a per-org-grantable scope.**

## Gated (7 mutating routes) → `auth.ScopeAdmin`

`POST /admin/terraform-mirrors`, `PUT /:id`, `DELETE /:id`, `POST /:id/sync`, `DELETE /:id/versions/:version`, and `POST`/`DELETE /:id/versions/:version/deprecate`.

`PUT /:id` is the security-downgrade surface — `gpg_verify`, `verify_github_attestation`, `requires_approval`, plus `upstream_url`. All three verification flags are settable **only** through that route (checked against `UpdateTerraformMirrorConfigRequest`; `custom_gpg_key`/`skip_gpg_verify` exist on the model but are not bindable from any request body), so gating it covers the whole downgrade surface.

## Deliberately left on `mirrors:read` (7 read routes + `/releases-gpg-keys`)

These tables hold no tenant data and no credentials — names, upstream URLs, version catalogues, sync status, and cached **public** release-signing keys. The binary mirror is a shared service every tenant consumes, so its catalogue and health are legitimately visible to tenant operators; over-gating would blank the Terraform Mirrors page for `devops`/`org_owner` with no confidentiality gain. Same read/write split `/admin/policies` and `/admin/version-approvals` already use in this file.

Per-route `RequireScope(auth.ScopeAdmin)` rather than `group.Use(...)`, matching those neighbours — a group-level guard would sweep the reads in too.

## Tests

`backend/internal/api/platform_mirror_routes_test.go` — all 14 routes × 3 principal classes = **45 subtests**, driving the real `registerAPIV1Routes` wiring. Asserts **both directions**: org-with-`mirrors:manage` denied on the 7 mutations *and allowed on the reads*; org-without denied everywhere; platform admin allowed everywhere. A 404 fails loudly so a stale route table cannot silently pass.

## Mutation check

Each gate reverted individually (all mutants compiled) → **each produced exactly one red row, the matching one**. Mutant A (all 7 at once) → exactly those 7 red, admin rows green. Mutant B (over-gate a *read* on `admin`) → the read row goes red, proving the allow-side assertions bite and the table is not denial-only.

## Verification

`go build`, `go vet`, `gofmt -l` clean; `go test ./...` 62 packages ok, 0 failures. Swagger regenerated with CI's pinned `swag@v1.16.6` + `swagger2openapi -p` exactly as `ci.yml` runs it (not `make swag`, whose node post-processing reindents the whole file) — 7 description changes in each of `swagger.json` and `openapi3.json`, nothing else.

## Operator-visible behaviour change — breaking

**This removes binary-mirror management from org-level users, which is the point.** `devops`/`org_owner` principals get `403` on create/update/delete/sync/deprecate; the Terraform Mirrors page stays viewable but its action buttons fail for them. **Any CI token calling `POST /:id/sync` with a `mirrors:manage` credential must be re-issued with `admin`.**

Nothing about mirror runtime changes — synced binaries keep serving and the scheduled sync job is untouched. Documented in `docs/upgrade-guide.md` with a per-route before/after table, plus scope-table corrections in `architecture.md` and `api-reference.md`.

## Two findings deliberately not fixed here

Both belong to the wider class and deserve their own issues rather than scope creep:

- `GET /api/v1/users` exposes the whole platform directory on the org-grantable `users:read` — this is **#735**, already filed.
- `GET /api/v1/admin/scanning/scans/:id` fetches a scan by UUID with **no organization predicate** on `scanning:read` (held by `devops` and `auditor`). That is the #719 cross-org-read class, not this one, and appears unfiled.