### PR TITLE
fix(tenancy): bind created rows to the organization the namespace guard authorized

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -1668,6 +1668,17 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Caller holds modules:write in no organization",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "content": {
@@ -3740,6 +3751,17 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "organization_id does not match the organization the namespace guard authorized, or the caller holds providers:write in no organization",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1325,6 +1325,13 @@
                             "additionalProperties": true
                         }
                     },
+                    "403": {
+                        "description": "Caller holds modules:write in no organization",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
                         "schema": {
@@ -3020,6 +3027,13 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "organization_id does not match the organization the namespace guard authorized, or the caller holds providers:write in no organization",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/modules.go
+++ b/backend/internal/api/admin/modules.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/analyzer"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -60,6 +61,7 @@ func (h *ModuleAdminHandlers) WithScanQueue(repo *repositories.ModuleScanReposit
 // @Success      201  {object}  models.Module  "Module created"
 // @Failure      400  {object}  map[string]interface{}  "Invalid request"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "Caller holds modules:write in no organization"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/modules/create [post]
 // CreateModuleRecord creates a module record without a version file.
@@ -84,14 +86,29 @@ func (h *ModuleAdminHandlers) CreateModuleRecord(c *gin.Context) {
 		}
 	}
 
-	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
-	if err != nil || org == nil {
+	// GUARD namespace-create-owner-org (issue #778). Same defect as the provider
+	// create axis, with a narrower reach: this request body carries no
+	// organization_id, so a caller could not aim the row at an organization of
+	// their choosing — every create landed in the single default organization
+	// regardless of which organization the publish guard had authorized. That
+	// makes it a tenancy-BINDING gap rather than a targetable cross-tenant
+	// create: a caller holding modules:write in organization O, publishing into
+	// a namespace owned by O, still had the module row written into an
+	// organization they need no membership in, and the existence check ahead of
+	// it looked for collisions in that same wrong organization.
+	orgID, ok := resolveNamespaceCreateOrganization(c, h.orgRepo, auth.ScopeModulesWrite, "")
+	if !ok {
+		return
+	}
+	if orgID == "" {
+		// modules.organization_id is written through unconverted, so an empty
+		// value is a failed resolution rather than a single-tenant NULL owner.
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get organization context"})
 		return
 	}
 
 	// Return existing module if it already exists
-	existing, err := h.moduleRepo.GetModule(c.Request.Context(), org.ID, req.Namespace, req.Name, req.System)
+	existing, err := h.moduleRepo.GetModule(c.Request.Context(), orgID, req.Namespace, req.Name, req.System)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query module"})
 		return
@@ -102,7 +119,7 @@ func (h *ModuleAdminHandlers) CreateModuleRecord(c *gin.Context) {
 	}
 
 	module := &models.Module{
-		OrganizationID: org.ID,
+		OrganizationID: orgID,
 		Namespace:      req.Namespace,
 		Name:           req.Name,
 		System:         req.System,

--- a/backend/internal/api/admin/modules_test.go
+++ b/backend/internal/api/admin/modules_test.go
@@ -9,6 +9,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 )
 
@@ -88,7 +89,13 @@ func newModuleRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	h := NewModuleAdminHandlers(db, &mockStorage{}, &config.Config{})
 
 	r := gin.New()
-	r.POST("/modules/create", h.CreateModuleRecord)
+	// The real route carries nsAuthz.RequirePublishAccessFromJSON, which
+	// resolves the namespace's owning organization and publishes it as
+	// owner_org_id; the handler binds the new row to that value (issue #778),
+	// so the test route has to reproduce it. The unowned variant is the same
+	// handler with no owner published, which is what exercises the fallback.
+	r.POST("/modules/create", setOwnerOrg("org-1"), h.CreateModuleRecord)
+	r.POST("/modules/create-unowned", createAxisCaller(string(auth.ScopeModulesWrite)), h.CreateModuleRecord)
 	r.GET("/modules/:namespace/:name/:system", h.GetModule)
 	r.GET("/modules/:namespace/:name/:system/:version", h.GetModuleVersion)
 	r.DELETE("/modules/:namespace/:name/:system", h.DeleteModule)
@@ -151,15 +158,16 @@ func TestCreateModuleRecord_InvalidSegmentFormat(t *testing.T) {
 	}
 }
 
+// With no owner published the handler falls back to the caller's own tenancy,
+// so a failed membership lookup is the org-resolution error path — it must not
+// degrade into "no organization named, use the default one".
 func TestCreateModuleRecord_OrgDBError(t *testing.T) {
 	mock, r := newModuleRouter(t)
 
-	mock.ExpectQuery("SELECT.*FROM organizations").
-		WithArgs("default").
-		WillReturnError(errDB)
+	mock.ExpectQuery("(?s)FROM organization_members").WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest("POST", "/modules/create",
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/modules/create-unowned",
 		jsonBody(map[string]string{"namespace": "hashicorp", "name": "vpc", "system": "aws"})))
 
 	if w.Code != http.StatusInternalServerError {
@@ -170,7 +178,6 @@ func TestCreateModuleRecord_OrgDBError(t *testing.T) {
 func TestCreateModuleRecord_ExistingModule_ReturnsOK(t *testing.T) {
 	mock, r := newModuleRouter(t)
 
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM modules").
 		WillReturnRows(sampleModuleRow())
 
@@ -186,7 +193,6 @@ func TestCreateModuleRecord_ExistingModule_ReturnsOK(t *testing.T) {
 func TestCreateModuleRecord_Success(t *testing.T) {
 	mock, r := newModuleRouter(t)
 
-	expectOrgFound(mock)
 	// GetModule returns not found (no existing module)
 	mock.ExpectQuery("SELECT.*FROM modules").
 		WillReturnRows(emptyModuleRow())
@@ -207,7 +213,6 @@ func TestCreateModuleRecord_Success(t *testing.T) {
 func TestCreateModuleRecord_CreateError(t *testing.T) {
 	mock, r := newModuleRouter(t)
 
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM modules").
 		WillReturnRows(emptyModuleRow())
 	mock.ExpectQuery("INSERT INTO modules").

--- a/backend/internal/api/admin/namespace_create_org_test.go
+++ b/backend/internal/api/admin/namespace_create_org_test.go
@@ -1,0 +1,464 @@
+// namespace_create_org_test.go is the coverage of record for issue #778: a
+// namespaced CREATE must write the new row into the organization the request
+// was AUTHORIZED against, and into no other.
+//
+// The defect these rows pin is not "the request succeeded when it should have
+// failed" — it succeeded either way. It is that the organization the route's
+// publish guard checked and the organization the row landed in were two
+// independent values, so a caller holding the scope in organization O created a
+// row owned by the DEFAULT organization, which they need no membership in. A
+// test that only asserted the status code passed throughout the entire lifetime
+// of the bug. So every row here asserts the ORGANIZATION the handler addressed:
+// the conflict lookup's predicate and the INSERT's organization_id are pinned
+// with WithArgs, and the created row's organization_id is checked in the
+// response body.
+//
+// The table is driven over both create paths — provider records and module
+// records — because they are the same defect behind the same guard, and over
+// both wiring states of that guard: owner_org_id published (every ordinary
+// request) and owner_org_id absent (a platform admin passing through the
+// ambiguous-ownership branch), which is the only path where the handler falls
+// back to resolveTargetOrganization.
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+const (
+	// createOrgOwner is the organization that owns the namespace being
+	// published into — the organization the publish guard authorized.
+	createOrgOwner = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+	// createOrgOther is an organization the caller has nothing to do with.
+	createOrgOther = "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb"
+	// createOrgDefault is the DEFAULT organization: the answer the defect
+	// produced, and therefore the answer that must never appear except on the
+	// one path that legitimately asks for it (a platform admin with no
+	// namespace owner resolved).
+	createOrgDefault = "cccccccc-3333-4333-8333-cccccccccccc"
+
+	createUserID = "dddddddd-4444-4444-8444-dddddddddddd"
+
+	createNamespace = "hashicorp"
+	createType      = "aws"
+	createModName   = "vpc"
+	createModSystem = "aws"
+)
+
+// setOwnerOrg stands in for middleware.NamespaceAuthorizer's publish guard,
+// which resolves the namespace's owning organization and publishes it as
+// owner_org_id before the handler runs. Mirroring only that one effect is the
+// point: the handler must bind the row to the value the guard resolved, without
+// re-deriving ownership from anything else.
+func setOwnerOrg(orgID string) gin.HandlerFunc {
+	return func(c *gin.Context) { c.Set("owner_org_id", orgID) }
+}
+
+// createAxisCaller installs an ordinary non-admin JWT principal.
+func createAxisCaller(scopes ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("scopes", scopes)
+		c.Set("user_id", createUserID)
+	}
+}
+
+// createAxisAdmin installs a platform admin, the only principal for which the
+// default-organization fallback survives.
+func createAxisAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", createUserID)
+	}
+}
+
+// createAxisMemberships builds a GetUserMemberships result granting `scopes` in
+// each named organization.
+func createAxisMemberships(scopes string, orgIDs ...string) *sqlmock.Rows {
+	rows := sqlmock.NewRows(membershipCols)
+	for i, id := range orgIDs {
+		rows.AddRow(id, fmt.Sprintf("org-%d", i), "role-1", time.Now(),
+			"devops", "DevOps", []byte(scopes))
+	}
+	return rows
+}
+
+// createAxisWant is the outcome required of ONE create path.
+type createAxisWant struct {
+	status int
+	// org is the organization the handler must address: the predicate of the
+	// conflict lookup and, when a row is written, the INSERT's
+	// organization_id. Empty means the handler must refuse before touching the
+	// resource table at all.
+	org string
+	// existing primes the conflict lookup with a row already present in `org`,
+	// so no INSERT may follow. This is the half of the defect that is not about
+	// authorization: the lookup ran against the wrong organization, so a
+	// genuine collision in the authorized organization went unseen and the
+	// insert met the UNIQUE (organization_id, namespace, ...) constraint
+	// instead of returning cleanly.
+	existing bool
+}
+
+type createAxisCase struct {
+	name string
+	// ownerOrg is what the route's publish guard published as owner_org_id.
+	// Empty means the guard published nothing.
+	ownerOrg  string
+	principal gin.HandlerFunc
+	// memberships is primed only when the fallback resolver is expected to
+	// reach GetUserMemberships; a nil value asserts by omission that it does
+	// not (an unexpected statement fails the row).
+	memberships *sqlmock.Rows
+	// membershipsErr makes the membership lookup fail.
+	membershipsErr error
+	// wantDefaultOrgLookup primes GetDefaultOrganization, which only the
+	// platform-admin fallback may reach.
+	wantDefaultOrgLookup bool
+	// bodyOrgID is the organization_id the caller puts in the request body.
+	bodyOrgID string
+
+	provider createAxisWant
+	module   createAxisWant
+}
+
+func createAxisCases() []createAxisCase {
+	const writeScopes = `["providers:write","modules:write"]`
+	callerScopes := []string{string(auth.ScopeProvidersWrite), string(auth.ScopeModulesWrite)}
+
+	return []createAxisCase{
+		{
+			// THE #778 ROW. Nothing is wrong with this request; the caller holds
+			// the scope in the organization that owns the namespace and says so
+			// by saying nothing. Before the fix the row was written into the
+			// default organization anyway.
+			name:      "guard authorized the owner, organization_id omitted",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisCaller(callerScopes...),
+			provider:  createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+			module:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			name:      "guard authorized the owner, organization_id supplied and matching",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisCaller(callerScopes...),
+			bodyOrgID: createOrgOwner,
+			provider:  createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+			module:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// THE IMPACT DISTINCTION between the two paths, encoded. The
+			// provider request body has an organization_id field, so a caller
+			// can name an organization other than the one the guard authorized;
+			// that is refused. The module request body has no such field, so the
+			// same key is inert there and the row still lands in the authorized
+			// organization — a tenancy-BINDING gap, not a targetable
+			// cross-tenant create.
+			name:      "guard authorized the owner, organization_id names another organization",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisCaller(callerScopes...),
+			bodyOrgID: createOrgOther,
+			provider:  createAxisWant{status: http.StatusForbidden},
+			module:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// A platform admin crosses organization boundaries, but the row
+			// still belongs to the namespace's owner: crossing the boundary is
+			// permission to act, not licence to mis-attribute the row. Note what
+			// is NOT primed — no GetDefaultOrganization lookup.
+			name:      "platform admin, guard authorized the owner, organization_id omitted",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisAdmin(),
+			provider:  createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+			module:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// Admins are refused the mismatch too. The middleware exempts them
+			// from its own organization_id/owner check, so this is the only
+			// place the disagreement is caught, and silently overriding the
+			// field would answer 201 to a write that discarded what was asked
+			// for.
+			name:      "platform admin, organization_id disagrees with the authorized owner",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisAdmin(),
+			bodyOrgID: createOrgOther,
+			provider:  createAxisWant{status: http.StatusForbidden},
+			module:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// THE CONFLICT-CHECK HALF. An existing row in the authorized
+			// organization must be seen. Before the fix the lookup carried the
+			// default organization's id, so this collision was invisible.
+			name:      "existing row in the authorized organization is detected",
+			ownerOrg:  createOrgOwner,
+			principal: createAxisCaller(callerScopes...),
+			provider:  createAxisWant{status: http.StatusConflict, org: createOrgOwner, existing: true},
+			// The module create path answers 200 with the existing row rather
+			// than 409; either way the lookup must address the authorized
+			// organization.
+			module: createAxisWant{status: http.StatusOK, org: createOrgOwner, existing: true},
+		},
+
+		// ------------------------------------------------------------------
+		// FALLBACK WIRING: the guard published no owner. Reachable when a
+		// platform admin passes through authorizeNamespaceMutation's
+		// ambiguous-ownership branch, which returns without setting
+		// owner_org_id. resolveTargetOrganization answers from the caller's own
+		// tenancy here, and must never reach for the default organization on
+		// behalf of a non-admin.
+		// ------------------------------------------------------------------
+		{
+			name:        "no owner published, caller holds the scope in exactly one organization",
+			principal:   createAxisCaller(callerScopes...),
+			memberships: createAxisMemberships(writeScopes, createOrgOwner),
+			provider:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+			module:      createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// Fail closed rather than guess. Guessing is how the default
+			// organization became a dumping ground for other tenants' rows.
+			name:        "no owner published, caller holds the scope in several organizations",
+			principal:   createAxisCaller(callerScopes...),
+			memberships: createAxisMemberships(writeScopes, createOrgOwner, createOrgOther),
+			provider:    createAxisWant{status: http.StatusBadRequest},
+			module:      createAxisWant{status: http.StatusBadRequest},
+		},
+		{
+			name:        "no owner published, organization_id supplied and permitted",
+			principal:   createAxisCaller(callerScopes...),
+			memberships: createAxisMemberships(writeScopes, createOrgOwner, createOrgOther),
+			bodyOrgID:   createOrgOwner,
+			provider:    createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+			// Inert on the module path, so this row is the ambiguous case there.
+			module: createAxisWant{status: http.StatusBadRequest},
+		},
+		{
+			name:        "no owner published, organization_id supplied and NOT permitted",
+			principal:   createAxisCaller(callerScopes...),
+			memberships: createAxisMemberships(writeScopes, createOrgOwner),
+			bodyOrgID:   createOrgOther,
+			provider:    createAxisWant{status: http.StatusForbidden},
+			// Inert on the module path: the caller cannot aim the row, so it
+			// lands in their single in-scope organization.
+			module: createAxisWant{status: http.StatusCreated, org: createOrgOwner},
+		},
+		{
+			// Membership without the scope is not authority — the role template
+			// decides. A member of the owner organization whose role grants only
+			// reads holds the scope nowhere, so there is no organization to
+			// create in.
+			name:        "no owner published, caller holds the scope in no organization",
+			principal:   createAxisCaller(callerScopes...),
+			memberships: createAxisMemberships(`["providers:read","modules:read"]`, createOrgOwner),
+			provider:    createAxisWant{status: http.StatusForbidden},
+			module:      createAxisWant{status: http.StatusForbidden},
+		},
+		{
+			// The one path on which the default organization is still the right
+			// answer: a platform admin acting as a registry operator with no
+			// namespace owner resolved. Preserved deliberately — narrowing it is
+			// a separate decision from binding the row to the guard's answer.
+			name:                 "no owner published, platform admin falls back to the default organization",
+			principal:            createAxisAdmin(),
+			wantDefaultOrgLookup: true,
+			provider:             createAxisWant{status: http.StatusCreated, org: createOrgDefault},
+			module:               createAxisWant{status: http.StatusCreated, org: createOrgDefault},
+		},
+		{
+			// A membership lookup that fails must not degrade into "no
+			// organization named, use the default one".
+			name:           "no owner published, membership lookup fails",
+			principal:      createAxisCaller(callerScopes...),
+			membershipsErr: errDB,
+			provider:       createAxisWant{status: http.StatusInternalServerError},
+			module:         createAxisWant{status: http.StatusInternalServerError},
+		},
+	}
+}
+
+// primeResolution primes the statements the organization resolution itself
+// issues, in order. Nothing is primed for the guarded rows: resolving from
+// owner_org_id must cost no queries at all, and an unexpected statement fails
+// the row.
+func primeResolution(mock sqlmock.Sqlmock, tc createAxisCase) {
+	if tc.ownerOrg != "" {
+		return
+	}
+	switch {
+	case tc.membershipsErr != nil:
+		mock.ExpectQuery("(?s)FROM organization_members").WillReturnError(tc.membershipsErr)
+	case tc.memberships != nil:
+		mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(tc.memberships)
+	}
+	if tc.wantDefaultOrgLookup {
+		mock.ExpectQuery("SELECT.*FROM organizations").
+			WithArgs("default").
+			WillReturnRows(sqlmock.NewRows(orgCols).
+				AddRow(createOrgDefault, "default", "Default Org", nil, nil, time.Now(), time.Now()))
+	}
+}
+
+func createAxisBody(extra map[string]string) *strings.Reader {
+	pairs := make([]string, 0, len(extra))
+	for k, v := range extra {
+		pairs = append(pairs, fmt.Sprintf("%q:%q", k, v))
+	}
+	return strings.NewReader("{" + strings.Join(pairs, ",") + "}")
+}
+
+func createAxisRequest(t *testing.T, r *gin.Engine, path string, body *strings.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// assertCreateAxis checks the outcome AND the organization the row landed in.
+// Status alone is what let this defect live: every ordinary request answered
+// 201 both before and after the fix.
+func assertCreateAxis(t *testing.T, w *httptest.ResponseRecorder, mock sqlmock.Sqlmock, want createAxisWant) {
+	t.Helper()
+	if w.Code != want.status {
+		t.Fatalf("status = %d, want %d: body=%s", w.Code, want.status, w.Body.String())
+	}
+	if want.status == http.StatusCreated {
+		if !strings.Contains(w.Body.String(), want.org) {
+			t.Errorf("created row is not owned by the authorized organization %s: body=%s",
+				want.org, w.Body.String())
+		}
+		if want.org != createOrgDefault && strings.Contains(w.Body.String(), createOrgDefault) {
+			t.Errorf("created row leaked into the default organization: body=%s", w.Body.String())
+		}
+	}
+	// The WithArgs expectations carry the real assertion: the lookup predicate
+	// and the INSERT's organization_id. An unmet or unmatched expectation means
+	// the handler addressed a different organization.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("organization the handler addressed does not match: %v", err)
+	}
+}
+
+func TestCreateProviderRecord_BindsRowToAuthorizedOrganization(t *testing.T) {
+	for _, tc := range createAxisCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			primeResolution(mock, tc)
+			if want := tc.provider; want.org != "" {
+				lookup := mock.ExpectQuery("SELECT.*FROM providers").
+					WithArgs(want.org, createNamespace, createType)
+				if want.existing {
+					lookup.WillReturnRows(sqlmock.NewRows(providerCols).AddRow(
+						"prov-1", want.org, createNamespace, createType,
+						nil, nil, nil, time.Now(), time.Now(), nil))
+				} else {
+					lookup.WillReturnRows(emptyProviderRow())
+					mock.ExpectQuery("INSERT INTO providers").
+						WithArgs(want.org, createNamespace, createType,
+							sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+						WillReturnRows(sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
+							AddRow("prov-new", time.Now(), time.Now()))
+				}
+			}
+
+			h := NewProviderAdminHandlers(db, &mockStorage{}, &config.Config{})
+			r := gin.New()
+			r.Use(tc.principal)
+			handlers := []gin.HandlerFunc{}
+			if tc.ownerOrg != "" {
+				handlers = append(handlers, setOwnerOrg(tc.ownerOrg))
+			}
+			handlers = append(handlers, h.CreateProviderRecord)
+			r.POST("/admin/providers", handlers...)
+
+			body := map[string]string{"namespace": createNamespace, "type": createType}
+			if tc.bodyOrgID != "" {
+				body["organization_id"] = tc.bodyOrgID
+			}
+			w := createAxisRequest(t, r, "/admin/providers", createAxisBody(body))
+			assertCreateAxis(t, w, mock, tc.provider)
+		})
+	}
+}
+
+func TestCreateModuleRecord_BindsRowToAuthorizedOrganization(t *testing.T) {
+	for _, tc := range createAxisCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+
+			primeResolution(mock, tc)
+			if want := tc.module; want.org != "" {
+				lookup := mock.ExpectQuery("SELECT.*FROM modules").
+					WithArgs(want.org, createNamespace, createModName, createModSystem)
+				if want.existing {
+					lookup.WillReturnRows(sqlmock.NewRows(moduleCols).AddRow(
+						"mod-1", want.org, createNamespace, createModName, createModSystem,
+						nil, nil, nil, time.Now(), time.Now(), nil, false, nil, nil, nil))
+				} else {
+					lookup.WillReturnRows(emptyModuleRow())
+					mock.ExpectQuery("INSERT INTO modules").
+						WithArgs(want.org, createNamespace, createModName, createModSystem,
+							sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+						WillReturnRows(sqlmock.NewRows(modCreateCols).
+							AddRow("mod-new", time.Now(), time.Now()))
+				}
+			}
+
+			h := NewModuleAdminHandlers(db, &mockStorage{}, &config.Config{})
+			r := gin.New()
+			r.Use(tc.principal)
+			handlers := []gin.HandlerFunc{}
+			if tc.ownerOrg != "" {
+				handlers = append(handlers, setOwnerOrg(tc.ownerOrg))
+			}
+			handlers = append(handlers, h.CreateModuleRecord)
+			r.POST("/admin/modules/create", handlers...)
+
+			body := map[string]string{
+				"namespace": createNamespace,
+				"name":      createModName,
+				"system":    createModSystem,
+			}
+			if tc.bodyOrgID != "" {
+				body["organization_id"] = tc.bodyOrgID
+			}
+			w := createAxisRequest(t, r, "/admin/modules/create", createAxisBody(body))
+			// The existing-module path answers 200 with the row it found, so the
+			// organization assertion for it is the lookup predicate plus the
+			// body, not a 201.
+			if tc.module.status == http.StatusOK && tc.module.existing {
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+				if !strings.Contains(w.Body.String(), tc.module.org) {
+					t.Errorf("existing row was looked up in the wrong organization: body=%s", w.Body.String())
+				}
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Errorf("organization the handler addressed does not match: %v", err)
+				}
+				return
+			}
+			assertCreateAxis(t, w, mock, tc.module)
+		})
+	}
+}

