### PR TITLE
fix(api): rate limit the public Terraform-protocol, OCI and mirror route table

### DIFF
--- a/backend/internal/api/public_routes_ratelimit_test.go
+++ b/backend/internal/api/public_routes_ratelimit_test.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// Issue #743 — registerPublicRoutes had no rate limiting anywhere.
+//
+// Every route family under registerAPIV1Routes is wrapped in one of the
+// configured limiters. registerPublicRoutes — the anonymous,
+// internet-reachable Terraform-protocol/OCI/mirror table — was wrapped in
+// none, so the highest-volume handlers in the service, the ones doing DB
+// lookups, presigned-URL round trips to S3/Azure/GCS, pull-through fetches
+// with DB writes on a cache miss, and full archive streams through io.Copy,
+// had no request-volume defence at the application layer at all.
+//
+// This test is written against the ROUTE TABLE, not a list of paths I typed
+// out: it enumerates whatever registerPublicRoutes actually mounted and
+// requires each route to be limited or to be a named exemption. A new public
+// route lands unlimited exactly once, and this fails.
+
+// rateLimitExemptPublicRoutes are the routes that must NOT be rate limited,
+// each with the reason. Asserted in both directions: an exempt route that
+// starts returning 429 fails, and a route dropped from the real table while
+// still listed here fails too, so the list cannot rot into an unread allowlist.
+var rateLimitExemptPublicRoutes = map[string]string{
+	"GET /health": "liveness probe: kubelet probes for every pod on a node share " +
+		"that node's source address, and rate-limiting liveness restarts healthy pods",
+	"GET /ready": "readiness probe: a 429 here pulls a healthy pod out of service — " +
+		"the limiter causing the outage it exists to prevent",
+}
+
+// publicRouteRouter mounts the real public route table with a limiter tight
+// enough that a short burst crosses it.
+func publicRouteRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 60, BurstSize: 2, CleanupInterval: time.Minute,
+	})
+	t.Cleanup(limiter.Stop)
+
+	r := gin.New()
+	// Handlers reached with sparse dependencies may panic; the limiter runs
+	// ahead of the handler, so a recovered 500 does not affect what is asserted.
+	r.Use(gin.Recovery())
+	registerPublicRoutes(r, &publicRouteDeps{
+		cfg:                 &config.Config{},
+		db:                  db,
+		userRepo:            repositories.NewUserRepository(db),
+		orgRepo:             repositories.NewOrganizationRepository(db),
+		protocolRateLimiter: limiter,
+	})
+	return r
+}
+
+// concretePath turns a gin route pattern into a requestable path.
+func concretePath(pattern string) string {
+	parts := strings.Split(pattern, "/")
+	for i, p := range parts {
+		switch {
+		case strings.HasPrefix(p, "*"):
+			parts[i] = "x"
+		case strings.HasPrefix(p, ":"):
+			parts[i] = "x"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func TestPublicRoutes_EveryRouteIsRateLimitedOrNamedExempt(t *testing.T) {
+	for _, ri := range publicRouteRouter(t).Routes() {
+		key := ri.Method + " " + ri.Path
+		reason, exempt := rateLimitExemptPublicRoutes[key]
+
+		t.Run(key, func(t *testing.T) {
+			// A fresh router per route: the limiter keys on client address, so
+			// a shared engine would let one route drain the bucket and make
+			// every later route look limited whether it is or not.
+			r := publicRouteRouter(t)
+			path := concretePath(ri.Path)
+
+			// Burst 2, so by the 6th request a limited route must have answered
+			// 429 at least once.
+			var got429 bool
+			for i := 0; i < 6; i++ {
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest(ri.Method, path, nil))
+				if w.Code == http.StatusTooManyRequests {
+					got429 = true
+				}
+			}
+
+			if exempt && got429 {
+				t.Errorf("%s is rate limited but listed exempt (%s); "+
+					"remove the exemption or the middleware", key, reason)
+			}
+			if !exempt && !got429 {
+				t.Errorf("%s is NOT rate limited. Add protocolLimit to its group "+
+					"or route in registerPublicRoutes, or add it to "+
+					"rateLimitExemptPublicRoutes with a reason.", key)
+			}
+		})
+	}
+}
+
+func TestRateLimitExemptions_AreAllStillRealRoutes(t *testing.T) {
+	// The other direction. Without this, a route removed or renamed leaves a
+	// dead exemption behind, and the next route to take that path inherits an
+	// exemption nobody chose for it.
+	mounted := map[string]bool{}
+	for _, ri := range publicRouteRouter(t).Routes() {
+		mounted[ri.Method+" "+ri.Path] = true
+	}
+	for key := range rateLimitExemptPublicRoutes {
+		if !mounted[key] {
+			t.Errorf("rateLimitExemptPublicRoutes lists %q, which registerPublicRoutes "+
+				"no longer mounts — drop the entry", key)
+		}
+	}
+}
+
+func TestPublicRoutes_TableIsNotEmpty(t *testing.T) {
+	// The failure mode the two tests above cannot see: if registerPublicRoutes
+	// mounted nothing (a sparse-deps panic swallowed by a future refactor, a
+	// renamed helper), both would iterate an empty set and report green while
+	// checking nothing.
+	routes := publicRouteRouter(t).Routes()
+	if len(routes) < len(rateLimitExemptPublicRoutes)+8 {
+		t.Fatalf("registerPublicRoutes mounted only %d routes — the table is not "+
+			"being enumerated, so the rate-limit coverage assertions are vacuous",
+			len(routes))
+	}
+}
+
+// TestProtocolRateLimit_IsNotTheGeneralBudget pins the reason for a separate
+// limiter. If these ever converge, one `terraform init` from a CI fleet behind
+// a shared egress address can exhaust the same bucket the UI and API use.
+func TestProtocolRateLimit_IsNotTheGeneralBudget(t *testing.T) {
+	protocol := middleware.ProtocolRateLimitConfig()
+	general := middleware.DefaultRateLimitConfig()
+
+	if protocol.RequestsPerMinute <= general.RequestsPerMinute {
+		t.Errorf("protocol rpm (%d) must exceed the general API rpm (%d): a single "+
+			"terraform init fans out across discovery, version listing, download and "+
+			"file fetch for every module and provider",
+			protocol.RequestsPerMinute, general.RequestsPerMinute)
+	}
+	if protocol.BurstSize <= general.BurstSize {
+		t.Errorf("protocol burst (%d) must exceed the general burst (%d)",
+			protocol.BurstSize, general.BurstSize)
+	}
+}
+
+// TestPublicRoutes_NilLimiterPassesThrough covers the rate-limiting-disabled
+// deployment: the middleware must not become a hard block when no backend is
+// configured.
+func TestPublicRoutes_NilLimiterPassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	registerPublicRoutes(r, &publicRouteDeps{
+		cfg:                 &config.Config{},
+		db:                  db,
+		userRepo:            repositories.NewUserRepository(db),
+		orgRepo:             repositories.NewOrganizationRepository(db),
+		protocolRateLimiter: nil, // rate limiting disabled
+	})
+
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/version", nil))
+		if w.Code == http.StatusTooManyRequests {
+			t.Fatalf("request %d got 429 with rate limiting disabled", i+1)
+		}
+	}
+}
+
+// TestProtocolRateLimit_KeyIsNotHeaderSpoofable is what separates a real limit
+// from a cosmetic one on these routes.
+//
+// The protocol routes are anonymous, so getRateLimitPrincipal falls back to
+// c.ClientIP(). Gin's default engine trusts every proxy, and under that default
+// ClientIP() returns whatever X-Forwarded-For says -- a client could send a
+// fresh address per request and never share a bucket with itself, leaving the
+// limiter applied and useless. NewRouter calls SetTrustedProxies with
+// cfg.Server.TrustedProxies, which defaults to empty (trust nothing).
+//
+// This asserts the resulting behaviour rather than the config value: rotating
+// X-Forwarded-For must not buy extra requests.
+func TestProtocolRateLimit_KeyIsNotHeaderSpoofable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 60, BurstSize: 2, CleanupInterval: time.Minute,
+	})
+	defer limiter.Stop()
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	// The production default: empty list, i.e. trust no proxy.
+	if err := r.SetTrustedProxies([]string{}); err != nil {
+		t.Fatalf("SetTrustedProxies: %v", err)
+	}
+	registerPublicRoutes(r, &publicRouteDeps{
+		cfg:                 &config.Config{},
+		db:                  db,
+		userRepo:            repositories.NewUserRepository(db),
+		orgRepo:             repositories.NewOrganizationRepository(db),
+		protocolRateLimiter: limiter,
+	})
+
+	var got429 bool
+	for i := 0; i < 8; i++ {
+		req := httptest.NewRequest("GET", "/version", nil)
+		// A different claimed client address every time.
+		req.Header.Set("X-Forwarded-For", "203.0.113."+string(rune('1'+i)))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			got429 = true
+		}
+	}
+	if !got429 {
+		t.Error("rotating X-Forwarded-For evaded the rate limit — the limiter is " +
+			"keyed on a client-controlled header. Check SetTrustedProxies / " +
+			"server.trusted_proxies; it must not trust arbitrary proxies.")
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -391,6 +391,91 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		router.Use(mtls.AuthMiddleware(mtlsProvider))
 	}
 
