### PR TITLE
refactor(crypto): replace the duplicated TokenCipher with the shared one

### DIFF
--- a/backend/internal/crypto/tokencipher.go
+++ b/backend/internal/crypto/tokencipher.go
@@ -1,193 +1,82 @@
-// Package crypto provides AES-256-GCM authenticated encryption for sensitive
-// values that must be stored at rest in the database, specifically SCM OAuth
-// tokens. SCM tokens are far more sensitive than registry API keys: they grant
-// write access to source code repositories, so a leaked token could allow an
-// attacker to push malicious code to every repository the SCM account can reach.
-// Registry API keys, by contrast, are already bcrypt-hashed and provide access
-// only to the registry itself. AES-256-GCM is chosen because it provides both
-// confidentiality and authenticated integrity, ensuring stored tokens cannot be
-// silently tampered with even if the database is partially compromised.
+// tokencipher.go re-exports the shared TokenCipher from
+// github.com/sethbacon/terraform-suite-identity/identity/crypto.
+//
+// It used to be a 295-line COPY of that implementation, and the copy had
+// drifted: suite-identity #153 raised the PBKDF2 floor to OWASP's 600,000 and
+// made it reject rather than silently rewrite, and it added the GCM
+// additional-authenticated-data pair that binds a ciphertext to the row it
+// belongs to. Neither reached this file. A security fix had been applied to one
+// copy of a cryptographic primitive and not the other, and nothing anywhere
+// produced a signal — the ADO extension repo gates its duplicated modules with
+// scripts/check-shared-modules.js, but no equivalent exists between the Go
+// repos (#835).
+//
+// Aliasing rather than re-syncing is deliberate: a parity gate only tells you
+// after a copy has already drifted, whereas there is now no second copy to
+// drift. It also means the AAD methods arrive here automatically, since they are
+// methods on the aliased type.
+//
+// This is a drop-in for data already at rest. The two implementations were
+// verified wire-compatible in both directions before the swap — same
+// construction (AES-256-GCM), same framing (nonce prepended), same encoding
+// (base64.URLEncoding), same nil AAD, same empty-string handling — so every SCM
+// token, client secret, app private key and storage credential already stored
+// keeps opening. No re-encryption, no migration.
+//
+// entropy.go stays local: it is this service's own heuristic, not shared.
 package crypto
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
-	"errors"
-	"io"
-
-	"golang.org/x/crypto/pbkdf2"
+	identitycrypto "github.com/sethbacon/terraform-suite-identity/identity/crypto"
 )
 
+// TokenCipher encrypts and decrypts sensitive values held at rest.
+//
+// Alias, not a wrapper, so the methods added upstream — SealWithContext,
+// OpenWithContext, OpenWithContextOrLegacy and ReSealWithContext — are available
+// here without this file having to track them.
+type TokenCipher = identitycrypto.TokenCipher
+
+// Constructors. Vars rather than wrapper funcs so the signatures cannot drift
+// from upstream's.
 var (
-	// ErrKeyLengthInvalid is returned when a master key is not exactly 32 bytes (required for AES-256).
-	ErrKeyLengthInvalid = errors.New("crypto: key must be exactly 32 bytes for AES-256")
-	// ErrCiphertextCorrupted is returned when the ciphertext fails base64 decoding or is too short to contain a valid nonce.
-	ErrCiphertextCorrupted = errors.New("crypto: ciphertext is corrupted or tampered")
-	// ErrDecryptionFailed is returned when AES-GCM authentication or decryption fails, indicating tampering or a wrong key.
-	ErrDecryptionFailed = errors.New("crypto: decryption operation failed")
-	// ErrSaltTooShort is returned when the provided salt is fewer than 16 bytes, which would weaken PBKDF2 key derivation.
-	ErrSaltTooShort = errors.New("crypto: salt must be at least 16 bytes")
+	// NewTokenCipher creates a cipher with a 32-byte master key.
+	NewTokenCipher = identitycrypto.NewTokenCipher
+	// NewTokenCipherWithPrevious creates a cipher that supports dual-key
+	// decryption for zero-downtime key rotation.
+	NewTokenCipherWithPrevious = identitycrypto.NewTokenCipherWithPrevious
+	// DeriveTokenCipher derives a key from a passphrase.
+	//
+	// Behaviour change from the copy this replaces: an explicit iteration count
+	// below MinPBKDF2Iterations is now REJECTED with ErrIterationsTooLow instead
+	// of being silently rewritten, and the floor is OWASP's 600,000 rather than
+	// 10,000. Nothing in this repo calls it, so the change is latent here — but
+	// a future caller now fails loudly instead of deriving a weak key while
+	// believing otherwise.
+	DeriveTokenCipher = identitycrypto.DeriveTokenCipher
+	// GenerateKey creates a cryptographically secure random 32-byte key.
+	GenerateKey = identitycrypto.GenerateKey
+	// GenerateSalt creates a cryptographically secure random salt.
+	GenerateSalt = identitycrypto.GenerateSalt
 )
 
