### PR TITLE
fix(auth): actually start the documented JWT secret file watch

### DIFF
--- a/backend/cmd/server/jwt_secret_file_watch_test.go
+++ b/backend/cmd/server/jwt_secret_file_watch_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Issue #737: TFR_JWT_SECRET_FILE hot-rotation was documented in
+// docs/secrets-rotation.md as the recommended zero-downtime path, wired into the
+// Helm chart, fully implemented in auth.StartJWTSecretFileWatch -- and started
+// by nobody. Setting the variable did nothing at all.
+//
+// Two things are tested here, and the second is the one that matters. A unit
+// test of the overlap parser would have passed just as happily while the watch
+// was never started, because the defect was not in any function's logic; it was
+// the absence of a call. So the wiring itself is asserted, structurally.
+
+func TestJWTSecretOverlap(t *testing.T) {
+	const def = 5 * time.Minute
+
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{"unset falls back to the documented default", "", def},
+		{"whitespace only is unset", "   ", def},
+		{"a valid duration is honoured", "90s", 90 * time.Second},
+		{"minutes", "10m", 10 * time.Minute},
+		{"surrounding whitespace is trimmed", "  2m  ", 2 * time.Minute},
+		// Not an error: the overlap only widens the window in which an OLD key
+		// still validates, so a bad value cannot open access the current key
+		// does not already grant. Refusing to boot over it would trade a
+		// harmless typo for an outage.
+		{"unparseable falls back rather than failing", "banana", def},
+		{"zero falls back", "0s", def},
+		{"negative falls back", "-5m", def},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := jwtSecretOverlap(tt.raw); got != tt.want {
+				t.Errorf("jwtSecretOverlap(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJWTSecretFileWatchIsStarted is the guard for the actual defect.
+//
+// It reads main.go and asserts that serve() both reads TFR_JWT_SECRET_FILE and
+// calls auth.StartJWTSecretFileWatch. A behavioural test cannot cover this:
+// serve() opens listeners and databases, and the failure mode is not a wrong
+// answer from a function but a function nobody invokes -- which is invisible to
+// every test that does not look for the call site.
+//
+// This is the same shape as the defect: something documented, implemented and
+// never reached. If the call is deleted or refactored out, this fails and says
+// so, instead of the feature silently going back to doing nothing.
+func TestJWTSecretFileWatchIsStarted(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	text := string(src)
+
+	for _, want := range []string{
+		`os.Getenv("TFR_JWT_SECRET_FILE")`,
+		"auth.StartJWTSecretFileWatch(",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("main.go no longer contains %s -- TFR_JWT_SECRET_FILE is documented "+
+				"in docs/secrets-rotation.md as the recommended zero-downtime rotation "+
+				"path, and without this call setting it does nothing (issue #737)", want)
+		}
+	}
+
+	// The call must be reachable from serve(), not merely present somewhere in
+	// the file -- a call parked in a helper nothing invokes is the same defect.
+	serveBody := funcBody(text, "func serve(cfg *config.Config) error {")
+	if serveBody == "" {
+		t.Fatal("could not locate serve() in main.go; this guard cannot verify anything")
+	}
+	if !strings.Contains(serveBody, "auth.StartJWTSecretFileWatch(") {
+		t.Error("auth.StartJWTSecretFileWatch is not called from serve(); the watch " +
+			"only runs if the server startup path starts it (issue #737)")
+	}
+
+	// Fail-closed: a read/watch failure must abort startup rather than fall back
+	// to the env secret while the operator believes rotation is live.
+	if !regexp.MustCompile(`TFR_JWT_SECRET_FILE is set but`).MatchString(serveBody) {
+		t.Error("the watch failure path no longer aborts startup; booting with the env " +
+			"secret after the operator asked for file-based secrets reintroduces #737 " +
+			"by another route")
+	}
+}
+
+// funcBody returns the source between header and the next top-level closing
+// brace, or "" if the header is absent.
+func funcBody(src, header string) string {
+	i := strings.Index(src, header)
+	if i < 0 {
+		return ""
+	}
+	rest := src[i+len(header):]
+	if j := strings.Index(rest, "\n}\n"); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -226,6 +226,34 @@ func scanWorker(cfg *config.Config) error {
 	}
 }
 
+// jwtSecretOverlapEnv names the variable that tunes how long a rotated-out JWT
+// signing key keeps validating. docs/secrets-rotation.md described the overlap
+// as "configurable" without naming anything; this is the name that makes that
+// sentence true.
+const jwtSecretOverlapEnv = "TFR_JWT_SECRET_OVERLAP"
+
+// jwtSecretOverlap parses the documented 5-minute default out of raw.
+//
+// It never returns an error. An unparseable value falls back to the default
+// rather than refusing to boot: the overlap only widens the window in which an
+// OLD key still validates, so getting it wrong cannot open access that the
+// current key does not already grant, and a typo here should not take a
+// deployment down. A non-positive value is also the default, matching
+// StartJWTSecretFileWatch's own contract rather than restating it differently.
+func jwtSecretOverlap(raw string) time.Duration {
+	const defaultOverlap = 5 * time.Minute
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultOverlap
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		log.Printf("WARNING: %s=%q is not a positive duration; using the %s default", jwtSecretOverlapEnv, raw, defaultOverlap) // #nosec G706 -- value comes from process env, not request input
+		return defaultOverlap
+	}
+	return d
+}
+
 func serve(cfg *config.Config) error {
 	// Initialise structured logger as early as possible so all subsequent log output
 	// uses the configured format (json / text) and level.
@@ -271,6 +299,33 @@ func serve(cfg *config.Config) error {
 		return fmt.Errorf("security configuration error: %w", err)
 	}
 	log.Println("JWT secret validated successfully")
+
+	// GUARD jwt-secret-file-watch (issue #737): the file watch is STARTED, not
+	// merely available.
+	//
+	// docs/secrets-rotation.md presents TFR_JWT_SECRET_FILE as "Option A:
+	// File-Based Hot-Reload (Recommended, Zero-Downtime)" and walks an operator
+	// through rotating the Kubernetes Secret and watching for
+	// "JWT secret reloaded from file" in the logs. StartJWTSecretFileWatch
+	// implements all of that -- including those exact log lines -- and had no
+	// non-test caller. Setting the variable did nothing. An operator following
+	// that runbook rotated the Secret, saw no error, and kept serving with the
+	// original key; the same doc tells them a restart is only needed "if not
+	// using file-watch", so they would deliberately skip the one action that
+	// would have applied the new secret.
+	if secretFile := strings.TrimSpace(os.Getenv("TFR_JWT_SECRET_FILE")); secretFile != "" {
+		// Fail closed. If the operator asked for file-based secrets and the file
+		// cannot be read or watched, booting anyway would serve with the env
+		// secret while they believe rotation is live -- which is the defect
+		// above, reached a second way.
+		stopWatch, watchErr := auth.StartJWTSecretFileWatch(secretFile, jwtSecretOverlap(os.Getenv(jwtSecretOverlapEnv)))
+		if watchErr != nil {
+			return fmt.Errorf("TFR_JWT_SECRET_FILE is set but its watch could not start: %w", watchErr)
+		}
+		defer stopWatch()
+		log.Printf("JWT secret file watch started: %s (overlap %s)", // #nosec G706 -- path and duration come from server config/env, not request input
+			secretFile, jwtSecretOverlap(os.Getenv(jwtSecretOverlapEnv)))
+	}
 
 	// Extend JWT issuer validation to trusted sibling apps in a coupled suite
 	// deployment (issue #559 finding [0]). Safe to call unconditionally:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -230,7 +230,14 @@ func scanWorker(cfg *config.Config) error {
 // signing key keeps validating. docs/secrets-rotation.md described the overlap
 // as "configurable" without naming anything; this is the name that makes that
 // sentence true.
-const jwtSecretOverlapEnv = "TFR_JWT_SECRET_OVERLAP"
+//
+// G101 flags this on the identifier ("Secret"), not the value: the value is a
+// duration setting that never holds secret material, and the variable that does
+// carry the secret is read via os.Getenv at its use site. Suppressed the way
+// this repo already suppresses the same false positive on suite.go's
+// X-Suite-Service-Token header name -- as a TRAILING comment, which is where
+// gosec looks.
+const jwtSecretOverlapEnv = "TFR_JWT_SECRET_OVERLAP" // #nosec G101 -- environment variable name, not a credential
 
 // jwtSecretOverlap parses the documented 5-minute default out of raw.
 //

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,8 @@ For example, `database.host` in YAML becomes `TFR_DATABASE_HOST` as an env var.
 | `TFR_REDIS_TLS`                                      | bool     | `false`                 | No         | Enable TLS for Redis connection                                              |
 | `TFR_REDIS_POOL_SIZE`                                | int      | `10`                    | No         | Redis connection pool size                                                   |
 | `TFR_REDIS_DIAL_TIMEOUT`                             | duration | `5s`                    | No         | Redis connection timeout                                                     |
-| `TFR_JWT_SECRET_FILE`                                | string   | —                       | No         | Path to file containing JWT secret (enables hot-reload)                      |
+| `TFR_JWT_SECRET_FILE`                                | string   | —                       | No         | Path to file containing JWT secret (enables hot-reload). Startup fails if set and unreadable. |
+| `TFR_JWT_SECRET_OVERLAP`                             | duration | `5m`                    | No         | How long a rotated-out JWT signing key keeps validating. Only used with `TFR_JWT_SECRET_FILE`. |
 | `ENCRYPTION_KEY_PREVIOUS`                            | string   | —                       | No         | Previous encryption key for zero-downtime rotation                           |
 | `TFR_ALLOW_LOW_ENTROPY_ENCRYPTION_KEY`                | bool     | `false`                 | No         | Temporary bridge to bypass the fail-closed low-entropy `ENCRYPTION_KEY` startup check while rotating an existing deployment |
 | `TFR_ALLOW_FEATURE_SETUP_REARM`                      | bool     | `false`                 | No         | Allow minting a setup token scoped to a pending optional feature (e.g. scanning) after initial setup has completed          |

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -19,7 +19,9 @@ This document describes step-by-step procedures for rotating the three main secr
 
 ### Option A: File-Based Hot-Reload (Recommended, Zero-Downtime)
 
-The backend supports watching a secret file for changes using `fsnotify`. When the file is updated, the signing key is atomically swapped. Tokens signed with the previous key remain valid for a configurable overlap period (default: 5 minutes).
+The backend supports watching a secret file for changes using `fsnotify`. When the file is updated, the signing key is atomically swapped. Tokens signed with the previous key remain valid for an overlap period set by `TFR_JWT_SECRET_OVERLAP` (a Go duration such as `10m`; default: 5 minutes). An unset, unparseable or non-positive value uses the default — the overlap only widens the window in which an *old* key still validates, so it is not worth failing a deploy over.
+
+The watch starts only when `TFR_JWT_SECRET_FILE` is set. If it is set and the file cannot be read or watched, the server **refuses to start** rather than falling back to `TFR_JWT_SECRET` — otherwise a rotation you believed was live would silently never happen.
 
 **Prerequisites:**
 


### PR DESCRIPTION
Closes #737.

## The gap

`docs/secrets-rotation.md` presents `TFR_JWT_SECRET_FILE` as **"Option A: File-Based Hot-Reload (Recommended, Zero-Downtime)"** and walks an operator through rotating the Kubernetes Secret, then watching for `JWT secret reloaded from file` in the logs.

`auth.StartJWTSecretFileWatch` implements all of it — down to those exact log strings — and had **no caller outside its own tests**. Setting the variable did nothing.

## Why it's worse than a missing feature

That same document says a restart is required only *"if not using file-watch"*.

So an operator on this path rotates the Secret, sees no error, **deliberately skips the restart** — and keeps serving with the original signing key indefinitely, believing the old one has been retired.

## The change

- `serve()` starts the watch when `TFR_JWT_SECRET_FILE` is set, and stops it on shutdown.
- **Fails closed.** If the file cannot be read or watched, startup aborts rather than falling back to `TFR_JWT_SECRET` — booting anyway reproduces the same defect by another route: rotation believed live, not happening.
- `TFR_JWT_SECRET_OVERLAP` introduced and documented. The doc already called the overlap *"configurable"* without naming anything to configure; this is the name that makes that sentence true.

An unset, unparseable or non-positive overlap falls back to the documented 5 minutes rather than refusing to boot. The overlap only widens the window in which an **old** key still validates, so a typo there cannot grant access the current key does not already grant — trading that for an outage is the wrong bargain.

## On testing this

A unit test would have missed it entirely. The defect was not wrong logic in a function; it was **the absence of a call**, which no test of any function's behaviour can see.

So the *wiring* is asserted structurally — that `TFR_JWT_SECRET_FILE` is read, that `StartJWTSecretFileWatch` is called, that the call is reachable from `serve()` specifically rather than parked in an uninvoked helper, and that the failure path still aborts startup.

Mutation-verified: deleting the call fails the guard on **all four** counts, each naming #737.

```
main.go no longer contains os.Getenv("TFR_JWT_SECRET_FILE") -- ... (issue #737)
main.go no longer contains auth.StartJWTSecretFileWatch( -- ... (issue #737)
auth.StartJWTSecretFileWatch is not called from serve(); ... (issue #737)
the watch failure path no longer aborts startup; ... reintroduces #737 by another route
```

`jwtSecretOverlap` is separately table-tested over unset / whitespace / valid / unparseable / zero / negative. `go build`, `go vet` and `go test ./cmd/server/ ./internal/auth/` all clean.