### PR TITLE
fix(middleware): let mTLS clients mutate, without blanket-exempting them from CSRF

### DIFF
--- a/backend/internal/middleware/csrf.go
+++ b/backend/internal/middleware/csrf.go
@@ -169,6 +169,9 @@ func requestOrigin(c *gin.Context) string {
 //	jwt (Bearer) absent          exempt (programmatic client: CLI, CI, curl)
 //	jwt (Bearer) present         origin allowlist — 403 unless scheme+host matches
 //	                             server public/base URL or a configured CORS origin
+//	mtls         absent          exempt (machine-to-machine client)
+//	mtls         present         origin allowlist — a browser holding a client
+//	                             certificate presents it automatically, like a cookie
 //	jwt_cookie   any             double-submit token validation
 //
 // Bearer browser clients may not hold the tfr_csrf cookie (they never went
@@ -195,13 +198,26 @@ func CSRFMiddleware(cfg *config.Config) gin.HandlerFunc {
 			}
 		}
 
-		// Bearer header JWT (auth_method == "jwt"). Historically exempted as
+		// Bearer header JWT (auth_method == "jwt") and mTLS client certificates
+		// (auth_method == "mtls"). Historically the JWT case was exempted as
 		// "programmatic", but a browser can carry a Bearer token too. Detect
 		// browser context via Origin (Referer fallback): no Origin/Referer means
 		// a non-browser client and stays exempt; a browser origin must match the
 		// deployment's own origins or the request is rejected.
