### PR TITLE
fix(auth): guard the default_role fallback against admin-bearing templates

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1146,6 +1146,23 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			return fmt.Errorf("check membership default org user=%s: %w", userID, err)
 		}
 		if !isMember {
+			// Same guard the two group-mapping branches apply (issue #766).
+			// This branch was missing it, and it is the wider of the three: a
+			// group mapping grants to members of a mapped group, whereas
+			// default_role grants to EVERY user on first login. With
+			// default_role set to an admin-bearing template, anyone who could
+			// authenticate was handed the platform-wide wildcard -- and because
+			// the session scope union is org-less (#652), holding it in the
+			// default organization means holding it everywhere.
+			//
+			// The scopes are not needed here: adding a membership is an
+			// authority increase, so no existing credential of this user in
+			// this org can be a snapshot of an authority they did not have.
+			if _, guardErr := h.guardProvisionableRole(ctx, defaultRole); guardErr != nil {
+				slog.Warn(provider+" default_role rejected: it is not automatically provisionable by an IdP-driven mapping; a human admin must grant it explicitly",
+					"user_id", userID, "role", defaultRole, "error", guardErr)
+				return nil
+			}
 			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, defaultRole, repositories.OrgScopeAllOrganizations()); err != nil {
 				return fmt.Errorf("add default member user=%s role=%s: %w", userID, defaultRole, err)
 			}

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -1037,6 +1037,11 @@ func TestApplyGroupMappings_DefaultRoleFallback(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols))
 
