### PR TITLE
fix(auth): enforce JWT secret strength on every path that installs a signing key

### DIFF
--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -102,37 +102,13 @@ func ValidateJWTSecret() error {
 				return
 			}
 		} else {
-			// Validate secret length (minimum 32 characters recommended)
-			if len(secret) < 32 {
-				log.Printf("WARNING: TFR_JWT_SECRET is shorter than recommended 32 characters. Consider using a longer secret.")
-			}
-			// Low-entropy check: crypto.IsLikelyLowEntropySecret is documented as
-			// intended for both ENCRYPTION_KEY and TFR_JWT_SECRET and is already wired
-			// in for ENCRYPTION_KEY (see router.go), but was never called here -- a
-			// 32+ character secret that is still low-entropy (a repeated character or
-			// a short phrase padded to length) passed the length check above with zero
-			// warning even though this secret signs/validates every session and API
-			// bearer token suite-wide (issue #654).
-			// FAIL CLOSED, matching ENCRYPTION_KEY (issue #742).
-			//
-			// Both secrets run through the same crypto.IsLikelyLowEntropySecret
-			// heuristic, but only ENCRYPTION_KEY refused to boot. The asymmetry was
-			// backwards: a weak ENCRYPTION_KEY exposes stored SCM/OAuth tokens and
-			// needs prior database access to exploit, while a weak TFR_JWT_SECRET
-			// is an HS256 signing key -- guess it and you mint a token carrying any
-			// scope you like, including the platform-wide admin wildcard, with no
-			// access to anything beforehand. The larger blast radius had the weaker
-			// control.
-			//
-			// A warning is not a control when the process boots anyway: the operator
-			// who most needs to see it is the one least likely to be reading startup
-			// logs. Same opt-out shape as ENCRYPTION_KEY so an existing deployment
-			// can restart once to rotate rather than being unable to start.
-			if shouldRejectLowEntropyJWTSecret([]byte(secret), allowLowEntropyJWTSecret()) {
-				jwtSecretErr = errors.New("SECURITY ERROR: TFR_JWT_SECRET has low estimated entropy and does not look CSPRNG-generated. " +
-					"It signs and validates every session and API bearer token, so a guessable value lets an attacker forge tokens with arbitrary scopes. " +
-					"Generate one with: openssl rand -hex 32. " +
-					"To restart once and rotate an existing deployment, set TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true temporarily.")
+			// One gate for every path that installs a signing key (issue #759).
+			// This used to be a length WARNING followed by an inline entropy
+			// check; the length half never stopped anything, so an 8-character
+			// secret booted production with the documented 32-character minimum
+			// printed as advice.
+			if err := validateJWTSecretStrength([]byte(secret)); err != nil {
+				jwtSecretErr = fmt.Errorf("TFR_JWT_SECRET: %w", err)
 				return
 			}
 			resolved = secret
@@ -305,6 +281,14 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 		return nil, fmt.Errorf("failed to read JWT secret file %q: %w", secretFilePath, err)
 	}
 	secret := trimSecretBytes(data)
+	// The same gate the env path uses. Without this, a whitespace-only secret
+	// file installed an EMPTY HMAC key at startup, and any weak file secret
+	// bypassed the entropy check entirely (issue #759). Returned as an error so
+	// cmd/server/main.go turns it into a boot failure rather than serving with
+	// a key that validates forged tokens.
+	if err := validateJWTSecretStrength(secret); err != nil {
+		return nil, fmt.Errorf("JWT secret file %q: %w", secretFilePath, err)
+	}
 	tm.RotateSecret(secret)
 	tm.ClearPreviousSecret()
 	storeSecret(string(secret))
@@ -335,8 +319,14 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 						continue
 					}
 					newSecret := trimSecretBytes(newData)
