### PR TITLE
fix(auth): bind the OAuth state to the browser that started the login

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -187,11 +187,25 @@ func (h *AuthHandlers) LoginHandler() gin.HandlerFunc {
 			return
 		}
 
+		// Bind this login to THIS browser (#738). Issued before any provider
+		// branch below so every path that saves sessionState carries it --
+		// a per-branch call is one a new provider forgets to add.
+		bindingSecret, bindingHash, bindErr := newLoginBinding()
+		if bindErr != nil {
+			slog.Error("failed to generate login binding", "error", bindErr)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to generate state",
+			})
+			return
+		}
+		issueLoginBinding(c, bindingSecret)
+
 		// Store state in session store with 10-minute TTL
 		sessionState := &auth.SessionState{
-			State:        state,
-			CreatedAt:    time.Now(),
-			ProviderType: provider,
+			State:              state,
+			CreatedAt:          time.Now(),
+			ProviderType:       provider,
+			BrowserBindingHash: bindingHash,
 		}
 		if err := h.stateStore.Save(c.Request.Context(), state, sessionState, 10*time.Minute); err != nil {
 			slog.Error("failed to save OIDC state", "error", err)
@@ -360,6 +374,22 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			callbackError("invalid_state", "Invalid state parameter. Please try logging in again.")
 			return
 		}
+
+		// GUARD login-csrf-browser-binding (issue #738): the state entry exists,
+		// but does THIS browser own it? Checked before the TTL and before the
+		// code exchange, so a forged callback costs nothing and reaches no IdP.
+		//
+		// The error is deliberately the same shape as an invalid state: a caller
+		// probing the callback learns whether a state string is live, not why it
+		// was refused.
+		if !loginBindingMatches(c, sessionState.BrowserBindingHash) {
+			clearLoginBinding(c)
+			slog.Warn("login callback rejected: browser binding missing or mismatched",
+				"provider", sessionState.ProviderType)
+			callbackError("invalid_state", "Invalid state parameter. Please try logging in again.")
+			return
+		}
+		clearLoginBinding(c)
 
 		// Check state expiration (5 minutes)
 		if time.Since(sessionState.CreatedAt) > 5*time.Minute {

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -375,11 +375,26 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			return
 		}
 
-		// GUARD login-csrf-browser-binding (issue #738): the state entry exists,
-		// but does THIS browser own it? Checked before the TTL and before the
-		// code exchange, so a forged callback costs nothing and reaches no IdP.
+		// Check state expiration (5 minutes)
+		if time.Since(sessionState.CreatedAt) > 5*time.Minute {
+			// State was already consumed by Load (single-use in both the Redis and
+			// in-memory stores) but check TTL anyway
+			callbackError("state_expired", "Login session expired. Please try logging in again.")
+			return
+		}
+
+		// GUARD login-csrf-browser-binding (issue #738): the state entry exists
+		// and is fresh, but does THIS browser own it?
 		//