+	// guardProvisionableRole → scopes lookup. The default_role path is guarded
+	// like the two group-mapping branches (issue #766); viewer is not
+	// admin-bearing, so the write proceeds.
+	expectRoleScopesLookup(mock, "viewer", []string{"modules:read"})
+
 	// AddMemberWithParams → lookup role template
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 		WithArgs("viewer").
@@ -1845,9 +1850,15 @@ func TestReconcile_DefaultRole_FirstLoginAdds(t *testing.T) {
 
 	expectOrgByName(mock, "default", "org-default")
 	expectNotMember(mock)
-	// default_role is a static, admin-configured fallback (not an IdP-driven
-	// group mapping), so guardProvisionableRole does not run here — no scopes
-	// lookup is expected, unlike expectAddMember's use elsewhere in this file.
+	// guardProvisionableRole → scopes lookup. This branch used to skip the
+	// guard entirely, and the comment here recorded that as expected ("so
+	// guardProvisionableRole does not run here — no scopes lookup is
+	// expected") — which is what the defect looked like from the test side.
+	// default_role being admin-configured rather than IdP-driven does not make
+	// it safe: it grants to EVERY user on first login (issue #766). viewer is
+	// not admin-bearing, so the write proceeds.
+	expectRoleScopesLookup(mock, "viewer", []string{"modules:read"})
+
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 		WithArgs("viewer").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("rt-viewer"))
@@ -1857,6 +1868,47 @@ func TestReconcile_DefaultRole_FirstLoginAdds(t *testing.T) {
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"whatever"})
 	if err != nil {
 		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestReconcile_DefaultRole_AdminBearingTemplateIsRejected is the point of the
+// #766 fix: default_role must not be able to hand out the platform-wide
+// wildcard.
+//
+// This is the widest of the three IdP membership-write paths. A group mapping
+// grants to members of a mapped group; default_role grants to EVERY user on
+// first login. With auth.<provider>.default_role naming an admin-bearing
+// template, anyone who could authenticate received `admin` — and because the
+// session scope union is org-less (#652), holding it in the default
+// organization means holding it everywhere.
+//
+// The assertion is that NO membership write follows: no role-template id
+// lookup, no INSERT. sqlmock fails on an unexpected query, so an
+// AddMemberWithParams that slipped through would be caught rather than ignored.
+func TestReconcile_DefaultRole_AdminBearingTemplateIsRejected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.DefaultRole = "admin"
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "default", "org-default")
+	expectNotMember(mock)
+	// The seeded admin template carries the wildcard scope.
+	expectRoleScopesLookup(mock, "admin", []string{"admin"})
+	// Deliberately nothing further: the guard must stop here.
+
+	// Login is not failed — the user simply does not get the membership. A
+	// rejected default_role should not lock everyone out of authenticating.
+	if err := h.applyGroupMappings(context.Background(), "user-1", []string{"whatever"}); err != nil {
+		t.Fatalf("applyGroupMappings should not fail login on a rejected default_role: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)

--- a/backend/internal/api/admin/idp_membership_guard_class_test.go
+++ b/backend/internal/api/admin/idp_membership_guard_class_test.go
@@ -1,0 +1,311 @@
+package admin
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// Issue #766 — every IdP-driven membership write must pass the provisionable
+// guard before it lands.
+//
+// The seeded `admin` role template carries the wildcard scope, and the session
+// scope union is org-less (#652), so holding it in ONE organization confers it
+// everywhere. auth.ValidateProvisionableScopes exists to keep an IdP-driven
+// mapping from granting it without a human in the loop, and
+// guardProvisionableRole is the wrapper that applies it.
+//
+// It was applied on two of the three membership-write branches in
+// reconcileGroupMemberships. The third — the default_role first-login fallback
+// — wrote the membership directly. That branch is the WIDEST of the three: a
+// group mapping grants to members of a mapped group, while default_role grants
+// to every user who can authenticate, on first login. With
+// auth.<provider>.default_role naming an admin-bearing template, anyone who
+// could log in received the platform-wide wildcard.
+//
+// The defect is an ABSENT CALL, so no test of any branch's behaviour
+// generalises to the next branch someone adds. This walks the AST instead and
+// requires the guard on every membership write in the file, which is the shape
+// that fails when a fourth branch appears without one.
+
+// membershipWriteMethods are the repository calls that create or change a
+// member's role. A new one added to this file without a row here would go
+// unexamined, so the vocabulary check below pins the list against the source.
+var membershipWriteMethods = map[string]bool{
+	"AddMemberWithParams":       true,
+	"AddMemberWithRoleTemplate": true,
+	"UpdateMemberRole":          true,
+	"UpdateMemberRoleTemplate":  true,
+}
+
+// guardCallNames are the accepted ways to reach auth.ValidateProvisionableScopes.
+// resolveProvisionableRole is the closure in reconcileGroupMemberships that
+// wraps guardProvisionableRole and logs the rejection.
+var guardCallNames = map[string]bool{
+	"guardProvisionableRole":   true,
+	"resolveProvisionableRole": true,
+}
+
+func parseAuthFile(t *testing.T) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "auth.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse auth.go: %v", err)
+	}
+	return fset, f
+}
+
+// callName returns the method or function name of a call expression.
+func callName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name
+	case *ast.Ident:
+		return fn.Name
+	}
+	return ""
+}
+
+// guardPositionsIn collects the offsets of guard calls inside n that could
+// actually run on the path to writePos.
+//
+// Path-awareness is the whole point, and this test reported a FALSE PASS twice
+// before it had any:
+//
+//  1. reconcileGroupMemberships defines resolveProvisionableRole as a closure
+//     whose body calls guardProvisionableRole. A naive walk finds that call at a
+//     position earlier than every membership write in the function.
+//  2. Two sibling `case` clauses call resolveProvisionableRole(). Those calls are
+//     also textually earlier than the default_role block that follows the loop,
+//     so ascending to the function body counted them for a write in a different
+//     branch entirely.
+//
+// Both made the unguarded default_role branch — the exact defect this test
+// exists to catch — look guarded. Verified each time by reverting the fix and
+// watching the test still pass.
+//
+// So a branch construct that does not contain writePos is not descended into.
+// But its HEADER still is: `if _, ok := resolveProvisionableRole(); !ok` puts
+// the guard in the if-statement's Init, which runs unconditionally even though
+// the write sits after the if rather than inside it. Skipping the whole node
+// there produced the opposite error — a false FAILURE on a correctly guarded
+// branch. Init/Cond/Post run on the way past; Body/Else do not.
+func guardPositionsIn(n ast.Node, writePos token.Pos) []token.Pos {
+	contains := func(x ast.Node) bool {
+		return x != nil && writePos >= x.Pos() && writePos <= x.End()
+	}
+	var out []token.Pos
+	var collect func(ast.Node)
+
+	// header gathers guard calls from parts that execute unconditionally when
+	// control reaches the construct at all.
+	header := func(parts ...ast.Node) {
+		for _, p := range parts {
+			if p != nil && !isNilNode(p) {
+				collect(p)
+			}
+		}
+	}
+
+	collect = func(root ast.Node) {
+		ast.Inspect(root, func(x ast.Node) bool {
+			if x == nil {
+				return false
+			}
+			if x != root && !contains(x) {
+				switch st := x.(type) {
+				case *ast.FuncLit:
+					return false // a definition, not a call on this path
+				case *ast.IfStmt:
+					header(st.Init, st.Cond)
+					return false
+				case *ast.SwitchStmt:
+					header(st.Init, st.Tag)
+					return false
+				case *ast.TypeSwitchStmt:
+					header(st.Init, st.Assign)
+					return false
+				case *ast.ForStmt:
+					header(st.Init, st.Cond, st.Post)
+					return false
+				case *ast.RangeStmt:
+					header(st.X)
+					return false
+				case *ast.SelectStmt, *ast.CaseClause, *ast.CommClause:
+					return false
+				}
+			}
+			if call, ok := x.(*ast.CallExpr); ok && guardCallNames[callName(call)] {
+				out = append(out, call.Pos())
+			}
+			return true
+		})
+	}
+	collect(n)
+	return out
+}
+
+// isNilNode reports whether an ast.Node interface holds a typed nil, which the
+// optional Init/Cond/Post fields above frequently are.
+func isNilNode(n ast.Node) bool {
+	switch v := n.(type) {
+	case *ast.AssignStmt:
+		return v == nil
+	case *ast.ExprStmt:
+		return v == nil
+	case *ast.BinaryExpr:
+		return v == nil
+	case *ast.CallExpr:
+		return v == nil
+	case *ast.Ident:
+		return v == nil
+	}
+	return false
+}
+
+func TestIdPMembershipWrites_AreAllBehindTheProvisionableGuard(t *testing.T) {
+	fset, file := parseAuthFile(t)
+
+	// Every enclosing node of each write, innermost first, so a guard applied
+	// anywhere up the chain within the same function counts.
+	var found int
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+
+		// Stack of enclosing block-ish nodes as we descend.
+		var stack []ast.Node
+		var walk func(ast.Node) bool
+		walk = func(n ast.Node) bool {
+			if n == nil {
+				return false
+			}
+			switch n.(type) {
+			case *ast.BlockStmt, *ast.CaseClause, *ast.IfStmt, *ast.FuncLit:
+				stack = append(stack, n)
+				defer func() { stack = stack[:len(stack)-1] }()
+			}
+
+			if call, ok := n.(*ast.CallExpr); ok && membershipWriteMethods[callName(call)] {
+				found++
+				pos := call.Pos()
+
+				var guarded bool
+				for _, enclosing := range stack {
+					for _, g := range guardPositionsIn(enclosing, pos) {
+						// Strictly before the write: a guard that runs after the
+						// membership has already landed is not a guard.
+						if g < pos {
+							guarded = true
+							break
+						}
+					}
+					if guarded {
+						break
+					}
+				}
+
+				if !guarded {
+					t.Errorf("%s: %s is called in %s with no guardProvisionableRole/"+
+						"resolveProvisionableRole ahead of it. An IdP-driven membership "+
+						"write must reject admin-bearing templates before it lands "+
+						"(issue #766) — the default_role fallback shipped without this "+
+						"and granted the platform-wide wildcard to every user on first "+
+						"login.", fset.Position(pos), callName(call), fn.Name.Name)
+				}
+			}
+
+			for _, child := range childrenOf(n) {
+				walk(child)
+			}
+			return true
+		}
+		walk(fn.Body)
+		return false // walk() already descended this function
+	})
+
+	// The failure mode the loop cannot see: if the method names drift, the
+	// walk matches nothing and reports green while checking nothing.
+	if found == 0 {
+		t.Fatal("found no membership-write calls in auth.go — membershipWriteMethods " +
+			"is stale, so this guard is vacuous. Re-derive it from the repository's " +
+			"organization-member write methods.")
+	}
+	t.Logf("checked %d membership-write call site(s)", found)
+}
+
+// childrenOf enumerates a node's direct children. ast.Inspect cannot be used
+// for the walk above because it gives no way to maintain an enclosing-node
+// stack across the descent.
+func childrenOf(n ast.Node) []ast.Node {
+	var out []ast.Node
+	first := true
+	ast.Inspect(n, func(c ast.Node) bool {
+		if first {
+			first = false
+			return true
+		}
+		if c != nil {
+			out = append(out, c)
+		}
+		return false // direct children only
+	})
+	return out
+}
+
+// TestMembershipWriteVocabulary_MatchesTheRepository keeps the method list above
+// honest. A repository method that writes a membership but is missing from
+// membershipWriteMethods would make the guard above silently skip it.
+func TestMembershipWriteVocabulary_MatchesTheRepository(t *testing.T) {
+	_, file := parseAuthFile(t)
+
+	// Every h.orgRepo.X(...) call in auth.go whose name looks like a membership
+	// mutation must be classified — either as a write we guard, or knowingly
+	// excluded below.
+	notAMembershipRoleWrite := map[string]bool{
+		"RemoveMember":                true, // deprovision: an authority DECREASE
+		"RemoveAllMembershipsForUser": true, // deprovision
+		"CheckMembership":             true, // read
+		"GetDefaultOrganization":      true, // read
+		"GetOrganizationByName":       true, // read
+		"ListOrganizations":           true, // read
+		"GetUserMemberships":          true, // read
+		"GetUserCombinedScopes":       true, // read
+		"GetByName":                   true, // read
+	}
+
+	var unclassified []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		// Only calls on the organization repository.
+		recv, ok := sel.X.(*ast.SelectorExpr)
+		if !ok || recv.Sel.Name != "orgRepo" {
+			return true
+		}
+		name := sel.Sel.Name
+		if membershipWriteMethods[name] || notAMembershipRoleWrite[name] {
+			return true
+		}
+		unclassified = append(unclassified, name)
+		return true
+	})
+
+	if len(unclassified) > 0 {
+		t.Errorf("unclassified orgRepo method(s) called in auth.go: %s. If one writes "+
+			"a membership role, add it to membershipWriteMethods so the guard check "+
+			"covers it; if it does not, add it to notAMembershipRoleWrite.",
+			strings.Join(unclassified, ", "))
+	}
+}


