### PR TITLE
feat(scm): bind user OAuth access and refresh tokens to their rows

### DIFF
--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -338,7 +338,7 @@ func (h *SCMOAuthHandlers) HandleOAuthCallback(c *gin.Context) {
 	}
 
 	// Encrypt access token
-	encryptedAccessToken, err := h.tokenCipher.Seal(oauthToken.AccessToken)
+	encryptedAccessToken, err := h.tokenCipher.SealWithContext(oauthToken.AccessToken, scm.UserTokenContext(userID, providerID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt access token"})
 		return
@@ -347,7 +347,7 @@ func (h *SCMOAuthHandlers) HandleOAuthCallback(c *gin.Context) {
 	// Encrypt refresh token if present
 	var encryptedRefreshToken *string
 	if oauthToken.RefreshToken != "" {
-		encrypted, err := h.tokenCipher.Seal(oauthToken.RefreshToken)
+		encrypted, err := h.tokenCipher.SealWithContext(oauthToken.RefreshToken, scm.UserRefreshTokenContext(userID, providerID))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt refresh token"})
 			return
@@ -490,7 +490,8 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 	// Decrypt refresh token
 	var refreshToken string
 	if tokenRecord.RefreshTokenEncrypted != nil {
-		refreshToken, err = h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted)
+		refreshToken, _, err = h.tokenCipher.OpenWithContextOrLegacy(
+			*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt refresh token"})
 			return
@@ -533,7 +534,7 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 	}
 
 	// Encrypt new tokens
-	encryptedAccessToken, err := h.tokenCipher.Seal(newToken.AccessToken)
+	encryptedAccessToken, err := h.tokenCipher.SealWithContext(newToken.AccessToken, scm.UserTokenContext(userID, providerID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt new access token"})
 		return
@@ -541,7 +542,7 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 
 	var encryptedRefreshToken *string
 	if newToken.RefreshToken != "" {
-		encrypted, err := h.tokenCipher.Seal(newToken.RefreshToken)
+		encrypted, err := h.tokenCipher.SealWithContext(newToken.RefreshToken, scm.UserRefreshTokenContext(userID, providerID))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt new refresh token"})
 			return
@@ -620,7 +621,7 @@ func (h *SCMOAuthHandlers) SavePATToken(c *gin.Context) {
 	}
 
 	// Encrypt the PAT
-	encryptedToken, err := h.tokenCipher.Seal(req.AccessToken)
+	encryptedToken, err := h.tokenCipher.SealWithContext(req.AccessToken, scm.UserTokenContext(userID, providerID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt token"})
 		return
@@ -775,7 +776,8 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 	}
 
 	// Decrypt the access token
-	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	accessToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		tokenRecord.AccessTokenEncrypted, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt access token"})
 		return
@@ -821,7 +823,8 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 
 	// Parse refresh token if present
 	if tokenRecord.RefreshTokenEncrypted != nil {
-		refreshToken, err := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted)
+		refreshToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+			*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 		if err == nil {
 			token.RefreshToken = refreshToken
 		}
@@ -853,12 +856,12 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 		if renewErr != nil {
 			return false
 		}
-		if encAccess, encErr := h.tokenCipher.Seal(newToken.AccessToken); encErr == nil {
+		if encAccess, encErr := h.tokenCipher.SealWithContext(newToken.AccessToken, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); encErr == nil {
 			tokenRecord.AccessTokenEncrypted = encAccess
 			tokenRecord.ExpiresAt = newToken.ExpiresAt
 			tokenRecord.UpdatedAt = time.Now()
 			if newToken.RefreshToken != "" {
-				if encRefresh, rErr := h.tokenCipher.Seal(newToken.RefreshToken); rErr == nil {
+				if encRefresh, rErr := h.tokenCipher.SealWithContext(newToken.RefreshToken, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); rErr == nil {
 					tokenRecord.RefreshTokenEncrypted = &encRefresh
 				}
 			}
@@ -1096,7 +1099,8 @@ func (h *SCMOAuthHandlers) refreshAndPersistToken(ctx context.Context, connector
 	if tokenRecord.RefreshTokenEncrypted == nil {
 		return nil, fmt.Errorf("no refresh token available")
 	}
-	refreshToken, err := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted)
+	refreshToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decrypt refresh token: %w", err)
 	}
@@ -1105,7 +1109,7 @@ func (h *SCMOAuthHandlers) refreshAndPersistToken(ctx context.Context, connector
 		return nil, fmt.Errorf("token refresh failed: %w", err)
 	}
 	// Encrypt and persist the new credentials.
-	encAccess, err := h.tokenCipher.Seal(newToken.AccessToken)
+	encAccess, err := h.tokenCipher.SealWithContext(newToken.AccessToken, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt new access token: %w", err)
 	}
@@ -1113,7 +1117,7 @@ func (h *SCMOAuthHandlers) refreshAndPersistToken(ctx context.Context, connector
 	tokenRecord.ExpiresAt = newToken.ExpiresAt
 	tokenRecord.UpdatedAt = time.Now()
 	if newToken.RefreshToken != "" {
-		if encRefresh, rErr := h.tokenCipher.Seal(newToken.RefreshToken); rErr == nil {
+		if encRefresh, rErr := h.tokenCipher.SealWithContext(newToken.RefreshToken, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); rErr == nil {
 			tokenRecord.RefreshTokenEncrypted = &encRefresh
 		}
 	}
@@ -1143,7 +1147,8 @@ func (h *SCMOAuthHandlers) buildConnectorWithToken(ctx context.Context, provider
 	}
 
 	// Decrypt the access token
-	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	accessToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		tokenRecord.AccessTokenEncrypted, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to decrypt access token")
 	}
@@ -1186,7 +1191,8 @@ func (h *SCMOAuthHandlers) buildConnectorWithToken(ctx context.Context, provider
 
 	// Parse refresh token if present
 	if tokenRecord.RefreshTokenEncrypted != nil {
-		refreshToken, err := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted)
+		refreshToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+			*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 		if err == nil {
 			token.RefreshToken = refreshToken
 		}

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -94,7 +94,8 @@ func (h *SCMLinkingHandler) connectorAndToken(ctx context.Context, provider *scm
 	if err != nil || tokenRecord == nil {
 		return connector, nil, nil
 	}
-	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	accessToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		tokenRecord.AccessTokenEncrypted, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		return connector, nil, nil
 	}
@@ -104,7 +105,8 @@ func (h *SCMLinkingHandler) connectorAndToken(ctx context.Context, provider *scm
 		ExpiresAt:   tokenRecord.ExpiresAt,
 	}
 	if tokenRecord.RefreshTokenEncrypted != nil {
-		if rt, rErr := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted); rErr == nil {
+		if rt, _, rErr := h.tokenCipher.OpenWithContextOrLegacy(
+			*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); rErr == nil {
 			token.RefreshToken = rt
 		}
 	}
@@ -562,7 +564,8 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 	}
 
 	// Decrypt the access token
-	accessToken, err := h.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	accessToken, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		tokenRecord.AccessTokenEncrypted, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt access token"})
 		return
@@ -609,7 +612,8 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 	// Parse refresh token if present
 	var decryptedRefreshToken string
 	if tokenRecord.RefreshTokenEncrypted != nil {
-		if rt, err := h.tokenCipher.Open(*tokenRecord.RefreshTokenEncrypted); err == nil {
+		if rt, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+			*tokenRecord.RefreshTokenEncrypted, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); err == nil {
 			token.RefreshToken = rt
 			decryptedRefreshToken = rt
 		}
@@ -623,12 +627,12 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 			token.RefreshToken = newToken.RefreshToken
 			token.ExpiresAt = newToken.ExpiresAt
 			// Persist the refreshed token so future requests don't need to refresh again.
-			if encAccess, err := h.tokenCipher.Seal(newToken.AccessToken); err == nil {
+			if encAccess, err := h.tokenCipher.SealWithContext(newToken.AccessToken, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); err == nil {
 				tokenRecord.AccessTokenEncrypted = encAccess
 				tokenRecord.ExpiresAt = newToken.ExpiresAt
 				tokenRecord.UpdatedAt = time.Now()
 				if newToken.RefreshToken != "" {
-					if encRefresh, err := h.tokenCipher.Seal(newToken.RefreshToken); err == nil {
+					if encRefresh, err := h.tokenCipher.SealWithContext(newToken.RefreshToken, scm.UserRefreshTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID)); err == nil {
 						tokenRecord.RefreshTokenEncrypted = &encRefresh
 					}
 				}

--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -39,16 +39,16 @@ import (
 // unboundSealSites maps a repo-relative file to how many TokenCipher.Seal calls
 // it still contains, with the column and why it has not been converted yet.
 //
+// Converted so far: scm_provider_tokens.access_token (the app-token cache), and
+// the user OAuth access + refresh tokens across scm_oauth.go, scm_linking.go and
+// scm_publisher.go. What remains is the operator-entered material, which needs a
+// backfill per column before its reads can stop accepting the unbound form.
+//
 // Ordered by recoverability, which is the order the conversion follows: a column
 // whose failure mode is "re-mint" is safe to convert first; one whose failure
 // mode is "an operator re-enters the secret by hand" is converted last, with a
 // verified backfill.
 var unboundSealSites = map[string]int{
-	// User OAuth access + refresh tokens. Recoverable: the user reconnects.
-	// Two distinct contexts needed (access vs refresh) so a long-lived refresh
-	// token cannot be written into the access column of its own row.
-	"internal/api/admin/scm_oauth.go": 9,
-
 	// Storage-backend credentials: Azure account key, S3 access key id and
 	// secret, GCS credentials JSON. IRREPLACEABLE — an operator re-enters them.
 	"internal/api/admin/storage.go": 8,
@@ -59,10 +59,6 @@ var unboundSealSites = map[string]int{
 
 	// SCM client secret and app private key. IRREPLACEABLE.
 	"internal/api/admin/scm_providers.go": 4,
-
-	// User token re-seal on the module-linking path; converts with scm_oauth.go
-	// since it writes the same two columns.
-	"internal/api/modules/scm_linking.go": 2,
 
 	// This service's own notification channel target. The sibling column in
 	// tsm-backend is already bound (tsm #359) via identity/notify.TargetContext;

--- a/backend/internal/scm/aad.go
+++ b/backend/internal/scm/aad.go
@@ -37,3 +37,30 @@ import "github.com/google/uuid"
 func ProviderTokenContext(scmProviderID uuid.UUID) []byte {
 	return []byte("scm_provider_tokens:" + scmProviderID.String() + ":access_token")
 }
+
+// UserTokenContext binds a user's OAuth access token to its row in
+// scm_user_tokens.
+//
+// The row is keyed by BOTH the user and the provider, so both are in the
+// context: binding to one axis alone would let a token be replayed across the
+// other. Every SCMUserTokenRecord carries both fields, so read sites derive this
+// from the record they are already holding rather than from surrounding scope —
+// which is what keeps eleven call sites uniform and hard to get wrong.
+//
+// Distinct from ProviderTokenContext even though both columns are named
+// AccessTokenEncrypted. Those are different tables with different keys, and the
+// compiler cannot tell them apart.
+func UserTokenContext(userID, scmProviderID uuid.UUID) []byte {
+	return []byte("scm_user_tokens:" + userID.String() + ":" + scmProviderID.String() + ":access_token")
+}
+
+// UserRefreshTokenContext binds a user's OAuth refresh token to its row.
+//
+// Deliberately distinct from UserTokenContext for the SAME row. Without that, an
+// access token could be written into the refresh column of its own row, or the
+// reverse, and still authenticate — a move WITHIN one row that a row-level
+// context alone does not catch, and one that hands a long-lived credential to a
+// path expecting a short-lived one.
+func UserRefreshTokenContext(userID, scmProviderID uuid.UUID) []byte {
+	return []byte("scm_user_tokens:" + userID.String() + ":" + scmProviderID.String() + ":refresh_token")
+}

--- a/backend/internal/scm/aad_test.go
+++ b/backend/internal/scm/aad_test.go
@@ -1,0 +1,95 @@
+package scm_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	identitycrypto "github.com/sethbacon/terraform-suite-identity/identity/crypto"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// suite-identity #153 — the contexts that bind each stored SCM secret to the row
+// and column it belongs to. What is worth pinning is not the string format but
+// the SEPARATIONS: which ciphertexts must not be interchangeable with which.
+
+func cipher(t *testing.T) *identitycrypto.TokenCipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 7)
+	}
+	tc, err := identitycrypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return tc
+}
+
+// The separation that a row-level context alone would NOT give: access and
+// refresh live in the same row, so binding only to the row would let a
+// long-lived refresh token be written into the access column and still
+// authenticate — handing a long-lived credential to a path expecting a short one.
+func TestUserTokenContexts_AccessAndRefreshAreNotInterchangeableWithinARow(t *testing.T) {
+	tc := cipher(t)
+	user, provider := uuid.New(), uuid.New()
+
+	access, err := tc.SealWithContext("access-token", scm.UserTokenContext(user, provider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.OpenWithContext(access, scm.UserRefreshTokenContext(user, provider)); err == nil {
+		t.Error("an access token opened as its own row's refresh token")
+	}
+
+	refresh, err := tc.SealWithContext("refresh-token", scm.UserRefreshTokenContext(user, provider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.OpenWithContext(refresh, scm.UserTokenContext(user, provider)); err == nil {
+		t.Error("a refresh token opened as its own row's access token")
+	}
+}
+
+// The row is keyed by user AND provider, so a token must not move along either
+// axis. Binding to one alone would leave the other replayable.
+func TestUserTokenContext_BindsBothAxes(t *testing.T) {
+	tc := cipher(t)
+	user, provider := uuid.New(), uuid.New()
+
+	sealed, err := tc.SealWithContext("token", scm.UserTokenContext(user, provider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.OpenWithContext(sealed, scm.UserTokenContext(uuid.New(), provider)); err == nil {
+		t.Error("opened for a different user on the same provider")
+	}
+	if _, err := tc.OpenWithContext(sealed, scm.UserTokenContext(user, uuid.New())); err == nil {
+		t.Error("opened for the same user on a different provider")
+	}
+}
+
+// The two tables share the field NAME AccessTokenEncrypted but are keyed
+// differently. Nothing in the type system stops one family's context being used
+// for the other's ciphertext, so the separation is asserted here instead.
+func TestProviderAndUserTokenContexts_AreNotInterchangeable(t *testing.T) {
+	tc := cipher(t)
+	provider := uuid.New()
+	user := uuid.New()
+
+	cached, err := tc.SealWithContext("app-token", scm.ProviderTokenContext(provider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.OpenWithContext(cached, scm.UserTokenContext(user, provider)); err == nil {
+		t.Error("a cached app token opened as a user's OAuth token")
+	}
+
+	userTok, err := tc.SealWithContext("user-token", scm.UserTokenContext(user, provider))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tc.OpenWithContext(userTok, scm.ProviderTokenContext(provider)); err == nil {
+		t.Error("a user's OAuth token opened as the shared app-token cache entry")
+	}
+}

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -106,7 +106,8 @@ func (p *SCMPublisher) resolveSourceToken(ctx context.Context, createdBy *string
 	if tokenErr != nil || tokenRecord == nil {
 		return nil
 	}
-	accessToken, decryptErr := p.tokenCipher.Open(tokenRecord.AccessTokenEncrypted)
+	accessToken, _, decryptErr := p.tokenCipher.OpenWithContextOrLegacy(
+		tokenRecord.AccessTokenEncrypted, scm.UserTokenContext(tokenRecord.UserID, tokenRecord.SCMProviderID))
 	if decryptErr != nil {
 		return nil
 	}


### PR DESCRIPTION
Refs #153. Column 2, following #837 (the cache) and #838 (the inventory guard).

**11 read sites and 11 write sites** across `scm_oauth.go`, `scm_linking.go` and `scm_publisher.go`, covering both encrypted columns of `scm_user_tokens`.

## Two contexts, not one

The row is keyed by **user AND provider**, so both are bound — binding one axis alone leaves the other replayable.

And access and refresh get **distinct** contexts *within the same row*. That's the decision most likely to look unnecessary, so it's worth stating plainly: with a row-level context only, a long-lived **refresh** token could be written into the **access** column of its own row and still authenticate — handing a long-lived credential to a path that expects a short-lived one. It has its own test, in both directions.

## What made 22 sites tractable

Every read derives its context from the `SCMUserTokenRecord` it's already holding, which carries both keys. That turned eleven scattered call sites into a uniform edit rather than eleven chances to pick the wrong id out of surrounding scope.

Reads go through `OpenWithContextOrLegacy`, so tokens sealed before this change keep working — nobody is forced to reconnect on the deploy that ships it.

## Completeness, which mattered more than usual here

A missed **read** site doesn't fail the build. It compiles, and then fails at runtime for a user trying to publish a module.

The arity change (`Open` returns 2, `OpenWithContextOrLegacy` returns 3) catches a *botched* conversion at compile time — but not an *omitted* one. So that was checked separately: **no plain `Open` on `AccessTokenEncrypted` or `RefreshTokenEncrypted` remains anywhere outside tests.**

## The guard earned its keep immediately

#838's inventory failed on the stale entries for both converted files and wouldn't pass until they were removed — exactly the intended workflow. Updated inventory:

**21 unbound sites across 5 files remain**, all operator-entered material (storage credentials ×8, setup secrets ×6, client secret + app private key ×4, this repo's channel target ×2, SMTP password ×1). Each needs a backfill before its reads can stop accepting the unbound form.

## Verification

Mutation: collapsing the refresh context onto the access one — i.e. row-level binding only — fails the same-row separation test in both directions.

63 packages pass; `go build`, `go vet`, `gofmt` clean. gosec reports two findings in the touched packages, both **pre-existing and outside this diff**: `connector.go` has zero diff lines here, and the `scm_publisher` G304 is at line 699 while this change's only hunk in that file is at 109.