+	// Rate limiters are constructed HERE, ahead of route registration, because
+	// registerPublicRoutes now consumes protocolRateLimiter (issue #743). Gin
+	// binds a group's middleware at registration time, so a limiter built after
+	// this call would never reach the protocol routes.
+	// Initialize rate limiters (conditionally, based on config)
+	var authRateLimiter, generalRateLimiter, uploadRateLimiter middleware.RateLimiterBackend
+	// protocolRateLimiter covers the anonymous Terraform-protocol/OCI/mirror
+	// surface registered by registerPublicRoutes (issue #743).
+	var protocolRateLimiter middleware.RateLimiterBackend
+	var orgRateLimiter middleware.RateLimiterBackend
+	if cfg.Security.RateLimiting.Enabled {
+		// Build effective configs: use config values when set, otherwise fall back to presets
+		generalCfg := middleware.DefaultRateLimitConfig()
+		if cfg.Security.RateLimiting.RequestsPerMinute > 0 {
+			generalCfg.RequestsPerMinute = cfg.Security.RateLimiting.RequestsPerMinute
+		}
+		if cfg.Security.RateLimiting.Burst > 0 {
+			generalCfg.BurstSize = cfg.Security.RateLimiting.Burst
+		}
+		authCfg := middleware.AuthRateLimitConfig()
+		uploadCfg := middleware.UploadRateLimitConfig()
+		protocolCfg := middleware.ProtocolRateLimitConfig()
+
+		if cfg.Redis.Host != "" {
+			// Redis-backed rate limiters for HA deployments
+			var redisErr error
+			generalRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, generalCfg)
+			if redisErr != nil {
+				slog.Warn("failed to create Redis rate limiter for general, falling back to in-memory", "error", redisErr)
+				generalRateLimiter = middleware.NewRateLimiter(generalCfg)
+			}
+			authRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, authCfg)
+			if redisErr != nil {
+				slog.Warn("failed to create Redis rate limiter for auth, falling back to in-memory", "error", redisErr)
+				authRateLimiter = middleware.NewRateLimiter(authCfg)
+			}
+			uploadRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, uploadCfg)
+			if redisErr != nil {
+				slog.Warn("failed to create Redis rate limiter for upload, falling back to in-memory", "error", redisErr)
+				uploadRateLimiter = middleware.NewRateLimiter(uploadCfg)
+			}
+			protocolRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, protocolCfg)
+			if redisErr != nil {
+				slog.Warn("failed to create Redis rate limiter for protocol routes, falling back to in-memory", "error", redisErr)
+				protocolRateLimiter = middleware.NewRateLimiter(protocolCfg)
+			}
+			// Per-organization rate limiter (only when configured)
+			if cfg.Security.RateLimiting.OrgRequestsPerMinute > 0 {
+				orgCfg := middleware.RateLimitConfig{
+					RequestsPerMinute: cfg.Security.RateLimiting.OrgRequestsPerMinute,
+					BurstSize:         cfg.Security.RateLimiting.OrgBurst,
+					CleanupInterval:   5 * time.Minute,
+				}
+				if orgCfg.BurstSize == 0 {
+					orgCfg.BurstSize = orgCfg.RequestsPerMinute / 4
+				}
+				orgRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, orgCfg)
+				if redisErr != nil {
+					slog.Warn("failed to create Redis org rate limiter, falling back to in-memory", "error", redisErr)
+					orgRateLimiter = middleware.NewRateLimiter(orgCfg)
+				}
+			}
+			log.Println("Rate limiting enabled with Redis backend")
+		} else {
+			// In-memory rate limiters (single-instance only)
+			slog.Warn("redis.host not configured: rate limiting will use in-memory backend (not suitable for multi-pod HA)")
+			generalRateLimiter = middleware.NewRateLimiter(generalCfg)
+			authRateLimiter = middleware.NewRateLimiter(authCfg)
+			uploadRateLimiter = middleware.NewRateLimiter(uploadCfg)
+			protocolRateLimiter = middleware.NewRateLimiter(protocolCfg)
+			// Per-organization rate limiter
+			if cfg.Security.RateLimiting.OrgRequestsPerMinute > 0 {
+				orgCfg := middleware.RateLimitConfig{
+					RequestsPerMinute: cfg.Security.RateLimiting.OrgRequestsPerMinute,
+					BurstSize:         cfg.Security.RateLimiting.OrgBurst,
+					CleanupInterval:   5 * time.Minute,
+				}
+				if orgCfg.BurstSize == 0 {
+					orgCfg.BurstSize = orgCfg.RequestsPerMinute / 4
+				}
+				orgRateLimiter = middleware.NewRateLimiter(orgCfg)
+			}
+		}
+	}
+
 	// Public + Terraform-protocol routes (issue #565 finding [39]). See registerPublicRoutes.
 	registerPublicRoutes(router, &publicRouteDeps{
 		cfg:                     cfg,
@@ -405,6 +490,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		auditRepo:               auditRepo,
 		pullThroughSvc:          pullThroughSvc,
 		tfBinariesHandler:       tfBinariesHandler,
+		protocolRateLimiter:     protocolRateLimiter,
 	})
 
 	// Initialize admin handlers
