### PR TITLE
docs: correct three inaccurate claims (#760, #761, #763)

### DIFF
--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -52,6 +52,10 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000043 | `setup_notifications`                  | ✅ Yes         | Drops notification-config columns; persisted SMTP config lost |
 | 000044 | `scanner_binary_versions`              | ✅ Yes         | Drops the scanner-binary-versions table and approval-event column |
 | 000045 | `namespace_org_claims`                 | ✅ Yes         | Drops the namespace-ownership table; bindings are re-derived from artifacts on re-apply |
+| 000046 | `user_token_revocations`               | ✅ Yes         | Drops the per-user token revocation table; outstanding revocations are lost, so any token revoked before the rollback becomes valid again until it expires |
+| 000047 | `terraform_mirror_github_attestation`  | ✅ Yes         | Drops `verify_github_attestation` and `attestation_verified`; mirrors revert to unverified and the record of which artifacts were attested is lost |
+| 000048 | `notification_channels`                | ✅ Yes         | Drops the notification-channel table (CASCADE); configured destinations must be re-added |
+| 000049 | `add_org_owner_provisioner_roles`      | ✅ Yes         | Deletes the `org_owner` and `org_provisioner` system role templates; memberships referencing them are left with a NULL `role_template_id` by the FK's ON DELETE SET NULL, so those members lose their scopes |
 | 000050 | `quarantine_orphaned_api_keys`         | ⚠️ No-op down  | Data-only: expires `api_keys` rows with `user_id IS NULL` (detached by a user deletion under `ON DELETE SET NULL`). The down cannot distinguish them from deliberately expired keys, so re-arming would undo the retirement; restore individual rows by hand. See `docs/upgrade-guide.md` |
 
 ## How to Run Migrations

--- a/docs/OIDC_CONFIGURATION.md
+++ b/docs/OIDC_CONFIGURATION.md
@@ -557,37 +557,61 @@ curl -s https://your-issuer-url/.well-known/openid-configuration | jq .
 
 ### Test OIDC Login via API
 
+The OIDC login flow is **browser-based and cookie-only**. On a successful callback the server sets
+an **HttpOnly** `tfr_auth_token` cookie; it never returns the JWT in a response body, so there is no
+value to copy into an `Authorization: Bearer` header. (This page previously showed a
+`TOKEN="eyJ..."` step — that token could not be obtained by any supported flow.)
+
+Because the cookie is HttpOnly, JavaScript cannot read it either; browser clients rely on the cookie
+being sent automatically and add the `X-CSRF-Token` header from the readable `tfr_csrf` cookie on
+mutating requests.
+
+To exercise the flow from a terminal, keep a cookie jar:
+
 ```bash
-# Redirect to OIDC provider
-curl -X GET "https://registry.example.com/api/v1/auth/login?provider=oidc"
-# This redirects to your identity provider
+# 1. Start the login. In a browser this redirects to your IdP; with curl,
+#    follow the Location header manually and complete the login there.
+curl -i "https://registry.example.com/api/v1/auth/login?provider=oidc"
 
-# After successful login and callback, you'll receive a JWT token
-TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-
-# Test authenticated endpoint
-curl https://registry.example.com/api/v1/auth/me \
-  -H "Authorization: Bearer $TOKEN"
+# 2. After the callback completes in the browser, export that session cookie
+#    into a jar (or use --cookie-jar with a full scripted login against your IdP).
+#    Then call authenticated endpoints with the cookie, not a bearer token:
+curl -b cookies.txt https://registry.example.com/api/v1/auth/me
 
 # Should return your user information
 ```
 
+For **programmatic** access — CI, the Terraform CLI, scripts — do not try to reuse a session
+cookie. Create an API key (next section) and send it as `Authorization: Bearer <api_key>`. That is
+the supported non-browser path, and it is exempt from CSRF precisely because it is never sent
+automatically by a browser.
+
 ### Create and Test API Key
 
+Creating a key is a **mutating, cookie-authenticated** request, so it needs the session cookie AND
+the CSRF header — not a bearer token. (The `Authorization: Bearer $TOKEN` shown here previously
+could never have worked: `$TOKEN` came from the removed walkthrough above.)
+
 ```bash
-# After authenticating, create an API key
+# Create an API key using the browser session cookie plus the double-submit
+# CSRF token. tfr_csrf is readable by design; tfr_auth_token is HttpOnly.
+CSRF=$(awk '$6=="tfr_csrf"{print $7}' cookies.txt)
+
 curl -X POST https://registry.example.com/api/v1/apikeys \
-  -H "Authorization: Bearer $TOKEN" \
+  -b cookies.txt \
+  -H "X-CSRF-Token: $CSRF" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Test Key",
     "scopes": ["modules:read", "providers:read"]
   }'
 
-# Save the returned key from response
+# Save the returned key from the response. It is shown ONCE.
 API_KEY="tfr_abc123..."
 
-# Test with the API key
+# From here on, use the API key. This is the supported programmatic path:
+# a bearer API key is never auto-sent by a browser, so it is CSRF-exempt and
+# needs no cookie jar.
 curl https://registry.example.com/api/v1/modules/search \
   -H "Authorization: Bearer $API_KEY"
 ```

--- a/docs/compliance/soc2-mapping.md
+++ b/docs/compliance/soc2-mapping.md
@@ -120,9 +120,21 @@ during SOC 2 Type II audits.
 | -------- | --------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
 | P1.1     | Privacy notice        | Privacy policy documentation                         | `PRIVACY.md` (frontend)                              |
 | P3.1     | Collection limitation | Minimal PII collection (email, username from IdP)    | Auth handlers, user model                            |
-| P4.1     | Use limitation        | PII used only for auth/audit; not shared externally  | Audit shipper config (self-hosted destinations only) |
+| P4.1     | Use limitation        | PII used only for auth/audit; audit destinations are operator-configured and MAY be external — see note below | `security.audit.shippers`, `internal/audit/shipper.go` |
 | P6.1     | Data subject access   | User data export endpoint                            | `/admin/users/:id/export`                            |
 | P8.1     | Data quality          | IdP-sourced attributes; SCIM sync keeps data current | SCIM provisioning                                    |
+
+> **P4.1 — read this before citing it.** The previous wording claimed PII was "not shared
+> externally", evidenced by "audit shipper config (self-hosted destinations only)". The code
+> enforces no such restriction, and the guard it does apply points the other way: audit webhooks
+> are dialled through `internal/httpsafe`, which **denies** loopback/RFC1918/link-local targets and
+> **permits public ones**. So the shipper is, if anything, biased toward external destinations.
+>
+> What is actually true: audit records containing user email and identity attributes are sent only
+> to destinations an operator explicitly configures in `security.audit.shippers`, and nowhere by
+> default. That is an operator-controlled disclosure boundary, not a technical guarantee of
+> non-disclosure. An assessor relying on this row should test the deployed shipper configuration
+> rather than the code.
 
 ---
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -272,7 +272,11 @@ Perform a DR drill quarterly to validate recovery procedures. Use a non-producti
 
 - [ ] Confirm backup retention has recent backups available
 - [ ] Prepare a separate namespace or cluster for the drill
-- [ ] Document the current database schema version (`SELECT version FROM schema_migrations`). This is the highest applied migration number (currently `40`, not `1`); see the [migrations README](../backend/internal/db/migrations/README.md) for the authoritative current value.
+- [ ] Document the current database schema version (`SELECT version FROM schema_migrations`). This is
+      the highest applied migration number, **not** `1`. Read it from the running database rather than
+      from this page: a literal here goes stale the moment a migration lands, and this one sat at `40`
+      while the tree held `50`. The [migrations README](../backend/internal/db/migrations/README.md)
+      lists every migration and its rollback behaviour.
 - [ ] Record the current module/provider count for post-recovery validation
 
 ### Drill Execution


### PR DESCRIPTION
Closes #760, #761, #763.

Grouped because they are one class — documentation asserting something the code does not do. Each was verified against the code rather than taken from the issue text, and **two of the three issues were partly wrong themselves**.

## #760 — a walkthrough that could never have worked

`OIDC_CONFIGURATION.md` told an integrator to copy a JWT out of the OIDC callback and send it as `Authorization: Bearer`. No such token exists: every session-issuing path sets an **HttpOnly** `tfr_auth_token` cookie and returns nothing in the body, so the `$TOKEN` the walkthrough builds on could never be obtained.

Rewritten around a cookie jar, with API keys named as the supported programmatic path. The **next** section then used that same dead `$TOKEN` to create an API key — also corrected, since creating a key is a cookie-authenticated *mutating* request that needs the `X-CSRF-Token` header, which the old example omitted entirely.

## #761 — stale count, and a false consequence

The DR checklist said the schema version was "currently `40`". The tree holds **50** (`000050_quarantine_orphaned_api_keys`), and the migrations README it defers to as *authoritative* listed only **46** rows — skipping `000046`–`000049` entirely.

Both fixed. The four missing rows are added with their real rollback behaviour (including that `000049`'s down leaves affected memberships with a `NULL role_template_id`, so those members lose their scopes). The checklist no longer hardcodes a number at all — it says to read it from the running database, because a literal there goes stale the moment a migration lands, which is exactly what happened.

**I did not repeat the issue's title claim, because it is false.** The drill would *not* "fail its own validation step": that step (`disaster-recovery.md:280`) compares the drill's schema version against **production**, and `scripts/dr-drill.sh` compares two live queries with no hardcoded number. The rot was real; the stated consequence was not.

## #763 — an inverted control claim

The SOC2 P4.1 row claimed PII is *"not shared externally"*, evidenced by *"audit shipper config (self-hosted destinations only)"*.

The code enforces no such restriction — and the guard it *does* apply points the other way. Audit webhooks are dialled through `internal/httpsafe`, which **denies** loopback/RFC1918/link-local and **permits public** destinations. If anything the shipper is biased toward external targets.

The row now states what is true — destinations are operator-configured and may be external — with a note telling an assessor to test the deployed configuration rather than cite the code. An inverted control claim in a compliance mapping is worse than a missing one, because it is the kind of thing that gets quoted verbatim into an audit response.

## Verification

Docs-only; no code paths touched. Every claim checked against source:

- `SetCookie(… "tfr_auth_token" …)` at three sites in `internal/api/admin/auth.go`, no body-returned JWT
- `ls migrations/*.up.sql | wc -l` → 50; README table rows → 46 before, 50 after
- `internal/audit/shipper.go` constructs its client via `httpsafe.NewClient`
