### PR TITLE
feat(maintenance): add bind-secrets, a per-column backfill with a verify gate

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -68,6 +68,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
+	"github.com/terraform-registry/terraform-registry/internal/maintenance"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"golang.org/x/crypto/bcrypt"
@@ -119,8 +120,12 @@ func run() error {
 		return runUpgrade(configPath)
 	case "scan-worker":
 		return scanWorker(cfg)
+	case "bind-secrets":
+		// bind-secrets [verify] — convert stored secrets to the row-bound
+		// ciphertext form, or report what remains without writing.
+		return runBindSecrets(cfg, len(os.Args) > 2 && os.Args[2] == "verify")
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker", command)
+		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker, bind-secrets", command)
 	}
 }
 
@@ -961,4 +966,39 @@ func runMigrations(cfg *config.Config, direction string) error {
 
 	log.Printf("Migration completed successfully. Current version: %d (dirty: %v)", version, dirty) // #nosec G706 -- logged value is application-internal (config string, integer, or application-constructed path); not raw user-controlled request input
 	return nil
+}
+
+// runBindSecrets converts stored secrets to the row-bound ciphertext form
+// (suite-identity #153), or with "verify" reports what remains unbound without
+// writing anything.
+//
+// Operator-invoked rather than a startup hook: a boot-time sweep runs on every
+// replica at once and would need a cross-replica claim to be safe.
+//
+// The verify form is the exit criterion. While any row of a column is unbound,
+// that column's reads must keep accepting the unbound form — which is the
+// property being retired — so without a completion signal the transition reader
+// becomes permanent. It exits non-zero while work remains, so a runbook step or
+// CI check can gate the removal rather than someone reading output.
+func runBindSecrets(cfg *config.Config, verify bool) error {
+	database, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	cipher, err := api.BuildTokenCipherFromEnv()
+	if err != nil {
+		return fmt.Errorf("bind-secrets needs the encryption key the server uses: %w", err)
+	}
+
+	results, err := maintenance.BindSecrets(context.Background(), database, cipher, verify)
+	mode := "convert"
+	if verify {
+		mode = "verify"
+	}
+	for name, res := range results {
+		slog.Info("bind-secrets column complete", "mode", mode, "column", name, "result", res.String())
+	}
+	return err
 }

