### PR TITLE
refactor(storage): make safeJoin check the value it returns

### DIFF
--- a/backend/internal/storage/local/delete_parent_walk_test.go
+++ b/backend/internal/storage/local/delete_parent_walk_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -144,5 +145,68 @@ func TestDelete_StopsAtANonEmptyParent(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(base, "2.0.0.tar.gz")); err != nil {
 		t.Errorf("sibling artifact was removed: %v", err)
+	}
+}
+
+// TestSafeJoin_ReturnsACleanedPath — safeJoin must return the same value it
+// checked (CodeQL alerts 57/60, go/path-injection).
+//
+// It used to check filepath.Clean(full) and return plain full. Identical in
+// practice, since filepath.Join already cleans, but the containment test then
+// named a different expression than the one leaving the function — so the
+// sanitiser was invisible to dataflow analysis, and Delete's os.Remove calls
+// stayed flagged HIGH.
+//
+// Note honestly what this test can and cannot do: filepath.Join already cleans,
+// so the OLD code also returned a canonical path. This change has no
+// behavioural effect and no test can distinguish it -- reverting it leaves this
+// test passing. It pins the property so a future edit cannot quietly break it;
+// whether CodeQL now recognises the sanitiser is confirmed by the next scan,
+// not here.
+func TestSafeJoin_ReturnsACleanedPath(t *testing.T) {
+	root := t.TempDir()
+	s, err := New(&config.LocalStorageConfig{BasePath: root}, "http://localhost")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for _, key := range []string{
+		"modules/acme/vpc/aws/1.0.0.tar.gz",
+		"modules/acme/vpc/aws/./1.0.0.tar.gz",
+		"modules//acme/vpc/aws/1.0.0.tar.gz",
+		"modules/acme/extra/../vpc/aws/1.0.0.tar.gz",
+	} {
+		t.Run(key, func(t *testing.T) {
+			got, err := s.safeJoin(key)
+			if err != nil {
+				t.Fatalf("safeJoin(%q): %v", key, err)
+			}
+			if cleaned := filepath.Clean(got); got != cleaned {
+				t.Errorf("safeJoin(%q) = %q, which is not canonical (%q). The value "+
+					"returned must be the value checked.", key, got, cleaned)
+			}
+			if !strings.HasPrefix(got, filepath.Clean(root)+string(os.PathSeparator)) {
+				t.Errorf("safeJoin(%q) = %q, outside the storage root %q", key, got, root)
+			}
+		})
+	}
+}
+
+// TestSafeJoin_StillRejectsEscapes — the change must not weaken containment.
+func TestSafeJoin_StillRejectsEscapes(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "storage")
+	s, err := New(&config.LocalStorageConfig{BasePath: root}, "http://localhost")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	for _, key := range []string{
+		"../escape.txt",
+		"../../etc/passwd",
+		"modules/../../../etc/shadow",
+	} {
+		if _, err := s.safeJoin(key); err == nil {
+			t.Errorf("safeJoin(%q) was accepted; it escapes the storage root", key)
+		}
 	}
 }

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -67,11 +67,21 @@ func New(cfg *config.LocalStorageConfig, serverBaseURL string) (*LocalStorage, e
 // this ensures the storage layer cannot be exploited even if a future code path
 // skips that check.
 func (s *LocalStorage) safeJoin(path string) (string, error) {
-	full := filepath.Join(s.basePath, filepath.FromSlash(path))
-	// filepath.Clean normalises the joined path (resolves any remaining ".." segments).
-	// We require the result to remain inside basePath by verifying the prefix.
+	// Cleaned once, up front, so the value CHECKED below and the value RETURNED
+	// are the same variable.
+	//
+	// This was previously `full := filepath.Join(...)` with the containment test
+	// applied to `filepath.Clean(full)` while plain `full` was returned.
+	// Functionally identical -- filepath.Join already cleans -- but the test then
+	// referred to a different expression than the one that escapes the function,
+	// which is why CodeQL's go/path-injection could not recognise safeJoin as a
+	// sanitiser and kept flagging Delete's os.Remove calls as HIGH.
+	//
+	// Checking exactly what you return is the clearer contract regardless of the
+	// scanner.
+	full := filepath.Clean(filepath.Join(s.basePath, filepath.FromSlash(path)))
 	base := filepath.Clean(s.basePath) + string(os.PathSeparator)
-	if !strings.HasPrefix(filepath.Clean(full)+string(os.PathSeparator), base) {
+	if !strings.HasPrefix(full+string(os.PathSeparator), base) {
 		return "", fmt.Errorf("path escapes storage root: %s", path)
 	}
 	return full, nil


### PR DESCRIPTION
Addresses the two remaining CodeQL alerts (57, 60 — `go/path-injection`, HIGH) on `Delete`'s `os.Remove` calls.

Both are guarded by `safeJoin`, but:

```go
full := filepath.Join(s.basePath, filepath.FromSlash(path))
if !strings.HasPrefix(filepath.Clean(full)+string(os.PathSeparator), base) { ... }
return full, nil          // <-- checked Clean(full), returned full
```

The containment test named a **different expression** than the one leaving the function, so the sanitiser was invisible to dataflow analysis. Cleaned once up front now, so the value checked and the value returned are the same variable.

## What I can and cannot claim

**This has no behavioural effect.** `filepath.Join` already cleans, so the old code also returned a canonical path. No test can distinguish the two — I reverted the change and confirmed the new test still passes, rather than assuming it would catch it. So:

| Mutation | Result |
|---|---|
| Revert (check , return ) | ok — **cannot** be detected, as expected |
| Disable the containment check | ✅ FAIL |

Whether CodeQL now recognises  as a sanitiser **will be confirmed by the next scan, not locally** — I can't run CodeQL here. If it doesn't clear them, the remaining option is dismissing the two alerts with justification, since the containment guarantee itself is sound and separately tested.

I'm shipping it because "check exactly what you return" is the better contract independent of the scanner, and it's zero-risk. It is a legibility change, not a fix, and I'd rather label it that way than overstate it.

`go test ./...` passes across the backend.