### PR TITLE
fix(db): return the migration helpers' pooled connection instead of leaking it

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -39,22 +40,77 @@ func Connect(dsn string, maxConnections, minIdleConnections int) (*sql.DB, error
 	return db, nil
 }
 
-// RunMigrations runs database migrations
-func RunMigrations(db *sql.DB, direction string) error {
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
+// newMigrator builds a migrator over a single connection borrowed from db.
+//
+// Every migrator returned here MUST be handed to closeMigrator, which returns
+// the borrowed connection to db's pool. Callers keep ownership of db itself,
+// which this package never closes.
+//
+// The borrowing is explicit for a reason (issue #788). postgres.WithInstance(db, ...)
+// also checks out a dedicated connection and holds it for the driver's
+// lifetime, but it additionally records db on the driver, so the driver's
+// Close() closes the caller's shared *sql.DB. That makes the obvious fix --
+// "just defer m.Close()" -- worse than the leak it repairs: at startup it would
+// close the application pool. postgres.WithConnection takes a connection this
+// package obtained itself and leaves the driver's db field nil, so Close()
+// releases exactly what was borrowed and nothing more.
+//
+// Without that release, each call permanently consumed one slot of the pool's
+// MaxOpenConns. cmd/server/main.go calls GetMigrationVersion with the
+// long-lived application pool, so the loss was not reclaimed until shutdown --
+// and that is the pool backing identity queries on the auth hot path.
+//
+// This mirrors terraform-suite-identity's newMigrator/closeMigrator
+// (sethbacon/terraform-suite-identity#139). The same defect was implemented
+// twice, so the module-side fix never reached this copy.
+func newMigrator(ctx context.Context, db *sql.DB) (*migrate.Migrate, error) {
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create migration driver: %w", err)
+		return nil, fmt.Errorf("failed to acquire a connection for migrations: %w", err)
+	}
+
+	driver, err := postgres.WithConnection(ctx, conn, &postgres.Config{})
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to create migration driver: %w", err)
 	}
 
 	sourceDriver, err := iofs.New(migrationsFS, "migrations")
 	if err != nil {
-		return fmt.Errorf("failed to create migration source: %w", err)
+		// driver.Close() releases the borrowed connection back to db's pool
+		// (and only that: WithConnection leaves the driver's db field nil).
+		_ = driver.Close()
+		return nil, fmt.Errorf("failed to create migration source: %w", err)
 	}
 
 	m, err := migrate.NewWithInstance("iofs", sourceDriver, "postgres", driver)
 	if err != nil {
-		return fmt.Errorf("failed to create migration instance: %w", err)
+		_ = driver.Close()
+		_ = sourceDriver.Close()
+		return nil, fmt.Errorf("failed to create migration instance: %w", err)
 	}
