### PR TITLE
fix(policy): bound the bundle parser's entry count and decompressed size

### DIFF
--- a/backend/internal/policy/bundle_limits_test.go
+++ b/backend/internal/policy/bundle_limits_test.go
@@ -1,0 +1,188 @@
+package policy
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Issue #750 — the bundle parser had no entry cap and no cumulative budget.
+//
+// maxBundleBytes bounds the COMPRESSED archive only. gzip amplifies, so 50 MB
+// of archive can encode far more than 50 MB of entries, and every .rego entry
+// is retained in memory for the lifetime of the parse. Non-.rego entries were
+// worse than unbounded — they were `continue`d, so their bodies were
+// decompressed to reach the next header and accounted at nothing.
+//
+// Reachable from a hostile or compromised bundle host. The SHA-256 pin fails
+// closed, but pinning is optional, so an unpinned deployment had no protection.
+
+// tarGz builds a gzipped tar from (name, size) pairs. Bodies are zero bytes,
+// which compress to almost nothing — that IS the amplification being tested.
+func tarGz(t *testing.T, entries []struct {
+	name string
+	size int64
+}) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: e.name, Mode: 0o644, Size: e.size, Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("WriteHeader(%s): %v", e.name, err)
+		}
+		if _, err := tw.Write(make([]byte, e.size)); err != nil {
+			t.Fatalf("Write(%s): %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func entriesOf(n int, name string, size int64) []struct {
+	name string
+	size int64
+} {
+	out := make([]struct {
+		name string
+		size int64
+	}, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, struct {
+			name string
+			size int64
+		}{fmt.Sprintf(name, i), size})
+	}
+	return out
+}
+
+func TestParseBundle_RejectsTooManyEntries(t *testing.T) {
+	archive := tarGz(t, entriesOf(maxBundleEntries+1, "policy%d.rego", 0))
+
+	// The compressed archive is tiny — that is the point. The old parser would
+	// have walked every entry and retained every one.
+	t.Logf("compressed archive: %d bytes for %d entries", len(archive), maxBundleEntries+1)
+
+	if _, err := parseBundleTarGz(bytes.NewReader(archive)); err == nil {
+		t.Fatal("an archive with more than maxBundleEntries entries was accepted")
+	} else if !strings.Contains(err.Error(), "entries") {
+		t.Errorf("error = %q, want it to name the entry cap", err)
+	}
+}
+
+func TestParseBundle_RejectsCumulativeDecompressedSize(t *testing.T) {
+	// Each entry is under the per-file cap; together they blow the budget.
+	// The per-file limit alone never sees this.
+	per := int64(maxRegoFileBytes)
+	count := int(maxBundleDecompressedBytes/per) + 1
+	if count > maxBundleEntries {
+		t.Skipf("entry cap (%d) is reached before the byte budget with %d entries",
+			maxBundleEntries, count)
+	}
+	archive := tarGz(t, entriesOf(count, "policy%d.rego", per))
+
+	if _, err := parseBundleTarGz(bytes.NewReader(archive)); err == nil {
+		t.Fatal("an archive exceeding the cumulative decompressed budget was accepted")
+	} else if !strings.Contains(err.Error(), "decompresses") {
+		t.Errorf("error = %q, want it to name the decompression budget", err)
+	}
+}
+
+// TestParseBundle_ChargesSkippedEntries is the half the issue called out as
+// worse than unbounded: entries the parser skips are still decompressed to
+// reach the next header, and used to cost nothing.
+//
+// Every entry here is a NON-.rego file, so under the old accounting the parse
+// was free no matter how large the archive claimed to be.
+func TestParseBundle_ChargesSkippedEntries(t *testing.T) {
+	per := int64(maxRegoFileBytes)
+	count := int(maxBundleDecompressedBytes/per) + 1
+	if count > maxBundleEntries {
+		t.Skipf("entry cap reached first with %d entries", count)
+	}
+	archive := tarGz(t, entriesOf(count, "data%d.json", per))
+
+	if _, err := parseBundleTarGz(bytes.NewReader(archive)); err == nil {
+		t.Fatal("an archive of skipped (non-.rego) entries was accepted — skipped " +
+			"entries must be charged against the budget, since reaching the next " +
+			"header decompresses them anyway")
+	}
+}
+
+// TestParseBundle_RejectsOversizedPolicyRatherThanTruncating.
+//
+// The previous per-file io.LimitReader(tr, 1<<20) silently cut a larger file
+// off mid-source, so the bundle loaded as a POLICY THAT WAS NEVER WRITTEN. A
+// truncation landing after an allow rule but before the deny that qualifies it
+// inverts the outcome, with nothing in the logs to say so.
+func TestParseBundle_RejectsOversizedPolicyRatherThanTruncating(t *testing.T) {
+	archive := tarGz(t, []struct {
+		name string
+		size int64
+	}{{"big.rego", maxRegoFileBytes + 1}})
+
+	files, err := parseBundleTarGz(bytes.NewReader(archive))
+	if err == nil {
+		t.Fatalf("oversized policy file was accepted, returning %d file(s) — a "+
+			"truncated policy is not the policy the operator wrote", len(files))
+	}
+	if !strings.Contains(err.Error(), "big.rego") {
+		t.Errorf("error = %q, want it to name the offending file", err)
+	}
+}
+
+// TestParseBundle_AcceptsARealisticBundle is the other direction: the limits
+// must not reject ordinary bundles, or they get raised until meaningless.
+func TestParseBundle_AcceptsARealisticBundle(t *testing.T) {
+	archive := tarGz(t, []struct {
+		name string
+		size int64
+	}{
+		{"policies/upload.rego", 4096},
+		{"policies/naming.rego", 2048},
+		{"data.json", 1024}, // skipped, but charged
+		{"README.md", 512},  // skipped
+		{"policies/limits.rego", 8192},
+	})
+
+	files, err := parseBundleTarGz(bytes.NewReader(archive))
+	if err != nil {
+		t.Fatalf("a realistic bundle was rejected: %v", err)
+	}
+	if len(files) != 3 {
+		t.Errorf("got %d .rego files, want 3: %+v", len(files), files)
+	}
+	for _, f := range files {
+		if !strings.HasSuffix(f.name, ".rego") {
+			t.Errorf("non-.rego file retained: %s", f.name)
+		}
+	}
+}
+
+// TestParseBundle_ExactLimitsAreAccepted pins the boundary: a file of exactly
+// maxRegoFileBytes is legal, one byte more is not.
+func TestParseBundle_ExactLimitsAreAccepted(t *testing.T) {
+	archive := tarGz(t, []struct {
+		name string
+		size int64
+	}{{"exact.rego", maxRegoFileBytes}})
+
+	files, err := parseBundleTarGz(bytes.NewReader(archive))
+	if err != nil {
+		t.Fatalf("a policy file of exactly the limit was rejected: %v", err)
+	}
+	if len(files) != 1 || int64(len(files[0].source)) != maxRegoFileBytes {
+		t.Errorf("got %d file(s); source length = %d, want %d",
+			len(files), len(files[0].source), maxRegoFileBytes)
+	}
+}

