### PR TITLE
ci: the checkout pin comment says v6 and the SHA is v7.0.1

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -217,7 +217,7 @@ jobs:
       pull-requests: write # only used for the bot-PR path below (#657)
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download generated docs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -314,7 +314,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -390,7 +390,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build backend Docker image
         run: docker build -t terraform-registry-backend:ci backend/
@@ -435,7 +435,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate Docker Compose configs
         working-directory: deployments
@@ -505,7 +505,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need full history to walk ancestry
 
@@ -66,7 +66,7 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # GoReleaser needs full history to resolve previous tag
 
@@ -150,7 +150,7 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -265,7 +265,7 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -382,7 +382,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: CHANGELOG.md
           sparse-checkout-cone-mode: false

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -36,7 +36,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run OSV-Scanner
         id: osv
@@ -105,7 +105,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -163,7 +163,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## The comment and the SHA disagree

Every `actions/checkout` pin in this repository reads:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
```

That SHA is tagged **v7.0.1** (and `v7`) upstream. `v6` is `d23441a48e51` — a
different commit.

```
$ gh api repos/actions/checkout/git/ref/tags/v6     -> d23441a48e516b6c34aea4fa41551a30e30af803
$ gh api repos/actions/checkout/git/ref/tags/v7.0.1 -> 3d3c42e5aac5ba805825da76410c181273ba90b1
```

So CI has been running checkout **v7** while every comment claimed **v6**. The SHA
is what executes; the comment is what a reviewer reads. A major-version bump of
the most privileged action in the pipeline was never reviewed as one.

**Comment-only — no SHA changes.** Nothing about what CI runs changes here.

## Deliberately not touched

`# v4` on `actions/attest-build-provenance` and `# v7` on `actions/github-script`
are **floating major** labels whose tag has since moved past the pinned commit.
That is the normal convention for a major-tag pin, not a false statement about the
major, so they stay. I verified those steps still work rather than assuming: the
`Attest build provenance` steps succeeded in the most recent release run.

## Why this drifted everywhere at once

| repo | mislabelled `# v6` | correct `# v7` | runs zizmor |
|---|---|---|---|
| terraform-registry-backend | 18 | 0 | no |
| terraform-registry-frontend | 17 | 0 | no |
| terraform-state-manager-backend | 12 | 0 | no |
| terraform-state-manager-frontend | 11 | 0 | no |
| terraform-suite-identity | 7 | 0 | no |
| security-orchestration | 7 | 0 | no |
| **terraform-suite-ui** | **0** | **9** | **yes** |

The one repository that labels this SHA correctly is the one running zizmor, whose
`ref-version-mismatch` audit is precisely this check. That is the durable fix, and
it is **not** bundled here — zizmor lints considerably more than pin comments and
adding it to six repositories with established workflows needs its own remediation
pass rather than riding along on a comment correction.
