### PR TITLE
fix(webhooks): cap the one unauthenticated body this service reads unbounded

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -16185,91 +16185,6 @@
                     }
                 }
             }
-        },
-        "/webhooks/scm/{module_source_repo_id}/{secret}": {
-            "post": {
-                "description": "Receives and processes incoming webhook events from SCM providers (GitHub, GitLab, Azure DevOps, Bitbucket).\nTwo-layer security is applied: the URL-embedded secret (last path segment of the registered callback URL)\nis verified first with a constant-time comparison, and then the provider's HMAC payload signature is\nvalidated against the stored webhook secret. Both checks must pass before the payload is processed.\nAccepted events are logged. Tag-push events trigger asynchronous auto-publish when AutoPublish is enabled.",
-                "tags": [
-                    "Webhooks"
-                ],
-                "summary": "Receive SCM webhook",
-                "parameters": [
-                    {
-                        "description": "Module source repository link ID (UUID) — uniquely identifies the SCM-to-module mapping",
-                        "name": "module_source_repo_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "URL-embedded webhook secret generated at link time; used as a first-line constant-time guard before HMAC validation",
-                        "name": "secret",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/webhooks.WebhookReceivedResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid repository ID or malformed/unreadable payload",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "URL secret mismatch or HMAC payload signature invalid",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Repository link or SCM provider not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error (connector build, log write, etc.)",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
     },
     "servers": [
@@ -21324,17 +21239,6 @@
                         "type": "string"
                     },
                     "tool": {
-                        "type": "string"
-                    }
-                }
-            },
-            "webhooks.WebhookReceivedResponse": {
-                "type": "object",
-                "properties": {
-                    "log_id": {
-                        "type": "string"
-                    },
-                    "message": {
                         "type": "string"
                     }
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -13109,73 +13109,6 @@
                     }
                 }
             }
-        },
-        "/webhooks/scm/{module_source_repo_id}/{secret}": {
-            "post": {
-                "description": "Receives and processes incoming webhook events from SCM providers (GitHub, GitLab, Azure DevOps, Bitbucket).\nTwo-layer security is applied: the URL-embedded secret (last path segment of the registered callback URL)\nis verified first with a constant-time comparison, and then the provider's HMAC payload signature is\nvalidated against the stored webhook secret. Both checks must pass before the payload is processed.\nAccepted events are logged. Tag-push events trigger asynchronous auto-publish when AutoPublish is enabled.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Webhooks"
-                ],
-                "summary": "Receive SCM webhook",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Module source repository link ID (UUID) — uniquely identifies the SCM-to-module mapping",
-                        "name": "module_source_repo_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "URL-embedded webhook secret generated at link time; used as a first-line constant-time guard before HMAC validation",
-                        "name": "secret",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/webhooks.WebhookReceivedResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid repository ID or malformed/unreadable payload",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "401": {
-                        "description": "URL secret mismatch or HMAC payload signature invalid",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "404": {
-                        "description": "Repository link or SCM provider not found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error (connector build, log write, etc.)",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
         }
     },
     "definitions": {
@@ -18132,17 +18065,6 @@
                     "type": "string"
                 },
                 "tool": {
-                    "type": "string"
-                }
-            }
-        },
-        "webhooks.WebhookReceivedResponse": {
-            "type": "object",
-            "properties": {
-                "log_id": {
-                    "type": "string"
-                },
-                "message": {
                     "type": "string"
                 }
             }

--- a/backend/internal/api/webhooks/scm_webhook.go
+++ b/backend/internal/api/webhooks/scm_webhook.go
@@ -57,6 +57,15 @@ func NewSCMWebhookHandler(scmRepo *repositories.SCMRepository, publisher *servic
 // @Failure      404  {object}  map[string]interface{}  "Repository link or SCM provider not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error (connector build, log write, etc.)"
 // @Router       /webhooks/scm/{module_source_repo_id}/{secret} [post]
+// maxWebhookPayloadBytes caps the unauthenticated webhook body.
+//
+// 5 MiB is comfortably above every real SCM push payload -- GitHub documents a
+// 25 MB delivery ceiling but real push/PR events are kilobytes, and this handler
+// only reads a handful of fields -- while being small enough that concurrent
+// abuse cannot exhaust the process. Sized from what the sender actually sends
+// rather than from what the protocol permits.
+const maxWebhookPayloadBytes = 5 << 20
+
 // HandleWebhook processes incoming webhooks from SCM providers
 // POST /webhooks/scm/:module_source_repo_id/:secret
 func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
@@ -69,10 +78,34 @@ func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
 		return
 	}
 
-	// Read the webhook payload
+	// Read the webhook payload, CAPPED.
+	//
+	// This is the only unauthenticated route in the service that reads a request
+	// body, and it read it unbounded (#744). The read happens before the
+	// URL-embedded secret and before the HMAC signature are checked -- it has to,
+	// since the signature is computed over the body -- so the only precondition
+	// for reaching it was a syntactically valid UUID in the path. The UUID does
+	// not even have to name a real link: a non-existent one still reaches this
+	// read before the 404 below.
+	//
+	// With ReadTimeout at 30s and no global body-size middleware anywhere, a
+	// handful of concurrent slow POSTs could hold arbitrary heap with zero
+	// credentials. Every other body-decode path in this codebase -- SCM API
+	// responses, OSV, mirror upstreams, provider uploads -- is already capped;
+	// this was the exception, and also the only one reachable anonymously.
+	//
+	// MaxBytesReader rather than io.LimitReader: LimitReader TRUNCATES silently,
+	// which here would mean computing the HMAC over a partial body and rejecting
+	// a legitimate large payload as a signature mismatch -- a confusing failure
+	// pointing at the wrong cause. MaxBytesReader makes the read itself fail, so
+	// an oversized payload is reported as oversized.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxWebhookPayloadBytes)
 	payloadBytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read payload"})
+		// Deliberately does not distinguish "too large" from "read failed" in the
+		// response: this endpoint is unauthenticated, and the caller has not yet
+		// proved it knows the secret, so it learns nothing about limits here.
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "failed to read payload"})
 		return
 	}
 