-// TokenCipher encrypts and decrypts sensitive token data.
-// It supports dual-key decryption for zero-downtime key rotation:
-// encryption always uses the current (primary) key, while decryption
-// tries the primary key first, then falls back to the previous key.
-type TokenCipher struct {
-	masterKey   []byte
-	previousKey []byte // optional, used for decryption fallback during key rotation
-}
+// Sentinel errors, re-exported so existing errors.Is checks in this service keep
+// matching. They must be the SAME values upstream returns, not new ones with the
+// same text — a fresh errors.New here would compare unequal and silently break
+// every errors.Is call site.
+var (
+	ErrKeyLengthInvalid    = identitycrypto.ErrKeyLengthInvalid
+	ErrCiphertextCorrupted = identitycrypto.ErrCiphertextCorrupted
+	ErrDecryptionFailed    = identitycrypto.ErrDecryptionFailed
+	ErrSaltTooShort        = identitycrypto.ErrSaltTooShort
+	// ErrIterationsTooLow has no local predecessor: the copy silently rewrote a
+	// low iteration count instead of rejecting it.
+	ErrIterationsTooLow = identitycrypto.ErrIterationsTooLow
+)
 
-// NewTokenCipher creates a cipher with a 32-byte master key
-func NewTokenCipher(masterKey []byte) (*TokenCipher, error) {
-	if len(masterKey) != 32 {
-		return nil, ErrKeyLengthInvalid
-	}
-	keyCopy := make([]byte, 32)
-	copy(keyCopy, masterKey)
-	return &TokenCipher{masterKey: keyCopy}, nil
-}
-
-// NewTokenCipherWithPrevious creates a cipher that supports dual-key decryption.
-// The current key is used for all encryption. Decryption first tries the current
-// key; if that fails with an authentication error, it retries with previousKey.
-// This enables zero-downtime rotation: set the new key as current, the old key
-// as previous, restart pods, then re-encrypt all tokens in a background job.
-func NewTokenCipherWithPrevious(currentKey, previousKey []byte) (*TokenCipher, error) {
-	if len(currentKey) != 32 {
-		return nil, ErrKeyLengthInvalid
-	}
-	if len(previousKey) != 0 && len(previousKey) != 32 {
-		return nil, ErrKeyLengthInvalid
-	}
-	curCopy := make([]byte, 32)
-	copy(curCopy, currentKey)
-	tc := &TokenCipher{masterKey: curCopy}
-	if len(previousKey) == 32 {
-		prevCopy := make([]byte, 32)
-		copy(prevCopy, previousKey)
-		tc.previousKey = prevCopy
-	}
-	return tc, nil
-}
-
-// DeriveTokenCipher creates a cipher by deriving a key from a passphrase
-func DeriveTokenCipher(passphrase string, salt []byte, iterations int) (*TokenCipher, error) {
-	if len(salt) < 16 {
-		return nil, ErrSaltTooShort
-	}
-	if iterations < 10000 {
-		iterations = 100000 // Secure default
-	}
-	derivedKey := pbkdf2.Key([]byte(passphrase), salt, iterations, 32, sha256.New)
-	return NewTokenCipher(derivedKey)
-}
-
-// Seal encrypts plaintext and returns a base64-encoded ciphertext
-func (tc *TokenCipher) Seal(plaintext string) (string, error) {
-	if plaintext == "" {
-		return "", nil
-	}
-
-	blockCipher, err := aes.NewCipher(tc.masterKey)
-	if err != nil {
-		return "", err
-	}
-
-	aead, err := cipher.NewGCM(blockCipher)
-	if err != nil {
-		return "", err
-	}
-
-	nonce := make([]byte, aead.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", err
-	}
-
-	sealed := aead.Seal(nonce, nonce, []byte(plaintext), nil)
-	return base64.URLEncoding.EncodeToString(sealed), nil
-}
-
-// Open decrypts a base64-encoded ciphertext and returns the plaintext.
-// When a previous key is configured, Open tries the current key first;
-// if GCM authentication fails it retries with the previous key before
-// returning an error.
-func (tc *TokenCipher) Open(encodedCiphertext string) (string, error) {
-	if encodedCiphertext == "" {
-		return "", nil
-	}
-
-	ciphertext, err := base64.URLEncoding.DecodeString(encodedCiphertext)
-	if err != nil {
-		return "", ErrCiphertextCorrupted
-	}
-
-	// Try current key first
-	plaintext, err := tc.decryptWithKey(tc.masterKey, ciphertext)
-	if err == nil {
-		return plaintext, nil
-	}
-
-	// If we have a previous key and the error was an authentication failure,
-	// try the previous key (the ciphertext may have been encrypted before rotation).
-	if tc.previousKey != nil && errors.Is(err, ErrDecryptionFailed) {
-		plaintext, prevErr := tc.decryptWithKey(tc.previousKey, ciphertext)
-		if prevErr == nil {
-			return plaintext, nil
-		}
-	}
-
-	return "", err
-}
-
-// decryptWithKey performs AES-256-GCM decryption with the given key.
-func (tc *TokenCipher) decryptWithKey(key, ciphertext []byte) (string, error) {
-	blockCipher, err := aes.NewCipher(key)
-	if err != nil {
-		return "", err
-	}
-
-	aead, err := cipher.NewGCM(blockCipher)
-	if err != nil {
-		return "", err
-	}
-
-	nonceLen := aead.NonceSize()
-	if len(ciphertext) < nonceLen {
-		return "", ErrCiphertextCorrupted
-	}
-
-	nonce := ciphertext[:nonceLen]
-	actualCiphertext := ciphertext[nonceLen:]
-
-	plaintext, err := aead.Open(nil, nonce, actualCiphertext, nil)
-	if err != nil {
-		return "", ErrDecryptionFailed
-	}
-
-	return string(plaintext), nil
-}
-
-// GenerateKey creates a cryptographically secure random 32-byte key
-func GenerateKey() ([]byte, error) {
-	key := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, key); err != nil {
-		return nil, err
-	}
-	return key, nil
-}
-
-// GenerateSalt creates a cryptographically secure random salt
-func GenerateSalt(length int) ([]byte, error) {
-	if length < 16 {
-		length = 16
-	}
-	salt := make([]byte, length)
-	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
-		return nil, err
-	}
-	return salt, nil
-}
+// MinPBKDF2Iterations and DefaultPBKDF2Iterations are re-exported so callers can
+// reason about the work factor without importing the upstream package directly.
+const (
+	MinPBKDF2Iterations     = identitycrypto.MinPBKDF2Iterations
+	DefaultPBKDF2Iterations = identitycrypto.DefaultPBKDF2Iterations
+)

