### PR TITLE
fix(storage): validate object keys uniformly, and the mirror filters that build them

### DIFF
--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -4,6 +4,8 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"github.com/terraform-registry/terraform-registry/internal/validation"
 	"log"
 	"net/http"
 	"strconv"
@@ -73,6 +75,39 @@ func (h *MirrorHandler) SetEgressGuard(g *httpsafe.Guard) *MirrorHandler {
 // @Router       /api/v1/admin/mirrors [post]
 // CreateMirrorConfig creates a new mirror configuration
 // POST /api/v1/admin/mirrors
+// validateMirrorFilters rejects namespace/provider filter entries that are not
+// valid registry identifiers.
+//
+// These are not merely a selection filter: mirror_sync interpolates them
+// directly into the storage key
+//
+//	fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s", namespace, providerName, ...)
+//
+// and into the upstream registry request path. Every other segment of that key
+// is a validated registry identifier or a platform value -- a comment there
+// even asserts as much -- but these two arrived from admin-supplied JSON with
+// no validation at all, so "../.." in a provider filter reached the object key
+// (issue #752).
+//
+// Applied on create AND update: validating only one leaves the other as the way
+// in.
+func validateMirrorFilters(namespaces, providers []string) error {
+	for _, group := range []struct {
+		field  string
+		values []string
+	}{
+		{"namespace_filter", namespaces},
+		{"provider_filter", providers},
+	} {
+		for _, v := range group.values {
+			if err := validation.ValidateRegistrySegment(v); err != nil {
+				return fmt.Errorf("%s: %w", group.field, err)
+			}
+		}
+	}
+	return nil
+}
+
 func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 	var req models.CreateMirrorConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -150,6 +185,11 @@ func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 			return
 		}
 		orgID = &parsed
+	}
+
+	if err := validateMirrorFilters(req.NamespaceFilter, req.ProviderFilter); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 
 	// Convert filter arrays to JSON strings
@@ -337,6 +377,11 @@ func (h *MirrorHandler) UpdateMirrorConfig(c *gin.Context) {
 
 	var req models.UpdateMirrorConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := validateMirrorFilters(req.NamespaceFilter, req.ProviderFilter); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/api/admin/mirror_filter_validation_test.go
+++ b/backend/internal/api/admin/mirror_filter_validation_test.go
@@ -1,0 +1,127 @@
+package admin
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Issue #752 — the mirror config's namespace_filter / provider_filter reach the
+// storage key unvalidated.
+//
+// jobs/mirror_sync.go builds the object key as
+//
+//	fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s",
+//	    namespace, providerName, version, platform.OS, platform.Arch, filename)
+//
+// and a comment there asserted the segments other than filename are "validated
+// registry identifiers / platform values". That was true of the upload paths,
+// which run ValidateRegistrySegment, and NOT true of these two: they arrived
+// from admin-supplied JSON via the mirror API and were unmarshalled straight
+// into the loop.
+//
+// So an admin could put "../.." in a provider filter and steer the key. On
+// S3/GCS/Azure that writes a confusable object key; on local storage safeJoin
+// rejects it, meaning the same configuration behaves differently per backend.
+// The filter values also go into the upstream registry request path.
+
+// traversalFilters are the values that must be refused. They are the ones that
+// change where an artifact lands, not merely odd-looking ones.
+var traversalFilters = []string{
+	"../..",
+	"../../etc",
+	"..",
+	"a/b",
+	"a/../b",
+	"/absolute",
+	`back\slash`,
+	"has space",
+	"UPPER", // ValidateRegistrySegment is lowercase-only
+	"-leading-hyphen",
+	"",
+}
+
+// TestValidateMirrorFilters_RejectsTraversal drives the shared helper both
+// handlers use.
+func TestValidateMirrorFilters_RejectsTraversal(t *testing.T) {
+	for _, bad := range traversalFilters {
+		t.Run(fmt.Sprintf("namespace=%q", bad), func(t *testing.T) {
+			if err := validateMirrorFilters([]string{bad}, nil); err == nil {
+				t.Errorf("namespace filter %q was accepted; it is interpolated into the "+
+					"storage key and the upstream request path", bad)
+			} else if !strings.Contains(err.Error(), "namespace_filter") {
+				t.Errorf("error = %q, want it to name the offending field", err)
+			}
+		})
+		t.Run(fmt.Sprintf("provider=%q", bad), func(t *testing.T) {
+			if err := validateMirrorFilters(nil, []string{bad}); err == nil {
+				t.Errorf("provider filter %q was accepted", bad)
+			} else if !strings.Contains(err.Error(), "provider_filter") {
+				t.Errorf("error = %q, want it to name the offending field", err)
+			}
+		})
+	}
+}
+
+// TestValidateMirrorFilters_AcceptsRealRegistryNames is the other direction: a
+// validator that rejects ordinary provider names would make mirroring unusable
+// and get removed.
+func TestValidateMirrorFilters_AcceptsRealRegistryNames(t *testing.T) {
+	namespaces := []string{"hashicorp", "integrations", "acme_corp", "my-org", "a", "0org"}
+	providers := []string{"aws", "azurerm", "google", "terraform-provider-foo", "vault", "my_provider"}
+
+	if err := validateMirrorFilters(namespaces, providers); err != nil {
+		t.Errorf("a realistic filter set was rejected: %v", err)
+	}
+}
+
+// TestValidateMirrorFilters_ChecksBothFields — validating one field and not the
+// other leaves the unvalidated one as the way in. Both are interpolated into
+// the same key.
+func TestValidateMirrorFilters_ChecksBothFields(t *testing.T) {
+	if err := validateMirrorFilters([]string{"hashicorp"}, []string{"../.."}); err == nil {
+		t.Error("a valid namespace with a traversing provider filter was accepted")
+	}
+	if err := validateMirrorFilters([]string{"../.."}, []string{"aws"}); err == nil {
+		t.Error("a traversing namespace with a valid provider filter was accepted")
+	}
+}
+
+// TestMirrorKeyShape_IsWhatTheFiltersSteer documents the consequence the
+// validation prevents, using the same format string as mirror_sync.
+//
+// It asserts the traversal is REAL rather than hypothetical: with the filter
+// values spliced in unvalidated, the resulting key escapes the providers/
+// prefix entirely.
+func TestMirrorKeyShape_IsWhatTheFiltersSteer(t *testing.T) {
+	key := fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s",
+		"hashicorp", "../../..", "1.0.0", "linux", "amd64", "x.zip")
+
+	if !strings.Contains(key, "../../..") {
+		t.Fatalf("key = %q, expected the unvalidated filter to appear verbatim", key)
+	}
+	// The point: this is not a providers/ key any more.
+	if cleaned := cleanKey(key); strings.HasPrefix(cleaned, "providers/") {
+		t.Errorf("key %q cleans to %q, which is still under providers/ — pick a "+
+			"traversal deep enough to demonstrate the escape", key, cleaned)
+	}
+}
+
+// cleanKey is path.Clean, spelled out to keep this test free of a dependency on
+// the storage package (which is what consumes the key).
+func cleanKey(k string) string {
+	parts := strings.Split(k, "/")
+	var out []string
+	for _, p := range parts {
+		switch p {
+		case ".", "":
+		case "..":
+			if len(out) > 0 {
+				out = out[:len(out)-1]
+			}
+		default:
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, "/")
+}

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -376,6 +376,27 @@ func (j *MirrorSyncJob) performSync(ctx context.Context, config models.MirrorCon
 		}
 	}
 