+
+	return m, nil
+}
+
+// closeMigrator releases the migrator's source driver and returns its borrowed
+// connection to the pool it came from. Best-effort by design: a close failure
+// must not mask (or manufacture) an error from the migration itself, and the
+// connection is released either way.
+func closeMigrator(m *migrate.Migrate) {
+	if m == nil {
+		return
+	}
+	_, _ = m.Close()
+}
+
+// RunMigrations runs database migrations
+func RunMigrations(db *sql.DB, direction string) error {
+	m, err := newMigrator(context.Background(), db)
+	if err != nil {
+		return err
+	}
+	defer closeMigrator(m)
 
 	switch direction {
 	case "up":
@@ -74,20 +130,11 @@ func RunMigrations(db *sql.DB, direction string) error {
 
 // GetMigrationVersion returns the current migration version
 func GetMigrationVersion(db *sql.DB) (version uint, dirty bool, err error) {
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	m, err := newMigrator(context.Background(), db)
 	if err != nil {
-		return 0, false, fmt.Errorf("failed to create migration driver: %w", err)
+		return 0, false, err
 	}
-
-	sourceDriver, err := iofs.New(migrationsFS, "migrations")
-	if err != nil {
-		return 0, false, fmt.Errorf("failed to create migration source: %w", err)
-	}
-
-	m, err := migrate.NewWithInstance("iofs", sourceDriver, "postgres", driver)
-	if err != nil {
-		return 0, false, fmt.Errorf("failed to create migration instance: %w", err)
-	}
+	defer closeMigrator(m)
 
 	version, dirty, err = m.Version()
 	if err != nil && err != migrate.ErrNilVersion {

--- a/backend/internal/db/migration_conn_leak_test.go
+++ b/backend/internal/db/migration_conn_leak_test.go
@@ -1,0 +1,141 @@
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/terraform-registry/terraform-registry/internal/db"
+)
+
+// Issue #788 — the migration helpers leaked a pooled connection.
+//
+// postgres.WithInstance checks out a *sql.Conn and holds it for the driver's
+// lifetime; neither helper closed the driver, so every call permanently
+// consumed one slot of the caller's MaxOpenConns. cmd/server/main.go calls
+// GetMigrationVersion with the long-lived application pool (25 connections),
+// so the slot was never reclaimed — and that pool backs identity queries on
+// the auth hot path.
+//
+// The obvious fix is a trap worth naming: postgres.WithInstance records the
+// *sql.DB on the driver, so driver.Close()/m.Close() closes the caller's
+// shared pool. "defer m.Close()" would have turned a one-connection leak into
+// a closed application pool at startup. The helpers now borrow a connection
+// explicitly and use postgres.WithConnection, which leaves that field nil.
+
+// TestMigrationHelpers_DoNotUseWithInstance is the re-runnable signature for
+// the defect, and the half that runs everywhere — no database required.
+//
+// The behavioural test below is the honest proof, but it only runs where a
+// Postgres is reachable. This one fails in any environment the moment the
+// pool-closing constructor reappears, including in a new helper nobody thought
+// to write a connection test for.
+func TestMigrationHelpers_DoNotUseWithInstance(t *testing.T) {
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fail rather than pass vacuously if the glob ever stops finding this
+	// package's sources.
+	if len(sources) == 0 {
+		t.Fatal("no .go sources found — this guard is not scanning anything")
+	}
+
+	var scanned int
+	for _, path := range sources {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanned++
+		for i, line := range strings.Split(string(src), "\n") {
+			// Skip prose: the fix is explained in a comment that names the
+			// symbol on purpose.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			if strings.Contains(line, "postgres.WithInstance(") {
+				t.Errorf("%s:%d uses postgres.WithInstance, which records the caller's "+
+					"*sql.DB on the driver — the driver then holds a pooled connection "+
+					"for its lifetime AND its Close() closes the caller's pool. Use "+
+					"newMigrator/closeMigrator (postgres.WithConnection over a borrowed "+
+					"connection) instead. See issue #788.", path, i+1)
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no non-test sources — the guard is vacuous")
+	}
+}
+
+// TestGetMigrationVersion_ReturnsItsConnectionToThePool is the test the issue
+// asked for: a pool of exactly one connection, so a leak is not a statistic
+// but a deadlock.
+//
+// Asserted against a context deadline rather than db.Stats(), because the
+// failure mode is that the next query BLOCKS waiting for a connection that
+// will never come back. Stats alone would report a plausible-looking
+// InUse count and tell you nothing about whether the pool still works.
+//
+// Set TFR_TEST_DATABASE_URL to run this (any reachable Postgres; the helpers
+// only read golang-migrate's version table).
+func TestGetMigrationVersion_ReturnsItsConnectionToThePool(t *testing.T) {
+	dsn := os.Getenv("TFR_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TFR_TEST_DATABASE_URL not set — needs a reachable Postgres")
+	}
+
+	pool, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer pool.Close()
+
+	// One connection. With the leak, the helper takes it and never gives it
+	// back, and every subsequent query waits forever.
+	pool.SetMaxOpenConns(1)
+	pool.SetMaxIdleConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := pool.PingContext(ctx); err != nil {
+		t.Skipf("Postgres not reachable at TFR_TEST_DATABASE_URL: %v", err)
+	}
+
+	// Call it more than once: a per-call leak with MaxOpenConns(1) blocks on
+	// the second call, which is itself the regression signal.
+	for i := 0; i < 3; i++ {
+		if _, _, err := db.GetMigrationVersion(pool); err != nil {
+			t.Fatalf("GetMigrationVersion call %d: %v", i+1, err)
+		}
+	}
+
+	// The real assertion: the pool still serves queries. A short deadline, so
+	// a leak fails fast and unambiguously instead of hanging the suite.
+	queryCtx, queryCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer queryCancel()
+
+	var one int
+	if err := pool.QueryRowContext(queryCtx, "SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("pool is unusable after GetMigrationVersion — the borrowed "+
+			"connection was never returned (issue #788): %v", err)
+	}
+	if one != 1 {
+		t.Fatalf("SELECT 1 returned %d", one)
+	}
+
+	// Stats is a secondary check, not the assertion: with the connection
+	// returned, nothing should still be checked out.
+	if inUse := pool.Stats().InUse; inUse != 0 {
+		t.Errorf("pool reports %d connection(s) still in use after the helper returned", inUse)
+	}
+}


### PR DESCRIPTION
Closes #788.

`postgres.WithInstance` checks out a `*sql.Conn` and holds it for the driver's lifetime. Neither `RunMigrations` nor `GetMigrationVersion` closed the driver, so **every call permanently consumed one slot of the caller's `MaxOpenConns`**. `cmd/server/main.go` calls `GetMigrationVersion` with the long-lived application pool, so the slot was never reclaimed for the life of the process — and that pool is the one backing identity queries on the auth hot path.

## The obvious fix is a trap

`postgres.WithInstance` also records the `*sql.DB` on the driver:

```go
px, err := WithConnection(ctx, conn, config)
px.db = instance          // <-- and Close() closes this
```

So `driver.Close()` — and therefore `m.Close()` — **closes the caller's shared pool**. A plain `defer m.Close()` would have turned a one-connection leak into a closed application pool at startup, which is worse than the defect it repairs.

Both helpers now borrow a connection explicitly and build the driver with `postgres.WithConnection`, which leaves that field nil, so `Close()` releases exactly what was borrowed and nothing more. This mirrors `terraform-suite-identity`'s `newMigrator`/`closeMigrator` (sethbacon/terraform-suite-identity#139).

## Scope

The issue reported `GetMigrationVersion`. `RunMigrations` had the identical pattern in the same file and is fixed with it.

## Verification

Against a **real Postgres** with `SetMaxOpenConns(1)`, where a leak is a deadlock rather than a statistic — asserted on a context deadline, not `db.Stats()`, because the failure mode is that the next query blocks forever:

| Code | Result |
|---|---|
| Fixed | three successive calls, pool still serves `SELECT 1`, `InUse == 0` ✅ |
| Reverted to `WithInstance` | **blocks until the 60s test timeout** ✅ |

The behavioural test skips without `TFR_TEST_DATABASE_URL`, so it is paired with a structural guard that scans the package for `postgres.WithInstance(` and fails in any environment — including for a future helper nobody writes a connection test for. That guard fails vacuously-safe too: it errors if it scans zero sources.

I ran this against a scratch database created and dropped for the purpose, not the dev database.

## Note for a follow-up

`terraform-state-manager-backend/backend/internal/db/db.go:80` has the same `postgres.WithInstance` pattern — a third independent copy. Not touched here; flagging it rather than folding an unrelated repo into this PR.