--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
@@ -453,6 +454,7 @@ type CreateProviderRecordRequest struct {
 // @Success      201  {object}  models.Provider
 // @Failure      400  {object}  map[string]interface{}  "Invalid request body"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "organization_id does not match the organization the namespace guard authorized, or the caller holds providers:write in no organization"
 // @Failure      409  {object}  map[string]interface{}  "Provider already exists"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/providers [post]
@@ -465,19 +467,16 @@ func (h *ProviderAdminHandlers) CreateProviderRecord(c *gin.Context) {
 		return
 	}
 
-	// Get organization context (default org for single-tenant mode)
-	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get organization context"})
+	// GUARD namespace-create-owner-org (issue #778): the row is created in the
+	// organization this request was authorized against — the namespace's owner,
+	// as resolved and published by the route's publish guard — and never in the
+	// default organization on the strength of an omitted field. The existence
+	// check below therefore runs against the same organization the insert
+	// targets, so a collision in that organization is seen as a 409 instead of
+	// being missed and turned into a constraint violation.
+	orgID, ok := resolveNamespaceCreateOrganization(c, h.orgRepo, auth.ScopeProvidersWrite, req.OrganizationID)
+	if !ok {
 		return
-	}
-
-	// Use organization from request if provided, otherwise fall back to default
-	var orgID string
-	if req.OrganizationID != "" {
-		orgID = req.OrganizationID
-	} else if org != nil {
-		orgID = org.ID
 	}
 
 	existing, err := h.providerRepo.GetProvider(c.Request.Context(), orgID, req.Namespace, req.Type)

--- a/backend/internal/api/admin/providers_test.go
+++ b/backend/internal/api/admin/providers_test.go
@@ -11,6 +11,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 )
@@ -129,7 +130,13 @@ func newProviderRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	r.DELETE("/providers/:namespace/:type/versions/:version", h.DeleteVersion)
 	r.POST("/providers/:namespace/:type/versions/:version/deprecate", h.DeprecateVersion)
 	r.DELETE("/providers/:namespace/:type/versions/:version/deprecate", h.UndeprecateVersion)