-		// The error is deliberately the same shape as an invalid state: a caller
+		// Ordered AFTER the expiry check deliberately. Both run before the code
+		// exchange, so neither reaches the IdP and the security ordering is a
+		// wash -- but unauth_principal_class_test.go asserts that an expired
+		// state is refused BY THE EXPIRY GUARD, naming its message. Checking the
+		// binding first made that guard unreachable for a caller with no cookie,
+		// and the test caught it. Reordering keeps that assertion true rather
+		// than editing the artifact that proves the guard is reachable.
+		//
+		// The error deliberately reuses the invalid-state message: a caller
 		// probing the callback learns whether a state string is live, not why it
 		// was refused.
 		if !loginBindingMatches(c, sessionState.BrowserBindingHash) {
@@ -390,14 +405,6 @@ func (h *AuthHandlers) CallbackHandler() gin.HandlerFunc {
 			return
 		}
 		clearLoginBinding(c)
-
-		// Check state expiration (5 minutes)
-		if time.Since(sessionState.CreatedAt) > 5*time.Minute {
-			// State was already consumed by Load (single-use in both the Redis and
-			// in-memory stores) but check TTL anyway
-			callbackError("state_expired", "Login session expired. Please try logging in again.")
-			return
-		}
 
 		// State was already atomically consumed by Load (both the Redis and
 		// in-memory stores delete on read); this Delete is a no-op belt-and-braces

--- a/backend/internal/api/admin/auth_browser_binding.go
+++ b/backend/internal/api/admin/auth_browser_binding.go
@@ -1,0 +1,115 @@
+package admin
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Login-CSRF binding for the OAuth/OIDC/SAML flows (issue #738).
+//
+// The `state` parameter alone proves only that SOME login was started on this
+// server -- it is stored server-side keyed by itself, so any holder of a valid
+// state string can complete the flow from any browser. That makes the standard
+// login-CSRF attack work: the attacker starts a login, authenticates at the IdP
+// as themselves, captures code+state, and induces the victim's browser to load
+// the callback as a plain top-level GET. SameSite=Lax does not block that, so
+// the victim is issued a session for the ATTACKER's identity.
+//
+// In a registry that is not cosmetic. The victim may then publish a module,
+// upload a provider with signing material, link an SCM provider, or mint an API
+// key -- all inside an account the attacker controls and later collects.
+//
+// The fix is the one the OAuth 2.0 Security BCP prescribes: bind `state` to a
+// value only the initiating browser holds. `/auth/login` issues a random secret
+// in an HttpOnly cookie and stores only its SHA-256 in the session state; the
+// callback recomputes and compares. A browser that did not start the login has
+// no cookie, so the callback refuses.
+//
+// The stored value is a HASH, not the secret: whoever can read the state store
+// -- a Redis operator, a backup, a memory dump -- still cannot forge the cookie.
+// That is the same reasoning as storing password hashes, applied to a value with
+// a five-minute life.
+
+const (
+	// loginBindingCookie is scoped to the auth path rather than "/": it is only
+	// ever read at the callback, and a cookie that rides every request to the
+	// API is one more thing that can leak in a log or a Referer.
+	loginBindingCookie = "tfr_login_binding"
+	loginBindingPath   = "/api/v1/auth"
+	// Matches the callback's own 5-minute state freshness check. A binding that
+	// outlives the state it binds protects nothing.
+	loginBindingMaxAge = 300
+)
+
+// newLoginBinding returns a fresh browser secret and the hash to persist.
+func newLoginBinding() (secret string, hash string, err error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", err
+	}
+	secret = base64.RawURLEncoding.EncodeToString(b)
+	sum := sha256.Sum256([]byte(secret))
+	return secret, hex.EncodeToString(sum[:]), nil
+}
+
+// issueLoginBinding sets the browser-bound cookie for a login just started.
+//
+// Secure and HttpOnly unconditionally: this is only read server-side, and a
+// deployment serving the callback over plain HTTP has a larger problem than
+// this cookie. SameSite=Lax because the callback arrives as a top-level
+// navigation from the IdP -- Strict would drop the cookie and break every login,
+// which is precisely the mistake that makes people delete the check.
+func issueLoginBinding(c *gin.Context, secret string) {
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     loginBindingCookie,
+		Value:    secret,
+		Path:     loginBindingPath,
+		MaxAge:   loginBindingMaxAge,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearLoginBinding expires the cookie once the callback has consumed it. The
+// binding is single-use like the state it accompanies.
+func clearLoginBinding(c *gin.Context) {
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     loginBindingCookie,
+		Value:    "",
+		Path:     loginBindingPath,
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// loginBindingMatches reports whether this request's cookie matches the hash
+// stored with the login state.
+//
+// FAILS CLOSED on an empty stored hash. That is the case for a state entry
+// written before this binding existed, and treating "no expectation recorded"
+// as "anything matches" is how a check like this becomes decorative during a
+// rolling deploy. The cost is that logins already in flight across the upgrade
+// must be retried, which is a five-minute window and the same behaviour the
+// nonce/PKCE bindings already have.
+func loginBindingMatches(c *gin.Context, storedHash string) bool {
+	if storedHash == "" {
+		return false
+	}
+	cookie, err := c.Request.Cookie(loginBindingCookie)
+	if err != nil || cookie.Value == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(cookie.Value))
+	// Constant time: the comparison is against a value an attacker supplies and
+	// can iterate on, so it should not leak a prefix length through timing.
+	return subtle.ConstantTimeCompare([]byte(hex.EncodeToString(sum[:])), []byte(storedHash)) == 1
+}

--- a/backend/internal/api/admin/auth_browser_binding_test.go
+++ b/backend/internal/api/admin/auth_browser_binding_test.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Issue #738 — login CSRF / forced session fixation.
+//
+// The table is over the STATES OF THE BINDING rather than over one crafted
+// attack, because every one of these is a way the check can be defeated and
+// they fail for different reasons: no cookie at all is the attacker's browser,
+// a wrong cookie is a guess, and an empty stored hash is a state entry written
+// before the binding existed.
+
+func ctxWithCookie(value string) *gin.Context {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/v1/auth/callback?code=x&state=y", nil)
+	if value != "" {
+		c.Request.AddCookie(&http.Cookie{Name: loginBindingCookie, Value: value})
+	}
+	return c
+}
+
+func TestLoginBindingMatches(t *testing.T) {
+	secret, hash, err := newLoginBinding()
+	if err != nil {
+		t.Fatalf("newLoginBinding: %v", err)
+	}
+	_, otherHash, _ := newLoginBinding()
+
+	tests := []struct {
+		name       string
+		cookie     string
+		storedHash string
+		want       bool
+	}{
+		{"the browser that started the login", secret, hash, true},
+		{"no cookie at all — the attacker's browser", "", hash, false},
+		{"a cookie that does not match", "not-the-secret", hash, false},
+		{"the right secret against someone else's hash", secret, otherHash, false},
+		// Fails closed. A state entry written before this binding existed has no
+		// expectation recorded, and treating that as "anything matches" is how a
+		// check like this becomes decorative during a rolling deploy.
+		{"empty stored hash — no expectation recorded", secret, "", false},
+		{"empty stored hash and no cookie", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loginBindingMatches(ctxWithCookie(tt.cookie), tt.storedHash); got != tt.want {
+				t.Errorf("loginBindingMatches(cookie=%q, stored=%q) = %v, want %v",
+					tt.cookie, tt.storedHash, got, tt.want)
+			}
+		})
+	}
+}
+
+// The stored value must be a hash, not the secret: read access to the state
+// store must not yield a forgeable cookie.
+func TestNewLoginBindingStoresAHashNotTheSecret(t *testing.T) {
+	secret, hash, err := newLoginBinding()
+	if err != nil {
+		t.Fatalf("newLoginBinding: %v", err)
+	}
+	if secret == "" || hash == "" {
+		t.Fatal("both the secret and its hash must be non-empty")
+	}
+	if secret == hash {
+		t.Fatal("the stored value is the secret itself; a state-store read would forge the cookie")
+	}
+	if len(hash) != 64 {
+		t.Errorf("hash length = %d, want 64 hex chars (sha256)", len(hash))
+	}
+}
+
+// Two logins must not share a binding, or one user's callback completes
+// another's login.
+func TestNewLoginBindingIsUniquePerCall(t *testing.T) {
+	seen := make(map[string]bool, 64)
+	for i := 0; i < 64; i++ {
+		secret, hash, err := newLoginBinding()
+		if err != nil {
+			t.Fatalf("newLoginBinding: %v", err)
+		}
+		if seen[secret] || seen[hash] {
+			t.Fatal("newLoginBinding repeated a value")
+		}
+		seen[secret], seen[hash] = true, true
+	}
+}
+
+// The cookie has to survive the IdP's top-level redirect back to the callback,
+// and must not be readable by script or ride every API request.
+func TestIssueLoginBindingCookieAttributes(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/v1/auth/login", nil)
+	issueLoginBinding(c, "the-secret")
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected exactly one cookie, got %d", len(cookies))
+	}
+	got := cookies[0]
+	if got.Name != loginBindingCookie {
+		t.Errorf("name = %q, want %q", got.Name, loginBindingCookie)
+	}
+	if !got.HttpOnly {
+		t.Error("must be HttpOnly — it is only ever read server-side")
+	}
+	if !got.Secure {
+		t.Error("must be Secure")
+	}
+	// Strict would be dropped on the IdP's cross-site top-level redirect, which
+	// breaks every login — the failure that gets a check like this deleted.
+	if got.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite = %v, want Lax so it survives the IdP redirect", got.SameSite)
+	}
+	if got.Path != loginBindingPath {
+		t.Errorf("Path = %q, want %q — it should not ride every API request", got.Path, loginBindingPath)
+	}
+}

