### PR TITLE
fix(api): scope the /users family to the caller's tenancy

### DIFF
--- a/backend/internal/api/admin/users.go
+++ b/backend/internal/api/admin/users.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
@@ -28,6 +29,37 @@ type UserHandlers struct {
 
 // UserHandlersOption configures optional UserHandlers dependencies.
 type UserHandlersOption func(*UserHandlers)
+
+// userAxisScope resolves the tenancy this caller may act in on the /users
+// family, in the spelling the user-axis accessors want.
+//
+// The whole family used to pass OrgScopeAllOrganizations(). Every route in it is
+// gated on the FLAT users:read / users:write scope, and those are granted by the
+// per-organization user_manager and org_owner role templates, then unioned
+// org-lessly into the JWT (#652) -- so a role holder in organization A read and
+// wrote users whose only memberships were in organizations they belong to
+// nowhere. On GET /users/:id the disclosed field was the user's organization
+// list itself: the owning tenant was both the thing being protected and the
+// thing being handed out (identity #161).
+//
+// .WithUnowned() is deliberate and is the one widening here. A user is tenant-
+// scoped through organization_members, so a user with NO memberships matches no
+// organization scope and would 404 for every non-platform-admin -- including the
+// caller who just created them, since POST /users leaves a user membership-less
+// until they are added to an organization. There is no tenant boundary to cross
+// on such a user, which is the same call terraform-state-manager's
+// requireSharedOrgAdminWithTargetUser makes, and identity documents
+// .WithUnowned() as the spelling for exactly this case.
+//
+// GUARD users-family-tenant-scope (identity #161): the /users routes address
+// only users sharing an organization with the caller, plus the unowned.
+func userAxisScope(c *gin.Context, orgRepo *repositories.OrganizationRepository, required auth.Scope) (repositories.OrgScope, bool) {
+	scope, ok := resolveTenantScope(c, orgRepo, required)
+	if !ok {
+		return repositories.OrgScope{}, false
+	}
+	return scope.OrgScope().WithUnowned(), true
+}
 
 // WithUserCredentialSweeper wires the credential sweeper used when a principal
 // is deleted.
@@ -78,8 +110,13 @@ func (h *UserHandlers) ListUsersHandler() gin.HandlerFunc {
 
 		offset := (page - 1) * perPage
 
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+		if !ok {
+			return
+		}
+
 		// Get users with memberships (2 queries total, not N+1)
-		users, total, err := h.userRepo.ListUsersWithMemberships(c.Request.Context(), perPage, offset, repositories.OrgScopeAllOrganizations())
+		users, total, err := h.userRepo.ListUsersWithMemberships(c.Request.Context(), perPage, offset, scope)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to list users",
@@ -115,7 +152,16 @@ func (h *UserHandlers) GetUserHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID := c.Param("id")
 
-		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations())
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+		if !ok {
+			return
+		}
+
+		// Out of scope is 404, not 403: on this route the organization list IS
+		// the disclosed field, so answering "exists, but not yours" would leak
+		// the membership the scope exists to withhold. Indistinguishable from a
+		// user id that was never issued.
+		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, scope)
 		if identityerr.Missing(user, err) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "User not found",
@@ -129,8 +175,9 @@ func (h *UserHandlers) GetUserHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Get user's organizations
-		orgs, err := h.orgRepo.GetUserOrganizations(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations())
+		// Get user's organizations -- the same scope, so a shared user's
+		// memberships elsewhere stay withheld even though the user is visible.
+		orgs, err := h.orgRepo.GetUserOrganizations(c.Request.Context(), userID, scope)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to retrieve user organizations",
@@ -254,8 +301,13 @@ func (h *UserHandlers) UpdateUserHandler() gin.HandlerFunc {
 			return
 		}
 
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersWrite)
+		if !ok {
+			return
+		}
+
 		// Get existing user
-		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations())
+		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, scope)
 		if identityerr.Missing(user, err) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "User not found",
