### PR TITLE
fix(ci): check out the two ADO extension repos the replay gate requires

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -109,6 +109,22 @@ jobs:
             token: "${{ secrets.SUITE_READ_TOKEN }}",
             persist-credentials: false,
           }
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          {
+            repository: sethbacon/azure-pipelines-terraform,
+            path: suite/azure-pipelines-terraform,
+            token: "${{ secrets.SUITE_READ_TOKEN }}",
+            persist-credentials: false,
+          }
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          {
+            repository: sethbacon/azure-pipelines-packer,
+            path: suite/azure-pipelines-packer,
+            token: "${{ secrets.SUITE_READ_TOKEN }}",
+            persist-credentials: false,
+          }
 
       # Overwrite this repo's sibling copy with the commit under test, so the
       # replay reads the PR's code and not origin/main's. Guarded because


### PR DESCRIPTION
The signature replay gate has been failing on `main`, on release branches, and on **every PR** in all six repos that run it:

```
GATE ERROR: repos in SIGNATURE_SCOPE are not checked out, so no signature can run against them:
  packer-ext    -> suite/azure-pipelines-packer
  terraform-ext -> suite/azure-pipelines-terraform
```

That is the gate **working as designed** — exit 2 means a signature could not *execute*, which is never a pass. But the cause is this workflow, not the code under test.

`security-orchestration`'s ledger gained `packer-ext` and `terraform-ext` entries from the ADO extension audit, and these checkout lists were never extended to match. So the scope named two repos that were never on disk, and the gate correctly refused to claim anything about them.

## Why fix it rather than narrow the scope

A required check that is permanently red is one everybody learns to ignore — which costs more than the gate is worth, and defeats the point of having installed it. The two repos genuinely are in scope: the ledger tracks confirmed findings in both.

## The change

Both repos added to the checkout list, with `persist-credentials: false` like every sibling checkout — the reason that flag is on the others (the `SUITE_READ_TOKEN` would otherwise be left in `.git/config` inside a job that uploads an artifact) applies identically here.

Applied to all six repos that run this workflow, since all six were red for the same reason.

`actionlint` clean.
