### PR TITLE
fix(api): bind scan-by-id to the caller's tenancy

### DIFF
--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -62,7 +62,11 @@ func GetModuleScanHandler(db *sql.DB) gin.HandlerFunc {
 			return
 		}
 
-		scan, err := scanRepo.GetLatestScan(c.Request.Context(), mv.ID)
+		// The module was already resolved within an organization above, so the
+		// scan is bound to that same organization -- a scan cannot be returned
+		// for a module version the caller did not just look up.
+		scan, err := scanRepo.GetLatestScan(c.Request.Context(), mv.ID,
+			repositories.OrgScopeOrganizations(module.OrganizationID))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query scan result"})
 			return

--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -87,7 +88,7 @@ func GetModuleScanHandler(db *sql.DB) gin.HandlerFunc {
 // @Failure      404  {object}  map[string]interface{}  "Scan not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/scanning/scans/{id} [get]
-func GetScanByIDHandler(db *sql.DB) gin.HandlerFunc {
+func GetScanByIDHandler(db *sql.DB, orgRepo *repositories.OrganizationRepository) gin.HandlerFunc {
 	scanRepo := repositories.NewModuleScanRepository(db)
 
 	return func(c *gin.Context) {
@@ -97,7 +98,20 @@ func GetScanByIDHandler(db *sql.DB) gin.HandlerFunc {
 			return
 		}
 
-		scan, err := scanRepo.GetScanByID(c.Request.Context(), id)
+		// GUARD scan-byid-tenant-scope (issue #783): the by-id axis of the
+		// #718/#719 class. The row is organization-owned transitively, through
+		// module_versions -> modules, so nothing about the scan row itself says
+		// whose it is -- which is why fetching by primary key looked harmless.
+		//
+		// Out of scope answers 404, not 403: the response body is another
+		// tenant's vulnerability findings, so confirming the id exists is itself
+		// the disclosure. Indistinguishable from an id that was never issued.
+		scope, ok := resolveTenantScope(c, orgRepo, auth.ScopeScanningRead)
+		if !ok {
+			return
+		}
+
+		scan, err := scanRepo.GetScanByID(c.Request.Context(), id, scope.OrgScope())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query scan result"})
 			return

--- a/backend/internal/api/admin/scans_tenant_scope_test.go
+++ b/backend/internal/api/admin/scans_tenant_scope_test.go
@@ -1,0 +1,153 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Issue #783 — the by-id axis of the #718/#719 tenant-scoping class.
+//
+// GET /api/v1/admin/scanning/scans/:id was gated on RequireScope(scanning:read)
+// and nothing else, and fetched purely by primary key. scanning:read is granted
+// by the seeded devops and auditor role templates through membership in a
+// SINGLE organization, so any such holder could read another tenant's
+// vulnerability findings by naming a scan id — no platform authority required.
+//
+// module_version_scans carries no organization_id of its own; it is
+// organization-owned transitively through module_versions -> modules. Nothing
+// about the row says whose it is, which is exactly why fetching it by primary
+// key looked harmless.
+//
+// These tests assert the SCOPED form of the query specifically. sqlmock matches
+// query text and arguments; it does not evaluate predicates. An expectation that
+// merely said "FROM module_version_scans" would be satisfied by the unscoped
+// query too, and would pass with the guard reverted.
+
+const (
+	scanOrgAlpha = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+	scanID       = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+)
+
+// scopedScanRouter wires the handler behind a non-admin scanning:read principal
+// holding that scope in one organization only.
+func scopedScanRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeScanningRead)})
+		c.Set("user_id", "scoped-user")
+	})
+	r.GET("/admin/scanning/scans/:id", GetScanByIDHandler(db, repositories.NewOrganizationRepository(db)))
+	return mock, r
+}
+
+// membershipRowsForScanScope is the GetUserMemberships shape tenantscope.Resolve
+// reads to build the caller's scope.
+func membershipRowsForScanScope(orgID string, scopes string) *sqlmock.Rows {
+	return sqlmock.NewRows(membershipCols).
+		AddRow(orgID, "org-alpha", "role-1", time.Now(), "devops", "DevOps", []byte(scopes))
+}
+
+func TestGetScanByID_ScopedCallerGetsTheScopedQuery(t *testing.T) {
+	mock, r := scopedScanRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["scanning:read"]`))
+	// The scoped form joins through module_versions -> modules and binds
+	// m.organization_id. A platform-wide scope emits the literal TRUE and would
+	// not match this expectation, which is what makes the test meaningful.
+	mock.ExpectQuery("(?s)JOIN modules.*m.organization_id").
+		WillReturnRows(sampleScanResultRow())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/scanning/scans/"+scanID, nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetScanByID_OutOfScopeIs404NotForbidden(t *testing.T) {
+	mock, r := scopedScanRouter(t)
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["scanning:read"]`))
+	// A scan owned by another organization matches no row under this scope.
+	mock.ExpectQuery("(?s)JOIN modules.*m.organization_id").
+		WillReturnRows(sqlmock.NewRows(scanAdminCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/scanning/scans/"+scanID, nil))
+
+	// 404 rather than 403 on purpose: the response body is another tenant's
+	// vulnerability findings, so confirming the id exists is itself part of the
+	// disclosure. Out of scope must be indistinguishable from never issued.
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for an out-of-scope scan; body: %s", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); body != "" {
+		for _, leak := range []string{"critical", "raw_results", "module_version_id"} {
+			if containsFold(body, leak) {
+				t.Errorf("404 body leaked %q: %s", leak, body)
+			}
+		}
+	}
+}
+
+func TestGetScanByID_MembershipWithoutScanningReadReachesNothing(t *testing.T) {
+	mock, r := scopedScanRouter(t)
+	// A member of alpha, but the role template there does not grant
+	// scanning:read. Membership is not authority (#719).
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["modules:read"]`))
+	// The empty scope emits the literal FALSE rather than binding a column, so
+	// the predicate is unsatisfiable before the database considers a single row.
+	// Matching on FALSE here is the assertion: if this ever became a bound
+	// organization list, the caller would be reaching rows again.
+	mock.ExpectQuery("(?s)WHERE s.id = .*AND FALSE").
+		WillReturnRows(sqlmock.NewRows(scanAdminCols))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/admin/scanning/scans/"+scanID, nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func containsFold(haystack, needle string) bool {
+	if len(needle) == 0 || len(haystack) < len(needle) {
+		return false
+	}
+	lower := func(b byte) byte {
+		if b >= 'A' && b <= 'Z' {
+			return b + 32
+		}
+		return b
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		ok := true
+		for j := 0; j < len(needle); j++ {
+			if lower(haystack[i+j]) != lower(needle[j]) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -94,8 +94,10 @@ func TestGetModuleScan_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
 		WithArgs("mod-1", "1.0.0").
 		WillReturnRows(sampleVersionRowScan())
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
-		WithArgs("ver-1").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN modules.*WHERE s.module_version_id").
+		// Two args now: the version id, plus the organization list the scope
+		// binds. AnyArg for the second because it travels as a pq.Array.
+		WithArgs("ver-1", sqlmock.AnyArg()).
 		WillReturnRows(sampleScanResultRow())
 
 	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
@@ -181,7 +183,7 @@ func TestGetModuleScan_ScanDBError(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM modules.*WHERE").WillReturnRows(sampleModuleRowScan())
 	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
 		WillReturnRows(sampleVersionRowScan())
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN modules.*WHERE s.module_version_id").
 		WillReturnError(errors.New("db error"))
 
 	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")
@@ -196,7 +198,7 @@ func TestGetModuleScan_ScanNotFound(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM modules.*WHERE").WillReturnRows(sampleModuleRowScan())
 	mock.ExpectQuery("SELECT.*FROM module_versions.*WHERE module_id").
 		WillReturnRows(sampleVersionRowScan())
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN modules.*WHERE s.module_version_id").
 		WillReturnRows(sqlmock.NewRows(scanAdminCols))
 
 	w := doScanGET(r, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan")

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -10,6 +10,9 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
 var scanAdminCols = []string{
@@ -214,13 +217,20 @@ func newScanByIDRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	}
 	t.Cleanup(func() { db.Close() })
 	r := gin.New()
-	r.GET("/admin/scanning/scans/:id", GetScanByIDHandler(db))
+	// Platform admin: tenantscope.Resolve short-circuits to the whole platform,
+	// so these pre-existing cases keep asserting handler behaviour rather than
+	// tenancy. The tenancy cases are in scans_tenant_scope_test.go.
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", "admin-user")
+	})
+	r.GET("/admin/scanning/scans/:id", GetScanByIDHandler(db, repositories.NewOrganizationRepository(db)))
 	return mock, r
 }
 
 func TestGetScanByID_Success(t *testing.T) {
 	mock, r := newScanByIDRouter(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
 		WillReturnRows(sampleScanResultRow())
 
@@ -241,7 +251,7 @@ func TestGetScanByID_InvalidUUID(t *testing.T) {
 
 func TestGetScanByID_NotFound(t *testing.T) {
 	mock, r := newScanByIDRouter(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
 		WillReturnRows(sqlmock.NewRows(scanAdminCols))
 
@@ -253,7 +263,7 @@ func TestGetScanByID_NotFound(t *testing.T) {
 
 func TestGetScanByID_DBError(t *testing.T) {
 	mock, r := newScanByIDRouter(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11").
 		WillReturnError(errors.New("db error"))
 

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -693,7 +693,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				admin.GetScanningStatsHandler(sqlxDB))
 			authenticatedGroup.GET("/admin/scanning/scans/:id",
 				middleware.RequireScope(auth.ScopeScanningRead),
-				admin.GetScanByIDHandler(db))
+				admin.GetScanByIDHandler(db, orgRepo))
 			installHandler := admin.NewScanningInstallHandler(&cfg.Scanning, nil, scannerUpdateJob, sbvRepo, scannerApprovalRepo)
 			installHandler.SetEgressGuard(egressGuard)
 			authenticatedGroup.POST("/admin/scanning/install",

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -259,17 +259,43 @@ func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionI
 }
 
 // GetScanByID returns a single scan record by its primary key, or nil if not found.
-func (r *ModuleScanRepository) GetScanByID(ctx context.Context, scanID string) (*models.ModuleScan, error) {
-	const q = `
-		SELECT id, module_version_id, scanner, scanner_version, expected_version,
-		       status, scanned_at, critical_count, high_count, medium_count, low_count,
-		       raw_results, error_message, execution_log, created_at, updated_at
-		FROM module_version_scans
-		WHERE id = $1
+// GetScanByID fetches one scan, bound to the caller's tenancy.
+//
+// module_version_scans has no organization_id of its own -- it is transitively
+// organization-owned through module_versions -> modules.organization_id -- so
+// the predicate is a join rather than a column comparison. Before this took a
+// scope it fetched purely by primary key, and any scanning:read holder could
+// read another tenant's vulnerability findings by id (#783). scanning:read is
+// granted by the seeded devops and auditor role templates through membership in
+// a SINGLE organization, so that needed no platform authority at all.
+//
+// The scope is a required parameter rather than an optional filter: the zero
+// value selects nothing, so a caller that forgets tenancy gets no row instead of
+// every tenant's. That is the same shape the audit accessors took in #128, and
+// the reason it lives in the accessor rather than the handler is #719 -- the
+// by-id, list and export axes of that class drifted apart precisely because
+// each re-implemented the predicate.
+func (r *ModuleScanRepository) GetScanByID(ctx context.Context, scanID string, scope OrgScope) (*models.ModuleScan, error) {
+	// GUARD scan-byid-tenant-scope (issue #783).
+	q := `
+		SELECT s.id, s.module_version_id, s.scanner, s.scanner_version, s.expected_version,
+		       s.status, s.scanned_at, s.critical_count, s.high_count, s.medium_count, s.low_count,
+		       s.raw_results, s.error_message, s.execution_log, s.created_at, s.updated_at
+		FROM module_version_scans s
+		JOIN module_versions mv ON mv.id = s.module_version_id
+		JOIN modules m ON m.id = mv.module_id
+		WHERE s.id = $1
 	`
+	args := []interface{}{scanID}
+	clause, scopeArgs := scope.SQL("m.organization_id", len(args)+1)
+	// #nosec G202 -- clause comes from OrgScope.SQL: "TRUE", "FALSE", or a fixed
+	// template over an internal column constant and a $N placeholder. Scope
+	// values travel as query arguments and are never interpolated.
+	q += " AND " + clause
+	args = append(args, scopeArgs...)
 	s := &models.ModuleScan{}
 	var rawResults []byte
-	err := r.db.QueryRowContext(ctx, q, scanID).Scan(
+	err := r.db.QueryRowContext(ctx, q, args...).Scan(
 		&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
 		&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
 		&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,

--- a/backend/internal/db/repositories/module_scan_repository.go
+++ b/backend/internal/db/repositories/module_scan_repository.go
@@ -229,19 +229,37 @@ func (r *ModuleScanRepository) MarkError(ctx context.Context, scanID, errMsg str
 }
 
 // GetLatestScan returns the most recent scan for a module version, or nil if none exists.
-func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionID string) (*models.ModuleScan, error) {
-	const q = `
-		SELECT id, module_version_id, scanner, scanner_version, expected_version,
-		       status, scanned_at, critical_count, high_count, medium_count, low_count,
-		       raw_results, error_message, execution_log, created_at, updated_at
-		FROM module_version_scans
-		WHERE module_version_id = $1
-		ORDER BY created_at DESC
-		LIMIT 1
+// GetLatestScan fetches the newest scan for a module version, bound to a tenancy.
+//
+// Scoped for the same reason as GetScanByID: module_version_scans is
+// organization-owned only transitively, so an accessor without a tenant
+// parameter is one every caller has to remember to guard. The signature-replay
+// gate flagged this the moment its sibling was scoped -- which is the point of
+// scoping the accessor rather than the handler.
+//
+// Its one caller resolves the module first and passes that module's own
+// organization, so the scope here is a structural assertion rather than an
+// authorization decision: the scan returned belongs to the module that was
+// looked up, and cannot be one that merely shares a version id.
+func (r *ModuleScanRepository) GetLatestScan(ctx context.Context, moduleVersionID string, scope OrgScope) (*models.ModuleScan, error) {
+	// GUARD scan-latest-tenant-scope (issue #783, sibling axis).
+	q := `
+		SELECT s.id, s.module_version_id, s.scanner, s.scanner_version, s.expected_version,
+		       s.status, s.scanned_at, s.critical_count, s.high_count, s.medium_count, s.low_count,
+		       s.raw_results, s.error_message, s.execution_log, s.created_at, s.updated_at
+		FROM module_version_scans s
+		JOIN module_versions mv ON mv.id = s.module_version_id
+		JOIN modules m ON m.id = mv.module_id
+		WHERE s.module_version_id = $1
 	`
+	args := []interface{}{moduleVersionID}
+	clause, scopeArgs := scope.SQL("m.organization_id", len(args)+1)
+	// #nosec G202 -- clause comes from OrgScope.SQL; see GetScanByID.
+	q += " AND " + clause + " ORDER BY s.created_at DESC LIMIT 1"
+	args = append(args, scopeArgs...)
 	s := &models.ModuleScan{}
 	var rawResults []byte
-	err := r.db.QueryRowContext(ctx, q, moduleVersionID).Scan(
+	err := r.db.QueryRowContext(ctx, q, args...).Scan(
 		&s.ID, &s.ModuleVersionID, &s.Scanner, &s.ScannerVersion, &s.ExpectedVersion,
 		&s.Status, &s.ScannedAt, &s.CriticalCount, &s.HighCount, &s.MediumCount, &s.LowCount,
 		&rawResults, &s.ErrorMessage, &s.ExecutionLog, &s.CreatedAt, &s.UpdatedAt,

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -332,11 +332,11 @@ func TestGetScanByID_DBError(t *testing.T) {
 
 func TestGetLatestScan_Found(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.module_version_id").
 		WithArgs("ver-1").
 		WillReturnRows(sampleScanRow())
 
-	scan, err := repo.GetLatestScan(context.Background(), "ver-1")
+	scan, err := repo.GetLatestScan(context.Background(), "ver-1", OrgScopeAllOrganizations())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -350,11 +350,11 @@ func TestGetLatestScan_Found(t *testing.T) {
 
 func TestGetLatestScan_NotFound(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.module_version_id").
 		WithArgs("ver-99").
 		WillReturnRows(sqlmock.NewRows(scanCols))
 
-	scan, err := repo.GetLatestScan(context.Background(), "ver-99")
+	scan, err := repo.GetLatestScan(context.Background(), "ver-99", OrgScopeAllOrganizations())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -365,11 +365,11 @@ func TestGetLatestScan_NotFound(t *testing.T) {
 
 func TestGetLatestScan_DBError(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE module_version_id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.module_version_id").
 		WithArgs("ver-1").
 		WillReturnError(errors.New("db error"))
 
-	_, err := repo.GetLatestScan(context.Background(), "ver-1")
+	_, err := repo.GetLatestScan(context.Background(), "ver-1", OrgScopeAllOrganizations())
 	if err == nil {
 		t.Error("expected error, got nil")
 	}

--- a/backend/internal/db/repositories/module_scan_repository_test.go
+++ b/backend/internal/db/repositories/module_scan_repository_test.go
@@ -283,11 +283,11 @@ func TestMarkError_DBError(t *testing.T) {
 
 func TestGetScanByID_Found(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("scan-1").
 		WillReturnRows(sampleScanRow())
 
-	scan, err := repo.GetScanByID(context.Background(), "scan-1")
+	scan, err := repo.GetScanByID(context.Background(), "scan-1", OrgScopeAllOrganizations())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -301,11 +301,11 @@ func TestGetScanByID_Found(t *testing.T) {
 
 func TestGetScanByID_NotFound(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("scan-99").
 		WillReturnRows(sqlmock.NewRows(scanCols))
 
-	scan, err := repo.GetScanByID(context.Background(), "scan-99")
+	scan, err := repo.GetScanByID(context.Background(), "scan-99", OrgScopeAllOrganizations())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -316,11 +316,11 @@ func TestGetScanByID_NotFound(t *testing.T) {
 
 func TestGetScanByID_DBError(t *testing.T) {
 	repo, mock := newScanRepo(t)
-	mock.ExpectQuery("SELECT.*FROM module_version_scans.*WHERE id").
+	mock.ExpectQuery("(?s)FROM module_version_scans.*JOIN module_versions.*JOIN modules.*WHERE s.id").
 		WithArgs("scan-1").
 		WillReturnError(errors.New("db error"))
 
-	_, err := repo.GetScanByID(context.Background(), "scan-1")
+	_, err := repo.GetScanByID(context.Background(), "scan-1", OrgScopeAllOrganizations())
 	if err == nil {
 		t.Error("expected error, got nil")
 	}


### PR DESCRIPTION
Closes #783 — the by-id axis of the #718/#719 class.

## The defect

`GET /api/v1/admin/scanning/scans/:id` was gated on `RequireScope(scanning:read)` and nothing else, and fetched purely by primary key.

`scanning:read` is granted by the seeded **devops** and **auditor** role templates through membership in a **single** organization — so any such holder could read another tenant's vulnerability findings by naming a scan id. No platform authority required.

`module_version_scans` carries no `organization_id` of its own. It is organization-owned *transitively*, through `module_versions → modules`, so nothing about the row says whose it is. That is exactly why fetching by primary key looked harmless.

## The predicate lives in the accessor

#719 was closed while its siblings still leaked **precisely because each axis re-implemented the check**. A required scope parameter on `GetScanByID` means the by-id, list and export axes cannot drift apart the same way.

The zero value selects nothing, so a caller that forgets tenancy gets no row rather than every tenant's — and the **compiler** found the call sites rather than a reviewer having to.

## 404, not 403

The response body *is* another tenant's findings, so confirming the id exists is part of the disclosure. An unreachable scan must be indistinguishable from an id that was never issued. A test asserts the 404 body carries none of `critical` / `raw_results` / `module_version_id`.

## Tests assert the scoped SQL specifically

sqlmock matches query *text* and does not evaluate predicates — an expectation reading `FROM module_version_scans` would be satisfied by the unscoped query too, and would pass with the guard reverted. These match the join through `module_versions → modules` binding `m.organization_id`.

One case asserts the literal **`FALSE`** predicate: a member whose role template lacks `scanning:read` resolves to the empty scope, which emits `FALSE` rather than binding an organization list, so the query is unsatisfiable before the database considers a row. If that ever becomes a bound list, the caller is reaching rows again and the test says so.

## Mutation-verified

Passing `OrgScopeAllOrganizations()` instead of the caller's scope fails both scoped tests.

Deliberately with a **compiling** mutant — my first attempt only failed to *build* on an unused variable, which is the compiler catching it rather than the tests.

## Note

The issue also suggests checking `GET /admin/scanning/stats` in the same pass. That route takes `sqlxDB` through a different handler and aggregates rather than returning rows; it needs its own look and is not covered here.