+		//
+		// mTLS is handled here, not exempted outright (issue #746). It reached
+		// the cookie branch below, which assumes cookie authentication, so every
+		// mutating request from an mTLS client got 403 "CSRF cookie missing" --
+		// the documented machine-to-machine path could not perform a single
+		// mutation. Failing closed, but unusable.
+		//
+		// The blanket exemption that would obviously fix it is wrong for the
+		// same reason it was wrong for Bearer: a browser that holds a client
+		// certificate presents it automatically on a cross-site request, exactly
+		// like a cookie. So mTLS gets the identical treatment -- exempt with no
+		// browser context, origin-checked with one.
 		if authMethod, exists := c.Get("auth_method"); exists {
-			if am, ok := authMethod.(string); ok && am == "jwt" {
+			if am, ok := authMethod.(string); ok && (am == "jwt" || am == "mtls") {
 				origin := requestOrigin(c)
 				if origin == "" {
 					// No browser context — programmatic client, exempt.

--- a/backend/internal/middleware/csrf_test.go
+++ b/backend/internal/middleware/csrf_test.go
@@ -422,3 +422,95 @@ func TestGenerateCSRFToken_Uniqueness(t *testing.T) {
 		tokens[tok] = true
 	}
 }
+
+// Issue #746 — mTLS clients were rejected by CSRF on every mutating request.
+//
+// mtls.AuthMiddleware sets auth_method = "mtls" and AuthMiddleware lets such
+// requests through with no bearer token and no cookie. CSRFMiddleware's matrix
+// covered only api_key, jwt and jwt_cookie, so an mTLS request fell to the
+// final branch — which assumes cookie authentication, found no tfr_csrf cookie,
+// and returned 403 for every POST/PUT/PATCH/DELETE. The documented
+// machine-to-machine path could not perform a single mutation.
+//
+// The direction of failure was safe, which is why it went unnoticed: it also
+// means no test crossed the mTLS chain and the CSRF middleware together.
+
+func csrfRequestAs(t *testing.T, cfg *config.Config, authMethod, method, origin string) int {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("auth_method", authMethod) })
+	r.Use(CSRFMiddleware(cfg))
+	r.Handle(method, "/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(method, "/x", nil)
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// TestCSRF_MTLSMachineClientCanMutate is the regression: no Origin (a machine
+// client), so the request must go through.
+func TestCSRF_MTLSMachineClientCanMutate(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		t.Run(method, func(t *testing.T) {
+			if code := csrfRequestAs(t, csrfTestConfig(), "mtls", method, ""); code != http.StatusOK {
+				t.Errorf("%s as an mTLS machine client = %d, want 200 — the documented "+
+					"m2m path must be able to mutate", method, code)
+			}
+		})
+	}
+}
+
+// TestCSRF_MTLSFromAForeignOriginIsRejected is why mTLS is NOT blanket-exempt.
+//
+// A browser holding a client certificate presents it automatically on a
+// cross-site request, exactly like a cookie. Exempting mTLS outright — the
+// obvious one-line fix — would open the cross-site hole for anyone who
+// provisions client certs to browsers.
+func TestCSRF_MTLSFromAForeignOriginIsRejected(t *testing.T) {
+	if code := csrfRequestAs(t, csrfTestConfig(), "mtls", "POST", "https://evil.example.com"); code != http.StatusForbidden {
+		t.Errorf("mTLS POST from a foreign origin = %d, want 403 — a browser-held "+
+			"client certificate is auto-presented cross-site", code)
+	}
+}
+
+// TestCSRF_MTLSFromTheDeploymentsOwnOriginIsAllowed — a same-origin browser
+// request with a client cert is legitimate.
+func TestCSRF_MTLSFromOwnOriginIsAllowed(t *testing.T) {
+	if code := csrfRequestAs(t, csrfTestConfig(), "mtls", "POST", "https://registry.example.com"); code != http.StatusOK {
+		t.Errorf("mTLS POST from the deployment's own origin = %d, want 200", code)
+	}
+}
+
+// TestCSRF_MTLSMatchesTheJWTTreatment pins that the two are handled
+// identically. If they ever diverge, one of them is wrong — they are the same
+// shape of credential for CSRF purposes: not a cookie, but browser-auto-sendable.
+func TestCSRF_MTLSMatchesTheJWTTreatment(t *testing.T) {
+	cfg := csrfTestConfig()
+	for _, tc := range []struct{ name, origin string }{
+		{"no origin", ""},
+		{"own origin", "https://registry.example.com"},
+		{"foreign origin", "https://evil.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			jwtCode := csrfRequestAs(t, cfg, "jwt", "POST", tc.origin)
+			mtlsCode := csrfRequestAs(t, cfg, "mtls", "POST", tc.origin)
+			if jwtCode != mtlsCode {
+				t.Errorf("jwt = %d but mtls = %d for %s; the two must be treated alike",
+					jwtCode, mtlsCode, tc.name)
+			}
+		})
+	}
+}
+
+// TestCSRF_CookieAuthStillRequiresTheToken — the change must not weaken the
+// branch it moved mTLS out of.
+func TestCSRF_CookieAuthStillRequiresTheToken(t *testing.T) {
+	if code := csrfRequestAs(t, csrfTestConfig(), "jwt_cookie", "POST", ""); code != http.StatusForbidden {
+		t.Errorf("cookie-authenticated POST with no CSRF token = %d, want 403", code)
+	}
+}


### PR DESCRIPTION
Closes #746.

`mtls.AuthMiddleware` sets `auth_method = "mtls"` and `AuthMiddleware` lets such requests through with no bearer token and no cookie — but `CSRFMiddleware`'s enforcement matrix covered only `api_key`, `jwt` and `jwt_cookie`. An mTLS request therefore fell to the final branch, which **assumes cookie authentication**, found no `tfr_csrf` cookie, and returned `403 {"error":"CSRF cookie missing"}` for every `POST`/`PUT`/`PATCH`/`DELETE`.

The documented machine-to-machine path could not perform a single mutation. The direction of failure was safe, which is why it went unnoticed — and it also means nothing exercised the mTLS chain and the CSRF middleware together.

## Why not the one-line exemption

The obvious fix is to add `"mtls"` to the `api_key` exemption. That is wrong for the same reason it was wrong for Bearer JWT, which this file had already worked out:

> Historically exempted as "programmatic", but a browser can carry a Bearer token too.

A browser that holds a client certificate **presents it automatically on a cross-site request, exactly like a cookie**. Blanket-exempting mTLS would open the cross-site hole for any deployment that provisions client certs to browsers.

So mTLS gets the identical treatment to Bearer: exempt with no browser context, origin-allowlisted with one.

| auth_method | Origin/Referer | enforcement |
|---|---|---|
| `mtls` | absent | exempt (machine-to-machine client) |
| `mtls` | present | origin allowlist |

## Verification

| Mutation | Result |
|---|---|
| Revert — mTLS falls to the cookie branch | ✅ FAIL (machine client can't mutate) |
| **Blanket-exempt mTLS** (the wrong fix) | ✅ FAIL (foreign origin accepted) |

That second row is the one I care about: the tests reject the plausible-but-wrong fix, not just the original bug. A further test asserts `jwt` and `mtls` return the **same** status for no-origin, own-origin and foreign-origin, so the two cannot silently diverge later.

`go test ./...` passes across the backend.