--- a/backend/internal/api/webhooks/scm_webhook_body_cap_test.go
+++ b/backend/internal/api/webhooks/scm_webhook_body_cap_test.go
@@ -1,0 +1,63 @@
+package webhooks
+
+import (
+	"bytes"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Issue #744 — the unauthenticated webhook body was read unbounded.
+//
+// The read happens BEFORE the URL secret and before the HMAC signature are
+// checked. It has to: the signature is computed over the body. So the only
+// precondition for reaching it was a syntactically valid UUID in the path, and
+// that UUID did not need to name a real link — a non-existent one still reached
+// the read before the 404.
+//
+// These tests deliberately use a NON-EXISTENT link id and set up no database
+// expectations. If the cap ever moves to after the lookup, the test fails on an
+// unmet sqlmock expectation rather than passing quietly — the ordering is the
+// property under test, not just the limit.
+
+func TestWebhook_OversizedBodyRejectedBeforeAnyLookup(t *testing.T) {
+	_, r := newWebhookRouter(t)
+
+	// One byte over the cap.
+	body := bytes.Repeat([]byte("a"), maxWebhookPayloadBytes+1)
+	req := httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413 for an oversized body; body: %s", w.Code, w.Body.String())
+	}
+	// The caller has not proved it knows the secret, so it must not learn the
+	// limit or anything about the link from this response.
+	for _, leak := range []string{"5242880", "5 MiB", "maxWebhookPayloadBytes", "not found"} {
+		if strings.Contains(w.Body.String(), leak) {
+			t.Errorf("413 body disclosed %q: %s", leak, w.Body.String())
+		}
+	}
+}
+
+func TestWebhook_BodyAtTheCapIsNotRejectedForSize(t *testing.T) {
+	mock, r := newWebhookRouter(t)
+	// Exactly at the cap must be allowed through the read. It then fails later
+	// for an unrelated reason (no such link), which is the point: the size check
+	// is not what stops it.
+	mock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
+		WillReturnRows(sqlmock.NewRows(moduleSourceRepoCols))
+
+	body := bytes.Repeat([]byte("a"), maxWebhookPayloadBytes)
+	req := httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusRequestEntityTooLarge {
+		t.Errorf("a body exactly at the cap was rejected as too large; the boundary is off by one")
+	}
+}


### PR DESCRIPTION
Closes #744.

## The defect

The SCM webhook receiver read its payload with a bare `io.ReadAll`.

The read **must** happen before the URL-embedded secret and before the HMAC signature are checked — the signature is computed over the body. So the only precondition for reaching it was a syntactically valid UUID in the path, and that UUID did not even have to name a real link: a non-existent one still reached the read before the 404.

With `ReadTimeout` at 30s and **no global body-size middleware anywhere**, a handful of concurrent slow POSTs could hold arbitrary heap with **zero credentials**.

Every other body-decode path here — SCM API responses, OSV, mirror upstreams, provider uploads — is already capped. This was the exception, and also the only one reachable anonymously.

## `MaxBytesReader`, not `io.LimitReader`

`LimitReader` **truncates silently**. Here that would mean computing the HMAC over a partial body and rejecting a legitimate large payload as a *signature mismatch* — a confusing failure pointing at entirely the wrong cause.

`MaxBytesReader` makes the read itself fail, so an oversized payload is reported as oversized.

## Sizing and disclosure

**5 MiB**, sized from what senders actually send rather than what the protocol permits: GitHub documents a 25 MB delivery ceiling, but real push/PR events are kilobytes and this handler reads a handful of fields.

The 413 deliberately does not distinguish *too large* from *read failed*, and does not name the limit. The caller has not proved it knows the secret, so it learns nothing — a test asserts the response carries neither the byte count nor the link's existence.

## The tests pin the ordering, not just the limit

They use a **non-existent link id** and set up **no database expectations**. If the cap ever moves to after the lookup, they fail on an unmet sqlmock expectation rather than passing quietly.

A boundary case asserts a body *exactly at* the cap is not rejected for size.

Mutation-verified: removing the `MaxBytesReader` line makes the oversized case fail (500 from the lookup instead of 413).