-	r.POST("/providers/record", h.CreateProviderRecord)
+	// The real route carries nsAuthz.RequirePublishAccessFromJSON, which
+	// resolves the namespace's owning organization and publishes it as
+	// owner_org_id; the handler binds the new row to that value (issue #778),
+	// so the test route has to reproduce it. The unowned variant is the same
+	// handler with no owner published, which is what exercises the fallback.
+	r.POST("/providers/record", setOwnerOrg("org-1"), h.CreateProviderRecord)
+	r.POST("/providers/record-unowned", createAxisCaller(string(auth.ScopeProvidersWrite)), h.CreateProviderRecord)
 	r.GET("/providers/id/:id", h.GetProviderByID)
 	r.PUT("/providers/id/:id", h.UpdateProviderRecord)
 
@@ -1041,11 +1048,14 @@ func TestCreateProviderRecord_InvalidJSON(t *testing.T) {
 	}
 }
 
+// With no owner published the handler falls back to the caller's own tenancy,
+// so a failed membership lookup is the org-resolution error path — it must not
+// degrade into "no organization named, use the default one".
 func TestCreateProviderRecord_OrgDBError(t *testing.T) {
 	mock, r := newProviderRouter(t)
-	mock.ExpectQuery("SELECT.*FROM organizations").WithArgs("default").WillReturnError(errDB)
+	mock.ExpectQuery("(?s)FROM organization_members").WillReturnError(errDB)
 	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest("POST", "/providers/record",
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/providers/record-unowned",
 		jsonBody(map[string]string{"namespace": "hashicorp", "type": "aws"})))
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
@@ -1054,7 +1064,6 @@ func TestCreateProviderRecord_OrgDBError(t *testing.T) {
 
 func TestCreateProviderRecord_AlreadyExists(t *testing.T) {
 	mock, r := newProviderRouter(t)
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").WillReturnRows(sampleProviderRow())
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/providers/record",
@@ -1066,7 +1075,6 @@ func TestCreateProviderRecord_AlreadyExists(t *testing.T) {
 
 func TestCreateProviderRecord_CreateError(t *testing.T) {
 	mock, r := newProviderRouter(t)
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").WillReturnRows(emptyProviderRow())
 	mock.ExpectQuery("INSERT INTO providers").WillReturnError(errDB)
 	w := httptest.NewRecorder()
@@ -1079,7 +1087,6 @@ func TestCreateProviderRecord_CreateError(t *testing.T) {
 
 func TestCreateProviderRecord_Success(t *testing.T) {
 	mock, r := newProviderRouter(t)
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").WillReturnRows(emptyProviderRow())
 	mock.ExpectQuery("INSERT INTO providers").WillReturnRows(
 		sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).

--- a/backend/internal/api/admin/tenant_scope.go
+++ b/backend/internal/api/admin/tenant_scope.go
@@ -10,6 +10,7 @@ package admin
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -126,6 +127,67 @@ func resolveTargetOrganization(
 		})
 		return "", false
 	}
+}
+
+// resolveNamespaceCreateOrganization decides which organization a NAMESPACED
+// create writes into — a provider record, a module record — on the routes that
+// sit behind middleware.NamespaceAuthorizer's publish guards.
+//
+// Those guards already answer the question, and answer it better than the
+// handler can re-derive it: the guard resolves the namespace's owning
+// organization (the existing owner, or the organization it just claimed an
+// unowned namespace for), authorizes the caller against THAT organization, and
+// publishes it as owner_org_id. The handlers ignored it. They took the
+// organization from the request body or, when the body named none, from
+// GetDefaultOrganization — so the organization the route authorized and the
+// organization the row landed in were two independent values. A caller holding
+// the scope in organization O therefore created a row owned by the DEFAULT
+// organization, in which they need no membership at all, and the existence
+// check ahead of the insert queried that same wrong organization, so a genuine
+// collision in O went unseen and the write ran into the
+// UNIQUE (organization_id, namespace, ...) constraint instead of a clean 409.
+//
+// INVARIANT: an organization-owned row is created in the organization the
+// request was authorized against, and in no other.
+//
+// So the authorized owner wins, and resolveTargetOrganization is the FALLBACK
+// rather than the primary. On this axis it is the weaker answer, because it
+// resolves from the CALLER's memberships instead of from the namespace: a
+// caller holding the scope in two organizations would be refused as "ambiguous"
+// for a namespace whose owner is not ambiguous at all, and a platform admin
+// would be handed the default organization again — which is the defect itself,
+// merely reached by a different route. It is still the right fallback for the
+// one path where the guard legitimately publishes no owner (a platform admin
+// passing through the ambiguous-ownership branch), because it fails closed for
+// every other principal instead of reaching for the default organization.
+//
+// A body that names an organization other than the authorized owner is REFUSED
+// rather than silently overridden. The middleware already refuses that for
+// non-admin callers on the owned-namespace path; refusing it here as well means
+// the row can never be attributed to an organization the guard did not check,
+// whichever principal asked, and no caller is answered 201 for a write that
+// quietly discarded the field they sent.
+//
+// GUARD namespace-create-owner-org (issue #778).
+func resolveNamespaceCreateOrganization(
+	c *gin.Context,
+	orgRepo *repositories.OrganizationRepository,
+	required auth.Scope,
+	requestedOrgID string,
+) (string, bool) {
+	requestedOrgID = strings.TrimSpace(requestedOrgID)
+
+	if ownerOrgID := tenantscope.OwnerOrg(c); ownerOrgID != "" {
+		if requestedOrgID != "" && requestedOrgID != ownerOrgID {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "organization_id does not match the namespace's owning organization",
+			})
+			return "", false
+		}
+		return ownerOrgID, true
+	}
+
+	return resolveTargetOrganization(c, orgRepo, required, requestedOrgID)
 }
 
 // requireTenantScopeForOrg authorizes a write against an explicitly named

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -1066,3 +1066,54 @@ func TestParseProviderFilePath_Empty(t *testing.T) {
 		t.Error("expected ok=false for empty path")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// UploadHandler — the module row is bound to the AUTHORIZED organization
+// (issue #778)
+// ---------------------------------------------------------------------------
+
+// uploadOwnerOrg is the organization the route's publish guard resolved and
+// authorized the upload against. It is deliberately not the default
+// organization sampleOrgRow2 returns.
+const uploadOwnerOrg = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee"
+
+// TestUploadHandler_BindsModuleToAuthorizedOrganization pins the invariant: the
+// module row is stamped with the organization the route authorized, which
+// nsAuthz.RequirePublishAccessFromForm resolves from the namespace and
+// publishes as owner_org_id.
+//
+// Two things make the row fail if the handler reverts to
+// GetDefaultOrganization: the WithArgs on the INSERT names the authorized
+// organization, and NO organizations lookup is primed, so reaching for the
+// default organization is itself an unexpected statement.
+func TestUploadHandler_BindsModuleToAuthorizedOrganization(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	t.Cleanup(func() { db.Close() })
+	r := gin.New()
+	r.POST("/api/v1/modules",
+		func(c *gin.Context) { c.Set("owner_org_id", uploadOwnerOrg) },
+		UploadHandler(db, &mockStore{}, &config.Config{}, nil, nil, nil, nil))
+
+	mock.ExpectQuery("INSERT INTO modules").
+		WithArgs(uploadOwnerOrg, "hashicorp", "consul", "aws",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows(moduleInsertCols2).AddRow("mod-new", time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(moduleVersionGetCols2))
+	mock.ExpectQuery("INSERT INTO module_versions").
+		WillReturnRows(sqlmock.NewRows(moduleVersionInsertCols2).AddRow("ver-new", time.Now()))
+
+	req := buildModuleUploadRequest(t, "/api/v1/modules", map[string]string{
+		"namespace": "hashicorp",
+		"name":      "consul",
+		"system":    "aws",
+		"version":   "1.0.0",
+	}, makeValidModuleTarGz(t))
+	w := doPOSTReq(r, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("module was not written into the authorized organization: %v", err)
+	}
+}

--- a/backend/internal/api/modules/upload.go
+++ b/backend/internal/api/modules/upload.go
@@ -21,6 +21,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
+	"github.com/terraform-registry/terraform-registry/internal/tenantscope"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
@@ -174,25 +175,48 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			}
 		}
 
-		// Get organization context
-		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
-			})
-			return
-		}
-		if org == nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found",
-			})
-			return
+		// GUARD namespace-create-owner-org (issue #778): the module row is
+		// stamped with the organization this upload was AUTHORIZED against.
+		//
+		// This route's nsAuthz.RequirePublishAccessFromForm guard resolves the
+		// namespace's owning organization — the existing owner, or the
+		// organization it just claimed an unowned namespace for — checks the
+		// caller against it, and publishes it as owner_org_id. Reaching for
+		// GetDefaultOrganization instead meant the organization the route
+		// authorized and the organization the row landed in were two
+		// independent values: an uploader holding modules:write in organization
+		// O published a module owned by the DEFAULT organization, which they
+		// need no membership in, and the UpsertModule conflict target
+		// (organization_id, namespace, name, system) resolved in that same wrong
+		// organization.
+		//
+		// The default-organization fallback survives only where no guard
+		// published an owner. On this route that is the platform-admin path
+		// through authorizeNamespaceMutation's ambiguous-ownership branch: a
+		// request with an empty namespace is rejected above before reaching
+		// here, so every non-admin upload that gets this far carries an owner.
+		orgID := tenantscope.OwnerOrg(c)
+		if orgID == "" {
+			org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to get organization context",
+				})
+				return
+			}
+			if org == nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Default organization not found",
+				})
+				return
+			}
+			orgID = org.ID
 		}
 
 		// Atomically create-or-get the module to avoid race conditions when two
 		// concurrent uploads target the same namespace/name/system.
 		module := &models.Module{
-			OrganizationID: org.ID,
+			OrganizationID: orgID,
 			Namespace:      namespace,
 			Name:           name,
 			System:         system,

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -2016,3 +2016,66 @@ func TestDownloadHandler_SuccessWithAuditContext(t *testing.T) {
 	// Give async goroutines a moment to fire (best-effort)
 	time.Sleep(50 * time.Millisecond)
 }
+
+// ---------------------------------------------------------------------------
+// UploadHandler — the provider row is bound to the AUTHORIZED organization
+// (issue #778)
+// ---------------------------------------------------------------------------
+
+// uploadOwnerOrg is the organization the route's publish guard resolved and
+// authorized the upload against. It is deliberately not the default
+// organization sampleOrgRow returns.
+const uploadOwnerOrg = "eeeeeeee-5555-4555-8555-eeeeeeeeeeee"
+
+// TestUploadHandler_BindsProviderToAuthorizedOrganization pins the invariant:
+// the provider row is stamped with the organization the route authorized, which
+// nsAuthz.RequirePublishAccessFromForm resolves from the namespace and
+// publishes as owner_org_id.
+//
+// Two things make the row fail if the handler reverts to
+// GetDefaultOrganization: the WithArgs on the existence check and on the INSERT
+// name the authorized organization, and NO organizations lookup is primed, so
+// reaching for the default organization is itself an unexpected statement.
+func TestUploadHandler_BindsProviderToAuthorizedOrganization(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	t.Cleanup(func() { db.Close() })
+	r := gin.New()
+	r.POST("/v1/providers",
+		func(c *gin.Context) { c.Set("owner_org_id", uploadOwnerOrg) },
+		UploadHandler(db, &mockStore{}, &config.Config{}))
+
+	// GetProvider must look for a collision in the AUTHORIZED organization: the
+	// providers unique key is (organization_id, namespace, type), so a lookup in
+	// the wrong organization reports "not found" for a provider that exists.
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").
+		WithArgs(uploadOwnerOrg, "hashicorp", "aws").
+		WillReturnRows(sqlmock.NewRows(providerCols))
+	mock.ExpectQuery("INSERT INTO providers").
+		WithArgs(uploadOwnerOrg, "hashicorp", "aws",
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows(providerInsertCols).AddRow("prov-new", time.Now(), time.Now()))
+	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
+		WillReturnRows(sqlmock.NewRows(providerVersionGetCols))
+	mock.ExpectQuery("INSERT INTO provider_versions").
+		WillReturnRows(sqlmock.NewRows(providerVersionInsertCols).AddRow("ver-new", time.Now()))
+	mock.ExpectQuery("SELECT.*FROM provider_platforms.*WHERE provider_version_id").
+		WillReturnRows(sqlmock.NewRows(platformCols))
+	mock.ExpectQuery("INSERT INTO provider_platforms").
+		WillReturnRows(sqlmock.NewRows(platformInsertCols).AddRow("plat-new"))
+
+	req := buildUploadRequest(t, "/v1/providers", map[string]string{
+		"namespace": "hashicorp",
+		"type":      "aws",
+		"version":   "4.0.0",
+		"os":        "linux",
+		"arch":      "amd64",
+	}, makeValidZIP(t))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("provider was not written into the authorized organization: %v", err)
+	}
+}