--- a/backend/internal/crypto/tokencipher_test.go
+++ b/backend/internal/crypto/tokencipher_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -71,7 +72,10 @@ func TestNewTokenCipherIsolatesKey(t *testing.T) {
 func TestDeriveTokenCipher(t *testing.T) {
 	t.Run("valid passphrase and salt", func(t *testing.T) {
 		salt := bytes.Repeat([]byte("s"), 16)
-		tc, err := DeriveTokenCipher("my-secret-passphrase", salt, 100000)
+		// MinPBKDF2Iterations rather than a literal: the floor moved from 10,000
+		// to 600,000 with the swap onto the shared cipher (#835), and a literal
+		// here would need chasing again the next time guidance moves.
+		tc, err := DeriveTokenCipher("my-secret-passphrase", salt, MinPBKDF2Iterations)
 		if err != nil {
 			t.Fatalf("DeriveTokenCipher() unexpected error: %v", err)
 		}
@@ -87,12 +91,33 @@ func TestDeriveTokenCipher(t *testing.T) {
 		}
 	})
 
-	t.Run("low iteration count uses secure default", func(t *testing.T) {
+	// This sub-test previously asserted "low iteration count uses secure
+	// default" — that a caller passing 1 was silently bumped to 100,000. That
+	// was the behaviour suite-identity #153 identified as effectively inverted:
+	// the value silently rewritten was the one nobody chose, while an explicit
+	// 10,000 was honoured, so the weakest ACCEPTED work factor was reachable
+	// only by a caller who had thought about it. The local copy kept that
+	// behaviour after it was fixed upstream (#835); the assertions invert with
+	// the swap onto the shared implementation.
+	t.Run("an explicit iteration count below the floor is rejected", func(t *testing.T) {
 		salt := bytes.Repeat([]byte("s"), 16)
-		// Should not error; low count is silently bumped to 100000
 		tc, err := DeriveTokenCipher("pass", salt, 1)
+		if !errors.Is(err, ErrIterationsTooLow) {
+			t.Fatalf("DeriveTokenCipher(..., 1) error = %v, want ErrIterationsTooLow", err)
+		}
+		if tc != nil {
+			t.Error("a rejected derivation must not also return a usable cipher")
+		}
+	})
+
+	t.Run("no preference uses the secure default", func(t *testing.T) {
+		salt := bytes.Repeat([]byte("s"), 16)
+		// iterations <= 0 means "no preference" and is the one case that is
+		// still filled in rather than rejected — the caller expressed no belief
+		// about the work factor, so there is none to leave standing.
+		tc, err := DeriveTokenCipher("pass", salt, 0)
 		if err != nil {
-			t.Fatalf("DeriveTokenCipher() error: %v", err)
+			t.Fatalf("DeriveTokenCipher(..., 0) error: %v", err)
 		}
 		if tc == nil {
 			t.Fatal("DeriveTokenCipher() returned nil")
@@ -101,13 +126,25 @@ func TestDeriveTokenCipher(t *testing.T) {
 
 	t.Run("different passphrases produce different ciphers", func(t *testing.T) {
 		salt := bytes.Repeat([]byte("s"), 16)
-		tc1, _ := DeriveTokenCipher("passphrase-one", salt, 100000)
-		tc2, _ := DeriveTokenCipher("passphrase-two", salt, 100000)
+		// Was 100000, which is now below the floor: the derivation returned an
+		// error and a nil cipher, and the ignored error meant the next line
+		// dereferenced nil. Use the floor itself so the test exercises a
+		// derivation that is actually allowed.
+		tc1, err := DeriveTokenCipher("passphrase-one", salt, MinPBKDF2Iterations)
+		if err != nil {
+			t.Fatalf("DeriveTokenCipher(one): %v", err)
+		}
+		tc2, err := DeriveTokenCipher("passphrase-two", salt, MinPBKDF2Iterations)
+		if err != nil {
+			t.Fatalf("DeriveTokenCipher(two): %v", err)
+		}
 
-		sealed, _ := tc1.Seal("secret")
+		sealed, err := tc1.Seal("secret")
+		if err != nil {
+			t.Fatalf("Seal: %v", err)
+		}
 		// tc2 should NOT be able to decrypt what tc1 sealed
-		_, err := tc2.Open(sealed)
-		if err == nil {
+		if _, err := tc2.Open(sealed); err == nil {
 			t.Error("different-key cipher decrypted ciphertext; expected failure")
 		}
 	})


### PR DESCRIPTION
Closes #835. Unblocks the #153 AAD adoption for every credential column in this service.

`internal/crypto/tokencipher.go` was a **295-line copy** of `identity/crypto/tokencipher.go`, and the copy had drifted. suite-identity #153 raised the PBKDF2 floor to OWASP's 600,000 and made it *reject* rather than silently rewrite, and added the GCM additional-authenticated-data pair binding a ciphertext to the row it belongs to. **Neither reached this file** — a security fix applied to one copy of a cryptographic primitive and not the other, with nothing producing a signal.

## Aliased, not re-synced

Deliberate. A parity gate only tells you *after* a copy has drifted; there is now no second copy to drift. It also means the AAD methods arrive automatically, being methods on the aliased type.

## Drop-in for data at rest — verified, not assumed

Before swapping I round-tripped between the two implementations: a locally-sealed value opens with the library cipher, **and vice versa**. Same construction (AES-256-GCM), framing (nonce prepended), encoding (`base64.URLEncoding`), nil AAD and empty-string handling.

So every SCM token, client secret, app private key and storage credential already stored keeps opening. **No re-encryption, no migration, no downtime window.**

## Zero changes in the 25 importing files

The alias keeps the type, constructor and sentinel names identical. One detail that matters: the sentinels are re-exported as the **same values** upstream returns, not fresh `errors.New` calls with matching text — otherwise every `errors.Is` call site in this service would compare unequal and silently stop matching. That's the kind of break that passes compilation and fails in production.

## Tests that asserted the drift

Three sub-tests encoded the old behaviour and are **inverted, not deleted**:

- one expected a low iteration count to be silently upgraded;
- two passed `100000` — now below the floor — so the derivation returned a nil cipher that the next line dereferenced (that's the panic the swap first surfaced).

They now assert rejection, the no-preference default path, and use `MinPBKDF2Iterations` rather than a literal so the next move in guidance doesn't need chasing.

`DeriveTokenCipher` isn't called anywhere in this repo, so the stricter floor is latent here — a future caller now fails loudly instead of deriving a weak key while believing otherwise.

## Verification

`go build ./...` and `go vet ./...` clean. **62 packages pass.** One package (`internal/auth`) fails on `no space left on device` from fsnotify watch creation — I confirmed it fails **identically on clean main** with my changes stashed, so it's this machine's exhausted inotify instance limit, not this change. `internal/crypto`'s own suite passes.

`entropy.go` is this service's own heuristic and stays local; the package doesn't disappear.

## Follow-up

Adopting the binding per column is separate, starting with the `scm_provider_tokens` cache — that one is a cache with an expiry, so a conversion failure degrades to re-minting a token rather than losing an unrecoverable credential.