-					if len(newSecret) == 0 {
-						slog.Warn("JWT secret file is empty after update, keeping previous secret", "path", secretFilePath)
+					// Same gate again, but non-fatal: the server is already
+					// serving, so a bad rotation keeps the PREVIOUS secret
+					// rather than taking the process down. This branch
+					// previously checked emptiness only, so a rotation to a
+					// short or guessable secret was installed silently.
+					if err := validateJWTSecretStrength(newSecret); err != nil {
+						slog.Error("rejected JWT secret file update, keeping previous secret",
+							"path", secretFilePath, "error", err)
 						continue
 					}
 
@@ -387,6 +377,60 @@ func trimSecretBytes(data []byte) []byte {
 // the same reason router.go extracted shouldRejectLowEntropyEncryptionKey.
 func shouldRejectLowEntropyJWTSecret(secret []byte, overrideAllowed bool) bool {
 	return crypto.IsLikelyLowEntropySecret(secret) && !overrideAllowed
+}
+
+// minJWTSecretBytes is the minimum the documentation has always stated as a
+// hard requirement. Until now the code only warned about it (issue #759).
+const minJWTSecretBytes = 32
+
+// validateJWTSecretStrength is the single gate every path that installs an
+// HS256 signing key must pass.
+//
+// It exists because there were three such paths and only one of them checked
+// anything (issue #759):
+//
+//   - TFR_JWT_SECRET at startup: warned on length, failed closed on entropy.
+//   - TFR_JWT_SECRET_FILE at startup: NO check at all, not even for emptiness,
+//     so a whitespace-only file installed an EMPTY HMAC key.
+//   - TFR_JWT_SECRET_FILE on rotation: emptiness only.
+//
+// The file path is the one docs/secrets-rotation.md recommends, so the
+// recommended route bypassed the fail-closed entropy check entirely.
+//
+// Emptiness is never overridable. An empty HMAC key means every forged token
+// verifies, which no deployment can have a legitimate reason to run with.
+func validateJWTSecretStrength(secret []byte) error {
+	if len(secret) == 0 {
+		return errors.New("SECURITY ERROR: JWT secret is empty. " +
+			"An empty HMAC key validates every forged token. " +
+			"Generate one with: openssl rand -hex 32.")
+	}
+
+	override := allowLowEntropyJWTSecret()
+
+	// The documented minimum, enforced rather than merely logged. A warning is
+	// not a control when the process boots anyway, and the entropy heuristic
+	// does not stand in for length: "admin123" and "hunter2!" are 8 characters
+	// with 8 distinct bytes, so they clear the entropy check comfortably.
+	if len(secret) < minJWTSecretBytes && !override {
+		return fmt.Errorf("SECURITY ERROR: JWT secret is %d characters, below the documented "+
+			"minimum of %d. It signs and validates every session and API bearer token, so a "+
+			"short value is brute-forceable offline from any token an attacker holds. "+
+			"Generate one with: openssl rand -hex 32. "+
+			"To restart once and rotate an existing deployment, set "+
+			"TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true temporarily.",
+			len(secret), minJWTSecretBytes)
+	}
+
+	if shouldRejectLowEntropyJWTSecret(secret, override) {
+		return errors.New("SECURITY ERROR: JWT secret has low estimated entropy and does not look " +
+			"CSPRNG-generated. It signs and validates every session and API bearer token, so a " +
+			"guessable value lets an attacker forge tokens with arbitrary scopes. " +
+			"Generate one with: openssl rand -hex 32. " +
+			"To restart once and rotate an existing deployment, set " +
+			"TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true temporarily.")
+	}
+	return nil
 }
 
 // allowLowEntropyJWTSecret reports whether an operator has explicitly opted out

--- a/backend/internal/auth/jwt_secret_strength_test.go
+++ b/backend/internal/auth/jwt_secret_strength_test.go
@@ -1,0 +1,248 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Issue #759 — three paths install an HS256 signing key; only one checked
+// anything.
+//
+//	TFR_JWT_SECRET at startup       warned on length, failed closed on entropy
+//	TFR_JWT_SECRET_FILE at startup  NO check at all — not even for emptiness
+//	TFR_JWT_SECRET_FILE on rotation emptiness only
+//
+// The file path is the one docs/secrets-rotation.md RECOMMENDS, so the
+// recommended route bypassed the fail-closed entropy check added in #742/#809
+// entirely, and a whitespace-only file installed an empty HMAC key — under
+// which every forged token verifies.
+//
+// The length half mattered on its own: the documented 32-character minimum was
+// a log.Printf, and the entropy heuristic does not stand in for it. "admin123"
+// and "hunter2!" are 8 characters with 8 distinct bytes, so they clear entropy
+// comfortably. Both booted a production server.
+
+// weakSecrets are rejected by the shared gate. Each names why, so a future
+// change that lets one through says what it broke.
+var weakSecrets = []struct{ secret, why string }{
+	{"", "empty — an empty HMAC key validates every forged token"},
+	{"   \n\t ", "whitespace only — trims to empty"},
+	{"short", "5 chars"},
+	{"admin123", "8 chars, 8 distinct bytes: passes the entropy heuristic"},
+	{"hunter2!", "8 chars, passes entropy"},
+	{"0123456789abcdef", "16 chars, passes entropy"},
+	{strings.Repeat("a", 64), "long but a single repeated byte"},
+}
+
+// strongSecret is CSPRNG-shaped and 64 hex characters, the documented form.
+const strongSecret = "9f8c2e1a7b4d6053e2c9a8f1b7d403e6c5a2f9b8d1e7c4a0396b2d5f8e1c7a4b"
+
+func TestValidateJWTSecretStrength_RejectsWeakSecrets(t *testing.T) {
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+	for _, tc := range weakSecrets {
+		t.Run(tc.why, func(t *testing.T) {
+			if err := validateJWTSecretStrength(trimSecretBytes([]byte(tc.secret))); err == nil {
+				t.Errorf("accepted %q (%s)", tc.secret, tc.why)
+			}
+		})
+	}
+}
+
+func TestValidateJWTSecretStrength_AcceptsAStrongSecret(t *testing.T) {
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+	if err := validateJWTSecretStrength([]byte(strongSecret)); err != nil {
+		t.Errorf("rejected a 64-character CSPRNG-shaped secret: %v", err)
+	}
+}
+
+// TestValidateJWTSecretStrength_EmptyIsNeverOverridable — the opt-out exists so
+// an existing deployment can restart once and rotate. It must not extend to an
+// empty key, which no deployment can have a legitimate reason to run with.
+func TestValidateJWTSecretStrength_EmptyIsNeverOverridable(t *testing.T) {
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "true")
+	if err := validateJWTSecretStrength([]byte("")); err == nil {
+		t.Error("the override accepted an EMPTY secret")
+	}
+	// The override does apply to short/weak, which is its purpose.
+	if err := validateJWTSecretStrength([]byte("short")); err != nil {
+		t.Errorf("the override should permit a weak (non-empty) secret for rotation: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TFR_JWT_SECRET_FILE — the path that had no validation at all
+// ---------------------------------------------------------------------------
+
+func writeSecretFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "jwt.key")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestStartJWTSecretFileWatch_RejectsAWeakInitialSecret is the core regression.
+//
+// Returning an error is what makes cmd/server/main.go fail the boot instead of
+// serving with a key that validates forged tokens.
+func TestStartJWTSecretFileWatch_RejectsAWeakInitialSecret(t *testing.T) {
+	for _, tc := range weakSecrets {
+		t.Run(tc.why, func(t *testing.T) {
+			resetJWTSecret()
+			t.Setenv("TFR_JWT_SECRET", strongSecret)
+			t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+			if err := ValidateJWTSecret(); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			stop, err := StartJWTSecretFileWatch(writeSecretFile(t, tc.secret), time.Minute)
+			if err == nil {
+				if stop != nil {
+					stop()
+				}
+				t.Fatalf("a secret file containing %q (%s) was installed as the signing key",
+					tc.secret, tc.why)
+			}
+
+			// And the previously-valid env secret must survive: a rejected file
+			// must not leave the server with no usable key.
+			if got := GetJWTSecret(); got != strongSecret {
+				t.Errorf("after rejecting the file, GetJWTSecret() = %q, want the env secret", got)
+			}
+		})
+	}
+}
+
+func TestStartJWTSecretFileWatch_AcceptsAStrongInitialSecret(t *testing.T) {
+	resetJWTSecret()
+	t.Setenv("TFR_JWT_SECRET", strongSecret)
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+	if err := ValidateJWTSecret(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	fileSecret := "1a2b3c4d5e6f70819273645566778899aabbccddeeff00112233445566778899"
+	stop, err := StartJWTSecretFileWatch(writeSecretFile(t, fileSecret), time.Minute)
+	if err != nil {
+		t.Fatalf("a strong secret file was rejected: %v", err)
+	}
+	defer stop()
+
+	if got := GetJWTSecret(); got != fileSecret {
+		t.Errorf("GetJWTSecret() = %q, want the file secret to be in force", got)
+	}
+}
+
+// TestStartJWTSecretFileWatch_TrailingNewlineIsFine — the common shape of a
+// Kubernetes secret mount. A gate that rejected this would be turned off.
+func TestStartJWTSecretFileWatch_TrailingNewlineIsFine(t *testing.T) {
+	resetJWTSecret()
+	t.Setenv("TFR_JWT_SECRET", strongSecret)
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+	if err := ValidateJWTSecret(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	fileSecret := "1a2b3c4d5e6f70819273645566778899aabbccddeeff00112233445566778899"
+	stop, err := StartJWTSecretFileWatch(writeSecretFile(t, fileSecret+"\n"), time.Minute)
+	if err != nil {
+		t.Fatalf("a secret file with a trailing newline was rejected: %v", err)
+	}
+	defer stop()
+
+	if got := GetJWTSecret(); got != fileSecret {
+		t.Errorf("GetJWTSecret() = %q, want the trimmed file secret", got)
+	}
+}
+
+// TestJWTSecretStrength_AppliesToEveryInstallPath is the class guard.
+//
+// The defect was not that one check was wrong — it was that three code paths
+// installed a signing key and only one of them validated it. This asserts the
+// shared gate is reachable from each, so a fourth path added later without it
+// is the odd one out rather than the norm.
+func TestJWTSecretStrength_AppliesToEveryInstallPath(t *testing.T) {
+	const weak = "admin123" // passes entropy, fails length: the case a warning let through
+
+	t.Run("env at startup", func(t *testing.T) {
+		resetJWTSecret()
+		t.Setenv("TFR_JWT_SECRET", weak)
+		t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+		err := ValidateJWTSecret()
+		if err == nil {
+			t.Fatal("an 8-character TFR_JWT_SECRET booted the server")
+		}
+		if !strings.Contains(err.Error(), "TFR_JWT_SECRET") {
+			t.Errorf("error should name the source, got: %v", err)
+		}
+	})
+
+	t.Run("file at startup", func(t *testing.T) {
+		resetJWTSecret()
+		t.Setenv("TFR_JWT_SECRET", strongSecret)
+		t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+		if err := ValidateJWTSecret(); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		stop, err := StartJWTSecretFileWatch(writeSecretFile(t, weak), time.Minute)
+		if err == nil {
+			if stop != nil {
+				stop()
+			}
+			t.Fatal("an 8-character secret FILE was installed as the signing key")
+		}
+	})
+}
+
+// TestJWTSecretFileRotation_RejectsAWeakUpdate covers the third install path.
+//
+// Unlike the startup paths, a bad rotation must NOT take the process down — the
+// server is already serving. It keeps the previous secret and logs, matching
+// the shape the empty-file case already had. Before this, the branch checked
+// emptiness only, so rotating to "admin123" was installed silently.
+func TestJWTSecretFileRotation_RejectsAWeakUpdate(t *testing.T) {
+	resetJWTSecret()
+	t.Setenv("TFR_JWT_SECRET", strongSecret)
+	t.Setenv("TFR_ALLOW_LOW_ENTROPY_JWT_SECRET", "")
+	if err := ValidateJWTSecret(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	good := "1a2b3c4d5e6f70819273645566778899aabbccddeeff00112233445566778899"
+	path := writeSecretFile(t, good)
+	stop, err := StartJWTSecretFileWatch(path, time.Minute)
+	if err != nil {
+		t.Fatalf("StartJWTSecretFileWatch: %v", err)
+	}
+	defer stop()
+	if got := GetJWTSecret(); got != good {
+		t.Fatalf("setup: GetJWTSecret() = %q, want the file secret", got)
+	}
+
+	// Rotate to a secret that passes the entropy heuristic but is far too
+	// short — the exact case the old emptiness-only check let through.
+	if err := os.WriteFile(path, []byte("admin123"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give the watcher time to observe and reject. Poll rather than sleep once,
+	// so the test fails on the assertion rather than flaking on timing; if the
+	// weak secret is ever installed, it is installed quickly.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if GetJWTSecret() == "admin123" {
+			t.Fatal("a weak secret was installed by file rotation; the previous secret " +
+				"must be kept and the update rejected")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := GetJWTSecret(); got != good {
+		t.Errorf("after a rejected rotation, GetJWTSecret() = %q, want the previous secret %q",
+			got, good)
+	}
+}

--- a/backend/internal/auth/jwt_test.go
+++ b/backend/internal/auth/jwt_test.go
@@ -350,20 +350,19 @@ func TestStartJWTSecretFileWatch(t *testing.T) {
 func TestValidateJWTSecret_ShortSecret(t *testing.T) {
 	resetJWTSecret()
 	t.Setenv("TFR_JWT_SECRET", "short")
-	// Now REFUSED, where this used to boot with a warning (#742).
+	// Refused since #742, which made the entropy heuristic fail closed.
 	//
-	// The length check is still only a warning, but "short" also fails the
-	// entropy heuristic, and that is now fail-closed. The practical effect is
-	// that a 5-character signing key can no longer start the server, which was
-	// the previous behaviour and is hard to defend: the length warning was
-	// advisory in production, so a secret this weak booted and signed every
-	// session token.
+	// The rejection REASON changed with #759: the length check is no longer a
+	// warning, so a 5-character secret is now caught by the documented
+	// 32-character minimum before the entropy heuristic is reached. Both would
+	// reject it; the length message is the more actionable one, and asserting
+	// on it pins which gate fires.
 	err := ValidateJWTSecret()
 	if err == nil {
 		t.Fatal("ValidateJWTSecret() accepted a 5-character secret; it must fail closed (#742)")
 	}
-	if !strings.Contains(err.Error(), "low estimated entropy") {
-		t.Errorf("error should name the entropy check, got: %v", err)
+	if !strings.Contains(err.Error(), "below the documented minimum") {
+		t.Errorf("error should name the length minimum, got: %v", err)
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -469,7 +469,16 @@ export TFR_JWT_SECRET=$(openssl rand -hex 32)
 
 The JWT secret signs authentication tokens. In production:
 
-- Minimum 32 characters. The server refuses to start without a sufficient secret when `DEV_MODE` is not set.
+- **Minimum 32 characters, enforced.** The server refuses to start below it when `DEV_MODE` is
+  not set. This was previously documented as a requirement but only produced a startup warning,
+  so an 8-character signing key booted production.
+- The same check applies to `TFR_JWT_SECRET_FILE`, both when it is first read at startup and on
+  every rotation. A startup failure is fatal; a rejected **rotation** keeps the previous secret
+  and logs an error rather than stopping a running server.
+- A low-entropy secret is rejected regardless of length (a repeated character, or a short phrase
+  padded out). Set `TFR_ALLOW_LOW_ENTROPY_JWT_SECRET=true` to restart once and rotate an existing
+  deployment — it is a bridge, not a setting to leave on. It does **not** permit an empty secret,
+  which would validate every forged token.
 - Store in a secrets manager (Azure Key Vault, AWS Secrets Manager, HashiCorp Vault), not in environment files checked into source control.
 
 #### File-Based Hot-Reload (Zero-Downtime Rotation)


### PR DESCRIPTION
Closes #759 — which understated it. The issue was "documented as a hard 32-character minimum but only produces a warning". Verification found **three** paths install an HS256 signing key, and only one checked anything:

| path | validation |
|---|---|
| `TFR_JWT_SECRET` at startup | warned on length, failed closed on entropy |
| `TFR_JWT_SECRET_FILE` at startup | **none at all** — not even emptiness |
| `TFR_JWT_SECRET_FILE` on rotation | emptiness only |

The file path is the one `docs/secrets-rotation.md` **recommends**, so the recommended route bypassed the fail-closed entropy check from #742/#809 entirely — and a whitespace-only secret file installed an **empty HMAC key**, under which every forged token verifies.

## The length half mattered on its own

The documented minimum was a `log.Printf`, and the entropy heuristic does not stand in for it. Running the repo's own `IsLikelyLowEntropySecret`:

```
"abcd"              len= 4  rejected=true
"short"             len= 5  rejected=true
"admin123"          len= 8  rejected=false   ← boots production
"hunter2!"          len= 8  rejected=false   ← boots production
"0123456789abcdef"  len=16  rejected=false   ← boots production
```

8 characters with 8 distinct bytes clears the entropy check comfortably. A warning is not a control when the process boots anyway.

## The fix

All three paths share `validateJWTSecretStrength`: empty, below the documented minimum, or low-entropy. Startup failures are fatal. A rejected **rotation** keeps the previous secret and logs — the server is already serving, and a bad rotation should not take it down.

**Emptiness is never overridable.** `TFR_ALLOW_LOW_ENTROPY_JWT_SECRET` exists so an existing deployment can restart once and rotate; no deployment has a legitimate reason to run with a key that validates everything.

## Verification

| Mutation | Result |
|---|---|
| Drop the file-path gate | ✅ FAIL |
| Revert rotation to emptiness-only | ✅ FAIL |
| Return length to a warning | ✅ FAIL |
| Make empty overridable | ✅ FAIL |

**The rotation branch had no test at all** — I found that because reverting it initially *passed*, since I'd run the wrong test against it. It has one now: rotate a live watcher to `admin123` and assert the previous secret survives.

One existing test was updated rather than worked around. A 5-character secret is now caught by the length gate before the entropy heuristic, so its assertion moved to the length message — its comment claimed *"the length check is still only a warning"*, which is precisely what this change makes false.

A trailing-newline secret file (the normal Kubernetes mount shape) is asserted to still work, so the gate can't be "fixed" by making it unusable.

`go test ./...` passes across the backend.
