### PR TITLE
fix(auth)!: bound every authority ceiling by the presenting credential

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -7144,7 +7144,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Create a new API key with specified scopes. The full API key is only returned once during creation.",
+                "description": "Create a new API key with specified scopes. The full API key is only returned once during creation. Requested scopes must be within the caller's role template for the organization AND within the scopes of the credential making the request, so an API key can never mint a key broader than itself.",
                 "tags": [
                     "API Keys"
                 ],
@@ -7304,7 +7304,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope.",
+                "description": "Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope. New scopes are bounded the same way as on creation: by the caller's role template in the key's organization AND by the scopes of the credential making the request.",
                 "tags": [
                     "API Keys"
                 ],
@@ -7486,7 +7486,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope.",
+                "description": "Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope. The new key's scopes are re-derived from the key owner's current role template rather than copied from the old key, and are additionally bounded by the scopes of the credential making the request, so a rotation cannot re-mint authority the owner no longer holds.",
                 "tags": [
                     "API Keys"
                 ],
@@ -7547,7 +7547,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden - access denied to this key",
+                        "description": "Forbidden - access denied to this key, or the key's scopes exceed the authority available to this request",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -7904,7 +7904,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body.",
+                "description": "Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body. Requires an interactive session (Authorization: Bearer <jwt> or the session cookie); API keys cannot be exchanged for a session token and are rotated via /apikeys/{id}/rotate instead.",
                 "tags": [
                     "Authentication"
                 ],