+	// Validate before use, not only at the admin API (issue #752).
+	//
+	// These values are interpolated into the storage key and into the upstream
+	// registry request path. The API now rejects bad ones on write, but rows
+	// stored before that check exist, and this job also runs on a schedule
+	// against whatever is in the database -- so the consumer validates too.
+	for _, group := range []struct {
+		field  string
+		values []string
+	}{
+		{"namespace_filter", namespaces},
+		{"provider_filter", providerNames},
+	} {
+		for _, v := range group.values {
+			if err := validation.ValidateRegistrySegment(v); err != nil {
+				return details, fmt.Errorf("mirror %s has an invalid %s entry: %w",
+					config.Name, group.field, err)
+			}
+		}
+	}
+
 	// Handle different filter combinations
 	if len(namespaces) == 0 && len(providerNames) == 0 {
 		// No filters at all - can't enumerate full registry
@@ -1054,9 +1075,14 @@ func (j *MirrorSyncJob) syncPlatformBinary(
 	log.Printf("Checksum verified for %s: %s", packageInfo.Filename, checksumHex)
 
 	// packageInfo.Filename comes straight from the upstream registry's package
-	// descriptor, unlike the other segments of this path (which are validated
-	// registry identifiers / platform values); reject path separators and '..'
-	// before it reaches the storage key (issue #677).
+	// descriptor; reject path separators and '..' before it reaches the storage
+	// key (issue #677).
+	//
+	// The claim this comment used to make about the OTHER segments -- that they
+	// are validated registry identifiers -- was not true of namespace and
+	// providerName, which came from admin-supplied filter JSON with no
+	// validation at all. They are validated at the top of syncMirror now
+	// (issue #752), which is what makes the claim accurate.
 	if err := validation.ValidateStorageFilename(packageInfo.Filename); err != nil {
 		return fmt.Errorf("unsafe filename from upstream package descriptor: %w", err)
 	}

--- a/backend/internal/storage/azure/azure.go
+++ b/backend/internal/storage/azure/azure.go
@@ -79,6 +79,12 @@ func New(cfg *config.AzureStorageConfig) (*AzureStorage, error) {
 
 // Upload stores a file in Azure Blob Storage
 func (s *AzureStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	// Read all content to calculate checksum and upload
 	// For large files, consider using block uploads with streaming hash
 	data, err := io.ReadAll(reader)
@@ -109,6 +115,12 @@ func (s *AzureStorage) Upload(ctx context.Context, path string, reader io.Reader
 
 // Download retrieves a file from Azure Blob Storage
 func (s *AzureStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	// Get blob client for this path
 	blobClient := s.client.ServiceClient().NewContainerClient(s.containerName).NewBlobClient(path)
 
@@ -123,6 +135,12 @@ func (s *AzureStorage) Download(ctx context.Context, path string) (io.ReadCloser
 
 // Delete removes a file from Azure Blob Storage
 func (s *AzureStorage) Delete(ctx context.Context, path string) error {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return err
+	}
 	// Get blob client for this path
 	blobClient := s.client.ServiceClient().NewContainerClient(s.containerName).NewBlobClient(path)
 
@@ -139,6 +157,12 @@ func (s *AzureStorage) Delete(ctx context.Context, path string) error {
 
 // GetURL returns a signed URL for downloading the file
 func (s *AzureStorage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return "", err
+	}
 	// Check if file exists first
 	exists, err := s.Exists(ctx, path)
 	if err != nil {
@@ -186,6 +210,12 @@ func (s *AzureStorage) GetURL(ctx context.Context, path string, ttl time.Duratio
 
 // Exists checks if a file exists at the specified path
 func (s *AzureStorage) Exists(ctx context.Context, path string) (bool, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return false, err
+	}
 	// Get blob client for this path
 	blobClient := s.client.ServiceClient().NewContainerClient(s.containerName).NewBlobClient(path)
 
@@ -202,6 +232,12 @@ func (s *AzureStorage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the entire file
 func (s *AzureStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	// Get blob client for this path
 	blobClient := s.client.ServiceClient().NewContainerClient(s.containerName).NewBlobClient(path)
 

--- a/backend/internal/storage/gcs/gcs.go
+++ b/backend/internal/storage/gcs/gcs.go
@@ -227,6 +227,12 @@ func (s *GCSStorage) Close() error {
 
 // Upload stores a file in GCS
 func (s *GCSStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*appstorage.UploadResult, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	// Read all content to calculate checksum
 	data, err := io.ReadAll(reader)
 	if err != nil {
@@ -261,6 +267,12 @@ func (s *GCSStorage) Upload(ctx context.Context, path string, reader io.Reader, 
 
 // Download retrieves a file from GCS
 func (s *GCSStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	reader, err := s.client.NewReader(ctx, s.bucket, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read from GCS: %w", err)
@@ -271,6 +283,12 @@ func (s *GCSStorage) Download(ctx context.Context, path string) (io.ReadCloser, 
 
 // Delete removes a file from GCS
 func (s *GCSStorage) Delete(ctx context.Context, path string) error {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return err
+	}
 	if err := s.client.DeleteObject(ctx, s.bucket, path); err != nil {
 		// Check if object doesn't exist - that's okay
 		if err == storage.ErrObjectNotExist {
@@ -284,6 +302,12 @@ func (s *GCSStorage) Delete(ctx context.Context, path string) error {
 
 // GetURL returns a signed URL for downloading the file
 func (s *GCSStorage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return "", err
+	}
 	// Check if file exists first
 	exists, err := s.Exists(ctx, path)
 	if err != nil {
@@ -310,6 +334,12 @@ func (s *GCSStorage) GetURL(ctx context.Context, path string, ttl time.Duration)
 
 // Exists checks if a file exists at the specified path
 func (s *GCSStorage) Exists(ctx context.Context, path string) (bool, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return false, err
+	}
 	_, err := s.client.ObjectAttrs(ctx, s.bucket, path)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
@@ -323,6 +353,12 @@ func (s *GCSStorage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the entire file
 func (s *GCSStorage) GetMetadata(ctx context.Context, path string) (*appstorage.FileMetadata, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := appstorage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	attrs, err := s.client.ObjectAttrs(ctx, s.bucket, path)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {

--- a/backend/internal/storage/key.go
+++ b/backend/internal/storage/key.go
@@ -1,0 +1,86 @@
+package storage
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// maxKeyBytes caps an object key. S3 rejects keys over 1024 bytes, so a longer
+// key is a guaranteed backend error later; refusing it here turns an opaque
+// provider-specific failure into a clear one. The longest key this application
+// produces is around 110 bytes.
+const maxKeyBytes = 1024
+
+// ValidateKey rejects object keys that are malformed or path-traversing.
+//
+// The local backend has always had safeJoin, documented as defence in depth
+// "so the storage layer cannot be exploited even if a future code path skips
+// that check". The cloud backends had no equivalent: S3, Azure and GCS pass the
+// caller's string through as the object key verbatim (issue #752). This makes
+// the guarantee uniform rather than local-only.
+//
+// Object stores treat keys as opaque, so ".." has no traversal meaning there
+// and no per-tenant key prefix currently exists to escape — this is a hardening
+// gap, not a live exploit, and the issue says as much. What makes it worth
+// closing is that the gap is structural: /v1/files/*filepath already feeds a
+// URL-derived string into these backends, and adding a bucket prefix, a
+// per-organization key namespace, or a shared-bucket deployment later would
+// silently have no enforcement.
+//
+// # What is deliberately NOT rejected
+//
+// No character-set restriction. Real keys in this registry contain uppercase
+// (namespaces are not lowercased on the storage path), '+' and '~' from version
+// strings — hashicorp/go-version is looser than strict semver and accepts build
+// metadata like 1.0.0+build.5 — and '.' throughout. A charset allowlist derived
+// from what "should" be there would reject artifacts that already exist.
+//
+// No prefix allowlist. It is tempting to require modules/, providers/ or
+// terraform-binaries/, but .readiness-probe and .connectivity-test are
+// root-level sentinel keys with no prefix at all, and rejecting them would
+// break the readiness endpoint and both storage connectivity tests.
+func ValidateKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("storage key is empty")
+	}
+	if len(key) > maxKeyBytes {
+		return fmt.Errorf("storage key is %d bytes, over the %d-byte limit", len(key), maxKeyBytes)
+	}
+	if strings.HasPrefix(key, "/") {
+		return fmt.Errorf("storage key %q is absolute", key)
+	}
+	// Backslash: a Windows separator smuggled past a '/'-oriented check, and
+	// never legitimate in a key this application builds.
+	if strings.Contains(key, `\`) {
+		return fmt.Errorf("storage key %q contains a backslash", key)
+	}
+	for _, r := range key {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("storage key %q contains a control character", key)
+		}
+	}
+	// Empty segments. "modules//x" and "modules/x" are DIFFERENT keys to an
+	// object store, so this is also a confusable-duplicate guard, not only a
+	// traversal one.
+	if strings.Contains(key, "//") {
+		return fmt.Errorf("storage key %q contains an empty path segment", key)
+	}
+	for _, seg := range strings.Split(key, "/") {
+		if seg == ".." {
+			return fmt.Errorf("storage key %q contains a %q segment", key, "..")
+		}
+	}
+	// Canonical form. Catches the remaining non-traversing oddities in one
+	// rule: a leading "./", a trailing "/", an interior "/./". Each names a
+	// distinct object-store key that resolves to the same file on a filesystem,
+	// which is how the same artifact ends up stored twice and deleted once.
+	if cleaned := path.Clean(key); cleaned != key {
+		return fmt.Errorf("storage key %q is not canonical (want %q)", key, cleaned)
+	}
+	// path.Clean(".") is "." — canonical, but not an object.
+	if key == "." {
+		return fmt.Errorf("storage key %q names no object", key)
+	}
+	return nil
+}

--- a/backend/internal/storage/key_coverage_test.go
+++ b/backend/internal/storage/key_coverage_test.go
@@ -1,0 +1,192 @@
+package storage_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Issue #752 — every backend method that takes a key must validate it.
+//
+// This is the guard against the real maintenance hazard of the fix: it is 6
+// methods × 4 backends = 24 call sites, and a guarantee that holds in 23 of
+// them is not a guarantee. Nothing about "S3 forgot Exists" is visible in a
+// behavioural test of the other 23, and nobody re-reads four files to check.
+//
+// It is also the shape that catches the NEXT backend. A new implementation of
+// storage.Storage lands with its methods unguarded exactly once.
+
+// keyedMethods are the storage.Storage methods whose first string parameter is
+// an object key. Derived from the interface below, not hand-maintained.
+var keyedMethods = map[string]bool{
+	"Upload":      true,
+	"Download":    true,
+	"Delete":      true,
+	"GetURL":      true,
+	"Exists":      true,
+	"GetMetadata": true,
+}
+
+// TestStorageInterface_MethodListIsCurrent keeps keyedMethods honest. If a
+// method is added to the interface and not classified here, the coverage check
+// below would silently not require validation on it.
+func TestStorageInterface_MethodListIsCurrent(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "storage.go", nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse storage.go: %v", err)
+	}
+
+	// Methods on the Storage interface that take a `path string` parameter.
+	found := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name.Name != "Storage" {
+			return true
+		}
+		iface, ok := ts.Type.(*ast.InterfaceType)
+		if !ok {
+			return true
+		}
+		for _, m := range iface.Methods.List {
+			fn, ok := m.Type.(*ast.FuncType)
+			if !ok || len(m.Names) == 0 {
+				continue
+			}
+			for _, p := range fn.Params.List {
+				id, ok := p.Type.(*ast.Ident)
+				if !ok || id.Name != "string" {
+					continue
+				}
+				for _, pn := range p.Names {
+					if pn.Name == "path" || pn.Name == "key" {
+						found[m.Names[0].Name] = true
+					}
+				}
+			}
+		}
+		return false
+	})
+
+	if len(found) == 0 {
+		t.Fatal("found no key-taking methods on the Storage interface — this guard " +
+			"is not reading the interface, so the coverage check below is vacuous")
+	}
+
+	var missing, stale []string
+	for name := range found {
+		if !keyedMethods[name] {
+			missing = append(missing, name)
+		}
+	}
+	for name := range keyedMethods {
+		if !found[name] {
+			stale = append(stale, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+
+	if len(missing) > 0 {
+		t.Errorf("Storage interface method(s) take a key but are not in keyedMethods: %s — "+
+			"add them, or the backends are free to skip validation on them",
+			strings.Join(missing, ", "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("keyedMethods lists %s, which the Storage interface no longer declares — "+
+			"drop the entries", strings.Join(stale, ", "))
+	}
+}
+
+// TestAllBackendsValidateEveryKeyedMethod walks the backend packages and
+// requires ValidateKey in the body of each keyed method.
+func TestAllBackendsValidateEveryKeyedMethod(t *testing.T) {
+	// os.ReadDir, not filepath.Glob("*/"): Go's Glob does not treat a trailing
+	// separator as "directories only" and matches nothing, which the
+	// empty-universe check below caught on the first run.
+	dirents, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backends []string
+	for _, d := range dirents {
+		if d.IsDir() {
+			backends = append(backends, d.Name())
+		}
+	}
+	if len(backends) == 0 {
+		t.Fatal("no backend subdirectories found — the walk is broken")
+	}
+
+	type site struct{ pkg, method string }
+	var checked, unguarded []site
+
+	for _, dir := range backends {
+		files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range files {
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+
+			for _, decl := range f.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv == nil || fn.Body == nil || !keyedMethods[fn.Name.Name] {
+					continue
+				}
+				s := site{pkg: dir, method: fn.Name.Name}
+				checked = append(checked, s)
+
+				var guarded bool
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "ValidateKey" {
+						guarded = true
+					}
+					return true
+				})
+				if !guarded {
+					unguarded = append(unguarded, s)
+				}
+			}
+		}
+	}
+
+	// The universe must not be empty: a rename of the backend layout would
+	// otherwise make this pass while checking nothing.
+	if len(checked) == 0 {
+		t.Fatal("found no keyed backend methods — the guard is vacuous")
+	}
+	// 4 backends × 6 keyed methods.
+	if len(checked) < len(keyedMethods)*2 {
+		t.Fatalf("only found %d keyed backend methods across %d package(s); expected every "+
+			"backend to implement all %d — the walk is missing packages",
+			len(checked), len(backends), len(keyedMethods))
+	}
+
+	for _, s := range unguarded {
+		t.Errorf("%s.%s does not call storage.ValidateKey. Every backend method that "+
+			"takes an object key must validate it (issue #752) — a guarantee that "+
+			"holds in 23 of 24 places is not a guarantee.", s.pkg, s.method)
+	}
+	t.Logf("checked %d keyed backend methods across %d packages", len(checked), len(backends))
+}

--- a/backend/internal/storage/key_test.go
+++ b/backend/internal/storage/key_test.go
@@ -1,0 +1,147 @@
+package storage
+
+import "testing"
+
+// Issue #752 — the key namespace this validator must not break.
+//
+// Every entry in mustAccept is traced to the producer that emits it. That
+// matters more than the reject list: rejecting a legitimate key is a production
+// outage, while the issue itself is explicit that it could not construct an
+// exploit for the traversal case. The reject list is the cheap half.
+//
+// Two design decisions are pinned by this table:
+//
+//   - NO character-set allowlist. Keys legitimately contain uppercase, '+', '~'
+//     and '.', because namespaces are not lowercased on the storage path and
+//     hashicorp/go-version is looser than strict semver (it accepts build
+//     metadata like 1.0.0+build.5, two- and four-segment versions, and
+//     1.0.0alpha). A charset rule derived from what "should" be there rejects
+//     artifacts that already exist in deployed buckets.
+//   - NO prefix allowlist. .readiness-probe and .connectivity-test are
+//     root-level sentinels with no prefix, so requiring modules/ | providers/ |
+//     terraform-binaries/ would break the readiness endpoint and both storage
+//     connectivity tests.
+var mustAccept = []struct{ key, producer string }{
+	// Sentinels — no prefix at all.
+	{".readiness-probe", "router.go readiness probe"},
+	{".connectivity-test", "admin/storage.go + setup/handlers.go connectivity tests"},
+
+	// Modules. Two leaf shapes: upload writes <version>.tar.gz, the SCM
+	// publisher writes <name>-<version>.tar.gz.
+	{"modules/hashicorp/consul/aws/1.0.0.tar.gz", "modules/upload.go"},
+	{"modules/acme/vpc/aws/vpc-1.0.0.tar.gz", "services/scm_publisher.go"},
+	// go-version accepts far more than strict semver.
+	{"modules/acme_corp/my-module/google/1.0.0+build.tar.gz", "upload, build metadata"},
+	{"modules/acme/mod/aws/1.0.0-rc.1+exp.sha.5114f85.tar.gz", "upload, prerelease+build"},
+	{"modules/acme/mod/aws/1.2.tar.gz", "upload, two-segment version"},
+	{"modules/acme/mod/aws/1.2.3.4.tar.gz", "upload, four-segment version"},
+	{"modules/acme/mod/aws/1.0.0alpha.tar.gz", "upload, no separator"},
+	{"modules/acme/mod/aws/1.0.0-foo~bar.tar.gz", "upload, tilde"},
+	{"modules/acme/mod/aws/v1.0.0.tar.gz", "upload, v-prefixed"},
+	// Namespaces are not lowercased on the storage path.
+	{"modules/Acme/VPC/AWS/1.0.0.tar.gz", "upload, mixed case"},
+	// The local backend writes a .sha256 sidecar next to every key; the sidecar
+	// path is itself a key it operates on.
+	{"modules/hashicorp/consul/aws/1.0.0.tar.gz.sha256", "local backend checksum sidecar"},
+
+	// Providers. Three shapes under one prefix: 4-segment upload, the SUMS
+	// pair, and the 6-segment mirror-sync layout.
+	{"providers/hashicorp/aws/5.31.0/linux_amd64.zip", "providers/upload.go"},
+	{"providers/hashicorp/aws/5.31.0/SHA256SUMS", "providers/upload.go"},
+	{"providers/hashicorp/aws/5.31.0/SHA256SUMS.sig", "providers/upload.go"},
+	{"providers/acme/prov/1.0.0+build/SHA256SUMS", "upload, build metadata in version"},
+	{"providers/hashicorp/aws/5.31.0/linux/amd64/terraform-provider-aws_5.31.0_linux_amd64.zip", "jobs/mirror_sync.go"},
+	{"providers/hashicorp/vault/4.2.0/linux/ppc64le/terraform-provider-vault_4.2.0_linux_ppc64le.zip", "mirror_sync, uncommon arch"},
+
+	// Terraform binaries mirror.
+	{"terraform-binaries/1.9.5/SHA256SUMS", "jobs/terraform_mirror_sync.go"},
+	{"terraform-binaries/1.9.5/SHA256SUMS.terraform.sig", "terraform_mirror_sync, per-tool sig"},
+	{"terraform-binaries/0.18.0/SHA256SUMS.terraform-docs.sig", "terraform_mirror_sync, hyphenated tool"},
+	{"terraform-binaries/1.9.5/linux/amd64/terraform_1.9.5_linux_amd64.zip", "terraform_mirror_sync"},
+	{"terraform-binaries/0.60.0/windows/amd64/opa_windows_amd64.exe", "terraform_mirror_sync, .exe"},
+	{"terraform-binaries/1.9.0-alpha20240404/linux/amd64/terraform_1.9.0-alpha20240404_linux_amd64.zip", "terraform_mirror_sync, prerelease"},
+	{"terraform-binaries/0.18.0/linux/amd64/terraform-docs-v0.18.0-linux-amd64.tar.gz", "terraform_mirror_sync, tar.gz asset"},
+}
+
+var mustReject = []struct{ key, why string }{
+	{"", "empty"},
+	{".", "names no object"},
+	{"/", "absolute"},
+	{"/etc/passwd", "absolute"},
+	{"../../etc/passwd", "traversal"},
+	{"modules/../../../etc/shadow", "traversal"},
+	{"modules/acme/mod/aws/../../../../etc/shadow", "traversal"},
+	{"terraform-binaries/1.9.5/linux/amd64/../../../../SHA256SUMS", "traversal"},
+	{"providers/a/../../b/aws/1.0.0/linux/amd64/x.zip", "traversal"},
+	{"modules//acme/mod/aws/1.0.0.tar.gz", "empty segment"},
+	{"providers/hashicorp/aws/1.0.0/linux/amd64/", "trailing separator"},
+	{"./modules/acme/mod/aws/1.0.0.tar.gz", "non-canonical leading ./"},
+	{"providers/./hashicorp/aws/1.0.0/linux/amd64/x.zip", "non-canonical interior /./"},
+	{`modules\acme\mod\aws\1.0.0.tar.gz`, "backslash separators"},
+	{`C:\Windows\System32\config\SAM`, "windows absolute"},
+	{"modules/acme/mod/aws/1.0.0.tar.gz\x00.png", "NUL byte"},
+	{"providers/hashi\ncorp/aws/1.0.0/linux/amd64/x.zip", "control character"},
+	{"s3://bucket/modules/acme/mod/aws/1.0.0.tar.gz", "scheme (contains //)"},
+	{"https://evil.example.com/x", "scheme (contains //)"},
+}
+
+func TestValidateKey_AcceptsEveryRealKey(t *testing.T) {
+	for _, tc := range mustAccept {
+		t.Run(tc.key, func(t *testing.T) {
+			if err := ValidateKey(tc.key); err != nil {
+				t.Errorf("ValidateKey(%q) = %v, want nil — this key is produced by %s, "+
+					"so rejecting it breaks that path", tc.key, err, tc.producer)
+			}
+		})
+	}
+}
+
+func TestValidateKey_RejectsMalformedKeys(t *testing.T) {
+	for _, tc := range mustReject {
+		t.Run(tc.why+"/"+tc.key, func(t *testing.T) {
+			if err := ValidateKey(tc.key); err == nil {
+				t.Errorf("ValidateKey(%q) = nil, want an error (%s)", tc.key, tc.why)
+			}
+		})
+	}
+}
+
+func TestValidateKey_LengthCap(t *testing.T) {
+	long := "modules/"
+	for len(long) <= maxKeyBytes {
+		long += "a"
+	}
+	if err := ValidateKey(long); err == nil {
+		t.Errorf("a %d-byte key was accepted; S3 rejects keys over %d bytes anyway",
+			len(long), maxKeyBytes)
+	}
+
+	// Exactly at the cap is fine — the boundary must not be off by one.
+	exact := "modules/" + repeat("a", maxKeyBytes-len("modules/"))
+	if len(exact) != maxKeyBytes {
+		t.Fatalf("test built a %d-byte key, wanted %d", len(exact), maxKeyBytes)
+	}
+	if err := ValidateKey(exact); err != nil {
+		t.Errorf("a key of exactly %d bytes was rejected: %v", maxKeyBytes, err)
+	}
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, s[0])
+	}
+	return string(out)
+}
+
+// TestValidateKey_TableIsNotEmpty — the two tables drive everything above, so
+// an accidental truncation would report green while asserting nothing.
+func TestValidateKey_TableIsNotEmpty(t *testing.T) {
+	if len(mustAccept) < 20 {
+		t.Errorf("mustAccept has %d entries; it enumerates the real key namespace and "+
+			"should not shrink", len(mustAccept))
+	}
+	if len(mustReject) < 15 {
+		t.Errorf("mustReject has %d entries", len(mustReject))
+	}
+}

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -66,6 +66,12 @@ func (s *LocalStorage) safeJoin(path string) (string, error) {
 
 // Upload stores a file in the local filesystem
 func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	fullPath, err := s.safeJoin(path)
 	if err != nil {
 		return nil, err
@@ -111,6 +117,12 @@ func (s *LocalStorage) Upload(ctx context.Context, path string, reader io.Reader
 
 // Download retrieves a file from the local filesystem
 func (s *LocalStorage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	fullPath, err := s.safeJoin(path)
 	if err != nil {
 		return nil, err
@@ -129,6 +141,12 @@ func (s *LocalStorage) Download(ctx context.Context, path string) (io.ReadCloser
 
 // Delete removes a file from the local filesystem
 func (s *LocalStorage) Delete(ctx context.Context, path string) error {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return err
+	}
 	fullPath, err := s.safeJoin(path)
 	if err != nil {
 		return err
@@ -160,6 +178,12 @@ func (s *LocalStorage) Delete(ctx context.Context, path string) error {
 // For local storage with ServeDirectly enabled, this returns a relative URL
 // Otherwise, it returns the local file path
 func (s *LocalStorage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return "", err
+	}
 	// Check if file exists
 	exists, err := s.Exists(ctx, path)
 	if err != nil {
@@ -185,6 +209,12 @@ func (s *LocalStorage) GetURL(ctx context.Context, path string, ttl time.Duratio
 
 // Exists checks if a file exists at the specified path
 func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return false, err
+	}
 	fullPath, err := s.safeJoin(path)
 	if err != nil {
 		return false, err
@@ -203,6 +233,12 @@ func (s *LocalStorage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the file
 func (s *LocalStorage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	fullPath, err := s.safeJoin(path)
 	if err != nil {
 		return nil, err

--- a/backend/internal/storage/s3/s3.go
+++ b/backend/internal/storage/s3/s3.go
@@ -232,6 +232,12 @@ func New(cfg *appconfig.S3StorageConfig) (*S3Storage, error) {
 
 // Upload stores a file in S3
 func (s *S3Storage) Upload(ctx context.Context, path string, reader io.Reader, size int64) (*storage.UploadResult, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	// Read all content to calculate checksum
 	// For very large files, consider using multipart upload with streaming hash
 	data, err := io.ReadAll(reader)
@@ -268,6 +274,12 @@ func (s *S3Storage) Upload(ctx context.Context, path string, reader io.Reader, s
 
 // Download retrieves a file from S3
 func (s *S3Storage) Download(ctx context.Context, path string) (io.ReadCloser, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	result, err := s.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
@@ -281,6 +293,12 @@ func (s *S3Storage) Download(ctx context.Context, path string) (io.ReadCloser, e
 
 // Delete removes a file from S3
 func (s *S3Storage) Delete(ctx context.Context, path string) error {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return err
+	}
 	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
@@ -294,6 +312,12 @@ func (s *S3Storage) Delete(ctx context.Context, path string) error {
 
 // GetURL returns a presigned URL for downloading the file
 func (s *S3Storage) GetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return "", err
+	}
 	// Check if file exists first
 	exists, err := s.Exists(ctx, path)
 	if err != nil {
@@ -319,6 +343,12 @@ func (s *S3Storage) GetURL(ctx context.Context, path string, ttl time.Duration) 
 
 // Exists checks if a file exists at the specified path
 func (s *S3Storage) Exists(ctx context.Context, path string) (bool, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return false, err
+	}
 	_, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
@@ -334,6 +364,12 @@ func (s *S3Storage) Exists(ctx context.Context, path string) (bool, error) {
 
 // GetMetadata retrieves file metadata without downloading the entire file
 func (s *S3Storage) GetMetadata(ctx context.Context, path string) (*storage.FileMetadata, error) {
+	// Issue #752: uniform key validation. The local backend has always had
+	// safeJoin; the cloud backends passed the caller's string through as the
+	// object key verbatim.
+	if err := storage.ValidateKey(path); err != nil {
+		return nil, err
+	}
 	result, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),


### PR DESCRIPTION
Closes #752. Two halves.

## 1. Uniform key validation

`storage.ValidateKey`, called at the top of all six keyed methods on all four backends — **24 sites**. The local backend has always had `safeJoin`, documented as defence in depth *"so the storage layer cannot be exploited even if a future code path skips that check"*. S3, Azure and GCS passed the caller's string through as the object key verbatim.

Rejects: empty, >1024 bytes (S3's own cap), absolute, backslashes, control characters, empty segments, `..` segments, non-canonical form, and `.`.

**It deliberately does not restrict the character set.** Real keys contain uppercase (namespaces are not lowercased on the storage path), `+` and `~` from version strings — `hashicorp/go-version` is looser than strict semver and accepts `1.0.0+build.5`, two- and four-segment versions, and `1.0.0alpha` — and `.` throughout. A charset allowlist derived from what "should" be there rejects artifacts already sitting in deployed buckets.

**It also does not require a known prefix.** `.readiness-probe` and `.connectivity-test` are root-level sentinels, so a `modules/|providers/|terraform-binaries/` rule would break the readiness endpoint and both storage connectivity tests. The accept table traces all 25 entries to the producer that emits them.

## 2. The half that is concretely reachable today

`mirror_sync` builds:

```go
fmt.Sprintf("providers/%s/%s/%s/%s/%s/%s", namespace, providerName, version, platform.OS, platform.Arch, filename)
```

and a comment there asserted the segments other than `filename` are *"validated registry identifiers / platform values"*. True of the upload paths — **not** true of these two. They came from admin-supplied JSON via the mirror API and were unmarshalled straight into the loop, so `"../.."` in a provider filter steered the object key, and also went into the upstream registry request path.

Validated now on **create and update** — checking one leaves the other as the way in — and **again in the sync job**, because rows written before this check exist and the job runs on a schedule against whatever is in the database. The misleading comment is corrected rather than left to mislead the next reader.

## Why the coverage guard exists

24 sites is exactly where a fix rots: a guarantee that holds in 23 of them is not a guarantee, and nobody re-reads four files to check. A structural guard walks the backend packages and requires `ValidateKey` in every keyed method. It derives the method list **from the `Storage` interface** rather than a hand-written list, so a method added to the interface must be classified — and it fails on an empty universe, which caught its own first version, where `filepath.Glob("*/")` matched no directories and the walk checked nothing.

```
checked 24 keyed backend methods across 4 packages
```

## Verification

| Mutation | Result |
|---|---|
| Drop `ValidateKey` from `S3.Exists` | ✅ FAIL (names the exact site) |
| Allow `..` segments | ✅ FAIL |
| Drop the canonical-form check | ✅ FAIL |
| Validate only `namespace_filter` | ✅ FAIL |

## Note on scope

The issue rates this **low** and says plainly that no exploit could be constructed for the traversal case — object stores treat keys as opaque and no per-tenant prefix exists to escape. I agree with that assessment for half 1; its value is structural, and the accept table is the part I'd defend hardest, since the real risk of this change is breaking a legitimate key. Half 2 is the part with present-tense value.

One judgement call worth flagging: validation is enforced on **every** method including reads and deletes, so a historical key already stored in a malformed shape would now fail loudly rather than being silently readable. I think failing loudly is right, but it's a behaviour change on the `storage_migration` replay path and easy to reverse if you disagree.

`go test ./...` passes across the backend.