--- a/backend/internal/api/providers/upload.go
+++ b/backend/internal/api/providers/upload.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
+	"github.com/terraform-registry/terraform-registry/internal/tenantscope"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 	"github.com/terraform-registry/terraform-registry/pkg/checksum"
 )
@@ -236,23 +237,47 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 			return
 		}
 
-		// Get organization context
-		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to get organization context",
-			})
-			return
-		}
-		if org == nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Default organization not found",
-			})
-			return
+		// GUARD namespace-create-owner-org (issue #778): the provider row is
+		// stamped with the organization this upload was AUTHORIZED against.
+		//
+		// This route's nsAuthz.RequirePublishAccessFromForm guard resolves the
+		// namespace's owning organization — the existing owner, or the
+		// organization it just claimed an unowned namespace for — checks the
+		// caller against it, and publishes it as owner_org_id. Reaching for
+		// GetDefaultOrganization instead meant the organization the route
+		// authorized and the organization the row landed in were two
+		// independent values: an uploader holding providers:write in
+		// organization O published a provider owned by the DEFAULT
+		// organization, which they need no membership in, and the existence
+		// check below looked for the provider in that same wrong organization,
+		// so an upload into an existing provider created a second row instead
+		// of adding a version to the first.
+		//
+		// The default-organization fallback survives only where no guard
+		// published an owner. On this route that is the platform-admin path
+		// through authorizeNamespaceMutation's ambiguous-ownership branch: a
+		// request with an empty namespace is rejected above before reaching
+		// here, so every non-admin upload that gets this far carries an owner.
+		orgID := tenantscope.OwnerOrg(c)
+		if orgID == "" {
+			org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to get organization context",
+				})
+				return
+			}
+			if org == nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Default organization not found",
+				})
+				return
+			}
+			orgID = org.ID
 		}
 
 		// Check if provider already exists, create if not