@@ -304,7 +356,10 @@ func (h *UserHandlers) UpdateUserHandler() gin.HandlerFunc {
 		// Raced against a concurrent delete: 404, matching the existence
 		// pre-check at the top of this handler, instead of the false 200 the
 		// pre-v0.24.0 contract returned for an update that changed nothing.
-		if err := h.userRepo.UpdateUser(c.Request.Context(), user, repositories.OrgScopeAllOrganizations()); err != nil {
+		// Same scope as the pre-check, so the row written is the row authorized:
+		// a membership removed between the two turns this into the 404 above
+		// rather than a write the caller is no longer entitled to make.
+		if err := h.userRepo.UpdateUser(c.Request.Context(), user, scope); err != nil {
 			if identityerr.IsNotFound(err) {
 				c.JSON(http.StatusNotFound, gin.H{
 					"error": "User not found",
@@ -340,8 +395,13 @@ func (h *UserHandlers) DeleteUserHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID := c.Param("id")
 
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersWrite)
+		if !ok {
+			return
+		}
+
 		// Check if user exists
-		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations())
+		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, scope)
 		if identityerr.Missing(user, err) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "User not found",
@@ -398,7 +458,12 @@ func (h *UserHandlers) DeleteUserHandler() gin.HandlerFunc {
 		// Delete user (cascading deletes will handle related records).
 		// Already gone: 404, the same answer the existence pre-check gives a
 		// second DELETE, so both routes to "no such user" agree.
-		if err := h.userRepo.DeleteUser(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations()); err != nil {
+		// Scoped like the pre-check above. The credential sweep just before it is
+		// deliberately NOT -- see its own comment: the principal is being
+		// destroyed, so a key surviving in any organization outlives its owner.
+		// Authorization is tenant-scoped; the cleanup that follows from it is
+		// whole-principal, and the two are different questions.
+		if err := h.userRepo.DeleteUser(c.Request.Context(), userID, scope); err != nil {
 			if identityerr.IsNotFound(err) {
 				c.JSON(http.StatusNotFound, gin.H{
 					"error": "User not found",
@@ -456,7 +521,12 @@ func (h *UserHandlers) SearchUsersHandler() gin.HandlerFunc {
 		offset := (page - 1) * perPage
 
 		// Search users with memberships
-		users, err := h.userRepo.SearchWithMemberships(c.Request.Context(), query, perPage, offset, repositories.OrgScopeAllOrganizations())
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+		if !ok {
+			return
+		}
+
+		users, err := h.userRepo.SearchWithMemberships(c.Request.Context(), query, perPage, offset, scope)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to search users",
@@ -538,8 +608,13 @@ func (h *UserHandlers) GetUserMembershipsHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID := c.Param("id")
 
+		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+		if !ok {
+			return
+		}
+
 		// Check if user exists
-		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, repositories.OrgScopeAllOrganizations())
+		user, err := h.userRepo.GetUserByID(c.Request.Context(), userID, scope)
 		if identityerr.Missing(user, err) {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "User not found",
@@ -560,6 +635,23 @@ func (h *UserHandlers) GetUserMembershipsHandler() gin.HandlerFunc {
 				"error": "Failed to retrieve user memberships",
 			})
 			return
+		}
+
+		// Filtered in Go, and that is a gap rather than a preference:
+		// OrganizationRepository.GetUserMemberships is the one user-axis
+		// accessor in the shared module with NO scope parameter, so there is
+		// nothing to hand it. This is the reinvent-the-constraint-per-consumer
+		// shape identity #161 exists to remove -- filed upstream as its sibling.
+		// Until the accessor takes a scope, the rows are read and then dropped,
+		// which withholds them from the response but still fetches them.
+		if !scope.IsAllOrganizations() {
+			permitted := make([]*models.UserMembership, 0, len(memberships))
+			for _, m := range memberships {
+				if scope.PermitsOrganization(m.OrganizationID) {
+					permitted = append(permitted, m)
+				}
+			}
+			memberships = permitted
 		}
 
 		c.JSON(http.StatusOK, gin.H{

--- a/backend/internal/api/admin/users_tenant_scope_test.go
+++ b/backend/internal/api/admin/users_tenant_scope_test.go
@@ -1,0 +1,255 @@
+package admin
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// Tenant scoping for the /users family (identity #161).
+//
+// Every route in the family is gated on the FLAT users:read / users:write
+// scope, and both are granted by the per-organization user_manager and
+// org_owner role templates before being unioned org-lessly into the JWT (#652).
+// The handlers then passed OrgScopeAllOrganizations(), so a role holder in one
+// organization read and wrote users whose only memberships were elsewhere. On
+// GET /users/:id the disclosed field was the organization list itself.
+//
+// These tests are table-driven over the PRINCIPAL, not over the route, because
+// the defect was one decision (which tenancy to hand the accessor) reached from
+// every route. Asserting only the reported route would leave its siblings
+// unguarded and reporting green.
+//
+// They assert against userAxisScope directly rather than through sqlmock for
+// the scope shape, because sqlmock matches query text and arguments but does
+// not evaluate the predicate — a test that only checked "the query still ran"
+// would pass with the guard removed. The end-to-end cases below then confirm
+// the scope actually reaches the accessor, by asserting the 404 that an
+// out-of-scope target produces.
+
+// userScopeCtx builds a gin context carrying the given principal, plus the
+// mock database the organization repository will resolve memberships against.
+func userScopeCtx(t *testing.T, scopes []string, userID string) (*gin.Context, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/users/target", nil)
+	if scopes != nil {
+		c.Set("scopes", scopes)
+	}
+	if userID != "" {
+		c.Set("user_id", userID)
+	}
+	return c, mock, db
+}
+
+// membershipRow is one GetUserMemberships row granting `scopes` in `orgID`.
+func membershipRow(orgID string, scopes []string) *sqlmock.Rows {
+	raw, _ := json.Marshal(scopes)
+	return sqlmock.NewRows(membershipCols).
+		AddRow(orgID, "org-"+orgID[:4], "role-1", time.Now(), "user_manager", "User Manager", raw)
+}
+
+func TestUserAxisScope_ByPrincipal(t *testing.T) {
+	tests := []struct {
+		name string
+		// principal
+		scopes []string
+		userID string
+		// membership rows OrgScopeForUser will read (nil = no query expected)
+		rows *sqlmock.Rows
+		// expectations
+		wantAll          bool
+		wantPermitsAlpha bool
+		wantPermitsBeta  bool
+		wantUnowned      bool
+	}{
+		{
+			name:             "platform admin keeps the whole directory",
+			scopes:           []string{string(auth.ScopeAdmin)},
+			userID:           scopeUserID,
+			wantAll:          true,
+			wantPermitsAlpha: true,
+			wantPermitsBeta:  true,
+			wantUnowned:      true,
+		},
+		{
+			name:             "users:read in alpha only reaches alpha",
+			scopes:           []string{string(auth.ScopeUsersRead)},
+			userID:           scopeUserID,
+			rows:             membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}),
+			wantPermitsAlpha: true,
+			wantPermitsBeta:  false,
+			wantUnowned:      true,
+		},
+		{
+			name:   "membership without the required scope grants nothing",
+			scopes: []string{string(auth.ScopeUsersRead)},
+			userID: scopeUserID,
+			// A member of alpha, but the role template there does not carry
+			// users:read. Membership is not authority (#719).
+			rows:             membershipRow(orgAlpha, []string{string(auth.ScopeModulesRead)}),
+			wantPermitsAlpha: false,
+			wantPermitsBeta:  false,
+			wantUnowned:      true,
+		},
+		{
+			name:             "no principal at all reaches no organization",
+			wantPermitsAlpha: false,
+			wantPermitsBeta:  false,
+			wantUnowned:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, mock, db := userScopeCtx(t, tt.scopes, tt.userID)
+			if tt.rows != nil {
+				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(tt.rows)
+			}
+			h := NewUserHandlers(&config.Config{}, db)
+
+			scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+			if !ok {
+				t.Fatal("userAxisScope reported failure")
+			}
+			if got := scope.IsAllOrganizations(); got != tt.wantAll {
+				t.Errorf("IsAllOrganizations = %v, want %v (scope=%s)", got, tt.wantAll, scope.String())
+			}
+			if got := scope.PermitsOrganization(orgAlpha); got != tt.wantPermitsAlpha {
+				t.Errorf("PermitsOrganization(alpha) = %v, want %v (scope=%s)", got, tt.wantPermitsAlpha, scope.String())
+			}
+			if got := scope.PermitsOrganization(orgBeta); got != tt.wantPermitsBeta {
+				t.Errorf("PermitsOrganization(beta) = %v, want %v (scope=%s)", got, tt.wantPermitsBeta, scope.String())
+			}
+			// A membership-less user has no tenant boundary to cross, and
+			// POST /users creates exactly that, so the creator must still be
+			// able to read them back. This is the one deliberate widening.
+			if got := scope.IncludesUnowned(); got != tt.wantUnowned {
+				t.Errorf("IncludesUnowned = %v, want %v (scope=%s)", got, tt.wantUnowned, scope.String())
+			}
+		})
+	}
+}
+
+// TestUserAxisScope_IsNotAllOrganizations is the mutation guard. Reverting the
+// handlers to OrgScopeAllOrganizations() would leave every test above that
+// exercises a non-admin passing only if this distinction is asserted, so it is
+// asserted on its own: a scoped caller must NOT resolve to the whole directory.
+func TestUserAxisScope_ScopedCallerIsNotPlatformWide(t *testing.T) {
+	c, mock, db := userScopeCtx(t, []string{string(auth.ScopeUsersRead)}, scopeUserID)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	h := NewUserHandlers(&config.Config{}, db)
+
+	scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
+	if !ok {
+		t.Fatal("userAxisScope reported failure")
+	}
+	if scope.IsAllOrganizations() {
+		t.Fatal("a users:read holder in one organization resolved to the whole directory — the #161 defect")
+	}
+	if !scope.PermitsOrganization(orgAlpha) {
+		t.Error("the caller's own organization must remain reachable")
+	}
+}
+
+// --- end to end: the scope reaches the accessor -----------------------------
+
+// scopedUserRouter wires the /users routes behind a non-admin users:read
+// principal holding that scope in alpha only.
+func scopedUserRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewUserHandlers(&config.Config{}, db)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeUsersRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/users/:id", h.GetUserHandler())
+	r.GET("/users/:id/memberships", h.GetUserMembershipsHandler())
+	return mock, r
+}
+
+// A target the scope does not reach is 404, not 403: on this route the
+// organization list IS the disclosed field, so "exists, but not yours" would
+// leak the membership the scope exists to withhold.
+func TestGetUser_OutOfScopeTarget_Is404(t *testing.T) {
+	mock, r := scopedUserRouter(t)
+	// OrgScopeForUser: caller holds users:read in alpha.
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	// Match the SCOPED form of the query specifically. sqlmock does not
+	// evaluate predicates, so an expectation that merely said "FROM" would be
+	// satisfied by the unscoped query too and this test would pass with the
+	// guard reverted. OrgScope.membershipSQL emits this EXISTS ... = ANY($n)
+	// clause only when the scope names organizations; a platform-wide scope
+	// emits the literal TRUE and will not match here.
+	mock.ExpectQuery("(?s)osm.organization_id = ANY").WillReturnRows(emptyUserRows())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/users/target", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for an out-of-scope user: body=%s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); body != "" && json.Valid([]byte(body)) {
+		var m map[string]interface{}
+		_ = json.Unmarshal([]byte(body), &m)
+		// The response must not name the organizations it withheld.
+		if _, leaked := m["organizations"]; leaked {
+			t.Error("404 response carried an organizations field")
+		}
+	}
+}
+
+// GetUserMemberships has no scope parameter in the shared module, so the
+// handler filters in Go. Assert the filter, since nothing in the query does it.
+func TestGetUserMemberships_FiltersOutOfScopeOrganizations(t *testing.T) {
+	mock, r := scopedUserRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	// Scoped form, for the same reason as above.
+	mock.ExpectQuery("(?s)osm.organization_id = ANY").WillReturnRows(sampleUserRow())
+	// The target belongs to BOTH organizations; only alpha may be disclosed.
+	both := sqlmock.NewRows(membershipCols).
+		AddRow(orgAlpha, "org-alpha", "role-1", time.Now(), "viewer", "Viewer", []byte(`[]`)).
+		AddRow(orgBeta, "org-beta", "role-2", time.Now(), "viewer", "Viewer", []byte(`[]`))
+	mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(both)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/users/target/memberships", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); strings.Contains(body, orgBeta) {
+		t.Errorf("response disclosed a membership in an organization the caller cannot reach: %s", body)
+	}
+	if body := w.Body.String(); !strings.Contains(body, orgAlpha) {
+		t.Errorf("response dropped the membership the caller IS entitled to see: %s", body)
+	}
+}


### PR DESCRIPTION
Closes the consumer half of `sethbacon/terraform-suite-identity#161`.

## The defect

Every route under `/api/v1/users` is gated on the **flat** `users:read` /
`users:write` scope. Both are granted by the *per-organization* `user_manager` and
`org_owner` role templates, then unioned org-lessly into the JWT (#652). The
handlers passed `OrgScopeAllOrganizations()` at every accessor.

So a role holder in organization A read and wrote users whose only memberships were
in organizations they belong to nowhere. On `GET /users/:id` the disclosed field was
the user's **organization list itself** — the owning tenant was simultaneously the
thing being protected and the thing being handed out.

identity #161's module half shipped in v0.25.0: the accessors took a mandatory
scope parameter. This consumer kept handing them the widest possible value.

## The whole family moves, not the reported route

One decision — which tenancy to hand the accessor — is reached from seven call
sites. Fixing only `GET /users/:id` leaves the siblings unguarded and the class
reporting green.

| routes | scope required |
|---|---|
| list, search, get, get-memberships | `users:read` |
| update (pre-check + write), delete (pre-check + delete) | `users:write` |

**Out of scope is 404, not 403.** "Exists, but not yours" leaks the membership the
scope exists to withhold, so an unreachable user is indistinguishable from an id
that was never issued. The existing `identityerr.Missing` branches already produce
that answer once the scope is narrowed.

## Two sites deliberately stay platform-wide

Both say so at the call site:

- **The credential sweep in `DeleteUserHandler`.** The principal is being destroyed,
  so a key surviving in any organization outlives its owner (#736). Authorization to
  delete is tenant-scoped; the cleanup that follows is whole-principal. Different
  questions.
- **`/admin/users` GDPR export/erase**, behind the flat `admin` scope — not touched here.

## `.WithUnowned()` is the one widening

A user is tenant-scoped through `organization_members`, so a user with **no**
memberships matches no organization scope and would 404 for every non-admin —
including the caller who just created them, since `POST /users` leaves a user
membership-less until they join an organization. There is no tenant boundary to
cross on such a user. Same call `terraform-state-manager`'s
`requireSharedOrgAdminWithTargetUser` makes, and identity documents `.WithUnowned()`
as the spelling for exactly this case.

## One gap, filed rather than papered over

`GetUserMemberships` is filtered **in Go** because it is the one user-axis accessor
in the shared module with **no scope parameter** — there is nothing to hand it. That
is the reinvent-the-constraint-per-consumer shape #161 exists to remove; filed
upstream as its sibling. The rows are read and then dropped, so the disclosure is
closed but the fetch is not avoided.

## Tests

Table-driven over the **principal**, not the route, because the defect is one
decision reached from many places:

| principal | reaches |
|---|---|
| platform admin | whole directory |
| `users:read` in alpha only | alpha (+ unowned) |
| member of alpha whose role template lacks `users:read` | nothing (+ unowned) — membership is not authority (#719) |
| no principal at all | nothing (+ unowned) |

### The part worth reviewing

The end-to-end cases match the **scoped form of the query specifically**:

```go
mock.ExpectQuery("(?s)osm.organization_id = ANY").WillReturnRows(emptyUserRows())
```

`OrgScope.membershipSQL` emits that `EXISTS ... = ANY($n)` clause **only** when the
scope names organizations; a platform-wide scope emits the literal `TRUE`. My first
version matched on `"FROM"`, which the unscoped query satisfies too — so it passed
with the guard reverted. sqlmock matches query *text*; it does not evaluate
predicates.

Mutation-verified:

| state | result |
|---|---|
| baseline | pass |
| handlers reverted to `OrgScopeAllOrganizations()` | **both end-to-end tests fail** |
| restored | pass |

`go build ./...`, `go vet ./internal/api/...` and `go test ./internal/api/...` are clean.

## Operator impact

Automation that enumerated the directory with a per-organization `users:read`
credential must move to an `admin`-scoped one. Admin UI users who are org-scoped
rather than platform admins will see a shorter user list and 404s on users outside
their organizations — which is the intended behaviour, but it is a visible change.