@@ -589,77 +675,6 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize SCM webhook handler
 	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher, tokenCipher)
 	approvalWebhookHandler := webhooks.NewApprovalHandler(rbacRepo)
-
-	// Initialize rate limiters (conditionally, based on config)
-	var authRateLimiter, generalRateLimiter, uploadRateLimiter middleware.RateLimiterBackend
-	var orgRateLimiter middleware.RateLimiterBackend
-	if cfg.Security.RateLimiting.Enabled {
-		// Build effective configs: use config values when set, otherwise fall back to presets
-		generalCfg := middleware.DefaultRateLimitConfig()
-		if cfg.Security.RateLimiting.RequestsPerMinute > 0 {
-			generalCfg.RequestsPerMinute = cfg.Security.RateLimiting.RequestsPerMinute
-		}
-		if cfg.Security.RateLimiting.Burst > 0 {
-			generalCfg.BurstSize = cfg.Security.RateLimiting.Burst
-		}
-		authCfg := middleware.AuthRateLimitConfig()
-		uploadCfg := middleware.UploadRateLimitConfig()
-
-		if cfg.Redis.Host != "" {
-			// Redis-backed rate limiters for HA deployments
-			var redisErr error
-			generalRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, generalCfg)
-			if redisErr != nil {
-				slog.Warn("failed to create Redis rate limiter for general, falling back to in-memory", "error", redisErr)
-				generalRateLimiter = middleware.NewRateLimiter(generalCfg)
-			}
-			authRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, authCfg)
-			if redisErr != nil {
-				slog.Warn("failed to create Redis rate limiter for auth, falling back to in-memory", "error", redisErr)
-				authRateLimiter = middleware.NewRateLimiter(authCfg)
-			}
-			uploadRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, uploadCfg)
-			if redisErr != nil {
-				slog.Warn("failed to create Redis rate limiter for upload, falling back to in-memory", "error", redisErr)
-				uploadRateLimiter = middleware.NewRateLimiter(uploadCfg)
-			}
-			// Per-organization rate limiter (only when configured)
-			if cfg.Security.RateLimiting.OrgRequestsPerMinute > 0 {
-				orgCfg := middleware.RateLimitConfig{
-					RequestsPerMinute: cfg.Security.RateLimiting.OrgRequestsPerMinute,
-					BurstSize:         cfg.Security.RateLimiting.OrgBurst,
-					CleanupInterval:   5 * time.Minute,
-				}
-				if orgCfg.BurstSize == 0 {
-					orgCfg.BurstSize = orgCfg.RequestsPerMinute / 4
-				}
-				orgRateLimiter, redisErr = middleware.NewRedisRateLimiter(&cfg.Redis, orgCfg)
-				if redisErr != nil {
-					slog.Warn("failed to create Redis org rate limiter, falling back to in-memory", "error", redisErr)
-					orgRateLimiter = middleware.NewRateLimiter(orgCfg)
-				}
-			}
-			log.Println("Rate limiting enabled with Redis backend")
-		} else {
-			// In-memory rate limiters (single-instance only)
-			slog.Warn("redis.host not configured: rate limiting will use in-memory backend (not suitable for multi-pod HA)")
-			generalRateLimiter = middleware.NewRateLimiter(generalCfg)
-			authRateLimiter = middleware.NewRateLimiter(authCfg)
-			uploadRateLimiter = middleware.NewRateLimiter(uploadCfg)
-			// Per-organization rate limiter
-			if cfg.Security.RateLimiting.OrgRequestsPerMinute > 0 {
-				orgCfg := middleware.RateLimitConfig{
-					RequestsPerMinute: cfg.Security.RateLimiting.OrgRequestsPerMinute,
-					BurstSize:         cfg.Security.RateLimiting.OrgBurst,
-					CleanupInterval:   5 * time.Minute,
-				}
-				if orgCfg.BurstSize == 0 {
-					orgCfg.BurstSize = orgCfg.RequestsPerMinute / 4
-				}
-				orgRateLimiter = middleware.NewRateLimiter(orgCfg)
-			}
-		}
-	}
 
 	// Build per-principal override rate limiters (if configured)
 	var principalOverrides *middleware.PrincipalOverrideLimiters

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -65,6 +65,10 @@ type publicRouteDeps struct {
 	auditRepo               *repositories.AuditRepository
 	pullThroughSvc          *services.PullThroughService
 	tfBinariesHandler       *terraform_binaries.Handler
+	// protocolRateLimiter bounds anonymous request volume against the
+	// Terraform-protocol/OCI/mirror handlers (issue #743). Nil when rate
+	// limiting is disabled, which RateLimitMiddleware passes through.
+	protocolRateLimiter middleware.RateLimiterBackend
 }
 
 // registerPublicRoutes wires the unauthenticated Terraform-protocol/OCI/Swagger