--- a/backend/internal/policy/bundle_loader.go
+++ b/backend/internal/policy/bundle_loader.go
@@ -29,6 +29,29 @@ type regoFile struct {
 // contents are parsed and loaded as active upload policy.
 const maxBundleBytes = 50 << 20 // 50 MB
 
+// Decompression budget for the bundle archive (issue #750).
+//
+// maxBundleBytes bounds the COMPRESSED archive only. gzip amplifies, so 50 MB
+// of archive can encode far more than 50 MB of entries, and every .rego entry
+// is retained in memory for the lifetime of the parse. Without these, a hostile
+// or compromised bundle host could turn one 50 MB download into an
+// out-of-memory kill.
+//
+// Non-.rego entries are charged too. Skipping an entry is not free: the tar
+// reader must decompress its body to reach the next header, so an archive made
+// entirely of skipped entries costs the same CPU and I/O while previously being
+// accounted at zero.
+const (
+	// maxBundleEntries caps how many archive members are examined. Real OPA
+	// bundles hold tens of policies; thousands means something else is going on.
+	maxBundleEntries = 4096
+	// maxBundleDecompressedBytes caps the cumulative declared size of every
+	// entry, .rego or not.
+	maxBundleDecompressedBytes = 64 << 20 // 64 MB
+	// maxRegoFileBytes caps a single policy file.
+	maxRegoFileBytes = 1 << 20 // 1 MB
+)
+
 // fetchBundle downloads the bundle archive from bundleURL and returns all
 // .rego files it contains. bundleURL must use HTTPS unless its host is
 // covered by egress's allow-list (loopback/internal test mirrors). The
@@ -92,6 +115,11 @@ func parseBundleTarGz(r io.Reader) ([]regoFile, error) {
 	tr := tar.NewReader(gr)
 	var files []regoFile
 
+	var (
+		entries      int
+		decompressed int64
+	)
+
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -100,15 +128,47 @@ func parseBundleTarGz(r io.Reader) ([]regoFile, error) {
 		if err != nil {
 			return nil, fmt.Errorf("bundle tar: %w", err)
 		}
+
+		// Charged before any filtering, so entries this loop skips still cost
+		// against the budget -- reaching the next header decompresses them
+		// whether or not their contents are wanted.
+		entries++
+		if entries > maxBundleEntries {
+			return nil, fmt.Errorf("bundle contains more than %d entries", maxBundleEntries)
+		}
+		if hdr.Size > 0 {
+			decompressed += hdr.Size
+			if decompressed > maxBundleDecompressedBytes {
+				return nil, fmt.Errorf("bundle decompresses to more than %d bytes",
+					maxBundleDecompressedBytes)
+			}
+		}
+
 		if hdr.Typeflag == tar.TypeDir {
 			continue
 		}
 		if !strings.HasSuffix(hdr.Name, ".rego") {
 			continue
 		}
-		data, err := io.ReadAll(io.LimitReader(tr, 1<<20)) // 1 MB per file
+
+		// Reject an oversized policy rather than truncating it. The previous
+		// io.LimitReader(tr, 1<<20) silently cut a larger file off mid-source:
+		// the bundle then loaded as a POLICY THAT WAS NEVER WRITTEN -- a
+		// truncation landing after an allow rule but before the deny that
+		// qualifies it inverts the outcome, with nothing in the logs to say so.
+		if hdr.Size > maxRegoFileBytes {
+			return nil, fmt.Errorf("policy file %s is %d bytes, over the %d-byte limit",
+				hdr.Name, hdr.Size, maxRegoFileBytes)
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxRegoFileBytes+1))
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", hdr.Name, err)
+		}
+		// hdr.Size is the archive's own claim; this is the byte count actually
+		// produced, so a header understating its body is caught too.
+		if int64(len(data)) > maxRegoFileBytes {
+			return nil, fmt.Errorf("policy file %s exceeds the %d-byte limit",
+				hdr.Name, maxRegoFileBytes)
 		}
 		files = append(files, regoFile{name: hdr.Name, source: string(data)})
 	}

