### PR TITLE
fix(security): fail closed on a weak JWT secret, and stop deriving the log mask from the DB password

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -344,9 +344,21 @@ func serve(cfg *config.Config) error {
 	}
 
 	// Debug: Print database configuration (mask password)
+	// A CONSTANT, never derived from the password (issue #753). This previously
+	// read `cfg.Database.Password[:1] + "****"`, which wrote the real first
+	// character of the live database credential to stdout on every boot -- under
+	// a label saying "masked", on the production path, gated by nothing.
+	//
+	// One character is not nothing: it removes ~1/94 of the search space for
+	// free and confirms the credential's shape to anyone reading log
+	// aggregation, which is a wider audience than anyone with database access.
+	//
+	// The adjacent TestServe_NeverLogsGetDSN guarded the full-DSN leak (#651)
+	// and said nothing about this, which is why it survived the fix that
+	// introduced it. That test now covers both.
 	maskedPassword := "****"
-	if cfg.Database.Password != "" {
-		maskedPassword = cfg.Database.Password[:1] + "****"
+	if cfg.Database.Password == "" {
+		maskedPassword = "(unset)"
 	}
 	log.Printf("Database config: host=%s, port=%d, user=%s, password=%s, dbname=%s, sslmode=%s", // #nosec G706 -- logged value is application-internal (config string, integer, or application-constructed path); not raw user-controlled request input
 		cfg.Database.Host, cfg.Database.Port, cfg.Database.User, maskedPassword,

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -344,5 +345,37 @@ func TestShutdownServices_NilStopBackground_DoesNotPanic(t *testing.T) {
 	srv := &stubShutdowner{}
 	if err := shutdownServices(context.Background(), srv, nil, nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestServe_NeverDerivesTheMaskFromThePassword is the other half of #651's
+// guard, added for #753.
+//
+// TestServe_NeverLogsGetDSN above catches the loud failure -- a whole DSN with
+// the password interpolated. It says nothing about a mask BUILT FROM the
+// password, which is how `cfg.Database.Password[:1] + "****"` survived the very
+// commit that fixed #651 and then wrote the credential's first character to
+// stdout on every boot, under a label reading "masked".
+//
+// A partial leak under a reassuring label is worse than an obvious one: nobody
+// re-reads a line that says it is masked.
+func TestServe_NeverDerivesTheMaskFromThePassword(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+
+	// Any slice, index or concatenation whose operand is the password.
+	derived := regexp.MustCompile(`Password\s*\[|\bPassword\b[^\n]*\+|\+[^\n]*\bPassword\b`)
+	for i, line := range strings.Split(string(src), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") {
+			continue // the explanation of the defect names it deliberately
+		}
+		if derived.MatchString(line) {
+			t.Errorf("main.go:%d derives a value from the database password: %s\n"+
+				"A mask must be a constant. Deriving it leaks part of the credential "+
+				"under a label that says it does not (#753).", i+1, trimmed)
+		}
 	}
 }

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -113,8 +113,27 @@ func ValidateJWTSecret() error {
 			// a short phrase padded to length) passed the length check above with zero
 			// warning even though this secret signs/validates every session and API
 			// bearer token suite-wide (issue #654).
-			if crypto.IsLikelyLowEntropySecret([]byte(secret)) {
-				log.Printf("WARNING: TFR_JWT_SECRET has low estimated entropy and may not have been generated with a CSPRNG. Generate one with: openssl rand -hex 32")
+			// FAIL CLOSED, matching ENCRYPTION_KEY (issue #742).
+			//
+			// Both secrets run through the same crypto.IsLikelyLowEntropySecret
+			// heuristic, but only ENCRYPTION_KEY refused to boot. The asymmetry was
+			// backwards: a weak ENCRYPTION_KEY exposes stored SCM/OAuth tokens and
+			// needs prior database access to exploit, while a weak TFR_JWT_SECRET
+			// is an HS256 signing key -- guess it and you mint a token carrying any
+			// scope you like, including the platform-wide admin wildcard, with no
+			// access to anything beforehand. The larger blast radius had the weaker
+			// control.
+			//
+			// A warning is not a control when the process boots anyway: the operator
+			// who most needs to see it is the one least likely to be reading startup
+			// logs. Same opt-out shape as ENCRYPTION_KEY so an existing deployment
+			// can restart once to rotate rather than being unable to start.
+			if shouldRejectLowEntropyJWTSecret([]byte(secret), allowLowEntropyJWTSecret()) {
+				jwtSecretErr = errors.New("SECURITY ERROR: TFR_JWT_SECRET has low estimated entropy and does not look CSPRNG-generated. " +
+					"It signs and validates every session and API bearer token, so a guessable value lets an attacker forge tokens with arbitrary scopes. " +
+					"Generate one with: openssl rand -hex 32. " +
+					"To restart once and rotate an existing deployment, set TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true temporarily.")
+				return
 			}
 			resolved = secret
 		}
@@ -360,4 +379,22 @@ func trimSecretBytes(data []byte) []byte {
 	result := make([]byte, end)
 	copy(result, data[:end])
 	return result
+}
+
+// shouldRejectLowEntropyJWTSecret reports whether startup should refuse the
+// given TFR_JWT_SECRET. Extracted so the fail-closed decision (issue #742) is
+// unit-testable without going through the sync.Once in ValidateJWTSecret --
+// the same reason router.go extracted shouldRejectLowEntropyEncryptionKey.
+func shouldRejectLowEntropyJWTSecret(secret []byte, overrideAllowed bool) bool {
+	return crypto.IsLikelyLowEntropySecret(secret) && !overrideAllowed
+}
+
+// allowLowEntropyJWTSecret reports whether an operator has explicitly opted out
+// of the fail-closed check. Off by default; TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true
+// is a temporary bridge for rotating an existing deployment, not a setting to
+// leave on. Deliberately the same shape and spelling as
+// TFR_ALLOW_LOW_ENTROPY_ENCRYPTION_KEY, so an operator who has met one already
+// knows this one.
+func allowLowEntropyJWTSecret() bool {
+	return os.Getenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET") == "true"
 }

--- a/backend/internal/auth/jwt_entropy_test.go
+++ b/backend/internal/auth/jwt_entropy_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import "testing"
+
+// Issue #742: TFR_JWT_SECRET and ENCRYPTION_KEY run through the same entropy
+// heuristic, but only ENCRYPTION_KEY refused to boot. The asymmetry was
+// backwards -- a weak ENCRYPTION_KEY exposes stored tokens and needs prior
+// database access; a weak TFR_JWT_SECRET is an HS256 signing key, so guessing it
+// mints a token with any scope, from outside, with no prior access.
+func TestShouldRejectLowEntropyJWTSecret(t *testing.T) {
+	tests := []struct {
+		name     string
+		secret   string
+		override bool
+		want     bool
+	}{
+		{"repeated character padded to length is rejected", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false, true},
+		{"a CSPRNG-shaped secret is accepted", "9f2b7c1ad4e60835bb19fe4c7a0d3e51c8ab62f70d94e13a5c6f80b2d7e41a93", false, false},
+		{"the override lets a weak secret through, once", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true, false},
+		{"the override does not weaken a strong secret", "9f2b7c1ad4e60835bb19fe4c7a0d3e51c8ab62f70d94e13a5c6f80b2d7e41a93", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRejectLowEntropyJWTSecret([]byte(tt.secret), tt.override); got != tt.want {
+				t.Errorf("shouldRejectLowEntropyJWTSecret(%q, override=%v) = %v, want %v",
+					tt.secret, tt.override, got, tt.want)
+			}
+		})
+	}
+}
+
+// The opt-out must be OFF unless explicitly set to "true" -- an env var that
+// enables on any non-empty value is one a stray "false" turns on.
+func TestAllowLowEntropyJWTSecretDefaultsOff(t *testing.T) {
+	for _, v := range []string{"", "false", "0", "yes", "TRUE"} {
+		t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", v)
+		if allowLowEntropyJWTSecret() {
+			t.Errorf("value %q should not enable the override", v)
+		}
+	}
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "true")
+	if !allowLowEntropyJWTSecret() {
+		t.Error(`"true" should enable the override`)
+	}
+}

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -350,34 +350,57 @@ func TestStartJWTSecretFileWatch(t *testing.T) {
 func TestValidateJWTSecret_ShortSecret(t *testing.T) {
 	resetJWTSecret()
 	t.Setenv("TFR_JWT_SECRET", "short")
-	// Should succeed but log a warning (we can't check the log, but ensure no error)
-	if err := ValidateJWTSecret(); err != nil {
-		t.Errorf("ValidateJWTSecret() unexpected error with short secret: %v", err)
+	// Now REFUSED, where this used to boot with a warning (#742).
+	//
+	// The length check is still only a warning, but "short" also fails the
+	// entropy heuristic, and that is now fail-closed. The practical effect is
+	// that a 5-character signing key can no longer start the server, which was
+	// the previous behaviour and is hard to defend: the length warning was
+	// advisory in production, so a secret this weak booted and signed every
+	// session token.
+	err := ValidateJWTSecret()
+	if err == nil {
+		t.Fatal("ValidateJWTSecret() accepted a 5-character secret; it must fail closed (#742)")
 	}
-	if got := GetJWTSecret(); got != "short" {
-		t.Errorf("GetJWTSecret() = %q, want %q", got, "short")
+	if !strings.Contains(err.Error(), "low estimated entropy") {
+		t.Errorf("error should name the entropy check, got: %v", err)
 	}
 }
 
-// TestValidateJWTSecret_LowEntropyLongSecret is the core assertion for issue
-// #654: a TFR_JWT_SECRET that is 32+ characters (so it passes the length
-// check) but low-entropy (a short pattern repeated to length, as opposed to
-// CSPRNG output) must still trigger a warning, the same way ENCRYPTION_KEY
-// already does via crypto.IsLikelyLowEntropySecret (see router.go).
+// TestValidateJWTSecret_LowEntropyLongSecret was written for #654, which asked
+// for a WARNING here. #742 supersedes that: the same heuristic already refused
+// to boot for ENCRYPTION_KEY, and this secret has the larger blast radius of the
+// two -- guessing an HS256 signing key mints tokens with arbitrary scopes from
+// outside, where a weak ENCRYPTION_KEY needs prior database access.
+//
+// So the assertion is inverted deliberately, not relaxed: a 32+ character
+// low-entropy secret must now REFUSE TO START rather than log and continue.
 func TestValidateJWTSecret_LowEntropyLongSecret(t *testing.T) {
 	resetJWTSecret()
 	lowEntropySecret := strings.Repeat("ab", 20) // 40 chars, 2-symbol alphabet
 	t.Setenv("TFR_JWT_SECRET", lowEntropySecret)
 
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	err := ValidateJWTSecret()
+	if err == nil {
+		t.Fatal("ValidateJWTSecret() accepted a low-entropy 40-char secret; it must fail closed (#742)")
+	}
+	if !strings.Contains(err.Error(), "low estimated entropy") {
+		t.Errorf("error should name the entropy check, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "TFR_ALLOW_LOW_ENTROPY_JWT_SECRET") {
+		t.Errorf("error should tell the operator how to rotate, got: %v", err)
+	}
+}
+
+// The override is the migration bridge, and it has to actually work -- an
+// existing deployment on a weak secret must be able to start once to rotate.
+func TestValidateJWTSecret_LowEntropyAcceptedWithOverride(t *testing.T) {
+	resetJWTSecret()
+	t.Setenv("TFR_JWT_SECRET", strings.Repeat("ab", 20))
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "true")
 
 	if err := ValidateJWTSecret(); err != nil {
-		t.Fatalf("ValidateJWTSecret() unexpected error: %v", err)
-	}
-	if !strings.Contains(buf.String(), "low estimated entropy") {
-		t.Errorf("ValidateJWTSecret() with low-entropy 40-char secret did not warn; log output: %q", buf.String())
+		t.Fatalf("override should permit a weak secret for one restart, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #742. Closes #753.

Two startup defects in the same shape: **a control that reads as stronger than it behaves.**

## #742 — the bigger blast radius had the weaker control

`TFR_JWT_SECRET` and `ENCRYPTION_KEY` run through the same `crypto.IsLikelyLowEntropySecret` heuristic, but only `ENCRYPTION_KEY` refused to boot.

| secret | what a weak value costs | control before |
|---|---|---|
| `ENCRYPTION_KEY` | exposes stored SCM/OAuth tokens — needs **prior database access** | **fail closed** |
| `TFR_JWT_SECRET` | HS256 signing key — guess it and mint a token with **any scope**, including the admin wildcard, **from outside** | warning |

A warning is not a control when the process boots anyway: the operator who most needs to read it is the least likely to be watching startup logs.

It now refuses to start, with the same `TFR_ALLOW_LOW_ENTROPY_*` opt-out shape — same spelling, so an operator who has met one already knows this one — so an existing deployment can restart once to rotate rather than being unable to start at all.

## Superseding a recorded decision, not quietly

The existing tests encoded warn-only as the **intended** outcome of #654. Those assertions are **inverted deliberately**, with the reasoning in the test comments — not relaxed to make a build pass.

A side effect worth naming: `"short"` also fails the entropy heuristic, so a **5-character signing key can no longer start the server**. That was the previous behaviour and is hard to defend — the length check is advisory in production, so a secret that weak booted and signed every session token. The length check itself is unchanged.

A new test covers the **override actually working**. A migration bridge nobody tested is one that fails the first time someone needs it.

## #753 — a partial leak under a reassuring label

The startup line labelled *masked* printed the password's first character:

```go
maskedPassword = cfg.Database.Password[:1] + "****"
```

Unconditional, on the production path, gated by neither `DEV_MODE` nor log level. One character is not nothing — it removes ~1/94 of the search space for free and confirms the credential's shape to everyone reading log aggregation, a much wider audience than everyone with database access.

**It survived the commit that fixed #651.** `TestServe_NeverLogsGetDSN` guarded only the loud version — a whole DSN with the password interpolated — and said nothing about a mask *built from* the password.

That test now has a sibling which fails on any slice, index or concatenation whose operand is the password. Mutation-verified: restoring the one-character leak makes it name the file, line and expression.

A partial leak under a reassuring label is worse than an obvious one — nobody re-reads a line that says it is masked.