@@ -84,6 +88,23 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	pullThroughSvc := d.pullThroughSvc
 	tfBinariesHandler := d.tfBinariesHandler
 
+	// protocolLimit bounds anonymous request volume across this whole route
+	// table (issue #743). Every family here was previously unlimited: module
+	// and provider version listing/download, the network mirror (whose
+	// pull-through path issues upstream fetches and DB writes on a cache
+	// miss), OCI GetBlob (streams whole archives through io.Copy), and the
+	// binary mirror when BinaryMirror.Auth is the default "none". These are
+	// the highest-volume, fully unauthenticated, internet-reachable handlers
+	// in the service, and each one does DB lookups and storage round trips.
+	//
+	// Applied to everything below EXCEPT /health and /ready. Those two are
+	// deliberately unlimited: they are liveness/readiness probes, kubelet
+	// probes for every pod on a node share that node's source address, and a
+	// 429 on /ready pulls a healthy pod out of service -- a rate limiter
+	// causing the outage it exists to prevent. RateLimitMiddleware passes
+	// through when the backend is nil (rate limiting disabled).
+	protocolLimit := middleware.RateLimitMiddleware(d.protocolRateLimiter)
+
 	// Health check endpoint
 	router.GET("/health", healthCheckHandler(db))
 
@@ -91,10 +112,11 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	router.GET("/ready", readinessHandler(db, storageBackend))
 
 	// Service discovery endpoint (Terraform protocol)
