### PR TITLE
fix(audit): retry transient audit-webhook delivery failures

### DIFF
--- a/backend/internal/audit/shipper.go
+++ b/backend/internal/audit/shipper.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -330,11 +331,13 @@ func (ws *WebhookShipper) flushBatch() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), ws.timeout)
-	defer cancel()
-
-	if err := ws.sendRequest(ctx, data); err != nil {
-		slog.Error("failed to flush audit batch", "error", err)
+	// sendWithRetry owns the deadlines: it applies ws.timeout per attempt.
+	if err := ws.sendWithRetry(context.Background(), data); err != nil {
+		// Still dropped after retries. Say how many, because "failed to flush
+		// audit batch" gave an operator no way to size the visibility gap --
+		// and the database rows remain the durable record either way.
+		slog.Error("dropping audit batch after failed delivery",
+			"entries", len(ws.batch), "error", err)
 	}
 
 	ws.batch = ws.batch[:0]
@@ -358,7 +361,82 @@ func (ws *WebhookShipper) Ship(ctx context.Context, entry *LogEntry) error {
 		return fmt.Errorf("failed to marshal audit entry: %w", err)
 	}
 
-	return ws.sendRequest(ctx, data)
+	return ws.sendWithRetry(ctx, data)
+}
+
+// Retry policy for audit webhook delivery (issue #756).
+//
+// Deliberately modest. The durable record is the database row AuditMiddleware
+// writes alongside shipping, so this is external-SIEM VISIBILITY, not the audit
+// trail itself -- a long or aggressive retry would trade a bounded visibility
+// gap for unbounded memory in the batch path. Three attempts covers the case
+// this exists for: a SIEM restart or a transient 5xx, where the previous single
+// attempt discarded the batch outright.
+const (
+	auditWebhookMaxAttempts = 3
+	auditWebhookBaseBackoff = 250 * time.Millisecond
+)
+
+// webhookStatusError carries the HTTP status so retryability is a decision
+// about the response rather than a string match on an error message.
+type webhookStatusError struct{ status int }
+
+func (e *webhookStatusError) Error() string {
+	return fmt.Sprintf("webhook returned status %d", e.status)
+}
+
+// retryableWebhookErr reports whether another attempt could plausibly succeed.
+//
+// A 4xx is the shipper's own fault -- a malformed payload, a bad URL, a
+// rejected credential -- and will fail identically every time, so retrying it
+// only delays the batch and duplicates load on the SIEM. 429 is the exception:
+// it explicitly means "later". Everything that is not an HTTP response at all
+// (dial failure, TLS error, timeout) is transient by assumption.
+func retryableWebhookErr(err error) bool {
+	var statusErr *webhookStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.status >= 500 || statusErr.status == http.StatusTooManyRequests
+	}
+	return true
+}
+
+// sendWithRetry makes up to auditWebhookMaxAttempts attempts with exponential
+// backoff, each bounded by the configured per-request timeout.
+//
+// The per-ATTEMPT deadline matters: bounding all attempts with one ws.timeout
+// budget means a first attempt that consumes it leaves nothing for the retry,
+// which is precisely the slow-SIEM case this is for.
+func (ws *WebhookShipper) sendWithRetry(ctx context.Context, data []byte) error {
+	var lastErr error
+	for attempt := 1; attempt <= auditWebhookMaxAttempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, ws.timeout)
+		err := ws.sendRequest(attemptCtx, data)
+		cancel()
+		if err == nil {
+			if attempt > 1 {
+				slog.Info("audit webhook delivered after retry", "attempts", attempt)
+			}
+			return nil
+		}
+		lastErr = err
+
+		if !retryableWebhookErr(err) {
+			return err
+		}
+		if attempt == auditWebhookMaxAttempts {
+			break
+		}
+
+		backoff := auditWebhookBaseBackoff * time.Duration(1<<(attempt-1))
+		select {
+		case <-ctx.Done():
+			// Shutdown or caller cancellation: stop immediately rather than
+			// sleeping through it.
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+	return fmt.Errorf("audit webhook failed after %d attempts: %w", auditWebhookMaxAttempts, lastErr)
 }
 
 // sendRequest sends the HTTP request
@@ -380,7 +458,7 @@ func (ws *WebhookShipper) sendRequest(ctx context.Context, data []byte) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		return &webhookStatusError{status: resp.StatusCode}
 	}
 
 	return nil