--- a/backend/internal/policy/engine.go
+++ b/backend/internal/policy/engine.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
@@ -44,6 +45,18 @@ func NewPolicyEngineWithGuard(cfg Config, egress *httpsafe.Guard) (*PolicyEngine
 	}
 	if !cfg.Enabled || cfg.BundleURL == "" {
 		return e, nil
+	}
+	// Without a pinned digest the bundle host is fully trusted: whatever it
+	// serves becomes active upload policy on every refresh, and the archive's
+	// resource limits are the only thing standing between a compromised host
+	// and this process (issue #750). Pinning is optional by design -- some
+	// operators rotate policy continuously -- so this warns rather than
+	// refusing, but it says plainly what the deployment is relying on.
+	if cfg.BundleSHA256 == "" {
+		slog.Warn("policy bundle is NOT pinned: policy.bundle_sha256 is empty, so any "+
+			"content served by the bundle host becomes active upload policy",
+			"bundle_url", cfg.BundleURL,
+			"remedy", "set policy.bundle_sha256 to the expected archive digest")
 	}
 	if err := e.loadBundle(context.Background(), cfg.BundleURL); err != nil {
 		return nil, fmt.Errorf("policy engine: loading bundle: %w", err)


### PR DESCRIPTION
Closes #750.

`maxBundleBytes` bounds the **compressed** archive only. gzip amplifies, so 50 MB of archive can encode far more than 50 MB of entries, and every `.rego` entry is retained in memory for the lifetime of the parse — so one 50 MB download from a hostile or compromised bundle host could become an out-of-memory kill.

The test archive makes the amplification concrete:

```
compressed archive: 29146 bytes for 4097 entries
```

Non-`.rego` entries were **worse than unbounded**: they were `continue`d, so their bodies were decompressed to reach the next header and accounted at nothing. Every entry is now charged *before* any filtering, because skipping one is not free.

## A silent truncation the issue didn't mention

The per-file `io.LimitReader(tr, 1<<20)` had no accompanying check, so a larger policy file was cut off mid-source and the remainder loaded **as if it were complete**. The bundle then became a policy that was never written — a truncation landing after an `allow` rule but before the `deny` that qualifies it inverts the outcome, with nothing in the logs to say so.

Oversized files are now rejected, checked against **both** the declared header size and the bytes actually produced, so a header understating its body is caught too.

## Unpinned bundles

Added the startup warning the issue asked for. Without a pinned digest the bundle host is fully trusted, and whatever it serves becomes active upload policy on every refresh. Pinning stays optional — some operators rotate policy continuously — but the log now says plainly what the deployment is relying on.

## Limits

Deliberately generous: **4096 entries**, **64 MB cumulative**, **1 MB per file**. Real OPA bundles hold tens of policies, and a limit that rejects ordinary bundles gets raised until it means nothing. A realistic five-entry bundle and a file of *exactly* the per-file limit are both asserted to pass.

## Verification

| Mutation | Result |
|---|---|
| Drop the entry cap | ✅ FAIL |
| Drop the cumulative budget | ✅ FAIL |
| Charge only `.rego` entries | ✅ FAIL |
| Revert to silent truncation | ✅ FAIL |

`go test ./...` passes across the backend.