-	router.GET("/.well-known/terraform.json", serviceDiscoveryHandler(cfg))
+	router.GET("/.well-known/terraform.json", protocolLimit, serviceDiscoveryHandler(cfg))
 
 	// OCI Distribution Spec v1.1 — module archive pull endpoint
 	v2Group := router.Group("/v2")
+	v2Group.Use(protocolLimit)
 	{
 		v2Group.GET("/", ociHandler.Ping)
 		v2Group.HEAD("/:namespace/:name/:system/manifests/:reference", ociHandler.HeadManifest)
@@ -105,11 +127,17 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	}
 
 	// API version
-	router.GET("/version", versionHandler(cfg))
+	router.GET("/version", protocolLimit, versionHandler(cfg))
 
 	// Swagger UI - served from embedded static assets (air-gap safe)
 	swaggerUIFS, _ := fs.Sub(docs.SwaggerUIAssets, "swagger-ui")
-	router.StaticFS("/api-docs/static", http.FS(swaggerUIFS))
+	// StaticFS registers GET and HEAD under /api-docs/static/*filepath. It takes
+	// no per-route middleware, so the limiter is applied via a group -- found by
+	// the route-table enumeration in public_routes_ratelimit_test.go, which sees
+	// routes that reading the registration code does not.
+	swaggerStatic := router.Group("/api-docs/static")
+	swaggerStatic.Use(protocolLimit)
+	swaggerStatic.StaticFS("", http.FS(swaggerUIFS))
 
 	serveSwaggerUI := func(c *gin.Context) {
 		// Generate a per-request nonce for CSP
@@ -187,17 +215,17 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	}
 
 	// Register both exact and trailing-slash routes for Swagger UI
