### PR TITLE
test(credlifecycle): make the lockout-hazard guard able to fail

### DIFF
--- a/backend/internal/credlifecycle/sweeper_test.go
+++ b/backend/internal/credlifecycle/sweeper_test.go
@@ -336,6 +336,26 @@ func TestOrgKeysOnly_DoesNotTouchTheWatermark(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", nil, "idp deprovision")
+
+	// Incomplete is the assertion that makes this guard work, and its absence
+	// made the guard INERT: flipping OrgKeysOnly to OrgAuthorityReduced -- the
+	// exact change that permanently locks users out -- used to PASS.
+	//
+	// Why the obvious assertions do not catch it. sqlmock has no watermark
+	// expectation registered, so a watermark write is REJECTED at the driver
+	// rather than executed. The sweeper records that failure and carries on, so
+	// TokensRevoked stays false (the write did not succeed) and
+	// ExpectationsWereMet stays happy (it reports UNMET expectations, not
+	// unexpected calls). The only trace left is Incomplete.
+	//
+	// Verified by mutation: with this check present, OrgKeysOnly ->
+	// OrgAuthorityReduced fails; without it, it passes.
+	if out.Incomplete {
+		t.Error("Incomplete = true: OrgKeysOnly issued SQL this test did not expect. " +
+			"The likely cause is a watermark write — moving the watermark here revokes " +
+			"the session token this same request is about to mint, and the user can " +
+			"never log in.")
+	}
 	if out.TokensRevoked {
 		t.Error("TokensRevoked = true; OrgKeysOnly must leave the JWT watermark alone")
 	}


### PR DESCRIPTION
`TestOrgKeysOnly_DoesNotTouchTheWatermark` exists to prevent the one change that **permanently locks users out**: moving the JWT revocation watermark in the IdP group-mapping path.

That code runs microseconds before the same request mints a fresh session token. `RevokeAllUserTokens` writes a full-precision `NOW()` while a JWT `iat` is floored to the second (RFC 7519), and `TokensRevokedSince` resolves that same-second ambiguity toward *revoked*. The user can then never log in.

**The guard could not fail.** Flipping `OrgKeysOnly` to `OrgAuthorityReduced` — exactly that bug — passed.

## Why the assertions it had don't catch it

sqlmock has no watermark expectation registered, so a watermark write is **rejected at the driver** rather than executed:

- `TokensRevoked` stays `false` — because the write did not *succeed*
- `ExpectationsWereMet()` stays happy — it reports **unmet** expectations, not **unexpected** calls

Both existing assertions therefore hold while the bug is present. The only trace the sweeper leaves is `Incomplete`, which nothing checked.

## Verification

| Mutation | Before | After |
|---|---|---|
| `OrgKeysOnly` → `OrgAuthorityReduced` | ok (inert) | ✅ FAIL |

Found while adversarially reviewing a proposed transactional revoke-derived-credentials primitive for `terraform-suite-identity#129`. That primitive is **not** being built — the review killed it — but this guard protects the exact hazard the issue asked to preserve, so it had to actually work.