--- a/backend/internal/auth/statestore.go
+++ b/backend/internal/auth/statestore.go
@@ -33,6 +33,20 @@ type SessionState struct {
 	// SAML login. It is echoed back by the IdP as InResponseTo and validated
 	// at the ACS to bind the assertion to a request this SP actually made.
 	SAMLRequestID string `json:"saml_request_id,omitempty"`
+	// BrowserBindingHash is the SHA-256 of a secret held only by the browser
+	// that STARTED this login, issued as an HttpOnly cookie at /auth/login and
+	// re-checked at the callback (issue #738).
+	//
+	// Without it, `state` proves only that some login was started on this
+	// server, not that THIS browser started it -- so an attacker could begin a
+	// login, authenticate at the IdP as themselves, and induce a victim's
+	// browser to load the callback, handing the victim a session for the
+	// attacker's account. SameSite=Lax does not stop that: the callback is a
+	// plain top-level GET.
+	//
+	// A hash rather than the secret, so read access to the state store (Redis,
+	// a backup, a memory dump) does not yield a forgeable cookie.
+	BrowserBindingHash string `json:"browser_binding_hash,omitempty"`
 	// SCMUserID is the already-authenticated user who started an SCM connector
 	// authorization flow (GET /api/v1/scm-providers/:id/oauth/authorize). That
 	// flow's callback carries no auth middleware, so this stored value — not


### PR DESCRIPTION
Closes #738.

## The defect

`state` was stored server-side keyed by itself, and the callback checked only that the entry existed and was under five minutes old. That proves *some* login was started on this server — not that **this browser** started it.

So the standard login-CSRF attack worked:

1. attacker begins a login and authenticates at the IdP **as themselves**
2. captures the resulting `code` + `state`
3. induces the victim's browser to load `/api/v1/auth/callback?code=…&state=…` — a plain top-level GET, which **`SameSite=Lax` does not block**
4. the victim's browser is issued `tfr_auth_token` for the **attacker's** identity

In a registry that is not cosmetic. The victim may then publish a module, upload a provider with signing material, link an SCM provider, or mint an API key — inside an account the attacker controls and later collects.

## The fix

`/auth/login` issues a 32-byte secret in an HttpOnly cookie and stores **only its SHA-256** on the session state; the callback recomputes and compares. A browser that did not start the login has no cookie, so the callback refuses. This is what the OAuth 2.0 Security BCP prescribes.

| decision | why |
|---|---|
| store a **hash**, not the secret | read access to the state store — a Redis operator, a backup, a memory dump — must not yield a forgeable cookie |
| issue **before** the provider branches | every path that saves `sessionState` carries it; a per-branch call is one a new provider forgets |
| **fail closed** on an empty stored hash | that is a state entry written before this existed, and treating "no expectation recorded" as "anything matches" is how a check becomes decorative during a rolling deploy |
| `SameSite=Lax`, not Strict | Strict is dropped on the IdP's cross-site top-level redirect, breaking every login — and a check that breaks logins is one somebody deletes |
| constant-time compare | the value is attacker-supplied and iterable |
| reuse the invalid-state error | probing the callback reveals whether a state string is live, not why it was refused |

Cost of failing closed: logins already in flight across the upgrade must be retried — a five-minute window, and the same behaviour the nonce and PKCE bindings already have.

## A class test caught an ordering mistake

I first checked the binding *before* the TTL. `unauth_principal_class_test.go` asserts an expired state is refused **by the expiry guard**, matching its message — and my check made that guard unreachable for a caller with no cookie.

I reordered rather than editing the test. That artifact exists to prove each guard is reachable; adjusting it to accommodate a change is how a class test stops being evidence. Both checks run before the code exchange, so the security ordering is a wash.

## Tests

Table-driven over the **states of the binding** rather than one crafted attack — no cookie, wrong cookie, right secret against another's hash, empty stored hash — because each defeats the check differently. Plus uniqueness across 64 calls, hash-not-secret, and the cookie attributes.

Mutation-verified both ways: making an empty stored hash match, and switching to `SameSite=Strict`, each fail with the specific reason.