-	router.GET("/api-docs/index.html", serveSwaggerUI)
-	router.GET("/api-docs/", serveSwaggerUI)
+	router.GET("/api-docs/index.html", protocolLimit, serveSwaggerUI)
+	router.GET("/api-docs/", protocolLimit, serveSwaggerUI)
 	// Redirect /api-docs -> /api-docs/
-	router.GET("/api-docs", func(c *gin.Context) {
+	router.GET("/api-docs", protocolLimit, func(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, "/api-docs/")
 	})
 
 	// Raw Swagger JSON endpoint - serve embedded spec with runtime metadata.
 	// CORS is governed by the globally-applied CORSMiddleware like every
 	// other route; do not set Access-Control-Allow-Origin here (issue #684).
-	router.GET("/swagger.json", func(c *gin.Context) {
+	router.GET("/swagger.json", protocolLimit, func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
 
 		data := docs.SwaggerJSON
@@ -257,7 +285,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// oapi-codegen) only care about the route and schema surface, not
 	// terms-of-service / license fields. CORS is governed by the
 	// globally-applied CORSMiddleware like every other route (issue #684).
-	router.GET("/openapi3.json", func(c *gin.Context) {
+	router.GET("/openapi3.json", protocolLimit, func(c *gin.Context) {
 		c.Header("Content-Type", "application/json")
 		c.Data(http.StatusOK, "application/json", docs.OpenAPI3JSON)
 	})
@@ -265,6 +293,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// Module Registry endpoints (v1) - Terraform Protocol
 	// These are public endpoints that support optional authentication
 	v1Modules := router.Group("/v1/modules")
+	v1Modules.Use(protocolLimit)
 	v1Modules.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
 	{
 		v1Modules.GET("/:namespace/:name/:system/versions", modules.ListVersionsHandler(db, cfg))
@@ -272,11 +301,12 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	}
 
 	// File serving endpoint for local storage with ServeDirectly enabled
-	router.GET("/v1/files/*filepath", modules.ServeFileHandler(storageBackend, cfg, db, auditRepo))
+	router.GET("/v1/files/*filepath", protocolLimit, modules.ServeFileHandler(storageBackend, cfg, db, auditRepo))
 
 	// Provider Registry endpoints (v1)
 	// These are for the standard Provider Registry Protocol
 	v1Providers := router.Group("/v1/providers")
+	v1Providers.Use(protocolLimit)
 	v1Providers.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
 	{
 		v1Providers.GET("/:namespace/:type/versions", providers.ListVersionsHandler(db, cfg))
@@ -287,6 +317,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// These endpoints include the hostname of the origin registry as per the Network Mirror Protocol
 	// They use a different path structure: /terraform/providers/:hostname/:namespace/:type/...
 	v1Mirror := router.Group("/terraform/providers")
+	v1Mirror.Use(protocolLimit)
 	{
 		v1Mirror.GET("/:hostname/:namespace/:type/index.json", mirror.IndexHandler(db, cfg, pullThroughSvc))
 		v1Mirror.GET("/:hostname/:namespace/:type/:versionfile", mirror.PlatformIndexHandler(db, cfg, auditRepo, pullThroughSvc))
@@ -296,6 +327,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// Allows clients to discover and download official Terraform/OpenTofu binaries synced by
 	// any named mirror config.  The :name segment identifies the mirror configuration.
 	tfBinaries := router.Group("/terraform/binaries")
+	tfBinaries.Use(protocolLimit)
 	tfBinaries.Use(middleware.BinaryMirrorAuthMiddleware(cfg.BinaryMirror))
 	{
 		tfBinaries.GET("", tfBinariesHandler.ListConfigs)

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -55,6 +55,28 @@ func UploadRateLimitConfig() RateLimitConfig {
 	}
 }
 
+// ProtocolRateLimitConfig returns limits for the unauthenticated Terraform-protocol,
+// OCI, network-mirror and binary-mirror route table (issue #743).
+//
+// Deliberately far above DefaultRateLimitConfig rather than sharing it. One
+// `terraform init` fans out across service discovery, version listing, download
+// and file fetch for every module and provider in the configuration -- dozens of
+// requests for a single command -- and a CI fleet behind one NAT egress address
+// shares a single rate-limit principal, since these routes are anonymous and
+// keyed by IP. Sizing this like an interactive API caller would reject ordinary
+// CLI traffic, and sharing the general bucket would let a `terraform init` storm
+// lock the same IP out of the UI and API.
+//
+// The point is a ceiling on anonymous request volume against handlers that do DB
+// lookups, storage round trips and full blob streams -- not a tight quota.
+func ProtocolRateLimitConfig() RateLimitConfig {
+	return RateLimitConfig{
+		RequestsPerMinute: 1200, // room for a large `terraform init` from a shared egress IP
+		BurstSize:         300,
+		CleanupInterval:   5 * time.Minute,
+	}
+}
+
 // RateLimiterBackend is the interface that rate limiter backends must satisfy.
 // Implementations include the in-memory token bucket (MemoryRateLimiter) and
 // the Redis-backed GCRA limiter (RedisRateLimiter).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -548,6 +548,36 @@ Rate Algorithm) in Redis, which correctly enforces limits across all backend pod
 Redis, each pod maintains an independent in-memory token bucket -- clients can bypass limits
 by rotating across pods.
 
+#### Rate-Limit Tiers
+
+`requests_per_minute` / `burst` configure the **general** tier only. Three other tiers use
+fixed presets and are not configurable:
+
+| Tier         | Applies to                                                              | Limit           |
+| ------------ | ----------------------------------------------------------------------- | --------------- |
+| general      | authenticated API + public search/detail endpoints                      | configurable    |
+| auth         | login / OIDC callback / token endpoints                                 | 20/min, burst 15 |
+| upload       | module and provider version uploads                                     | 30/min, burst 5  |
+| **protocol** | Terraform-protocol, OCI, network-mirror and binary-mirror routes        | 1200/min, burst 300 |
+
+The protocol tier is deliberately far above the general tier. A single `terraform init`
+fans out across service discovery, version listing, download and file fetch for every
+module and provider in the configuration, and because these routes are anonymous they are
+keyed by client IP -- so an entire CI fleet behind one NAT egress address shares a single
+bucket. Sizing it like an interactive API caller would reject ordinary CLI traffic, and
+sharing the general bucket would let a `terraform init` storm lock the same address out of
+the UI and API. It is a ceiling on anonymous request volume, not a tight quota.
+
+`/health` and `/ready` are **not** rate limited: kubelet probes for every pod on a node
+share that node's source address, and a 429 on `/ready` would pull a healthy pod out of
+service.
+
+**`server.trusted_proxies` matters here.** Anonymous requests are keyed on the client IP,
+which is derived from `X-Forwarded-For` only for proxies you list. The default is empty
+(trust nothing), so the header is ignored and the connecting address is used. If you set
+this to a broad range such as `0.0.0.0/0`, any client can rotate `X-Forwarded-For` and
+evade every IP-keyed limit. List your actual load balancer's CIDR, nothing wider.
+
 #### Per-Organization Rate Limiting
 
 When `org_requests_per_minute` is set to a value greater than 0 and multi-tenancy is enabled,


### PR DESCRIPTION
Closes #743.

`registerPublicRoutes` wired `OptionalAuthMiddleware` and `BinaryMirrorAuthMiddleware` onto these groups but never a rate limiter — while **every** family under `registerAPIV1Routes` is wrapped in one. So the highest-volume, fully unauthenticated, internet-reachable handlers in the service had no request-volume defence at the application layer: module/provider version listing and download, the network mirror (whose pull-through path issues upstream fetches and DB writes on a cache miss), OCI `GetBlob` (streams whole archives through `io.Copy`), and the binary mirror when `BinaryMirror.Auth` is the default `"none"`.

## A dedicated tier, not the general limiter

| Tier | Limit |
|---|---|
| general | configurable (default 200/min, burst 50) |
| **protocol** (new) | 1200/min, burst 300 |

One `terraform init` fans out across service discovery, version listing, download and file fetch for *every* module and provider in the configuration. These routes are anonymous, so they key on client IP — an entire CI fleet behind one NAT egress address is a **single bucket**. Sizing this like an interactive API caller would reject ordinary CLI traffic, and sharing the general bucket would let a `terraform init` storm lock the same address out of the UI and API. It is a ceiling on anonymous volume, not a quota.

Limiter construction moves ahead of route registration, because gin binds a group's middleware when the group is registered.

## Exemptions

`/health` and `/ready`, with the reason recorded in the test: kubelet probes for every pod on a node share that node's source address, and a 429 on `/ready` pulls a healthy pod out of service — the limiter causing the outage it exists to prevent.

## The guard found a route I missed

It enumerates the route table `registerPublicRoutes` **actually mounted**, not a list of paths I typed. That surfaced `GET|HEAD /api-docs/static/*filepath`, registered by `StaticFS`, which takes no per-route middleware and is invisible when reading the registration code. It now goes through a group carrying the limiter; the registered paths are unchanged (verified).

## Verification

Mutation-verified in four directions:

| Mutation | Result |
|---|---|
| Drop `protocolLimit` from the mirror group | ✅ fails, naming both mirror routes |
| Add a stale exemption entry | ✅ fails — the allowlist cannot rot |
| Empty route table | ✅ fails rather than passing vacuously |
| `SetTrustedProxies(["0.0.0.0/0"])` | ✅ fails — rotating `X-Forwarded-For` evades the limit |

That last one is what separates a real limit from a cosmetic one here: anonymous requests key on `c.ClientIP()`, and under gin's *default* (trust all proxies) a client could send a fresh `X-Forwarded-For` per request and never share a bucket with itself. `server.trusted_proxies` defaults to empty, so that holds today — the test keeps it holding, and the docs now warn against widening it.

`go test ./...` passes across the backend.