-		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+		provider, err := providerRepo.GetProvider(c.Request.Context(), orgID, namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to query provider",
@@ -263,7 +288,7 @@ func UploadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Confi
 		if provider == nil {
 			// Create new provider
 			provider = &models.Provider{
-				OrganizationID: org.ID,
+				OrganizationID: orgID,
 				Namespace:      namespace,
 				Type:           providerType,
 			}

--- a/backend/internal/tenantscope/tenantscope.go
+++ b/backend/internal/tenantscope/tenantscope.go
@@ -42,12 +42,39 @@
 package tenantscope
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
+
+// OwnerOrgContextKey is where middleware publishes the organization it resolved
+// AND authorized the request against — the namespace's owner on the publish
+// guards, the addressed row's owner on the per-resource guards.
+const OwnerOrgContextKey = "owner_org_id"
+
+// OwnerOrg returns the organization a route guard has already resolved and
+// authorized this request against, or "" when no guard published one.
+//
+// It belongs next to Resolve because it answers the same question from the
+// other end. Resolve derives the organizations a CALLER may write to; OwnerOrg
+// reports the single organization a guard has already decided this REQUEST is
+// about. Where a guard has decided, that decision is the answer — re-deriving
+// it from the caller's memberships can only disagree with it, and issue #778 is
+// what disagreement costs: the guard authorized the namespace's owning
+// organization while the handler wrote the row into the default organization,
+// so the create axis authorized one tenant and wrote to another.
+//
+// Handlers must treat "" as "nobody has decided", not as "no tenant".
+func OwnerOrg(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.GetString(OwnerOrgContextKey))
+}
 
 // Scope is the set of organizations a request may read or write.
 //


### PR DESCRIPTION
Closes #778.

A handler decided the new row's owning organization independently of the guard that authorized the request. `CreateProviderRecord` read `req.OrganizationID` or fell back to `GetDefaultOrganization()`, while `nsAuthz.RequirePublishAccessFromJSON` had already resolved and published the namespace's real owner in `owner_org_id` — which the handler never read.

## Two unfiled siblings, same defect, same guard family

The enumeration found **four** sites, not one. Both upload handlers carry the identical shape behind `RequirePublishAccessFromForm`, which publishes `owner_org_id` the same way:

| Site | Route | Table |
|---|---|---|
| `admin/providers.go` `CreateProviderRecord` | `POST /api/v1/admin/providers` | `providers` |
| `admin/modules.go` `CreateModuleRecord` | `POST /api/v1/admin/modules/create` | `modules` |
| `providers/upload.go` `UploadHandler` | `POST /api/v1/providers` | `providers` |
| `modules/upload.go` `UploadHandler` | `POST /api/v1/modules` | `modules` |

All four fixed here. Fixing only the reported one would have left three siblings writing rows into an organization nobody authorized.

## Why not `resolveTargetOrganization` as the primary

The issue offered it, and it is the wrong primary on this axis: it answers from the **caller's memberships**, not from the namespace. A caller holding the scope in two organizations would get a 400 "ambiguous" for a namespace whose owner is unambiguous — and a **platform admin would be handed the default organization**, which is #778 itself reached by another route.

So the guard's own answer wins: `owner_org_id` first, `resolveTargetOrganization` only where the guard legitimately publishes nothing (a platform admin passing `authorizeNamespaceMutation`'s ambiguous-ownership branch, which `return true`s without setting the key). That fallback fails closed for every other principal rather than reaching for the default org.