--- a/backend/internal/audit/shipper_retry_test.go
+++ b/backend/internal/audit/shipper_retry_test.go
@@ -1,0 +1,190 @@
+package audit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+)
+
+// Issue #756 — the audit webhook made exactly one delivery attempt.
+//
+// flushBatch called sendRequest once and then ran `ws.batch = ws.batch[:0]`
+// unconditionally, so a network blip, a SIEM restart or a transient 5xx
+// discarded the batch with a single log line. The codebase already implements a
+// full retry/backoff state machine for the conceptually similar SCM webhook
+// path (internal/jobs/webhook_retry_job.go); the audit shipper — whose package
+// doc says these records "may be subject to compliance retention policies
+// measured in years" — had none.
+//
+// Impact is bounded because AuditMiddleware persists the row to the database
+// alongside shipping, so this is external-SIEM visibility rather than audit
+// trail loss. That bound is also why the retry is modest: a long or aggressive
+// policy would trade a visibility gap for unbounded memory in the batch path.
+
+// retryTestShipper builds a shipper pointed at srv with batching disabled, so
+// Ship exercises the direct delivery path synchronously.
+func retryTestShipper(t *testing.T, url string) *WebhookShipper {
+	t.Helper()
+	// The egress guard denies loopback by default (SSRF protection), so an
+	// httptest server is unreachable without allowlisting it. Without this the
+	// request never leaves and every assertion below reads "attempts = 0" —
+	// which looks like a retry bug and is actually the guard doing its job.
+	ws, err := NewWebhookShipperWithGuard(&WebhookConfig{
+		URL:     url,
+		Timeout: 2 * time.Second,
+	}, httpsafe.MustGuard("127.0.0.1", "::1"))
+	if err != nil {
+		t.Fatalf("NewWebhookShipper: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+	return ws
+}
+
+func TestWebhookShipper_RetriesTransientFailureAndSucceeds(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Fail twice with a transient status, then accept — the SIEM-restart
+		// shape this retry exists for.
+		if atomic.AddInt32(&attempts, 1) < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ws := retryTestShipper(t, srv.URL)
+	if err := ws.Ship(context.Background(), &LogEntry{Action: "test"}); err != nil {
+		t.Fatalf("Ship: %v, want success on the third attempt", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("attempts = %d, want 3 — with a single attempt this entry is lost", got)
+	}
+}
+
+// TestWebhookShipper_DoesNotRetryAClientError is the half that keeps the retry
+// from making things worse.
+//
+// A 400 is the shipper's own fault — malformed payload, bad URL, rejected
+// credential — and fails identically every time. Retrying only delays the batch
+// and multiplies load on a SIEM that is already rejecting us.
+func TestWebhookShipper_DoesNotRetryAClientError(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	ws := retryTestShipper(t, srv.URL)
+	if err := ws.Ship(context.Background(), &LogEntry{Action: "test"}); err == nil {
+		t.Fatal("Ship succeeded against a 400")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("attempts = %d, want 1 — a 4xx must not be retried", got)
+	}
+}
+
+// TestWebhookShipper_Retries429 — the one 4xx that means "later".
+func TestWebhookShipper_Retries429(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attempts, 1) < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ws := retryTestShipper(t, srv.URL)
+	if err := ws.Ship(context.Background(), &LogEntry{Action: "test"}); err != nil {
+		t.Fatalf("Ship: %v, want a retry after 429", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 2 {
+		t.Errorf("attempts = %d, want 2", got)
+	}
+}
+
+func TestWebhookShipper_GivesUpAfterMaxAttempts(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ws := retryTestShipper(t, srv.URL)
+	err := ws.Ship(context.Background(), &LogEntry{Action: "test"})
+	if err == nil {
+		t.Fatal("Ship succeeded against a server that always fails")
+	}
+	if got := atomic.LoadInt32(&attempts); got != auditWebhookMaxAttempts {
+		t.Errorf("attempts = %d, want %d — the retry must be bounded, not indefinite",
+			got, auditWebhookMaxAttempts)
+	}
+}
+
+// TestWebhookShipper_StopsRetryingOnContextCancellation — shutdown must not
+// wait out the backoff.
+func TestWebhookShipper_StopsRetryingOnContextCancellation(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ws := retryTestShipper(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		_ = ws.Ship(ctx, &LogEntry{Action: "test"})
+		close(done)
+	}()
+
+	// Cancel while it is backing off between attempts, and measure how long it
+	// takes to notice.
+	//
+	// Counting server-side attempts CANNOT detect this: once the parent context
+	// is cancelled, every derived per-attempt context is already dead, so no
+	// further request reaches the server whether the backoff selects on ctx or
+	// just sleeps. The observable difference is time — a sleeping backoff burns
+	// the remaining ~700ms of its schedule before returning. Verified: the
+	// attempt-count assertion passed with the select replaced by time.Sleep.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	cancelledAt := time.Now()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ship kept retrying after its context was cancelled")
+	}
+
+	if elapsed := time.Since(cancelledAt); elapsed > 150*time.Millisecond {
+		t.Errorf("Ship took %v to return after cancellation; the backoff must abort on "+
+			"ctx.Done() rather than sleep through it (shutdown waits on this)", elapsed)
+	}
+}
+
+// TestWebhookRetryPolicy_IsBounded pins the constants. A retry budget large
+// enough to hold a batch indefinitely is the failure this replaces.
+func TestWebhookRetryPolicy_IsBounded(t *testing.T) {
+	if auditWebhookMaxAttempts < 2 {
+		t.Errorf("auditWebhookMaxAttempts = %d, which is not a retry", auditWebhookMaxAttempts)
+	}
+	if auditWebhookMaxAttempts > 5 {
+		t.Errorf("auditWebhookMaxAttempts = %d; the database row is the durable record, "+
+			"so this should not hold a batch in memory for long", auditWebhookMaxAttempts)
+	}
+	if auditWebhookBaseBackoff <= 0 || auditWebhookBaseBackoff > time.Second {
+		t.Errorf("auditWebhookBaseBackoff = %v, want a short positive delay", auditWebhookBaseBackoff)
+	}
+}


### PR DESCRIPTION
Closes #756.

`flushBatch` made **exactly one** delivery attempt and then ran `ws.batch = ws.batch[:0]` unconditionally, so a network blip, a SIEM restart or a transient 5xx discarded the batch with a single log line. The codebase already implements a full persisted retry/backoff state machine for the conceptually similar SCM webhook path (`internal/jobs/webhook_retry_job.go`); the audit shipper — whose package doc says these records *"may be subject to compliance retention policies measured in years"* — had none.

## Deliberately modest

Three attempts with exponential backoff. The durable record is the database row `AuditMiddleware` writes alongside shipping, so this is external-SIEM **visibility**, not audit-trail loss — and a longer or more aggressive policy would trade a bounded visibility gap for unbounded memory in the batch path.

## Retryability is a decision about the response

A 4xx is the shipper's own fault — malformed payload, bad URL, rejected credential — and fails identically every time. Retrying it only delays the batch and multiplies load on a SIEM that is already rejecting us. **429 is the exception**, since it explicitly means "later". A typed `webhookStatusError` carries the code so that distinction is decidable at all, rather than string-matching an error message.

The deadline is **per attempt**, not one budget for all of them: a first attempt that consumes `ws.timeout` would otherwise leave nothing for the retry — exactly the slow-SIEM case this exists for. Backoff selects on `ctx.Done()` so shutdown doesn't wait it out.

When delivery still fails, the log now says **how many entries were dropped**. `"failed to flush audit batch"` gave an operator no way to size the visibility gap.

## Two test traps worth recording

1. **The egress guard denies loopback**, so an `httptest` server is unreachable without allowlisting it. Without that, every assertion reads `attempts = 0` — which looks like a retry bug and is actually the SSRF guard doing its job.
2. **The cancellation test could not be written against the attempt count.** Once the parent context is cancelled, every derived per-attempt context is already dead, so no further request reaches the server whether the backoff selects on `ctx` or just sleeps. It asserts **elapsed time** instead. The count-based version passed with the `select` replaced by `time.Sleep` — I only caught it because the mutation run said so.

## Verification

| Mutation | Result |
|---|---|
| Single attempt (revert the retry) | ✅ FAIL |
| Retry 4xx too (no discrimination) | ✅ FAIL |
| Never retry 429 | ✅ FAIL |
| Sleep through cancellation | ✅ FAIL |

`go test ./...` passes across the backend.
