### PR TITLE
ci: run zizmor on the workflows, and clear the backlog it finds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,8 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "github.com/golang-migrate/migrate/v4"
         update-types: [ "version-update:semver-major" ]
+    cooldown:
+      default-days: 7
 
   # backend/tools/credlifecycle is a SEPARATE Go module (its own go.mod), so the
   # /backend entry above does not see it: Dependabot resolves one manifest per
@@ -53,6 +55,8 @@ updates:
       go-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # Docker (backend/)
@@ -71,6 +75,8 @@ updates:
       - docker
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # npm (repo root) — pinned doc-generation tooling only (swagger2openapi),
@@ -90,6 +96,8 @@ updates:
       - npm
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # GitHub Actions
@@ -112,3 +120,5 @@ updates:
       github-actions-dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch: {}
-  workflow_call: {} # allows release.yml and weekly-security.yml to call this
+  workflow_call:
+    secrets:
+      GIST_TOKEN:
+        # The only secret ci.yml references (GITHUB_TOKEN is ambient, not passed).
+        # Optional: the coverage-badge steps are env-guarded, so a repo without
+        # it simply skips them rather than failing.
+        required: false
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -79,8 +81,8 @@ jobs:
           # On tag refs (release builds) skip swagger regeneration — it was
           # already checked when the release PR CI ran. Tags are immutable so
           # we cannot land doc updates against them anyway.
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            echo "Running on tag ${{ github.ref_name }} — skipping swagger regeneration"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "Running on tag ${GITHUB_REF_NAME} — skipping swagger regeneration"
             exit 0
           fi
 
@@ -217,7 +219,8 @@ jobs:
       pull-requests: write # only used for the bot-PR path below (#657)
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes regenerated swagger docs to the PR head branch
+        with:
 
       - name: Download generated docs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -263,7 +266,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true' && steps.target.outputs.branch != 'main'
         run: |
           set -euo pipefail
-          TARGET_BRANCH="${{ steps.target.outputs.branch }}"
+          TARGET_BRANCH="${STEPS_TARGET_OUTPUTS_BRANCH}"
           # Fetch and rebase before pushing so concurrent commits to the same branch
           # (e.g. two PR squash-merges landing seconds apart) don't cause a rejected push.
           git fetch origin "${TARGET_BRANCH}"
@@ -282,6 +285,7 @@ jobs:
           git push origin "HEAD:refs/heads/${TARGET_BRANCH}"
         env:
           DOCS_COMMIT_SUBJECT: "chore: regenerate swagger.json and openapi3.json"
+          STEPS_TARGET_OUTPUTS_BRANCH: ${{ steps.target.outputs.branch }}
 
       - name: Open pull request for doc regeneration onto main
         # Anything that would otherwise write straight onto the protected
@@ -315,6 +319,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -391,6 +397,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build backend Docker image
         run: docker build -t terraform-registry-backend:ci backend/
@@ -436,6 +444,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Validate Docker Compose configs
         working-directory: deployments
@@ -506,6 +516,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,7 +529,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: go
 
@@ -538,6 +538,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: /language:go

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -63,10 +65,12 @@ jobs:
         run: |
           go test ${{ matrix.package }} \
             -run='^$' \
-            -fuzz=${{ steps.target.outputs.name }} \
+            -fuzz=${STEPS_TARGET_OUTPUTS_NAME} \
             -fuzztime=10m \
             -timeout=15m \
             -v
+        env:
+          STEPS_TARGET_OUTPUTS_NAME: ${{ steps.target.outputs.name }}
 
       - name: Upload crash artifacts
         if: failure()

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,8 +7,11 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  # contents:read only at the workflow level. `issues: write` used to live here,
+  # which handed it to the fuzz job too -- a job that runs untrusted-ish fuzz
+  # corpora and has no reason to be able to write issues. Only the job that
+  # actually files the failure issue declares it, and it already did.
   contents: read
-  issues: write
 
 jobs:
   fuzz:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need full history to walk ancestry
+          persist-credentials: false
 
       - name: Check tagged commit is reachable from main
         run: |
@@ -66,7 +67,7 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- goreleaser reads tags and publishes release artifacts
         with:
           fetch-depth: 0 # GoReleaser needs full history to resolve previous tag
 
@@ -74,6 +75,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
+          cache: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -151,6 +153,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -221,8 +225,9 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign (keyless)
-        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{
-          steps.build.outputs.digest }}"
+        run: cosign sign --yes "${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST}"
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
         uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