--- a/backend/internal/api/tokencipher_env.go
+++ b/backend/internal/api/tokencipher_env.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"os"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+)
+
+// BuildTokenCipherFromEnv constructs the TokenCipher from the same environment
+// the server uses: ENCRYPTION_KEY, plus ENCRYPTION_KEY_PREVIOUS for the
+// zero-downtime rotation fallback.
+//
+// Exported so the bind-secrets maintenance command shares this exact key source
+// rather than re-reading the environment itself. The backfill must open what the
+// server sealed; a second key path is a second thing to drift, which is how the
+// duplicated cipher in #835 ended up an OWASP revision behind.
+//
+// It returns errors instead of calling log.Fatal, because a CLI subcommand
+// should report a bad key and exit rather than die inside a library call. The
+// server's startup path keeps its own fatal behaviour at the call site, so the
+// operator-facing messages there are unchanged.
+//
+// The low-entropy gate deliberately stays at startup and is NOT applied here. It
+// is a policy about whether this deployment should be SERVING, not about whether
+// a one-shot conversion may read the data already encrypted under that key —
+// refusing to convert because the existing key is weak would strand exactly the
+// deployments that most need to re-encrypt.
+func BuildTokenCipherFromEnv() (*crypto.TokenCipher, error) {
+	key := os.Getenv("ENCRYPTION_KEY")
+	if key == "" {
+		return nil, errors.New("ENCRYPTION_KEY must be set")
+	}
+	if previous := os.Getenv("ENCRYPTION_KEY_PREVIOUS"); previous != "" {
+		return crypto.NewTokenCipherWithPrevious([]byte(key), []byte(previous))
+	}
+	return crypto.NewTokenCipher([]byte(key))
+}

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -1,0 +1,185 @@
+// Package maintenance holds operator-invoked, one-shot data tasks that cannot be
+// expressed as SQL migrations.
+package maintenance
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	identitynotify "github.com/sethbacon/terraform-suite-identity/identity/notify"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+)
+
+// Converting a column to the row-bound ciphertext form (suite-identity #153)
+// cannot be a SQL migration: AES-GCM re-encryption needs the key, which only
+// exists in the running application. Each converted column therefore needs a
+// sweep, and this service has five more to go.
+//
+// Rather than five bespoke commands, a column describes itself with three
+// things — how to list its rows, how to derive a row's context, how to write a
+// converted value — and the sweep logic below is shared. The alternative is five
+// near-identical loops that drift in exactly the details that matter: whether a
+// bad row aborts the run, whether verify writes, whether an already-converted
+// row is skipped or double-sealed.
+
+// sealedRow is one candidate: a row id and the ciphertext currently stored.
+type sealedRow struct {
+	id     string
+	sealed string
+}
+
+// column is one convertible secret column.
+type column struct {
+	// name appears in output; use table.column so a partial run is readable.
+	name string
+	// list returns every row holding a secret. An empty ciphertext means
+	// "unset", not "unbound", and must be excluded here rather than filtered
+	// later — it is not a conversion candidate.
+	list func(ctx context.Context, db *sql.DB) ([]sealedRow, error)
+	// context derives the AAD binding for a row. It MUST match what the
+	// application seals with, or the conversion writes values the app cannot
+	// read.
+	context func(id string) []byte
+	// update writes the converted ciphertext back for one row.
+	update func(ctx context.Context, db *sql.DB, id, bound string) error
+}
+
+// Result is what one column's sweep did. Total is rows examined, not changed.
+type Result struct {
+	Total        int
+	Converted    int
+	AlreadyBound int
+	Failed       int
+}
+
+func (r Result) String() string {
+	return fmt.Sprintf("examined=%d converted=%d already-bound=%d failed=%d",
+		r.Total, r.Converted, r.AlreadyBound, r.Failed)
+}
+
+// ErrUnboundRemain is returned by a verify run that found rows still unbound.
+//
+// It exists so the check is scriptable. Verify is the gate that says whether a
+// column's reads can stop accepting the unbound form, and a gate that only
+// prints is not a gate — it needs a non-zero exit for CI or a runbook step to
+// hang off.
+var ErrUnboundRemain = errors.New("maintenance: secrets remain unbound")
+
+// columns is the registry of convertible columns.
+//
+// One entry today. The remaining four (storage credentials, setup secrets, SCM
+// client secret and app private key, SMTP password) are added here as each is
+// converted in the application — the sweep for a column must not exist before
+// the code that writes the bound form, or an operator can convert rows the
+// running service then cannot read.
+var columns = []column{
+	{
+		name:    "notification_channels.encrypted_target",
+		context: func(id string) []byte { return identitynotify.TargetContext(id) },
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			return listRows(ctx, db,
+				`SELECT id, encrypted_target FROM notification_channels WHERE encrypted_target <> ''`)
+		},
+		update: func(ctx context.Context, db *sql.DB, id, bound string) error {
+			_, err := db.ExecContext(ctx,
+				`UPDATE notification_channels SET encrypted_target = $2, updated_at = now() WHERE id = $1`,
+				id, bound)
+			return err
+		},
+	},
+}
+
+// listRows runs a two-column (id, ciphertext) query and drains it.
+//
+// The cursor is closed by a single deferred call, and closed BEFORE any caller
+// starts writing: holding a result set open across the conversion UPDATEs would
+// pin a connection for the length of the sweep.
+func listRows(ctx context.Context, db *sql.DB, query string) ([]sealedRow, error) {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []sealedRow
+	for rows.Next() {
+		var r sealedRow
+		if err := rows.Scan(&r.id, &r.sealed); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// BindSecrets converts every registered column to the row-bound form, or with
+// verifyOnly reports what remains without writing.
+//
+// Safe to re-run and safe to interrupt: an already-bound row is detected by
+// opening it under its own context — no schema flag can answer this, because the
+// form is a property of the ciphertext, not of the row — and skipped rather than
+// double-sealed.
+//
+// A row that cannot be decrypted at all is reported and stepped over. That is a
+// pre-existing problem this sweep did not cause and cannot fix, and abandoning
+// the remaining rows over it would be worse.
+func BindSecrets(
+	ctx context.Context,
+	db *sql.DB,
+	tc *crypto.TokenCipher,
+	verifyOnly bool,
+) (map[string]Result, error) {
+	if tc == nil {
+		return nil, errors.New("maintenance: no token cipher configured (set ENCRYPTION_KEY)")
+	}
+
+	results := make(map[string]Result, len(columns))
+	var unbound bool
+
+	for _, col := range columns {
+		rows, err := col.list(ctx, db)
+		if err != nil {
+			return results, fmt.Errorf("maintenance: list %s: %w", col.name, err)
+		}
+
+		res := Result{Total: len(rows)}
+		for _, row := range rows {
+			if _, err := tc.OpenWithContext(row.sealed, col.context(row.id)); err == nil {
+				res.AlreadyBound++
+				continue
+			}
+			bound, err := tc.ReSealWithContext(row.sealed, col.context(row.id))
+			if err != nil {
+				res.Failed++
+				slog.Error("secret could not be converted",
+					"column", col.name, "row_id", row.id, "error", err)
+				continue
+			}
+			if verifyOnly {
+				res.Converted++ // would convert
+				continue
+			}
+			if err := col.update(ctx, db, row.id, bound); err != nil {
+				res.Failed++
+				slog.Error("converted secret could not be written",
+					"column", col.name, "row_id", row.id, "error", err)
+				continue
+			}
+			res.Converted++
+		}
+
+		results[col.name] = res
+		if res.Converted > 0 || res.Failed > 0 {
+			unbound = true
+		}
+	}
+
+	if verifyOnly && unbound {
+		return results, ErrUnboundRemain
+	}
+	return results, nil
+}

--- a/backend/internal/maintenance/bindsecrets_test.go
+++ b/backend/internal/maintenance/bindsecrets_test.go
@@ -1,0 +1,216 @@
+package maintenance
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	identitynotify "github.com/sethbacon/terraform-suite-identity/identity/notify"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+)
+
+// suite-identity #153 backfill. The properties an operator relies on when
+// running this against live credentials: safe to re-run, one bad row does not
+// abandon the rest, and verify writes nothing but still fails while work remains.
+
+func newCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 3)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return tc
+}
+
+type capturedArg struct{ got *string }
+
+func (c capturedArg) Match(v driver.Value) bool {
+	if s, ok := v.(string); ok {
+		*c.got = s
+	}
+	return true
+}
+
+func channelRows(pairs ...[2]string) *sqlmock.Rows {
+	r := sqlmock.NewRows([]string{"id", "encrypted_target"})
+	for _, p := range pairs {
+		r.AddRow(p[0], p[1])
+	}
+	return r
+}
+
+const chanCol = "notification_channels.encrypted_target"
+
+func TestBindSecrets_ConvertsAnUnboundRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	legacy, err := tc.Seal("https://hooks.example.com/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+		WillReturnRows(channelRows([2]string{"chan-1", legacy}))
+
+	var stored string
+	mock.ExpectExec("UPDATE notification_channels").
+		WithArgs(sqlmock.AnyArg(), capturedArg{got: &stored}).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	if got := res[chanCol]; got.Converted != 1 || got.Failed != 0 {
+		t.Fatalf("result = %s; want one conversion", got)
+	}
+
+	got, err := tc.OpenWithContext(stored, identitynotify.TargetContext("chan-1"))
+	if err != nil || got != "https://hooks.example.com/a" {
+		t.Fatalf("converted value does not open under its row context: (%q, %v)", got, err)
+	}
+	if _, err := tc.Open(stored); err == nil {
+		t.Error("converted value still opens WITHOUT a context; it was not bound")
+	}
+}
+
+// Re-running must be a no-op, which is what makes an interrupted sweep safe to
+// resume. Asserted by the absence of any UPDATE — sqlmock fails an unexpected one.
+func TestBindSecrets_SkipsAnAlreadyBoundRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	bound, err := tc.SealWithContext("https://hooks.example.com/a", identitynotify.TargetContext("chan-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+		WillReturnRows(channelRows([2]string{"chan-1", bound}))
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	if got := res[chanCol]; got.AlreadyBound != 1 || got.Converted != 0 {
+		t.Fatalf("result = %s; want the row recognised as already bound", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("an already-bound row should trigger no write: %v", err)
+	}
+}
+
+func TestBindSecrets_OneUndecryptableRowDoesNotAbortTheSweep(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	good, err := tc.Seal("https://hooks.example.com/good")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+		WillReturnRows(channelRows(
+			[2]string{"chan-bad", "not-a-valid-ciphertext"},
+			[2]string{"chan-good", good},
+		))
+	mock.ExpectExec("UPDATE notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	got := res[chanCol]
+	if got.Failed != 1 || got.Converted != 1 {
+		t.Errorf("result = %s; want the bad row reported and the good one still converted", got)
+	}
+}
+
+func TestBindSecrets_VerifyWritesNothingAndFailsWhileUnboundRemain(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	legacy, err := tc.Seal("https://hooks.example.com/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+		WillReturnRows(channelRows([2]string{"chan-1", legacy}))
+
+	res, err := BindSecrets(context.Background(), db, tc, true)
+	if !errors.Is(err, ErrUnboundRemain) {
+		t.Fatalf("verify error = %v, want ErrUnboundRemain so it can gate a runbook step", err)
+	}
+	if res[chanCol].Converted != 1 {
+		t.Errorf("verify should report what WOULD convert; got %s", res[chanCol])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("verify must not write: %v", err)
+	}
+}
+
+// The zero that says a column's reads can stop accepting the unbound form.
+func TestBindSecrets_VerifySucceedsWhenAllBound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	bound, err := tc.SealWithContext("https://hooks.example.com/a", identitynotify.TargetContext("chan-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+		WillReturnRows(channelRows([2]string{"chan-1", bound}))
+
+	if _, err := BindSecrets(context.Background(), db, tc, true); err != nil {
+		t.Fatalf("verify with everything bound must succeed, got %v", err)
+	}
+}
+
+func TestBindSecrets_RequiresACipher(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := BindSecrets(context.Background(), db, nil, false); err == nil {
+		t.Fatal("a nil cipher must be refused, not treated as 'nothing to do'")
+	}
+}
+
+// Every registered column must derive its context from the row id. A constant
+// context would satisfy the round-trip tests above while making the binding
+// vacuous for that column, and this is the cheapest place to catch it as columns
+// are added.
+func TestRegisteredColumns_ContextsAreRowScoped(t *testing.T) {
+	for _, col := range columns {
+		if string(col.context("row-a")) == string(col.context("row-b")) {
+			t.Errorf("%s derives the same context for different rows; its binding is vacuous", col.name)
+		}
+	}
+}


### PR DESCRIPTION
Refs #153. Follows #840, which binds the channel target on create/edit — this converts the rows nobody touches, and is the framework the remaining four columns plug into.

```
registry bind-secrets          # convert
registry bind-secrets verify   # report what remains, write nothing
```

## A registry of columns, not one command per column

A column describes itself with three things — how to list its rows, how to derive a row's context, how to write a converted value — and the sweep logic is shared.

Five near-identical loops would drift in exactly the details that matter: whether a bad row aborts the run, whether verify writes, whether an already-converted row is skipped or double-sealed. Those are the details an operator is trusting when they run this against live credentials, so there should be one implementation of them.

## Safety properties

- **Safe to re-run and to interrupt.** An already-bound row is detected by opening it under its own context — no schema flag can answer this, since the form is a property of the ciphertext, not of the row — and skipped rather than double-sealed.
- **One undecryptable row is stepped over**, not fatal. That's a pre-existing problem this sweep didn't cause and can't fix; abandoning the rest over it would be worse.
- **Nothing plaintext is logged** — failures carry the column, row id and error only.

## The verify gate is the exit criterion

While any row of a column is unbound, that column's reads must keep accepting the unbound form — the property being retired. Without a completion signal the transition reader becomes permanent and the binding is never really enforced.

`verify` exits **non-zero while work remains**, so a runbook step or CI check can gate the removal rather than relying on someone reading output.

## Only one column is registered, deliberately

A column's sweep must **not** exist before the code that writes its bound form — otherwise an operator can convert rows the running service then cannot read. Entries get added here as each column converts, not in advance.

## Key handling

`BuildTokenCipherFromEnv` is **extracted, not duplicated**: the backfill must open what the server sealed, and a second key path is a second thing to drift (see #835 for how that ends). It returns errors instead of `log.Fatal` so a CLI reports a bad key rather than dying inside a library call; the server keeps its fatal behaviour at the call site, so startup messages are unchanged.

The low-entropy gate deliberately stays at startup. It's a policy about whether this deployment should be *serving* — refusing to convert because the existing key is weak would strand exactly the deployments that most need re-encrypting.

## Verification

Mutation, three ways:

| mutant | caught by |
| --- | --- |
| already-bound detection removed | idempotence + verify-clean |
| verify writes anyway | the no-write assertion |
| constant (non-row-scoped) context | three tests, incl. the registry-wide check that every column's context varies by row |

That last check runs over **all** registered columns, so a future column added with a vacuous context fails immediately rather than being discovered during its backfill.

64 packages pass; build, vet, gofmt clean; gosec Issues: 0 on the touched packages.