@@ -7922,6 +7922,17 @@
                     },
                     "401": {
                         "description": "Unauthorized - invalid or missing token",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - the request presented a machine credential (API key or mTLS); only an interactive session can be refreshed",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5789,7 +5789,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Create a new API key with specified scopes. The full API key is only returned once during creation.",
+                "description": "Create a new API key with specified scopes. The full API key is only returned once during creation. Requested scopes must be within the caller's role template for the organization AND within the scopes of the credential making the request, so an API key can never mint a key broader than itself.",
                 "consumes": [
                     "application/json"
                 ],
@@ -5919,7 +5919,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope.",
+                "description": "Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope. New scopes are bounded the same way as on creation: by the caller's role template in the key's organization AND by the scopes of the credential making the request.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6063,7 +6063,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope.",
+                "description": "Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope. The new key's scopes are re-derived from the key owner's current role template rather than copied from the old key, and are additionally bounded by the scopes of the credential making the request, so a rotation cannot re-mint authority the owner no longer holds.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6114,7 +6114,7 @@
                         }
                     },
                     "403": {
-                        "description": "Forbidden - access denied to this key",
+                        "description": "Forbidden - access denied to this key, or the key's scopes exceed the authority available to this request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -6411,7 +6411,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body.",
+                "description": "Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body. Requires an interactive session (Authorization: Bearer \u003cjwt\u003e or the session cookie); API keys cannot be exchanged for a session token and are rotated via /apikeys/{id}/rotate instead.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6431,6 +6431,13 @@
                     },
                     "401": {
                         "description": "Unauthorized - invalid or missing token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - the request presented a machine credential (API key or mTLS); only an interactive session can be refreshed",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/apikeys.go
+++ b/backend/internal/api/admin/apikeys.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/credscope"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
@@ -211,7 +212,7 @@ func (h *APIKeyHandlers) ListAPIKeysHandler() gin.HandlerFunc {
 }
 
 // @Summary      Create API key
-// @Description  Create a new API key with specified scopes. The full API key is only returned once during creation.
+// @Description  Create a new API key with specified scopes. The full API key is only returned once during creation. Requested scopes must be within the caller's role template for the organization AND within the scopes of the credential making the request, so an API key can never mint a key broader than itself.
 // @Tags         API Keys
 // @Security     Bearer
 // @Accept       json
@@ -303,28 +304,43 @@ func (h *APIKeyHandlers) CreateAPIKeyHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Validate requested scopes are within user's allowed scopes for this org
-		// Admin scope grants all permissions
-		userHasAdmin := false
-		for _, scope := range memberWithRole.RoleTemplateScopes {
+		// Validate requested scopes are within the ceiling this REQUEST may
+		// grant. Admin scope grants all permissions.
+		//
+		// GUARD credential-scope-binding (issue #733). The ceiling is the
+		// caller's role template in this organization, intersected with the
+		// scopes of the credential that made the request. Deriving it from the
+		// role template alone answered "what may this USER grant" when the
+		// question is "what may this CREDENTIAL grant": /apikeys carries no
+		// RequireScope (self-service key management is deliberately open to any
+		// authenticated caller) and CSRFMiddleware exempts API-key callers, so a
+		// key deliberately narrowed to modules:read could POST
+		// {"scopes":["admin"]} and receive a platform-wide key whenever its
+		// owner held the admin role template. Narrowing a machine credential
+		// must contain it; credscope.Bound is a no-op for the interactive
+		// sessions the UI uses.
+		allowedScopes := credscope.Bound(c, memberWithRole.RoleTemplateScopes)
+
+		callerHasAdmin := false
+		for _, scope := range allowedScopes {
 			if scope == "admin" {
-				userHasAdmin = true
+				callerHasAdmin = true
 				break
 			}
 		}
 
-		if !userHasAdmin {
-			// Check each requested scope is in user's allowed scopes
+		if !callerHasAdmin {
+			// Check each requested scope is within the ceiling
 			allowedScopeSet := make(map[string]bool)
-			for _, s := range memberWithRole.RoleTemplateScopes {
+			for _, s := range allowedScopes {
 				allowedScopeSet[s] = true
 			}
 
 			for _, requestedScope := range req.Scopes {
 				if !allowedScopeSet[requestedScope] {
 					c.JSON(http.StatusForbidden, gin.H{
-						"error":          "Scope '" + requestedScope + "' exceeds your role permissions for this organization",
-						"allowed_scopes": memberWithRole.RoleTemplateScopes,
+						"error":          "Scope '" + requestedScope + "' exceeds the permissions available to this request",
+						"allowed_scopes": allowedScopes,
 						"role_template":  *memberWithRole.RoleTemplateName,
 					})
 					return
@@ -511,7 +527,7 @@ func (h *APIKeyHandlers) DeleteAPIKeyHandler() gin.HandlerFunc {
 }
 
 // @Summary      Update API key
-// @Description  Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope.
+// @Description  Update an API key's name, scopes, or expiration. Users can only update their own keys unless they have admin scope. New scopes are bounded the same way as on creation: by the caller's role template in the key's organization AND by the scopes of the credential making the request.
 // @Tags         API Keys
 // @Security     Bearer
 // @Accept       json
@@ -621,26 +637,35 @@ func (h *APIKeyHandlers) UpdateAPIKeyHandler() gin.HandlerFunc {
 				return
 			}
 
-			// Validate requested scopes are within user's allowed scopes for this org
-			userHasAdmin := false
-			for _, scope := range memberWithRole.RoleTemplateScopes {
+			// Validate requested scopes are within the ceiling this REQUEST may
+			// grant.
+			//
+			// GUARD credential-scope-binding (issue #733): the same ceiling
+			// CreateAPIKeyHandler applies, for the same reason. Widening an
+			// existing key is minting authority by another name, so a narrowed
+			// credential must not be able to do it either — including on the
+			// key it is itself presenting.
+			allowedScopes := credscope.Bound(c, memberWithRole.RoleTemplateScopes)
+
+			callerHasAdmin := false
+			for _, scope := range allowedScopes {
 				if scope == "admin" {
-					userHasAdmin = true
+					callerHasAdmin = true
 					break
 				}
 			}
 
-			if !userHasAdmin {
+			if !callerHasAdmin {
 				allowedScopeSet := make(map[string]bool)
-				for _, s := range memberWithRole.RoleTemplateScopes {
+				for _, s := range allowedScopes {
 					allowedScopeSet[s] = true
 				}
 
 				for _, requestedScope := range req.Scopes {
 					if !allowedScopeSet[requestedScope] {
 						c.JSON(http.StatusForbidden, gin.H{
-							"error":          "Scope '" + requestedScope + "' exceeds your role permissions for this organization",
-							"allowed_scopes": memberWithRole.RoleTemplateScopes,
+							"error":          "Scope '" + requestedScope + "' exceeds the permissions available to this request",
+							"allowed_scopes": allowedScopes,
 							"role_template":  *memberWithRole.RoleTemplateName,
 						})
 						return
@@ -690,7 +715,7 @@ type RotateAPIKeyResponse struct {
 }
 
 // @Summary      Rotate API key
-// @Description  Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope.
+// @Description  Rotate an API key by creating a new key and optionally scheduling the old key's expiration. Users can only rotate their own keys unless they have admin scope. The new key's scopes are re-derived from the key owner's current role template rather than copied from the old key, and are additionally bounded by the scopes of the credential making the request, so a rotation cannot re-mint authority the owner no longer holds.
 // @Tags         API Keys
 // @Security     Bearer
 // @Accept       json
@@ -700,7 +725,7 @@ type RotateAPIKeyResponse struct {
 // @Success      200  {object}  RotateAPIKeyResponse  "New API key and old key status"
 // @Failure      400  {object}  map[string]interface{}  "Invalid grace period (must be 0-72 hours)"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized - user not authenticated"
-// @Failure      403  {object}  map[string]interface{}  "Forbidden - access denied to this key"
+// @Failure      403  {object}  map[string]interface{}  "Forbidden - access denied to this key, or the key's scopes exceed the authority available to this request"
 // @Failure      404  {object}  map[string]interface{}  "API key not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/apikeys/{id}/rotate [post]
@@ -753,6 +778,69 @@ func (h *APIKeyHandlers) RotateAPIKeyHandler() gin.HandlerFunc {
 					"error": "Access denied",
 				})
 				return
+			}
+		}
+
+		// GUARD credential-scope-binding (issue #733). Rotation MINTS a key, so
+		// the scopes it writes need the same ceiling as creation — re-derived,
+		// not inherited. Copying oldKey.Scopes and authorizing on ownership
+		// alone made rotation a scope-laundering primitive: it was the one
+		// minting path with no ceiling at all, so a narrowed credential could
+		// rotate a broader sibling key of its owner's and receive that key's
+		// full scopes, and a key whose owner had since been demoted could
+		// re-mint the authority the demotion removed.
+		//
+		// The user half of the ceiling is the KEY OWNER's current role
+		// template, not the caller's: rotation re-issues the owner's
+		// credential, and reading the caller's membership would 403 a platform
+		// admin rotating a key in an organization they do not belong to. The
+		// credential half is still the caller's, so a narrow key cannot launder
+		// scopes through a rotation it is not entitled to perform.
+		if oldKey.UserID == nil || *oldKey.UserID == "" {
+			// Matches middleware.verifyKeyOwnerAuthority: a userless key is a
+			// row whose owner was deleted (identity.api_keys.user_id is
+			// ON DELETE SET NULL), not an organization service credential, and
+			// there is no authority left to re-derive for it.
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "API key has no owning user; re-issue it through the API key endpoints",
+			})
+			return
+		}
+		owner, err := h.orgRepo.GetMemberWithRole(c.Request.Context(), oldKey.OrganizationID, *oldKey.UserID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to get user role information",
+			})
+			return
+		}
+		if owner == nil {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "API key owner is no longer a member of the key's organization",
+			})
+			return
+		}
+
+		rotateScopes := credscope.Bound(c, owner.RoleTemplateScopes)
+		ownerHasAdmin := false
+		for _, scope := range rotateScopes {
+			if scope == "admin" {
+				ownerHasAdmin = true
+				break
+			}
+		}
+		if !ownerHasAdmin {
+			allowedScopeSet := make(map[string]bool)
+			for _, s := range rotateScopes {
+				allowedScopeSet[s] = true
+			}
+			for _, existingScope := range oldKey.Scopes {
+				if !allowedScopeSet[existingScope] {
+					c.JSON(http.StatusForbidden, gin.H{
+						"error":          "Scope '" + existingScope + "' exceeds the permissions available to this request; update the key's scopes before rotating it",
+						"allowed_scopes": rotateScopes,
+					})
+					return
+				}
 			}
 		}
 

--- a/backend/internal/api/admin/apikeys_test.go
+++ b/backend/internal/api/admin/apikeys_test.go
@@ -724,6 +724,10 @@ func TestRotateAPIKey_NotFound(t *testing.T) {
 func TestRotateAPIKey_ImmediateRevoke(t *testing.T) {
 	mock, r := newAPIKeyRouter(t, "user-1", nil)
 	mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").WillReturnRows(sampleAKRow())
+	// Rotation re-derives the key owner's ceiling instead of trusting the old
+	// key's stored scopes (issue #733).
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sampleMemberRoleRow())
 	mock.ExpectExec("INSERT INTO api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("DELETE FROM api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -743,6 +747,10 @@ func TestRotateAPIKey_ImmediateRevoke(t *testing.T) {
 func TestRotateAPIKey_WithGracePeriod(t *testing.T) {
 	mock, r := newAPIKeyRouter(t, "user-1", nil)
 	mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").WillReturnRows(sampleAKRow())
+	// Rotation re-derives the key owner's ceiling instead of trusting the old
+	// key's stored scopes (issue #733).
+	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+		WillReturnRows(sampleMemberRoleRow())
 	mock.ExpectExec("INSERT INTO api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE api_keys.*SET name").WillReturnResult(sqlmock.NewResult(1, 1))
 

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -23,6 +23,7 @@ import (
 	samlpkg "github.com/terraform-registry/terraform-registry/internal/auth/saml"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
+	"github.com/terraform-registry/terraform-registry/internal/credscope"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
@@ -687,13 +688,14 @@ func deriveFrontendURL(cfg *config.Config) string {
 }
 
 // @Summary      Refresh JWT token
-// @Description  Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body.
+// @Description  Revokes the current JWT and sets a fresh one as an httpOnly auth cookie with extended expiration. The token itself is never returned in the response body. Requires an interactive session (Authorization: Bearer <jwt> or the session cookie); API keys cannot be exchanged for a session token and are rotated via /apikeys/{id}/rotate instead.
 // @Tags         Authentication
 // @Security     Bearer
 // @Accept       json
 // @Produce      json
 // @Success      200  {object}  admin.RefreshResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized - invalid or missing token"
+// @Failure      403  {object}  map[string]interface{}  "Forbidden - the request presented a machine credential (API key or mTLS); only an interactive session can be refreshed"
 // @Failure      500  {object}  map[string]interface{}  "Internal error during token generation"
 // @Router       /api/v1/auth/refresh [post]
 // RefreshHandler refreshes an existing JWT token
@@ -714,6 +716,22 @@ func (h *AuthHandlers) RefreshHandler() gin.HandlerFunc {
 		if !ok {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Invalid user ID format",
+			})
+			return
+		}
+
+		// GUARD credential-scope-binding (issue #733). Refresh mints a session
+		// token carrying the OWNER's cross-organization scope union, so
+		// honouring it for a machine credential is the whole of #733 in one
+		// call: an API key narrowed to modules:read would be exchanged for a
+		// JWT holding everything its owner holds, everywhere, with the key's
+		// organization binding dropped. There is no ceiling to intersect here
+		// because a session token is not scoped — the credential families are
+		// simply not interchangeable, so this endpoint is restricted to the one
+		// it refreshes. API keys are rotated via /apikeys/:id/rotate.
+		if !credscope.Interactive(c) {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "Token refresh requires an interactive session; API keys cannot be exchanged for a session token",
 			})
 			return
 		}

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -283,6 +283,7 @@ func TestRefreshHandler_UserNotFound(t *testing.T) {
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		c.Set("user_id", "user-1")
+		c.Set("auth_method", "jwt")
 		c.Next()
 	})
 	r.GET("/auth/refresh", h.RefreshHandler())
@@ -486,6 +487,7 @@ func TestRefreshHandler_Success(t *testing.T) {
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		c.Set("user_id", "user-1")
+		c.Set("auth_method", "jwt")
 		c.Next()
 	})
 	r.GET("/auth/refresh", h.RefreshHandler())

--- a/backend/internal/api/admin/credential_binding_class_test.go
+++ b/backend/internal/api/admin/credential_binding_class_test.go
@@ -1,0 +1,408 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// ---------------------------------------------------------------------------
+// Class test: an authority ceiling must be bound to the PRESENTING credential,
+// not to the credential owner's user record (issue #733)
+// ---------------------------------------------------------------------------
+//
+// DEFECT CLASS
+//
+//	A handler decides how much authority a request may exercise -- or GRANT --
+//	by reading the caller's USER record (organization membership + role
+//	template) and never asking what the credential in front of it actually
+//	carries. Where the two differ, the narrower one is the credential, and
+//	ignoring it makes scoping a machine credential decorative: a key issued
+//	with modules:read could mint, widen or rotate its way up to everything its
+//	owner holds, including the platform-wide admin wildcard. No interactive
+//	session is needed and CSRFMiddleware exempts API-key callers, so possession
+//	of one leaked narrow key was possession of its owner's maximum authority.
+//
+// The table below is the class on the minting axis: three operations that write
+// a scope set (create, update, rotate) x three principals (an interactive JWT
+// session, an API key strictly narrower than its owner, an API key equal to its
+// owner) x both directions of the decision.
+//
+// BOTH DIRECTIONS ARE ASSERTED ON PURPOSE. A table that only proves denials
+// passes just as happily when the ceiling resolver returns the empty set and
+// refuses everyone -- which is itself a defect, and one that a
+// deny-everything "fix" would hide. Every principal therefore has a row it
+// must still be ALLOWED, and the narrow key is allowed precisely the scope it
+// itself holds.
+//
+// Siblings of the class that do not write an API key scope set are covered
+// underneath the table: role assignment (role_ceiling.go) and token refresh
+// (auth.go), which was the same root cause with the credential families
+// swapped -- a machine credential exchanged for a session token carrying its
+// owner's whole cross-organization scope union.
+
+// ownerRoleScopes is what the key owner's role template grants in org-1: the
+// admin wildcard, i.e. the maximum authority a narrowed key must not reach.
+var ownerRoleScopes = []byte(`["admin"]`)
+
+// credBindingPrincipal is one authenticated caller shape.
+type credBindingPrincipal struct {
+	name string
+	// keyScopes is nil for an interactive JWT session and the presenting API
+	// key's own scopes otherwise.
+	keyScopes []string
+	// sessionScopes is what AuthMiddleware puts in c.Get("scopes") -- the JWT's
+	// embedded union for a session, the key's derived scopes for a key.
+	sessionScopes []string
+}
+
+var credBindingPrincipals = []credBindingPrincipal{
+	{
+		// The interactive path keeps today's user-derived ceiling: a browser
+		// session IS the user's full authority, so nothing narrows it.
+		name:          "jwt session",
+		sessionScopes: []string{"admin"},
+	},
+	{
+		// The escalation vector: a key deliberately scoped down, owned by a
+		// principal holding the admin role template in the same organization.
+		name:          "api key narrower than owner",
+		keyScopes:     []string{"modules:read"},
+		sessionScopes: []string{"modules:read"},
+	},
+	{
+		// The control: a key that carries everything its owner does must not
+		// lose anything to the new ceiling.
+		name:          "api key equal to owner",
+		keyScopes:     []string{"admin"},
+		sessionScopes: []string{"admin"},
+	},
+}
+
+// newCredBindingRouter mounts the API key handlers with the context
+// AuthMiddleware would have produced for p.
+func newCredBindingRouter(t *testing.T, p credBindingPrincipal) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewAPIKeyHandlers(&config.Config{}, db)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("user_id", "user-1")
+		c.Set("scopes", p.sessionScopes)
+		if p.keyScopes == nil {
+			c.Set("auth_method", "jwt")
+		} else {
+			owner := "user-1"
+			c.Set("auth_method", "api_key")
+			c.Set("organization_id", "org-1")
+			c.Set("api_key", &models.APIKey{
+				ID:             "presenting-key",
+				UserID:         &owner,
+				OrganizationID: "org-1",
+				Scopes:         p.keyScopes,
+			})
+		}
+		c.Next()
+	})
+	r.POST("/apikeys", h.CreateAPIKeyHandler())
+	r.PUT("/apikeys/:id", h.UpdateAPIKeyHandler())
+	r.POST("/apikeys/:id/rotate", h.RotateAPIKeyHandler())
+	return mock, r
+}
+
+// ownerMemberRow is the org-1 membership of user-1 under the admin role
+// template -- the user-derived half of every ceiling in this file.
+func ownerMemberRow() *sqlmock.Rows {
+	roleTemplateID := "role-owner"
+	roleName := "owner"
+	roleDisplay := "Owner"
+	return sqlmock.NewRows(memberRoleCols).AddRow(
+		"org-1", "user-1", &roleTemplateID, time.Now(),
+		"Alice", "alice@example.com",
+		&roleName, &roleDisplay,
+		ownerRoleScopes,
+	)
+}
+
+// storedKeyRow is an existing api_keys row owned by user-1 in org-1 carrying
+// scopes -- the subject of update and rotate.
+func storedKeyRow(scopes string) *sqlmock.Rows {
+	return sqlmock.NewRows(akCols).AddRow(
+		"key-1", "user-1", "org-1", "CI Key", nil, "hashedkey", "tfr_abc123",
+		[]byte(scopes), nil, nil, nil, time.Now(),
+	)
+}
+
+func TestCredentialBindingClass_KeyMinting(t *testing.T) {
+	// requested is the scope set the operation would write. "admin" is the
+	// escalation; "modules:read" is the scope the narrow key legitimately
+	// holds, and is what proves the ceiling has not collapsed to empty.
+	cases := []struct {
+		op        string
+		requested string
+	}{
+		{"create", "admin"},
+		{"create", "modules:read"},
+		{"update", "admin"},
+		{"update", "modules:read"},
+		{"rotate", "admin"},
+		{"rotate", "modules:read"},
+	}
+
+	for _, p := range credBindingPrincipals {
+		for _, tc := range cases {
+			// A key may write a scope set only if it holds those scopes
+			// itself; a session is bounded solely by the owner's role
+			// template, which here is the admin wildcard.
+			allowed := p.keyScopes == nil || auth.HasScope(p.keyScopes, auth.Scope(tc.requested))
+
+			t.Run(tc.op+"/"+p.name+"/"+tc.requested, func(t *testing.T) {
+				mock, r := newCredBindingRouter(t, p)
+				w := httptest.NewRecorder()
+
+				switch tc.op {
+				case "create":
+					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+						WillReturnRows(ownerMemberRow())
+					if allowed {
+						mock.ExpectExec("INSERT INTO api_keys").
+							WillReturnResult(sqlmock.NewResult(1, 1))
+					}
+					r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/apikeys",
+						jsonBody(map[string]interface{}{
+							"name":            "minted",
+							"organization_id": "org-1",
+							"scopes":          []string{tc.requested},
+						})))
+
+				case "update":
+					mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").
+						WillReturnRows(storedKeyRow(`["modules:read"]`))
+					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+						WillReturnRows(ownerMemberRow())
+					if allowed {
+						mock.ExpectExec("UPDATE api_keys.*SET name").
+							WillReturnResult(sqlmock.NewResult(1, 1))
+					}
+					r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/apikeys/key-1",
+						jsonBody(map[string]interface{}{
+							"scopes": []string{tc.requested},
+						})))
+
+				case "rotate":
+					// Rotation writes the OLD key's scopes into a new row, so
+					// the old row's stored scopes are the set under test.
+					mock.ExpectQuery("SELECT.*FROM api_keys WHERE id").
+						WillReturnRows(storedKeyRow(`["` + tc.requested + `"]`))
+					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
+						WillReturnRows(ownerMemberRow())
+					if allowed {
+						mock.ExpectExec("INSERT INTO api_keys").
+							WillReturnResult(sqlmock.NewResult(1, 1))
+						mock.ExpectExec("DELETE FROM api_keys").
+							WillReturnResult(sqlmock.NewResult(1, 1))
+					}
+					r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/apikeys/key-1/rotate",
+						jsonBody(map[string]interface{}{"grace_period_hours": 0})))
+				}
+
+				if allowed {
+					if w.Code != http.StatusOK && w.Code != http.StatusCreated {
+						t.Fatalf("%s with %q by %s: status = %d, want 2xx (a legitimate request must still succeed): body=%s",
+							tc.op, tc.requested, p.name, w.Code, w.Body.String())
+					}
+					// The minted scope set must be exactly what was asked for:
+					// a ceiling that silently narrows is as wrong as one that
+					// silently widens.
+					if got := mintedScopes(t, w); got != "" && got != tc.requested {
+						t.Fatalf("%s by %s minted scopes %q, want %q", tc.op, p.name, got, tc.requested)
+					}
+					return
+				}
+				if w.Code != http.StatusForbidden {
+					t.Fatalf("%s with %q by %s: status = %d, want 403 (a credential may not write a scope it does not hold): body=%s",
+						tc.op, tc.requested, p.name, w.Code, w.Body.String())
+				}
+			})
+		}
+	}
+}
+
+// mintedScopes reads the scope set a successful create/rotate wrote back, or
+// "" when the response carries none (update returns the whole key object).
+func mintedScopes(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Scopes []string `json:"scopes"`
+		NewKey struct {
+			Scopes []string `json:"scopes"`
+		} `json:"new_key"`
+		Key struct {
+			Scopes []string `json:"scopes"`
+		} `json:"key"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		return ""
+	}
+	for _, s := range [][]string{body.Scopes, body.NewKey.Scopes, body.Key.Scopes} {
+		if len(s) == 1 {
+			return s[0]
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Sibling: role assignment (role_ceiling.go)
+// ---------------------------------------------------------------------------
+
+// TestCredentialBindingClass_RoleAssignment covers the same root cause on a
+// different minting surface. checkRoleAssignment derives the caller's
+// assignment ceiling from their scopes in the target organization -- a USER
+// record -- so a key scoped to organizations:write, owned by an org owner,
+// could assign that owner's admin role template to any member. Assigning a
+// role is minting authority by another name.
+func TestCredentialBindingClass_RoleAssignment(t *testing.T) {
+	adminRoleID := "33333333-3333-3333-3333-333333333333"
+
+	tests := []struct {
+		name      string
+		keyScopes []string
+		roleScope string
+		want      bool
+	}{
+		{"jwt session may assign the org owner role", nil, "organizations:write", true},
+		{"narrow key may not assign a role beyond its own scopes", []string{"modules:read"}, "organizations:write", false},
+		{"narrow key may still assign a role within its own scopes", []string{"modules:read"}, "modules:read", true},
+		{"key equal to owner may assign the org owner role", []string{"organizations:write"}, "organizations:write", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+			h := &OrganizationHandlers{db: db, orgRepo: repositories.NewOrganizationRepository(db)}
+
+			mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+				WillReturnRows(sqlmock.NewRows([]string{"scopes"}).
+					AddRow([]byte(`["` + tt.roleScope + `"]`)))
+			// The caller's role in the target org grants both scopes, so the
+			// user-derived ceiling alone permits every row here; only the
+			// credential half can deny one.
+			mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+				WillReturnRows(sqlmock.NewRows(orgMembersWithUserCols).AddRow(
+					"org-1", "caller-1", "role-owner", time.Now(),
+					"Alice", "alice@example.com", "owner", "Owner",
+					[]byte(`["organizations:write","modules:read"]`),
+				))
+
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPut, "/organizations/org-1/members/u", nil)
+			c.Params = gin.Params{{Key: "id", Value: "org-1"}}
+			c.Set("user_id", "caller-1")
+			if tt.keyScopes == nil {
+				c.Set("auth_method", "jwt")
+				c.Set("scopes", []string{"organizations:write", "modules:read"})
+			} else {
+				owner := "caller-1"
+				c.Set("auth_method", "api_key")
+				c.Set("scopes", tt.keyScopes)
+				c.Set("api_key", &models.APIKey{
+					UserID: &owner, OrganizationID: "org-1", Scopes: tt.keyScopes,
+				})
+			}
+
+			chk := h.checkRoleAssignment(c, &adminRoleID)
+			if chk.allowed != tt.want {
+				t.Fatalf("allowed = %v, want %v (status %d)", chk.allowed, tt.want, chk.status)
+			}
+			if !tt.want && chk.status != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403", chk.status)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sibling: session-token refresh (auth.go)
+// ---------------------------------------------------------------------------
+
+// TestCredentialBindingClass_RefreshRejectsMachineCredential covers the same
+// root cause across credential FAMILIES. RefreshHandler mints a session token
+// from GetUserCombinedScopes -- the owner's union across every organization --
+// so honouring it for an API key exchanged a narrowed, organization-bound
+// machine credential for an unbounded session carrying the owner's whole
+// authority. There is no ceiling to intersect on a session token, so the
+// families are simply not interchangeable.
+func TestCredentialBindingClass_RefreshRejectsMachineCredential(t *testing.T) {
+	tests := []struct {
+		name       string
+		authMethod string
+		apiKey     *models.APIKey
+		wantStatus int
+	}{
+		{"interactive header session refreshes", "jwt", nil, http.StatusOK},
+		{"interactive cookie session refreshes", "jwt_cookie", nil, http.StatusOK},
+		{"api key is refused", "api_key", &models.APIKey{Scopes: []string{"modules:read"}}, http.StatusForbidden},
+		{"unrecorded auth method is refused", "", nil, http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			h, err := NewAuthHandlers(&config.Config{}, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+			if err != nil {
+				t.Fatalf("NewAuthHandlers: %v", err)
+			}
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set("user_id", "user-1")
+				if tt.authMethod != "" {
+					c.Set("auth_method", tt.authMethod)
+				}
+				if tt.apiKey != nil {
+					c.Set("api_key", tt.apiKey)
+				}
+				c.Next()
+			})
+			r.POST("/auth/refresh", h.RefreshHandler())
+
+			if tt.wantStatus == http.StatusOK {
+				mock.ExpectQuery("SELECT.*FROM users WHERE id").
+					WillReturnRows(sqlmock.NewRows(authUserCols).
+						AddRow("user-1", "refresh@example.com", "Refresh User", nil, time.Now(), time.Now()))
+			}
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/auth/refresh", nil))
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d: body=%s", w.Code, tt.wantStatus, w.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/api/admin/dev.go
+++ b/backend/internal/api/admin/dev.go
@@ -59,6 +59,15 @@ func (h *DevHandlers) ImpersonateUserHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		targetUserID := c.Param("user_id")
 
+		// GUARD credential-scope-binding (issue #733): this handler mints a
+		// session token from a USER record (the target's combined scopes), on
+		// a route AuthMiddleware lets an API key reach — the shape of #733.
+		// What binds it to the presenting credential is the entry gate below:
+		// c.Get("scopes") is the calling credential's own scope set, so a key
+		// that is not itself an admin key never reaches the mint. Holding the
+		// admin wildcard is already unrestricted authority, so there is no
+		// narrower ceiling left to intersect. Keep the gate first.
+
 		// Get current user's scopes to verify they're an admin
 		scopesVal, exists := c.Get("scopes")
 		if !exists {
@@ -127,6 +136,10 @@ func (h *DevHandlers) ImpersonateUserHandler() gin.HandlerFunc {
 // GET /api/v1/dev/users
 func (h *DevHandlers) ListUsersForImpersonationHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// GUARD credential-scope-binding (issue #733): same entry gate, same
+		// reasoning as ImpersonateUserHandler — the admin check reads the
+		// PRESENTING credential's scopes, not the caller's user record.
+
 		// Get current user's scopes to verify they're an admin
 		scopesVal, exists := c.Get("scopes")
 		if !exists {

--- a/backend/internal/api/admin/role_ceiling.go
+++ b/backend/internal/api/admin/role_ceiling.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/credscope"
 )
 
 type roleAssignmentCheck struct {
@@ -68,6 +69,16 @@ func (h *OrganizationHandlers) checkRoleAssignment(c *gin.Context, roleTemplateI
 		}
 		callerScopes = orgScopes
 	}
+
+	// GUARD credential-scope-binding (issue #733). The per-org branch above
+	// reads the caller's USER record, so on an API-key request it hands back an
+	// authority the presenting credential may not hold: a key scoped to
+	// organizations:write, owned by an org owner, could assign that owner's
+	// admin role template to any member — minting through role assignment the
+	// same escalation #733 closed on key creation. Intersecting with the
+	// credential's own scopes leaves the admin branch and every interactive
+	// session untouched (Bound is identity for both).
+	callerScopes = credscope.Bound(c, callerScopes)
 
 	if !auth.RoleScopesPermittedBy(callerScopes, roleScopes) {
 		return roleAssignmentCheck{allowed: false, status: http.StatusForbidden}

--- a/backend/internal/credscope/credscope.go
+++ b/backend/internal/credscope/credscope.go
@@ -1,0 +1,120 @@
+// Package credscope binds an authority ceiling to the credential that actually
+// made the request.
+//
+// THE CLASS (issue #733, CWE-269). A handler that decides how much authority a
+// request may exercise, or GRANT, by reading the caller's user record — their
+// organization membership and its role template — answers a question about the
+// PRINCIPAL when the question it needs answered is about the CREDENTIAL. The
+// two are not the same thing. A user holding the admin role template may also
+// hold a machine credential deliberately narrowed to `modules:read`; deriving
+// the ceiling from the user makes that narrowing decorative, because the narrow
+// credential can mint, widen or rotate its way to the owner's full authority.
+// Containment is the entire reason for issuing a scoped key, so a scoping that
+// does not survive the key's own use is not scoping at all.
+//
+// THE RULE. Every authority ceiling derived from a user record is intersected
+// with the scopes the presenting credential itself carries. An interactive
+// session (a JWT in the Authorization header or the session cookie) IS the
+// user's full authority by construction and keeps the user-derived ceiling
+// unchanged; an API key never rises above the scopes stored on its own row.
+//
+// WHY A PACKAGE. The same decision is needed in internal/api/admin (API key
+// create/update/rotate, role assignment) and would be needed by any future
+// caller in internal/middleware; a copy per package is precisely the divergence
+// tracked in issue #665, where two implementations of one check drift until one
+// of them is wrong. middleware.authorizeOrgAccess and tenantscope.Resolve
+// already read the API-key principal correctly for the ORGANIZATION axis; this
+// package is the same idea on the SCOPE axis, and new call sites should use it
+// rather than re-deriving the intersection inline.
+package credscope
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// Presented returns the scopes carried by the credential that authenticated
+// this request, and whether that credential is an API key.
+//
+// The scopes come from the request context in preference to the api_keys row:
+// AuthMiddleware.currentKeyScopes has already intersected the row's frozen
+// scopes with what the owner's CURRENT role template grants (issue #732), so
+// the context set is the narrower — and therefore correct — of the two. The
+// stored set is the fallback for a context that carries the key but no derived
+// scopes.
+//
+// An api_key context value of an unexpected type yields (nil, true): a
+// principal that cannot be interpreted grants nothing, rather than falling
+// through to the interactive path and inheriting the whole user-derived
+// ceiling.
+func Presented(c *gin.Context) ([]string, bool) {
+	keyVal, exists := c.Get("api_key")
+	if !exists {
+		return nil, false
+	}
+	apiKey, ok := keyVal.(*models.APIKey)
+	if !ok {
+		return nil, true
+	}
+	scopes := apiKey.Scopes
+	if scopesVal, ok := c.Get("scopes"); ok {
+		if ctxScopes, ok := scopesVal.([]string); ok {
+			scopes = ctxScopes
+		}
+	}
+	return scopes, true
+}
+
+// Interactive reports whether the request was authenticated by an interactive
+// session token — a JWT presented in the Authorization header or in the
+// tfr_auth_token cookie.
+//
+// Machine credentials (API keys, mTLS client certificates) are not
+// interactive, and neither is a request whose authentication method was never
+// recorded: this is a question about the credential, so the absence of one is
+// answered "no" rather than waved through.
+func Interactive(c *gin.Context) bool {
+	switch c.GetString("auth_method") {
+	case "jwt", "jwt_cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+// Bound narrows a ceiling derived from the caller's user record to the scopes
+// the presenting credential itself carries, and returns it in the same
+// []string form the call site already uses — so it drops straight into
+// auth.HasScope, auth.RoleScopesPermittedBy, or a membership set literal.
+//
+// For an interactive session userDerived is returned unchanged.
+//
+// The result is materialised by testing every candidate scope against BOTH
+// sets with auth.HasScope, rather than by set intersection, because either set
+// may contain the "admin" wildcard or a write scope that implies its read
+// sibling. A literal intersection of ["admin"] with ["modules:read"] is empty —
+// it would deny a request both sides plainly permit, and a ceiling that denies
+// everyone is a bug that a denial-only test cannot see.
+func Bound(c *gin.Context, userDerived []string) []string {
+	presented, isAPIKey := Presented(c)
+	if !isAPIKey {
+		return userDerived
+	}
+
+	seen := make(map[string]bool, len(userDerived)+len(presented))
+	out := make([]string, 0, len(userDerived))
+	for _, candidates := range [][]string{userDerived, presented} {
+		for _, s := range candidates {
+			if seen[s] {
+				continue
+			}
+			seen[s] = true
+			if auth.HasScope(userDerived, auth.Scope(s)) && auth.HasScope(presented, auth.Scope(s)) {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}

--- a/backend/internal/credscope/credscope_test.go
+++ b/backend/internal/credscope/credscope_test.go
@@ -1,0 +1,170 @@
+package credscope
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+func testContext(authMethod string, sessionScopes []string, key *models.APIKey) *gin.Context {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	if authMethod != "" {
+		c.Set("auth_method", authMethod)
+	}
+	if sessionScopes != nil {
+		c.Set("scopes", sessionScopes)
+	}
+	if key != nil {
+		c.Set("api_key", key)
+	}
+	return c
+}
+
+func key(scopes ...string) *models.APIKey {
+	owner := "user-1"
+	return &models.APIKey{UserID: &owner, OrganizationID: "org-1", Scopes: scopes}
+}
+
+// TestBound covers the scope lattice in both directions. The wildcard rows are
+// the reason Bound is not a set intersection: "admin" and a write scope each
+// stand in for scopes they do not literally contain, so a literal intersection
+// would return the empty set and deny a request both sides plainly permit.
+func TestBound(t *testing.T) {
+	tests := []struct {
+		name        string
+		userDerived []string
+		presented   *models.APIKey
+		// badPrincipal sets an api_key context value of the wrong type.
+		badPrincipal bool
+		want         []string
+	}{
+		{
+			name:        "interactive session keeps the user-derived ceiling",
+			userDerived: []string{"admin"},
+			presented:   nil,
+			want:        []string{"admin"},
+		},
+		{
+			name:        "narrow key under an admin owner keeps only what it holds",
+			userDerived: []string{"admin"},
+			presented:   key("modules:read"),
+			want:        []string{"modules:read"},
+		},
+		{
+			name:        "admin key under a narrow owner keeps only what the owner grants",
+			userDerived: []string{"modules:read"},
+			presented:   key("admin"),
+			want:        []string{"modules:read"},
+		},
+		{
+			name:        "admin on both sides survives",
+			userDerived: []string{"admin"},
+			presented:   key("admin"),
+			want:        []string{"admin"},
+		},
+		{
+			name:        "write does not survive a read-only key, but read does",
+			userDerived: []string{"modules:write"},
+			presented:   key("modules:read"),
+			want:        []string{"modules:read"},
+		},
+		{
+			name:        "disjoint sets yield nothing",
+			userDerived: []string{"modules:read"},
+			presented:   key("providers:read"),
+			want:        []string{},
+		},
+		{
+			name:        "overlap is kept, non-overlap is dropped",
+			userDerived: []string{"modules:read", "providers:write"},
+			presented:   key("modules:read", "scm:manage"),
+			want:        []string{"modules:read"},
+		},
+		{
+			name:         "an uninterpretable key principal grants nothing",
+			userDerived:  []string{"admin"},
+			badPrincipal: true,
+			want:         []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c *gin.Context
+			switch {
+			case tt.badPrincipal:
+				c, _ = gin.CreateTestContext(httptest.NewRecorder())
+				c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+				c.Set("api_key", "not-a-key")
+			case tt.presented == nil:
+				c = testContext("jwt", tt.userDerived, nil)
+			default:
+				c = testContext("api_key", tt.presented.Scopes, tt.presented)
+			}
+
+			got := Bound(c, tt.userDerived)
+			sort.Strings(got)
+			want := append([]string{}, tt.want...)
+			sort.Strings(want)
+			if len(got) == 0 && len(want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Bound = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestPresentedPrefersDerivedScopes proves Bound reads the NARROWER of the two
+// scope sets available for a key: AuthMiddleware already intersected the row's
+// frozen scopes with the owner's current role template (issue #732), so the
+// context set — not the stored row — is authoritative.
+func TestPresentedPrefersDerivedScopes(t *testing.T) {
+	c := testContext("api_key", []string{"modules:read"}, key("modules:read", "providers:write"))
+	got, isKey := Presented(c)
+	if !isKey {
+		t.Fatal("Presented did not report an API-key principal")
+	}
+	if !reflect.DeepEqual(got, []string{"modules:read"}) {
+		t.Fatalf("Presented = %v, want the derived context scopes [modules:read]", got)
+	}
+}
+
+// TestPresentedFallsBackToStoredScopes covers the wiring where a key is in
+// context but no derived scope set is (unit tests, and any middleware that sets
+// only the principal).
+func TestPresentedFallsBackToStoredScopes(t *testing.T) {
+	c := testContext("api_key", nil, key("modules:read"))
+	got, isKey := Presented(c)
+	if !isKey || !reflect.DeepEqual(got, []string{"modules:read"}) {
+		t.Fatalf("Presented = %v, %v; want [modules:read], true", got, isKey)
+	}
+}
+
+func TestInteractive(t *testing.T) {
+	tests := []struct {
+		authMethod string
+		want       bool
+	}{
+		{"jwt", true},
+		{"jwt_cookie", true},
+		{"api_key", false},
+		{"mtls", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run("auth_method="+tt.authMethod, func(t *testing.T) {
+			if got := Interactive(testContext(tt.authMethod, nil, nil)); got != tt.want {
+				t.Fatalf("Interactive = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/middleware/namespace_authz.go
+++ b/backend/internal/middleware/namespace_authz.go
@@ -435,6 +435,16 @@ func (a *NamespaceAuthorizer) authorizeNamespaceMutation(c *gin.Context, namespa
 // status and message. The checks are ordered from cheapest to most expensive
 // and every branch fails closed.
 func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID string, scope auth.Scope) (int, string) {
+	return authorizeOrgAccessWith(c, a.orgRepo, ownerOrgID, scope)
+}
+
+// authorizeOrgAccessWith is authorizeOrgAccess with the repository passed
+// explicitly, so the check is reachable from route guards that are plain
+// functions rather than methods on a NamespaceAuthorizer
+// (RequireOrgScopeForPathOrg). Extracted rather than reimplemented: this is
+// the single answer to "may this caller act in this organization, right now",
+// and a second copy of it is the divergence issue #665 tracks.
+func authorizeOrgAccessWith(c *gin.Context, orgRepo *repositories.OrganizationRepository, ownerOrgID string, scope auth.Scope) (int, string) {
 	scopesVal, exists := c.Get("scopes")
 	if !exists {
 		return http.StatusForbidden, "Insufficient permissions"
@@ -465,9 +475,9 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 		}
 		if apiKey.OrganizationID != "" {
 			if apiKey.OrganizationID != ownerOrgID {
-				return http.StatusForbidden, "Namespace is owned by another organization"
+				return http.StatusForbidden, "Resource is owned by another organization"
 			}
-			return a.verifyKeyOwnerAuthority(c, apiKey, ownerOrgID, scope)
+			return verifyKeyOwnerAuthorityWith(c, orgRepo, apiKey, ownerOrgID, scope)
 		}
 		// Keys without an organization binding (legacy rows) fall through to
 		// the owning user's membership check below.
@@ -482,12 +492,12 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 		return http.StatusForbidden, "Invalid user ID format"
 	}
 
-	member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), ownerOrgID, userID)
+	member, err := orgRepo.GetMemberWithRole(c.Request.Context(), ownerOrgID, userID)
 	if err != nil {
 		return http.StatusInternalServerError, "Failed to check organization membership"
 	}
 	if member == nil {
-		return http.StatusForbidden, "Namespace is owned by another organization"
+		return http.StatusForbidden, "Resource is owned by another organization"
 	}
 	if !auth.HasScope(member.RoleTemplateScopes, scope) {
 		return http.StatusForbidden, "Missing required scope in the owning organization"
@@ -514,6 +524,12 @@ func (a *NamespaceAuthorizer) authorizeOrgAccess(c *gin.Context, ownerOrgID stri
 // authority is reduced; this is the point-of-use guard that makes a key that
 // escaped a sweep fail closed anyway.
 func (a *NamespaceAuthorizer) verifyKeyOwnerAuthority(c *gin.Context, apiKey *models.APIKey, orgID string, scope auth.Scope) (int, string) {
+	return verifyKeyOwnerAuthorityWith(c, a.orgRepo, apiKey, orgID, scope)
+}
+
+// verifyKeyOwnerAuthorityWith is verifyKeyOwnerAuthority with the repository
+// passed explicitly; see authorizeOrgAccessWith for why the split exists.
+func verifyKeyOwnerAuthorityWith(c *gin.Context, orgRepo *repositories.OrganizationRepository, apiKey *models.APIKey, orgID string, scope auth.Scope) (int, string) {
 	// A key with no owning user is REFUSED, not waved through as an
 	// "organization service credential".
 	//
@@ -539,7 +555,7 @@ func (a *NamespaceAuthorizer) verifyKeyOwnerAuthority(c *gin.Context, apiKey *mo
 	if apiKey.UserID == nil || *apiKey.UserID == "" {
 		return http.StatusForbidden, "API key has no owning user; re-issue it through the API key endpoints"
 	}
-	member, err := a.orgRepo.GetMemberWithRole(c.Request.Context(), orgID, *apiKey.UserID)
+	member, err := orgRepo.GetMemberWithRole(c.Request.Context(), orgID, *apiKey.UserID)
 	if err != nil {
 		return http.StatusInternalServerError, "Failed to check organization membership"
 	}

--- a/backend/internal/middleware/rbac.go
+++ b/backend/internal/middleware/rbac.go
@@ -148,46 +148,19 @@ func RequireAllScopes(scopes ...auth.Scope) gin.HandlerFunc {
 // than the org-scoped-token primitives (HasScopeInOrg / GenerateForOrg) the
 // identity library also ships -- adopting those requires migrating the JWT
 // itself to carry an OrgID claim, tracked separately.
+//
+// The decision itself is authorizeOrgAccessWith, shared with the namespace and
+// per-resource guards, rather than a fourth hand-rolled membership lookup. The
+// copy this replaced re-derived authority from the caller's USER record alone
+// and never looked at the presenting credential, so an API key bound to
+// organization A could administer organization B whenever its owner happened to
+// be a member there -- the organization axis of issue #733, and a divergence
+// from the two siblings (authorizeOrgAccess, tenantscope.Resolve) that already
+// treat a key's organization binding as authoritative for that key. It reads
+// the same table through the same query, so the per-org check is unchanged for
+// interactive sessions.
 func RequireOrgScopeForPathOrg(scope auth.Scope, orgRepo *repositories.OrganizationRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		scopesVal, exists := c.Get("scopes")
-		if !exists {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "Insufficient permissions",
-			})
-			return
-		}
-
-		callerScopes, ok := scopesVal.([]string)
-		if !ok {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "Invalid scopes format",
-			})
-			return
-		}
-
-		// Global admin wildcard bypasses the per-org check -- see doc comment.
-		if auth.HasScope(callerScopes, auth.ScopeAdmin) {
-			c.Next()
-			return
-		}
-
-		userVal, userExists := c.Get("user_id")
-		if !userExists {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "User not authenticated",
-			})
-			return
-		}
-
-		userID, ok := userVal.(string)
-		if !ok || userID == "" {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": "Invalid user ID format",
-			})
-			return
-		}
-
 		orgID := c.Param("id")
 		if orgID == "" {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
@@ -196,19 +169,8 @@ func RequireOrgScopeForPathOrg(scope auth.Scope, orgRepo *repositories.Organizat
 			return
 		}
 
-		orgScopes, err := orgRepo.GetUserScopesForOrg(c.Request.Context(), userID, orgID)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to verify organization membership",
-			})
-			return
-		}
-
-		if !auth.HasScope(orgScopes, scope) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error":   "Missing required scope for this organization",
-				"details": "Required scope: " + string(scope),
-			})
+		if status, msg := authorizeOrgAccessWith(c, orgRepo, orgID, scope); status != 0 {
+			c.AbortWithStatusJSON(status, gin.H{"error": msg})
 			return
 		}
 

--- a/backend/internal/middleware/rbac_org_path_test.go
+++ b/backend/internal/middleware/rbac_org_path_test.go
@@ -9,6 +9,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -159,5 +160,80 @@ func TestRequireOrgScopeForPathOrg_GlobalAdminBypassesPerOrgCheck(t *testing.T) 
 	w := doGetPath(pathOrgRouter(mid, []string{"admin"}, orgMWUserID), "/organizations/some-other-org")
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200 (global admin must bypass per-org check): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Organization axis of the credential-binding class (issue #733)
+// ---------------------------------------------------------------------------
+//
+// The copy this middleware replaced re-derived authority from the caller's USER
+// record alone. An API key is bound to exactly one organization at creation,
+// and both siblings of this check -- NamespaceAuthorizer.authorizeOrgAccess and
+// tenantscope.Resolve -- treat that binding as authoritative for the key; this
+// one did not, so a key bound to org A could administer org B whenever its
+// owner happened to be a member there. Delegating to authorizeOrgAccessWith is
+// what makes the three answer identically.
+
+// orgBoundKeyContext injects the context AuthMiddleware produces for an
+// organization-bound API key.
+func orgBoundKeyContext(keyOrgID string, scopes []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		owner := orgMWUserID
+		c.Set("scopes", scopes)
+		c.Set("user_id", orgMWUserID)
+		c.Set("auth_method", "api_key")
+		c.Set("organization_id", keyOrgID)
+		c.Set("api_key", &models.APIKey{
+			UserID: &owner, OrganizationID: keyOrgID, Scopes: scopes,
+		})
+	}
+}
+
+func TestRequireOrgScopeForPathOrg_KeyBoundToAnotherOrgRejected(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	orgRepo := repositories.NewOrganizationRepository(db)
+	mid := RequireOrgScopeForPathOrg(auth.ScopeOrganizationsWrite, orgRepo)
+
+	// No membership lookup should be reached: the key's own binding already
+	// answers the question, so sqlmock would fail on an unexpected query.
+	_ = mock
+
+	r := gin.New()
+	r.GET("/organizations/:id",
+		orgBoundKeyContext("org-A", []string{"organizations:write"}),
+		mid,
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doGetPath(r, "/organizations/org-B")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (a key bound to org A must not act on org B): body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireOrgScopeForPathOrg_KeyBoundToTargetOrgAllowed(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	orgRepo := repositories.NewOrganizationRepository(db)
+	mid := RequireOrgScopeForPathOrg(auth.ScopeOrganizationsWrite, orgRepo)
+
+	// The key's owner is still a member of the bound org with the scope, which
+	// is re-verified at the point of use (issue #732).
+	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
+		WillReturnRows(sqlmock.NewRows(memberRoleColsMW).AddRow(
+			orgMWOrgID, orgMWUserID, "role-1", time.Now(),
+			"User Name", "user@test.com", "user_manager", "User Manager", []byte(`["organizations:write"]`),
+		))
+
+	r := gin.New()
+	r.GET("/organizations/:id",
+		orgBoundKeyContext(orgMWOrgID, []string{"organizations:write"}),
+		mid,
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	w := doGetPath(r, "/organizations/"+orgMWOrgID)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (a key acting on its own organization must still be allowed): body=%s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
Closes #733.

Authority was derived from the owning **user** record on paths an API-key principal can reach. A deliberately-narrowed machine credential could therefore mint a broader one — escalating to its owner's maximum authority, including the platform-wide `admin` scope — with no interactive session, and CSRF exempts api_key callers.

## The rule

**Intersect every authority ceiling with the scopes of the credential actually presenting the request.** An interactive session keeps today's user-derived ceiling.

`internal/credscope.Bound` implements it as a **predicate over the scope lattice, not a set intersection** — either side may carry the `admin` wildcard or a write scope implying its read sibling, and a literal `["admin"] ∩ ["modules:read"]` is empty, i.e. a ceiling that denies everyone. That failure mode is not hypothetical: batch B shipped a resolver that denied everyone and a denial-only test table could not see it, which is why the tests here assert both directions.

## Class enumeration — 6 sites fixed

Swept every `GetMemberWithRole` / `GetUserScopesForOrg` / `GetUserCombinedScopes` / `GetUserMemberships` call site plus every authority-minting sink.

| Site | Why in class |
|---|---|
| `CreateAPIKeyHandler` | the reported defect — ceiling was `memberWithRole.RoleTemplateScopes` alone |
| `UpdateAPIKeyHandler` | same shape; widening is minting |
| `RotateAPIKeyHandler` | **no ceiling at all** — copied `oldKey.Scopes`, authorized on ownership |
| `checkRoleAssignment` | a key with `organizations:write` could assign its owner's admin role template — minting by another name |
| `RefreshHandler` | same root, families swapped: a key was exchangeable for a JWT carrying the owner's whole cross-org union |
| `RequireOrgScopeForPathOrg` | the **organization** axis — a key bound to org A could administer org B. Now delegates to `authorizeOrgAccessWith`, the same check `authorizeOrgAccess` already ran |

`RotateAPIKeyHandler` re-derives from the **key owner's** current role template (so a platform admin can still rotate a key in an org they don't belong to) and bounds that by the caller's credential.

## Examined and deliberately left

- `ListAPIKeysHandler` — already credential-bound: `hasGlobalManage` comes from `c.Get("scopes")` *before* the per-org lookup.
- `ImpersonateUserHandler` / `ListUsersForImpersonationHandler` — structurally in class, but gated at entry on `HasScope(c.Get("scopes"), admin)`, which **is** the presenting credential. Marked with `GUARD credential-scope-binding` (the repo's existing machine-readable convention) rather than changed.
- `DevLoginHandler`, login/OIDC/SAML callbacks — unauthenticated; no presenting credential to bind to.
- `RequireOrgScope` / `RequireOrgMembership` — pre-existing **dead code**, zero call sites. Untouched; worth a separate cleanup.
- **API-key org binding on create/update/rotate** — left deliberately. The scope intersection already bounds it to ≤ the key's own scopes, and enforcing binding here would break legitimate multi-org key management. Called out rather than silently skipped.

## A re-runnable signature ships with the fix

This class had none — so nothing would have caught its regression. `credential-binding.py` is added to the orchestration repo's signature registry (separate repo, separate PR).

Two axes (*ceiling* read, *mint* write), routes filtered to those behind `Auth`/`OptionalAuthMiddleware` with **positional** `Use` resolution — gin applies a `Use` only to routes registered after it, and without that the dev group's unauthenticated `/login` reads as API-key-reachable. Comments are stripped before scanning, because this codebase documents its own defects at length and prose about a missing guard reads exactly like the guard.

Against `origin/main`: **17 enumerated, 9 sites, exit 1.** Against this branch: same universe, **0 sites, exit 0.** An empty universe emits a note and exits 1 — never a pass.

## Verification

`go build`, `go vet`, `gofmt -l` clean; `go test ./...` 63 packages ok.

**Mutation:** `Bound` returning `userDerived` unconditionally (compiles) turns red exactly the 3 escalation rows + the role-assignment escalation row + 5 `credscope` rows, while **all 15 legitimate rows stay green** — every `jwt session/*`, every `*/modules:read` for the narrow key, every `api key equal to owner/*`. The table is not passing by denying everyone. Two further mutants are each red on exactly one row: dropping the key/org binding, and dropping the refresh interactive check.

## Behaviour change API-key users will notice — breaking

1. A key can no longer create or update a key into a scope it does not hold → `403`; `allowed_scopes` now reports the **effective** ceiling rather than the owner's raw role template.
2. Rotation `403`s if the old key's stored scopes exceed the ceiling ("update the key's scopes before rotating it"); a userless key is refused, matching `verifyKeyOwnerAuthority`.
3. A key bound to org A gets `403` on `/organizations/B/*` (7 routes) — aligning it with `authorizeOrgAccess` and `tenantscope.Resolve`, which already behaved this way.
4. `POST /auth/refresh` with a key → `403`; keys rotate via `/apikeys/{id}/rotate`.
5. A key holding `admin`, or one already matching its owner's authority, is unaffected. **Interactive sessions are unaffected everywhere.**

Swagger `@Description`/`@Failure` updated on all four affected endpoints.