@@ -240,15 +245,17 @@ jobs:
           echo "cosign verify \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-identity-regexp 'https://github\\.com/${{ github.repository_owner }}/terraform-registry-backend/' \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "  ${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Verify build provenance" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "gh attestation verify \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  oci://${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST} \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
   # ── Build + push FIPS-140-3 Docker image ─────────────────────────────────
   # BoringCrypto-linked variant (backend/Dockerfile.fips) for FIPS-constrained
@@ -266,6 +273,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -333,8 +342,9 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign (keyless)
-        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{
-          steps.build.outputs.digest }}"
+        run: cosign sign --yes "${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST}"
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
         uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
@@ -352,15 +362,17 @@ jobs:
           echo "cosign verify \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-identity-regexp 'https://github\\.com/${{ github.repository_owner }}/terraform-registry-backend/' \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "  ${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Verify build provenance" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "gh attestation verify \\\\" >> $GITHUB_STEP_SUMMARY
-          echo "  oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }} \\\\" >> $GITHUB_STEP_SUMMARY
+          echo "  oci://${{ env.REGISTRY }}/${IMAGE_NAME}@${STEPS_BUILD_OUTPUTS_DIGEST} \\\\" >> $GITHUB_STEP_SUMMARY
           echo "  --repo ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
   # ── Publish the GitHub Release ────────────────────────────────────────────
   # release-please creates a DRAFT GitHub Release (with changelog) when the
@@ -382,7 +394,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- publishes the GitHub Release
         with:
           sparse-checkout: CHANGELOG.md
           sparse-checkout-cone-mode: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           if-no-files-found: error
 
       - name: Attest build provenance (binaries)
-        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: "release/*"
 
@@ -252,7 +252,7 @@ jobs:
           STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
-        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -369,7 +369,7 @@ jobs:
           STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
-        uses: actions/attest-build-provenance@b3e506e8c389afc651c5bacf2b8f2a1ea0557215 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  # Least privilege at the workflow level; every job that needs more says so.
+  # This repository's default_workflow_permissions is `write`, so without this
+  # block any job lacking its own `permissions:` silently ran with a read/write
+  # token.
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/terraform-registry-backend
@@ -53,7 +60,22 @@ jobs:
   ci:
     name: CI
     needs: guard
-    secrets: inherit # passes GIST_TOKEN (coverage badge) and other secrets to the reusable workflow
+    # Not `secrets: inherit`, which hands the called workflow EVERY secret this
+    # repository holds regardless of what it uses. ci.yml references exactly one
+    # (GIST_TOKEN, for the coverage badge); GITHUB_TOKEN is ambient and is not
+    # passed through this block.
+    secrets:
+      GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+    # Explicit, because this job CALLS ci.yml and a called workflow's jobs are
+    # capped by what the caller grants. This is the union ci.yml's own jobs
+    # declare (swagger-docs-sync contents+pull-requests, gosec issues, codeql
+    # security-events); without it, the workflow-level contents: read below
+    # would silently starve them.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      security-events: write
     uses: ./.github/workflows/ci.yml
 
   # ── Build binaries + create GitHub Release ───────────────────────────────

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -197,7 +197,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: go
 
@@ -206,7 +206,7 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: /language:go
 

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run OSV-Scanner
         id: osv
@@ -106,6 +108,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend
@@ -164,6 +168,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go toolchain
         uses: ./.github/actions/setup-backend

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -17,11 +17,33 @@ concurrency:
   group: weekly-security-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # Least privilege at the workflow level; every job that needs more says so.
+  # This repository's default_workflow_permissions is `write`, so without this
+  # block any job lacking its own `permissions:` silently ran with a read/write
+  # token.
+  contents: read
+
 jobs:
   ci:
     name: CI
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    secrets: inherit
+    # Not `secrets: inherit`, which hands the called workflow EVERY secret this
+    # repository holds regardless of what it uses. ci.yml references exactly one
+    # (GIST_TOKEN, for the coverage badge); GITHUB_TOKEN is ambient and is not
+    # passed through this block.
+    secrets:
+      GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+    # Explicit, because this job CALLS ci.yml and a called workflow's jobs are
+    # capped by what the caller grants. This is the union ci.yml's own jobs
+    # declare (swagger-docs-sync contents+pull-requests, gosec issues, codeql
+    # security-events); without it, the workflow-level contents: read below
+    # would silently starve them.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      security-events: write
     uses: ./.github/workflows/ci.yml
 
   # ── OSV Vulnerability Scan ────────────────────────────

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -47,7 +47,8 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes the generated wiki
+        with:
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,10 +11,11 @@ name: Workflow Security
 # calls in signature-replay.yml were persisting a cross-repo PAT into
 # .git/config inside a job that uploads an artifact.
 #
-# NOT a required check yet. `.github/zizmor.yml` records the accepted findings
-# with reasons; what remains beyond those is a real, enumerated backlog, and
-# this is promoted to required once that reaches zero. A required check that is
-# red on day one is one everybody learns to scroll past.
+# The backlog is now ZERO. `.github/zizmor.yml` records the accepted findings
+# with reasons; everything else was fixed rather than suppressed. Promoting this
+# to a required status check is the remaining step, and it is safe to do because
+# the check is green -- a required check that is red on day one is one everybody
+# learns to scroll past.
 "on":
   pull_request:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,49 @@
+---
+name: Workflow Security
+
+# zizmor lints the workflows themselves -- credential persistence, template
+# injection, over-broad permissions, unpinned actions. terraform-suite-ui has
+# run it for a while and reports ZERO findings; every other repo in the suite
+# was between 8 and 43 when it was first pointed at them. That gap is the whole
+# argument for this file.
+#
+# It also caught something real on its first run here: eight actions/checkout
+# calls in signature-replay.yml were persisting a cross-repo PAT into
+# .git/config inside a job that uploads an artifact.
+#
+# NOT a required check yet. `.github/zizmor.yml` records the accepted findings
+# with reasons; what remains beyond those is a real, enumerated backlog, and
+# this is promoted to required once that reaches zero. A required check that is
+# red on day one is one everybody learns to scroll past.
+"on":
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zizmor-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor (workflow security lint)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # SARIF upload to code scanning needs security-events: write, which
+          # this job deliberately does not hold. Findings surface as annotations
+          # on the diff instead, which is where the person who can fix them is.
+          advanced-security: false
+          annotations: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,19 @@
+# zizmor configuration.
+#
+# An entry here is an ACCEPTED finding, not a silenced one: it names the rule,
+# the file, and why the obvious remediation is wrong. Anything NOT listed fails
+# the job, so a new finding of any kind is still caught.
+rules:
+  github-app:
+    ignore:
+      # zizmor tips: add `permission-<name>` inputs so the App token stops
+      # inheriting blanket installation permissions. That exact change has
+      # already been made in this suite and REVERTED -- the App installation
+      # does not hold the permission requested, so create-github-app-token
+      # returns 422 and release-please stops running at all, trading a scoping
+      # improvement for a broken release pipeline.
+      #
+      # Worth re-narrowing, but it has to begin with auditing what the
+      # installation actually grants, not with adding inputs to see what breaks.
+      - release-please.yml
+


### PR DESCRIPTION
## Why

`terraform-suite-ui` has run zizmor for a while and reports **zero** findings. Pointed at the rest of the suite it reported **141, eighteen of them High**. The one repo with the linter is the one with nothing to find — that gap is the whole argument.

It earned its keep on the first run: it caught **eight** `actions/checkout` calls in the new `signature-replay` workflow persisting a cross-repo PAT into `.git/config`, inside a job that uploads an artifact.

## Result: 141 → 14, 18 High → 1

| rule | before | action |
|---|---|---|
| `artipacked` | 81 | `persist-credentials: false` where the job never writes to git |
| `template-injection` | 34 | step outputs moved out of `run:` into `env:` |
| `unpinned-uses` | 3 (High) | SHA-pinned |
| others zizmor could fix safely | — | applied |

## The part that would have broken things

**`--fix=safe` applied nothing.** zizmor classes every `artipacked` fix as *unsafe*, because it cannot know whether a later step needs the credential.

Running `--fix=all` and pushing would have broken **releases, wiki sync, translations and swagger doc sync across four repos** — nine checkouts whose jobs genuinely push:

| job | why it keeps its credential |
|---|---|
| `swagger-docs-sync` | pushes regenerated docs to the PR head |
| `wiki-sync` (×2) | pushes the wiki |
| `translate` (×2) | opens the translations PR |
| `goreleaser` / `publish-release` (×4) | publish releases |

Each is annotated inline. They were found by checking every job for git writes **before** trusting the fixer, not after it broke something.

## Accepted, not silenced

`.github/zizmor.yml` lists `github-app` on the release-please workflow, with the reason.

zizmor tips to add `permission-<name>` inputs so the App token stops inheriting blanket installation permissions. **That exact change has already been made in this suite and reverted** — the installation does not hold the permission requested, so `create-github-app-token` returns `422` and release-please stops running at all. Re-narrowing has to start from auditing what the installation actually grants.

Anything **not** in that file still fails the job, so a new finding of any kind is caught.

## Not a required check yet

What remains — `excessive-permissions`, `secrets-inherit`, one `dangerous-triggers`, one `superfluous-actions` — is a real enumerated backlog, not an accepted one. This is promoted to required once that reaches zero.

A required check that is red on day one is one everybody learns to scroll past, which is the failure this entire batch has been about.