### PR DESCRIPTION
Refs #766 — closes the concrete bypass. **Does not close the issue**; see the last section.

## The defect

`reconcileGroupMemberships` has three membership-write branches. Two call `guardProvisionableRole`, which rejects any role template carrying the wildcard `admin` scope. The third — the `default_role` first-login fallback — wrote the membership directly.

That branch is the **widest** of the three. A group mapping grants to members of a mapped group; `default_role` grants to **every user on first login**. With `auth.<provider>.default_role` naming an admin-bearing template, anyone who could authenticate received the platform-wide wildcard — and because the session scope union is org-less (#652), holding it in the default organization means holding it **everywhere**.

Config validation can't catch this: the group-mapping and `default_role` names are plain strings, and resolving them to scopes needs the database.

Login is not failed on rejection, matching the sibling branches — the user simply does not receive the membership. A misconfigured `default_role` should not lock everyone out of authenticating.

## Two existing tests encoded the defect as expected behaviour

One comment read, verbatim:

> `default_role` is a static, admin-configured fallback (not an IdP-driven group mapping), so `guardProvisionableRole` does not run here — no scopes lookup is expected

Both are updated rather than worked around. Being admin-configured rather than IdP-driven doesn't make it safe when it applies to every user.

## The class guard, and three false results getting there

The defect is an **absent call**, so no behavioural test of one branch generalises to the next branch someone adds. The guard walks the AST and requires a guard on every membership write in the file. It took three attempts to make it real:

| Attempt | Result | Cause |
|---|---|---|
| 1 | false **PASS** | the `resolveProvisionableRole` closure's *definition* contains a guard call earlier in the function |
| 2 | false **PASS** | two sibling `case` clauses call it earlier than the `default_role` block |
| 3 | false **FAILURE** | skipping non-containing branches also skipped an `if` statement's `Init`, where one guard actually lives |

It now models which constructs actually run on the path to the write (`Init`/`Cond`/`Post` run; `Body`/`Else` don't). Each of the three branches was then individually reverted and watched to fail **at its own line**:

```
M1 remove default_role guard  -> auth.go:1161:14 FAIL
M2 remove guard on !isMember  -> auth.go:1091:14 FAIL
M3 remove guard on isMember   -> auth.go:1061:14 FAIL
RESTORED                      -> ok
```

Plus a behavioural test that an admin-bearing `default_role` produces **no** membership write at all, which fails with the fix reverted. A companion vocabulary test forces every `orgRepo` method called in the file to be classified as a membership write or a read, so a new write method can't slip past unexamined — it caught two unclassified reads when first run.

## What this does NOT do

#766's broader recommendation is to reject admin-bearing templates as organization membership roles outright. **Org membership is currently the only carrier for platform admin** — including the setup wizard's bootstrap grant at `internal/api/setup/handlers.go:479`. Rejecting it would leave no way to have a platform admin at all. That needs a separate carrier and is entangled with #652, so I've left #766 open.

`go test ./...` passes across the backend.