### PR TITLE
fix(api): bound the fire-and-forget download-count goroutines

### DIFF
--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -320,7 +320,12 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 					if platform.OS == clientOS && platform.Arch == clientArch {
 						platformID := platform.ID
 						safego.Go(func() {
-							if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
+							// Bounded: this runs after the response is served, so a wedged
+							// database must shed the counter rather than accumulate goroutines
+							// (issue #758).
+							ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+							defer cancel()
+							if err := providerRepo.IncrementDownloadCount(ctx, platformID); err != nil {
 								slog.Error("failed to increment download count for mirror provider", "error", err)
 							}
 						})

--- a/backend/internal/api/modules/download.go
+++ b/backend/internal/api/modules/download.go
@@ -117,7 +117,12 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		versionID := moduleVersion.ID
 		safego.Go(func() {
 			// Use background context to avoid cancellation when request completes
-			if err := moduleRepo.IncrementDownloadCount(context.Background(), versionID); err != nil {
+			// Bounded: this runs after the response is served, so a wedged
+			// database must shed the counter rather than accumulate goroutines
+			// (issue #758).
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := moduleRepo.IncrementDownloadCount(ctx, versionID); err != nil {
 				slog.Warn("failed to increment module download count", "version_id", versionID, "error", err)
 			}
 		})

--- a/backend/internal/api/modules/download_track_timeout_test.go
+++ b/backend/internal/api/modules/download_track_timeout_test.go
@@ -1,0 +1,83 @@
+package modules
+
+import (
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Issue #758 — the fire-and-forget download-count goroutines had no deadline.
+//
+// trackProviderDownload runs after the response is served and makes FOUR
+// sequential queries on a bare context.Background(). Against a wedged database
+// every one of these goroutines stayed resident for the life of the process,
+// one per download — the failure mode that turns a slow database into an
+// out-of-memory kill.
+//
+// Postgres statement_timeout does not cover it: it bounds a running query, not
+// the wait for a free pooled connection or a blackholed server, which is
+// exactly when these accumulate.
+//
+// A grep-style test would be INERT here. serve.go already contained
+// "context.WithTimeout" before this fix — for the audit goroutine 30 lines
+// above — so asserting the string appears in the file passes on unfixed code.
+// This drives the function against a stalled driver and measures that it
+// actually returns.
+
+func TestTrackProviderDownload_ReturnsWhenTheDatabaseStalls(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// The first query the function makes stalls far longer than the deadline.
+	// WillDelayFor honours the context, so a bounded context aborts the wait and
+	// an unbounded one blocks for the full delay.
+	mock.ExpectQuery("(?s)SELECT.*organizations").
+		WillDelayFor(60 * time.Second).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("org-1"))
+
+	providerRepo := repositories.NewProviderRepository(db)
+	orgRepo := repositories.NewOrganizationRepository(db)
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		trackProviderDownload(providerRepo, orgRepo, "hashicorp", "aws", "5.31.0", "linux", "amd64")
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		// It must give up near the deadline, not immediately: returning in ~0s
+		// would mean the query never ran and the test proves nothing about the
+		// timeout.
+		if elapsed < downloadTrackTimeout {
+			t.Fatalf("returned after %v, before the %v deadline — the stalled query was "+
+				"not actually exercised, so this test would pass without the fix",
+				elapsed, downloadTrackTimeout)
+		}
+		if elapsed > downloadTrackTimeout+10*time.Second {
+			t.Errorf("returned after %v, far past the %v deadline", elapsed, downloadTrackTimeout)
+		}
+	case <-time.After(downloadTrackTimeout + 15*time.Second):
+		t.Fatal("trackProviderDownload never returned against a stalled database — the " +
+			"goroutine is unbounded and accumulates one per download")
+	}
+}
+
+// TestDownloadTrackTimeout_IsBounded pins the constant itself. A deadline long
+// enough to be indistinguishable from none is not a deadline.
+func TestDownloadTrackTimeout_IsBounded(t *testing.T) {
+	if downloadTrackTimeout <= 0 {
+		t.Fatalf("downloadTrackTimeout = %v, must be positive", downloadTrackTimeout)
+	}
+	if downloadTrackTimeout > 30*time.Second {
+		t.Errorf("downloadTrackTimeout = %v; the response is already sent, so this should "+
+			"shed the counter quickly rather than hold a goroutine", downloadTrackTimeout)
+	}
+}

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -175,6 +175,11 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 	}
 }
 
