### PR TITLE
feat(scm): bind the cached app token to its provider row

### DIFF
--- a/backend/internal/scm/aad.go
+++ b/backend/internal/scm/aad.go
@@ -1,0 +1,39 @@
+package scm
+
+import "github.com/google/uuid"
+
+// Additional-authenticated-data contexts for the SCM secrets held at rest.
+//
+// Each binds a ciphertext to the row and column it belongs to, so a sealed value
+// cannot be lifted out of one row and written into another by anyone with
+// database write access. Without a context, GCM authenticates that move happily,
+// because nothing in the ciphertext says where it belongs (suite-identity #153).
+//
+// They live in one file, and callers use them rather than building the string,
+// because the seal and the open are in different files — and for some columns
+// different packages. Two hand-built strings drift apart silently, and the
+// failure surfaces as "cannot decrypt credential" long after the change that
+// caused it.
+//
+// The identity in a context must be the identity of the ROW. Several encrypted
+// columns in this service share a field NAME across different tables:
+// AccessTokenEncrypted exists both on the shared per-provider app-token cache
+// (keyed by provider) and on the per-user OAuth token (keyed by user+provider).
+// Using one row family's context for another's ciphertext is not a mistake the
+// compiler catches, so each function below names its table explicitly.
+
+// ProviderTokenContext binds a cached shared app token to its provider row in
+// scm_provider_tokens.
+//
+// This column is a CACHE: entries carry an expiry and are re-minted from the
+// identity provider when stale. That is why it is the first column converted —
+// a failure here degrades to minting a fresh token, not to losing a credential
+// that only an operator could restore by hand.
+//
+// It is also why this column needs no backfill. Unbound entries are read through
+// the transition path until they expire, and every re-mint writes the bound
+// form, so the table converts itself. The irreplaceable columns do not have that
+// property and will each need a sweep.
+func ProviderTokenContext(scmProviderID uuid.UUID) []byte {
+	return []byte("scm_provider_tokens:" + scmProviderID.String() + ":access_token")
+}

