### PR TITLE
chore(release): breaking changes bump the minor, not the major

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,11 +1,13 @@
 {
   "draft": true,
   "force-tag-creation": true,
+  "versioning": "always-bump-minor",
   "packages": {
     ".": {
       "release-type": "go",
       "package-name": "terraform-registry",
       "include-component-in-tag": false,
+      "versioning": "always-bump-minor",
       "extra-files": [
         {
           "type": "yaml",


### PR DESCRIPTION
Sets `"versioning": "always-bump-minor"` so the next release is **4.1.0**, not 5.0.0.

## What happened

Two majors landed in one day — **3.5.2 → 4.0.0** here and 2.7.1 → 3.0.0 in the state manager — because the `BREAKING CHANGE:` footers added this morning are exactly what strict semver keys on.

The footers were the right fix. Without them, a release carrying *"any CI token calling `/sync` with a `mirrors:manage` credential now gets 403"* was about to ship as a **patch**. The version jump was the side effect, not the goal.

## Why the major number is cosmetic here

This is an **application**. Nothing imports it, so there is no Go `/vN` import-path requirement — the major is pure signalling, and 4.0.0 signals a fourth major redesign that did not happen.

## What changes, and what does not

- **Changes:** breaking changes bump the minor. Next release is 4.1.0.
- **Does not change:** `!` markers and `BREAKING CHANGE:` footers stay in commits and release notes. The operator warning — the thing that actually protects someone upgrading — is untouched.

## The trade, stated plainly

The version alone no longer says "this will break me." `CHANGELOG.md` and `docs/upgrade-guide.md` carry that instead.

That is reasonable for an application and would **not** be for a library. `terraform-suite-identity` deliberately stays pre-1.0 with `bump-minor-pre-major`, where a major would force `/v2`, `/v3` into every consumer's import path on each breaking change — so its 0.24.0 → 0.25.0 today was already the desired behaviour.

## Not doing

Renumbering backwards (4.0.0 → 0.x) would mean moving published tags, Docker images and Helm `appVersion`, and would break anyone already pinned. Left alone.