### PR TITLE
test(crypto): inventory the unbound Seal sites so the class cannot grow

### DIFF
--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -1,0 +1,177 @@
+package crypto_test
+
+// unbound_seal_sweep_test.go is a lint-style regression test for the
+// suite-identity #153 adoption: TokenCipher.Seal produces a ciphertext with no
+// binding to the row or column it belongs to, so a value sealed by it can be
+// moved between rows (or between columns of one row) by anyone with database
+// write access and GCM will authenticate the move.
+//
+// SealWithContext is the bound form. Converting every column is staged, because
+// each needs its own context derivation and — for the columns that cannot
+// self-convert — a backfill over live credentials.
+//
+// This test is the inventory of what has NOT been converted yet. It fails when:
+//
+//   - a Seal call appears in a file not listed below (a NEW unbound column, or
+//     an old one that grew a call site), or
+//   - a listed file's count changes without the expectation being updated
+//     (which is what happens when a column IS converted).
+//
+// Both directions matter. The first stops the class quietly growing while the
+// migration is in progress, which is exactly how this kind of effort stalls
+// half-done. The second forces the inventory to stay honest: converting a
+// column means editing this map, so the remaining work is always readable here
+// rather than reconstructed by grep.
+//
+// A count rather than a line number on purpose — line numbers churn on every
+// unrelated edit, and a stale allowlist is one people delete.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// unboundSealSites maps a repo-relative file to how many TokenCipher.Seal calls
+// it still contains, with the column and why it has not been converted yet.
+//
+// Ordered by recoverability, which is the order the conversion follows: a column
+// whose failure mode is "re-mint" is safe to convert first; one whose failure
+// mode is "an operator re-enters the secret by hand" is converted last, with a
+// verified backfill.
+var unboundSealSites = map[string]int{
+	// User OAuth access + refresh tokens. Recoverable: the user reconnects.
+	// Two distinct contexts needed (access vs refresh) so a long-lived refresh
+	// token cannot be written into the access column of its own row.
+	"internal/api/admin/scm_oauth.go": 9,
+
+	// Storage-backend credentials: Azure account key, S3 access key id and
+	// secret, GCS credentials JSON. IRREPLACEABLE — an operator re-enters them.
+	"internal/api/admin/storage.go": 8,
+
+	// First-run setup secrets. IRREPLACEABLE, and reached before most of the
+	// service exists, so the conversion needs care about ordering.
+	"internal/api/setup/handlers.go": 6,
+
+	// SCM client secret and app private key. IRREPLACEABLE.
+	"internal/api/admin/scm_providers.go": 4,
+
+	// User token re-seal on the module-linking path; converts with scm_oauth.go
+	// since it writes the same two columns.
+	"internal/api/modules/scm_linking.go": 2,
+
+	// This service's own notification channel target. The sibling column in
+	// tsm-backend is already bound (tsm #359) via identity/notify.TargetContext;
+	// this one is a separate table in this repo and still needs doing.
+	"internal/api/admin/notification_channels.go": 2,
+
+	// SMTP password.
+	"internal/api/admin/notifications.go": 1,
+}
+
+// backendRoot walks up to the module root so the test is runnable from its own
+// package directory.
+func backendRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatal("could not locate the module root (no go.mod found walking up)")
+	return ""
+}
+
+// isCipherSeal reports whether a call is <something cipher-ish>.Seal(...).
+//
+// Matches on the receiver name rather than resolving types: this is a
+// lint-style sweep, and a rename that defeated it would have to rename the
+// cipher field itself, which is the kind of change that gets read carefully
+// anyway. aead.Seal (the raw GCM primitive) lives in the identity module, not
+// here, but is excluded explicitly so this stays correct if that ever changes.
+func isCipherSeal(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Seal" {
+		return false
+	}
+	var recv string
+	switch x := sel.X.(type) {
+	case *ast.Ident:
+		recv = x.Name
+	case *ast.SelectorExpr:
+		recv = x.Sel.Name
+	default:
+		return false
+	}
+	if recv == "aead" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(recv), "cipher")
+}
+
+func TestNoNewUnboundSealSites(t *testing.T) {
+	root := backendRoot(t)
+	found := map[string]int{}
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // unparseable files are not this test's business
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		ast.Inspect(file, func(n ast.Node) bool {
+			if call, ok := n.(*ast.CallExpr); ok && isCipherSeal(call) {
+				found[rel]++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for file, n := range found {
+		want, listed := unboundSealSites[file]
+		if !listed {
+			t.Errorf("%s has %d unbound Seal call(s) and is not in unboundSealSites.\n"+
+				"A new column sealed without a context can be moved between rows by anyone with "+
+				"database write access. Use SealWithContext with a row-derived context (see "+
+				"internal/scm/aad.go), or add the file here with the reason it is deferred.", file, n)
+			continue
+		}
+		if n != want {
+			t.Errorf("%s has %d unbound Seal call(s), expected %d.\n"+
+				"If a column was converted, lower the count (or remove the entry) so the remaining "+
+				"work stays readable. If a call site was ADDED, it needs SealWithContext instead.",
+				file, n, want)
+		}
+	}
+
+	for file, want := range unboundSealSites {
+		if _, ok := found[file]; !ok {
+			t.Errorf("unboundSealSites lists %s (expecting %d) but it has no unbound Seal calls left. "+
+				"Remove the entry — a stale inventory is worse than none.", file, want)
+		}
+	}
+}


### PR DESCRIPTION
Refs #153. Follows #837 (the first converted column).

The AAD adoption is staged — each column needs its own context derivation, and the ones holding operator-entered secrets need a verified backfill before their reads can stop accepting unbound ciphertexts. So the codebase stays partially converted for a while, which is exactly the state where a migration quietly stalls and new unbound columns appear behind it.

This is the inventory that prevents that.

## Fails in both directions

- **A `Seal` in a file not listed** — a new unbound column, or an old one that grew a call site.
- **A listed file whose count changed without the expectation being updated** — which is what happens when a column *is* converted.

The second half is what keeps it honest. Converting a column *requires* editing the map, so the remaining work stays readable in one place rather than reconstructed by grep each time. Each entry names the column and why it's deferred, ordered by recoverability — "re-mint" columns first, "an operator re-enters the secret by hand" last.

Counts rather than line numbers, deliberately: line numbers churn on unrelated edits, and an allowlist that fails spuriously is one people delete.

## What the sweep actually found

Worth recording, because it's larger than the estimates it replaces:

**33 unbound `Seal` call sites across 8 files** (32 now the provider-token cache has landed).

| file | sites | column |
| --- | --- | --- |
| `admin/scm_oauth.go` | 9 | user OAuth access + refresh |
| `admin/storage.go` | 8 | Azure key, S3 id + secret, GCS JSON |
| `setup/handlers.go` | 6 | first-run setup secrets |
| `admin/scm_providers.go` | 4 | client secret, app private key |
| `modules/scm_linking.go` | 2 | user token re-seal |
| `admin/notification_channels.go` | 2 | this repo's own channel target |
| `admin/notifications.go` | 1 | SMTP password |

`setup/handlers.go` and this repo's own `notification_channels.go` were in **no prior count of mine**. I under-counted this surface twice by reading it, which is the argument for having a mechanical inventory rather than a written one.

## Verification

Mutation, both directions:

- adding an unbound `Seal` to an unlisted file → fails with the file named
- converting a listed column without lowering its count → fails

Placed in `internal/crypto` as a `_test.go`, so it runs inside the existing required test job — no workflow change and no new required status check, matching how the sibling repo enforces its disciplines.