--- a/backend/internal/scm/appcreds/minter.go
+++ b/backend/internal/scm/appcreds/minter.go
@@ -96,7 +96,12 @@ func (m *Minter) MintProviderToken(ctx context.Context, p *scm.SCMProvider) (*sc
 	if m.store != nil {
 		if rec, err := m.store.GetProviderToken(ctx, p.ID); err == nil && rec != nil {
 			if rec.ExpiresAt == nil || rec.ExpiresAt.Sub(m.now()) > m.refreshMargin {
-				if tok, derr := m.cipher.Open(rec.AccessTokenEncrypted); derr == nil && tok != "" {
+				// Accepts the row-bound form and the legacy unbound one, so a
+				// cache written before this change still serves rather than
+				// forcing every provider to re-mint on the deploy that ships it.
+				tok, _, derr := m.cipher.OpenWithContextOrLegacy(
+					rec.AccessTokenEncrypted, scm.ProviderTokenContext(p.ID))
+				if derr == nil && tok != "" {
 					return &scm.OAuthToken{AccessToken: tok, TokenType: rec.TokenType, ExpiresAt: rec.ExpiresAt}, nil
 				}
 			}
@@ -128,7 +133,9 @@ func (m *Minter) MintProviderToken(ctx context.Context, p *scm.SCMProvider) (*sc
 
 	// Best-effort cache write — a persistence failure must not fail the request.
 	if m.store != nil {
-		if enc, sealErr := m.cipher.Seal(token); sealErr == nil {
+		// Bound to the provider row: a cached token cannot be copied into another
+		// provider's cache row and served as that provider's.
+		if enc, sealErr := m.cipher.SealWithContext(token, scm.ProviderTokenContext(p.ID)); sealErr == nil {
 			exp := expiresAt
 			_ = m.store.UpsertProviderToken(ctx, &scm.SCMProviderTokenRecord{
 				SCMProviderID:        p.ID,

--- a/backend/internal/scm/appcreds/minter_test.go
+++ b/backend/internal/scm/appcreds/minter_test.go
@@ -120,9 +120,24 @@ func TestMintProviderToken_EntraApp(t *testing.T) {
 	if len(store.upserts) != 1 {
 		t.Fatalf("upserts = %d, want 1", len(store.upserts))
 	}
-	dec, _ := cipher.Open(store.upserts[0].AccessTokenEncrypted)
-	if dec != "ado-token" {
-		t.Errorf("cached token decrypts to %q, want ado-token", dec)
+	// The cached token is bound to its provider row (suite-identity #153), so it
+	// opens under that row's context and NOT with a plain Open. This assertion
+	// previously used Open and is inverted rather than relaxed: a value that
+	// still opened unbound would mean the binding never happened.
+	dec, err := cipher.OpenWithContext(
+		store.upserts[0].AccessTokenEncrypted, scm.ProviderTokenContext(p.ID))
+	if err != nil || dec != "ado-token" {
+		t.Errorf("cached token under its own context = (%q, %v), want ado-token", dec, err)
+	}
+	if _, err := cipher.Open(store.upserts[0].AccessTokenEncrypted); err == nil {
+		t.Error("cached token still opens WITHOUT a context; it was not bound to its provider row")
+	}
+	// And it must not open as another provider's cached token -- the move this
+	// binding exists to prevent.
+	if _, err := cipher.OpenWithContext(
+		store.upserts[0].AccessTokenEncrypted, scm.ProviderTokenContext(uuid.New()),
+	); err == nil {
+		t.Error("cached token opened under another provider's context; the binding is vacuous")
 	}
 }
 
@@ -403,5 +418,70 @@ func TestSignAppJWT_Structure(t *testing.T) {
 	}
 	if parts := strings.Split(jwt, "."); len(parts) != 3 {
 		t.Errorf("jwt has %d segments, want 3", len(parts))
+	}
+}
+
+// suite-identity #153 transition. A cache entry written before the binding
+// shipped must still serve, or the deploy that ships this forces every provider
+// to re-mint at once.
+func TestMintProviderToken_ServesALegacyUnboundCacheEntry(t *testing.T) {
+	cipher := testCipher(t)
+	providerID := uuid.New()
+
+	legacy, err := cipher.Seal("cached-legacy-token")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	future := time.Now().Add(time.Hour)
+	store := &fakeStore{get: &scm.SCMProviderTokenRecord{
+		SCMProviderID:        providerID,
+		AccessTokenEncrypted: legacy,
+		TokenType:            "Bearer",
+		ExpiresAt:            &future,
+	}}
+
+	m := NewMinterWithGuard(cipher, store, loopbackGuard)
+	tok, err := m.MintProviderToken(context.Background(), &scm.SCMProvider{
+		ID: providerID, AuthMode: scm.AuthModeEntraApp,
+	})
+	if err != nil {
+		t.Fatalf("MintProviderToken: %v", err)
+	}
+	if tok.AccessToken != "cached-legacy-token" {
+		t.Errorf("token = %q; an unbound cache entry must still serve during the transition", tok.AccessToken)
+	}
+	// Served from cache, so nothing was minted and nothing was written.
+	if len(store.upserts) != 0 {
+		t.Errorf("upserts = %d, want 0 — the cached entry should have been served as-is", len(store.upserts))
+	}
+}
+
+// The other side: a cache entry bound to a DIFFERENT provider must not be
+// served. It falls through to a fresh mint rather than handing one provider's
+// token to another.
+func TestMintProviderToken_IgnoresACacheEntryBoundToAnotherProvider(t *testing.T) {
+	cipher := testCipher(t)
+	providerID := uuid.New()
+
+	foreign, err := cipher.SealWithContext("someone-elses-token", scm.ProviderTokenContext(uuid.New()))
+	if err != nil {
+		t.Fatalf("SealWithContext: %v", err)
+	}
+	future := time.Now().Add(time.Hour)
+	store := &fakeStore{get: &scm.SCMProviderTokenRecord{
+		SCMProviderID:        providerID,
+		AccessTokenEncrypted: foreign,
+		TokenType:            "Bearer",
+		ExpiresAt:            &future,
+	}}
+
+	m := NewMinterWithGuard(cipher, store, loopbackGuard)
+	tok, err := m.MintProviderToken(context.Background(), &scm.SCMProvider{
+		ID: providerID, AuthMode: scm.AuthModeEntraApp,
+	})
+	// The mint itself fails here (no IdP configured in this fixture); what
+	// matters is that the foreign token was NOT returned.
+	if err == nil && tok != nil && tok.AccessToken == "someone-elses-token" {
+		t.Fatal("served a cached token bound to a different provider row")
 	}
 }


### PR DESCRIPTION
Refs #153. First column of the AAD adoption in this service, unblocked by #836 putting the shared cipher behind `internal/crypto`.

## Why this column first

`scm_provider_tokens.access_token` is a **cache** with an expiry. If anything about the conversion is wrong, the failure degrades to minting a fresh token — not to losing a credential that only an operator could restore by hand. The irreplaceable columns (client secret, app private key, the storage credentials) come later, once the shape is proven on one that can heal itself.

## No backfill needed here — and that's a property of the data

Entries expire, and every re-mint writes the bound form, so **the table converts itself**. That isn't true of the other columns; each of those will need a sweep like tsm-backend's `bind-targets`.

## The trap the new file documents

`internal/scm/aad.go` carries the reasoning that matters for the columns still to come: **the identity in a context must be the identity of the ROW.** This service has the same field *name* on different tables — `AccessTokenEncrypted` is both the per-provider app-token cache and the per-user OAuth token, keyed differently. Using one family's context for the other's ciphertext is not a mistake the compiler catches, and the symptom is "cannot decrypt credential" in production. So each function names its table.

## Behaviour

- **Seal** binds to the provider row: a cached token can't be copied into another provider's cache row and served as that provider's.
- **Read** goes through `OpenWithContextOrLegacy`: entries written before this change still serve, rather than the deploy forcing every provider to re-mint at once.

## Tests

The existing cache assertion used a plain `Open`. It's **inverted, not relaxed** — the stored value must open under its provider's context, must **not** open unbound, and must not open under another provider's. A value that still opened unbound would mean the binding never happened.

Added both sides of the transition:
- a legacy entry still serves, and is served *from cache* (no mint, no write)
- an entry bound to a **different** provider is not served

## Verification

Mutation: reverting only the seal to the unbound form fails on `cached token still opens WITHOUT a context`.

63 packages pass. gosec clean on the changed package — the single G115 it reports in `internal/scm/azuredevops/connector.go` is pre-existing and outside this diff (that file isn't touched here).