+// downloadTrackTimeout bounds the fire-and-forget download-count updates. The
+// response has already been sent, so the only thing at stake is a counter --
+// shedding it beats accumulating goroutines against a wedged database.
+const downloadTrackTimeout = 5 * time.Second
+
 // parseProviderFilePath extracts components from a provider file path of the form:
 // providers/{namespace}/{type}/{version}/{os}/{arch}/{filename}
 func parseProviderFilePath(path string) (namespace, providerType, version, os, arch string, ok bool) {
@@ -187,7 +192,17 @@ func parseProviderFilePath(path string) (namespace, providerType, version, os, a
 
 // trackProviderDownload looks up the provider platform and increments its download count.
 func trackProviderDownload(providerRepo *repositories.ProviderRepository, orgRepo *repositories.OrganizationRepository, namespace, providerType, version, osName, arch string) {
-	ctx := context.Background()
+	// One budget for the whole operation, matching the audit goroutine 30 lines
+	// above (issue #758). This runs fire-and-forget after the response is
+	// served and makes FOUR sequential queries; with a bare context.Background()
+	// a wedged database left every one of these goroutines resident for the life
+	// of the process, one per download.
+	//
+	// Postgres statement_timeout does not cover this: it bounds a running query,
+	// not the wait for a free pooled connection or a blackholed server -- which
+	// is precisely when these pile up.
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTrackTimeout)
+	defer cancel()
 	org, err := orgRepo.GetDefaultOrganization(ctx)
 	if err != nil || org == nil {
 		return
@@ -206,7 +221,13 @@ func trackProviderDownload(providerRepo *repositories.ProviderRepository, orgRep
 	}
 	for _, p := range platforms {
 		if p.OS == osName && p.Arch == arch {
-			_ = providerRepo.IncrementDownloadCount(ctx, p.ID)
+			if err := providerRepo.IncrementDownloadCount(ctx, p.ID); err != nil {
+				// Logged rather than discarded, matching the four sibling call
+				// sites. A silently-dropped counter is indistinguishable from
+				// a download that never happened.
+				slog.Error("failed to increment provider download count",
+					"platform_id", p.ID, "error", err)
+			}
 			return
 		}
 	}

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -192,7 +192,12 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 		platformID := platform.ID
 		safego.Go(func() {
 			// Use background context to avoid cancellation when request completes
-			if err := providerRepo.IncrementDownloadCount(context.Background(), platformID); err != nil {
+			// Bounded: this runs after the response is served, so a wedged
+			// database must shed the counter rather than accumulate goroutines
+			// (issue #758).
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := providerRepo.IncrementDownloadCount(ctx, platformID); err != nil {
 				slog.Warn("failed to increment provider download count", "platform_id", platformID, "error", err)
 			}
 		})

--- a/backend/internal/api/terraform_binaries/binaries.go
+++ b/backend/internal/api/terraform_binaries/binaries.go
@@ -332,7 +332,12 @@ func (h *Handler) DownloadBinary(c *gin.Context) {
 	// Increment Prometheus download counter and persist to DB (non-blocking).
 	telemetry.TerraformBinaryDownloadsTotal.WithLabelValues(versionStr, osStr, archStr).Inc()
 	safego.Go(func() {
-		if err := h.repo.IncrementDownloadCount(context.Background(), platform.ID); err != nil {
+		// Bounded: this runs after the response is served, so a wedged
+		// database must shed the counter rather than accumulate goroutines
+		// (issue #758).
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := h.repo.IncrementDownloadCount(ctx, platform.ID); err != nil {
 			log.Printf("[terraform-binaries] download count increment failed for platform %s: %v", platform.ID, err)
 		}
 	})


### PR DESCRIPTION
Closes #758.

Five call sites incremented a download counter from a detached goroutine on a bare `context.Background()`. These run **after the response is served**, so against a wedged database every one stayed resident for the life of the process — one per download, which turns a slow database into an out-of-memory kill.

`statement_timeout` does not cover this: it bounds a *running query*, not the wait for a free pooled connection or a blackholed server — which is exactly when these accumulate.

`trackProviderDownload` is the worst of the five: **four sequential queries**, no deadline, and the final error discarded with `_ =`. It now takes one 5-second budget for the whole operation and logs that error, matching its four siblings.

The idiom isn't new — the audit goroutine **30 lines above in the same file** has used exactly this shape all along:

```go
safego.Go(func() {
    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
    defer cancel()
    ...
})
```

## Blast radius

Stated so nobody removes the deadline later: the Prometheus download counter is incremented **synchronously, outside** the goroutine, so telemetry is unaffected. Only the persisted `download_count` is shed, and only when the database is already failing.

## The obvious test is inert

`serve.go` **already contained** `context.WithTimeout` before this change — for that audit goroutine — so grepping the file for it passes on unfixed code.

Instead the test drives `trackProviderDownload` against a sqlmock driver stalled for 60s and asserts it returns. It also asserts it returns **no earlier** than the deadline: an immediate return would mean the stalled query never ran, and the test would prove nothing.

| Mutation | Result |
|---|---|
| Revert to `context.Background()` | ✅ FAIL (blocks past the limit) |

`go test ./...` passes across the backend.