A body naming an organization other than the authorized owner is now refused — **including for admins**, since the middleware exempts them from its own owner-match check, leaving the handler as the only place that disagreement is caught.

## Impact, stated accurately rather than uniformly

For a **non-admin** the reachable defect is identical on both record-create paths: the omitted path put the row in the default organization, which the caller needs no membership in. The middleware does validate a *supplied* `organization_id` against the namespace owner for non-admins, so neither path let a non-admin aim a row at an arbitrary org — matching the issue's own scope note.

They differ in two ways:

- `providers.go` **has** the field, so the value the handler trusted was structurally not the value the guard verified, and a **platform admin's** supplied org was checked against nothing. An operator could put a `providers` row in org X under a namespace owned by Y, splitting it from every namespace-path route.
- `modules.go` has no such field, so nothing was aimable — every create landed in the one default organization. That is a **tenancy-binding gap, not a targetable cross-tenant create.**

Second half, on all four: `providers`/`modules` are `UNIQUE (organization_id, namespace, …)` and the existence check ran in the **wrong** organization, so a real collision was invisible — a 500 from the constraint instead of a 409, and the provider upload created a second row instead of adding a version to the first.

## Class enumeration

39 non-test `GetDefaultOrganization` call sites; the four above are the class. Notable exclusions, each verified:

- `admin/apikeys.go:266` writes `api_keys.organization_id`, but `GetMemberWithRole` immediately 403s a non-member and checks requested scopes against the role template — the fallback cannot mint a key in an org the caller isn't in.
- `setup/handlers.go`, `admin/auth.go` (IdP default role), `jobs/mirror_sync.go` — bootstrap/config/background, not caller-reachable with a request-supplied org.
- 24 read/filter sites where the org id only feeds a lookup predicate and every subsequent mutation is keyed on row id.

**No repo-wide ban or unexport**, per the triage critique: 35 of 39 sites are legitimate, so a ban would be pure noise now the writing sites are closed — and it would not have landed as a drive-by anyway, leaving the class open while the issue read fixed.

## Verification

`go build`, `go vet`, `gofmt -l`, full `go test ./...` clean across 60 packages. `golangci-lint run` on the four changed packages: 0 issues. Swagger: `@Failure 403` added to both create endpoints, regenerated per CI's procedure after confirming local `swag` reproduces the checked-in docs byte-for-byte — so the diff is only the two 403 blocks.

**Mutation check.** Reverting the resolver to `GetDefaultOrganization` turns **12 of 13 rows red** on each record-create test. The survivor is `no owner published, platform admin falls back to the default organization` — correct, since that row pins *preserved* behaviour. A second mutant that resolves the default org without a DB call (isolating the binding assertion from "unexpected query") gives the same result, and the upload mutants fail with the sharpest message of all — the INSERT's `organization_id` argument literally not matching the authorized org.

## Follow-ups worth filing

1. **Fail-close the upload fallback** — both upload handlers still fall back to the default org for any caller reaching them with no owner published; it should be platform-admin-only. Left deliberately: ~18 existing upload tests prime the default-org lookup and rewriting them does not belong in this fix.
2. **`api/mirror/index.go:50` and `platform_index.go:85`** — an *unauthenticated* GET that materializes `providers` rows stamped with the default organization via pull-through. Different class; deserves its own issue.
3. A targeted invariant check — a handler constructing `models.X{OrganizationID: …}` behind a namespace guard must read `owner_org_id` — would be cheap and would catch the next instance. A broad symbol ban would not.