### PR TITLE
feat(storage): bind the storage-backend credentials to their config row

### DIFF
--- a/backend/internal/api/admin/storage.go
+++ b/backend/internal/api/admin/storage.go
@@ -614,7 +614,8 @@ func (h *StorageHandlers) buildStorageConfig(input *models.StorageConfigInput, u
 		config.AzureContainerName = sql.NullString{String: input.AzureContainerName, Valid: input.AzureContainerName != ""}
 		config.AzureCDNURL = sql.NullString{String: input.AzureCDNURL, Valid: input.AzureCDNURL != ""}
 		if input.AzureAccountKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.AzureAccountKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.AzureAccountKey,
+				models.StorageConfigAzureAccountKeyContext(config.ID.String()))
 			if err != nil {
 				return nil, err
 			}
@@ -631,14 +632,16 @@ func (h *StorageHandlers) buildStorageConfig(input *models.StorageConfigInput, u
 		config.S3ExternalID = sql.NullString{String: input.S3ExternalID, Valid: input.S3ExternalID != ""}
 		config.S3WebIdentityTokenFile = sql.NullString{String: input.S3WebIdentityTokenFile, Valid: input.S3WebIdentityTokenFile != ""}
 		if input.S3AccessKeyID != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3AccessKeyID)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3AccessKeyID,
+				models.StorageConfigS3AccessKeyIDContext(config.ID.String()))
 			if err != nil {
 				return nil, err
 			}
 			config.S3AccessKeyIDEncrypted = sql.NullString{String: encrypted, Valid: true}
 		}
 		if input.S3SecretAccessKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3SecretAccessKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3SecretAccessKey,
+				models.StorageConfigS3SecretAccessKeyContext(config.ID.String()))
 			if err != nil {
 				return nil, err
 			}
@@ -652,7 +655,8 @@ func (h *StorageHandlers) buildStorageConfig(input *models.StorageConfigInput, u
 		config.GCSCredentialsFile = sql.NullString{String: input.GCSCredentialsFile, Valid: input.GCSCredentialsFile != ""}
 		config.GCSEndpoint = sql.NullString{String: input.GCSEndpoint, Valid: input.GCSEndpoint != ""}
 		if input.GCSCredentialsJSON != "" {
-			encrypted, err := h.tokenCipher.Seal(input.GCSCredentialsJSON)
+			encrypted, err := h.tokenCipher.SealWithContext(input.GCSCredentialsJSON,
+				models.StorageConfigGCSCredentialsJSONContext(config.ID.String()))
 			if err != nil {
 				return nil, err
 			}
@@ -680,7 +684,8 @@ func (h *StorageHandlers) updateStorageConfigFromInput(config *models.StorageCon
 		config.AzureContainerName = sql.NullString{String: input.AzureContainerName, Valid: input.AzureContainerName != ""}
 		config.AzureCDNURL = sql.NullString{String: input.AzureCDNURL, Valid: input.AzureCDNURL != ""}
 		if input.AzureAccountKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.AzureAccountKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.AzureAccountKey,
+				models.StorageConfigAzureAccountKeyContext(config.ID.String()))
 			if err != nil {
 				return err
 			}
@@ -697,14 +702,16 @@ func (h *StorageHandlers) updateStorageConfigFromInput(config *models.StorageCon
 		config.S3ExternalID = sql.NullString{String: input.S3ExternalID, Valid: input.S3ExternalID != ""}
 		config.S3WebIdentityTokenFile = sql.NullString{String: input.S3WebIdentityTokenFile, Valid: input.S3WebIdentityTokenFile != ""}
 		if input.S3AccessKeyID != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3AccessKeyID)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3AccessKeyID,
+				models.StorageConfigS3AccessKeyIDContext(config.ID.String()))
 			if err != nil {
 				return err
 			}
 			config.S3AccessKeyIDEncrypted = sql.NullString{String: encrypted, Valid: true}
 		}
 		if input.S3SecretAccessKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3SecretAccessKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3SecretAccessKey,
+				models.StorageConfigS3SecretAccessKeyContext(config.ID.String()))
 			if err != nil {
 				return err
 			}
@@ -718,7 +725,8 @@ func (h *StorageHandlers) updateStorageConfigFromInput(config *models.StorageCon
 		config.GCSCredentialsFile = sql.NullString{String: input.GCSCredentialsFile, Valid: input.GCSCredentialsFile != ""}
 		config.GCSEndpoint = sql.NullString{String: input.GCSEndpoint, Valid: input.GCSEndpoint != ""}
 		if input.GCSCredentialsJSON != "" {
-			encrypted, err := h.tokenCipher.Seal(input.GCSCredentialsJSON)
+			encrypted, err := h.tokenCipher.SealWithContext(input.GCSCredentialsJSON,
+				models.StorageConfigGCSCredentialsJSONContext(config.ID.String()))
 			if err != nil {
 				return err
 			}

--- a/backend/internal/api/admin/storage_binding_test.go
+++ b/backend/internal/api/admin/storage_binding_test.go
@@ -1,0 +1,278 @@
+package admin
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153 — the storage-backend credentials are bound to the
+// storage_config row AND the column they belong to, so a sealed credential
+// cannot be lifted out of one configuration and written into another, or into a
+// different credential column of its own row, by anyone with database write
+// access.
+//
+// These assert on the values REACHING the database rather than on the model the
+// builder returned, because the row id that goes into the context and the row id
+// that goes into the INSERT are set in different places; a test of the builder
+// alone would pass even if the handler stored the credential against a different
+// row.
+
+// storageInsertArgs and storageUpdateArgs are the positional-parameter counts of
+// StorageConfigRepository's INSERT and UPDATE. sqlmock's WithArgs needs one
+// matcher per parameter and has no "match the rest" form. If the repository's
+// column list ever changes, sqlmock fails with both counts, which points
+// straight back here.
+const (
+	storageInsertArgs = 29
+	storageUpdateArgs = 27
+)
+
+// recordArg accepts any value and records it. Recording every argument, rather
+// than pinning the credential's ordinal, keeps this test out of the business of
+// the repository's column order: the assertions below FIND the credential by
+// trying to open it, which is the property under test anyway.
+type recordArg struct {
+	into []driver.Value
+	idx  int
+}
+
+func (r recordArg) Match(v driver.Value) bool {
+	r.into[r.idx] = v
+	return true
+}
+
+func recordAll(n int) ([]driver.Value, []driver.Value) {
+	seen := make([]driver.Value, n)
+	matchers := make([]driver.Value, n)
+	for i := range matchers {
+		matchers[i] = recordArg{into: seen, idx: i}
+	}
+	return seen, matchers
+}
+
+// storageCredential is one encrypted column: what the request supplies and the
+// context the stored ciphertext must be bound to.
+type storageCredential struct {
+	column  string
+	secret  string
+	context func(string) []byte
+}
+
+// storageBackendCases covers all four encrypted columns across the three
+// backends that have them. S3 appears with both of its columns populated at
+// once on purpose: that row is the one where a column-blind binding would let
+// the access key id and the secret access key be swapped.
+var storageBackendCases = []struct {
+	name        string
+	input       map[string]interface{}
+	credentials []storageCredential
+}{
+	{
+		name: "azure",
+		input: map[string]interface{}{
+			"backend_type":         "azure",
+			"azure_account_name":   "acct",
+			"azure_container_name": "ctr",
+			"azure_account_key":    "dGVzdC1henVyZS1rZXk=",
+		},
+		credentials: []storageCredential{
+			{"azure_account_key_encrypted", "dGVzdC1henVyZS1rZXk=",
+				models.StorageConfigAzureAccountKeyContext},
+		},
+	},
+	{
+		name: "s3",
+		input: map[string]interface{}{
+			"backend_type":         "s3",
+			"s3_bucket":            "bkt",
+			"s3_region":            "us-east-1",
+			"s3_auth_method":       "static",
+			"s3_access_key_id":     "AKIAEXAMPLEKEYID",
+			"s3_secret_access_key": "wJalrXUtnFEMI-EXAMPLE-SECRET",
+		},
+		credentials: []storageCredential{
+			{"s3_access_key_id_encrypted", "AKIAEXAMPLEKEYID",
+				models.StorageConfigS3AccessKeyIDContext},
+			{"s3_secret_access_key_encrypted", "wJalrXUtnFEMI-EXAMPLE-SECRET",
+				models.StorageConfigS3SecretAccessKeyContext},
+		},
+	},
+	{
+		name: "gcs",
+		input: map[string]interface{}{
+			"backend_type":         "gcs",
+			"gcs_bucket":           "bkt",
+			"gcs_project_id":       "proj",
+			"gcs_auth_method":      "service_account",
+			"gcs_credentials_json": `{"type":"service_account","private_key":"-----BEGIN"}`,
+		},
+		credentials: []storageCredential{
+			{"gcs_credentials_json_encrypted", `{"type":"service_account","private_key":"-----BEGIN"}`,
+				models.StorageConfigGCSCredentialsJSONContext},
+		},
+	},
+}
+
+// assertStoredCredentials checks every credential the request carried against
+// the values that reached the database.
+//
+// The negative assertions are the ones with teeth. Opening under the right
+// context only proves the seal round-trips; it is the failures — no context, a
+// different row, a sibling column of the same row — that prove the binding is
+// not decorative.
+func assertStoredCredentials(
+	t *testing.T,
+	tc *crypto.TokenCipher,
+	stored []driver.Value,
+	configID string,
+	creds []storageCredential,
+) {
+	t.Helper()
+
+	for _, cred := range creds {
+		raw := findSealed(t, tc, stored, cred.context(configID))
+		if raw == "" {
+			t.Errorf("%s: no stored value opens under the row+column context; "+
+				"the credential was not bound to config %s", cred.column, configID)
+			continue
+		}
+
+		got, err := tc.OpenWithContext(raw, cred.context(configID))
+		if err != nil || got != cred.secret {
+			t.Errorf("%s: stored value = (%q, %v), want %q", cred.column, got, err, cred.secret)
+		}
+		if _, err := tc.Open(raw); err == nil {
+			t.Errorf("%s: stored value still opens WITHOUT a context; it was not bound", cred.column)
+		}
+		if _, err := tc.OpenWithContext(raw, cred.context(otherConfigID)); err == nil {
+			t.Errorf("%s: stored value opened under another config's context; "+
+				"it could be moved between storage configurations", cred.column)
+		}
+		for _, sibling := range allStorageContexts {
+			if sibling.column == cred.column {
+				continue
+			}
+			if _, err := tc.OpenWithContext(raw, sibling.context(configID)); err == nil {
+				t.Errorf("%s: stored value also opened as %s of the SAME row; "+
+					"the two columns are interchangeable", cred.column, sibling.column)
+			}
+		}
+	}
+}
+
+const otherConfigID = "99999999-9999-9999-9999-999999999999"
+
+// allStorageContexts is the whole column family, used for the sibling-column
+// assertions above.
+var allStorageContexts = []storageCredential{
+	{column: "azure_account_key_encrypted", context: models.StorageConfigAzureAccountKeyContext},
+	{column: "s3_access_key_id_encrypted", context: models.StorageConfigS3AccessKeyIDContext},
+	{column: "s3_secret_access_key_encrypted", context: models.StorageConfigS3SecretAccessKeyContext},
+	{column: "gcs_credentials_json_encrypted", context: models.StorageConfigGCSCredentialsJSONContext},
+}
+
+// findSealed returns the single recorded argument that opens under ctx, or "".
+func findSealed(t *testing.T, tc *crypto.TokenCipher, stored []driver.Value, ctx []byte) string {
+	t.Helper()
+	var found string
+	for _, v := range stored {
+		s, ok := v.(string)
+		if !ok || s == "" {
+			continue
+		}
+		if _, err := tc.OpenWithContext(s, ctx); err != nil {
+			continue
+		}
+		if found != "" {
+			t.Fatalf("two stored arguments open under the same context; the test cannot tell them apart")
+		}
+		found = s
+	}
+	return found
+}
+
+func newBindingCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 11)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return tc
+}
+
+func TestCreateStorageConfig_BindsCredentialsToTheNewRow(t *testing.T) {
+	for _, bc := range storageBackendCases {
+		t.Run(bc.name, func(t *testing.T) {
+			tc := newBindingCipher(t)
+			mock, r := newStorageRouterWithCipher(t, tc)
+
+			mock.ExpectQuery("SELECT storage_configured FROM system_settings").
+				WillReturnRows(sqlmock.NewRows([]string{"storage_configured"}))
+
+			stored, matchers := recordAll(storageInsertArgs)
+			mock.ExpectExec("INSERT INTO storage_config").
+				WithArgs(matchers...).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/storage/configs", jsonBody(bc.input)))
+			if w.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+			}
+
+			// The id the handler minted, as the API reported it. Binding to the
+			// wrong id would still round-trip inside the handler; only the
+			// stored id makes the assertion real.
+			var resp struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || resp.ID == "" {
+				t.Fatalf("create response carried no id: %v (body=%s)", err, w.Body.String())
+			}
+
+			assertStoredCredentials(t, tc, stored, resp.ID, bc.credentials)
+		})
+	}
+}
+
+func TestUpdateStorageConfig_BindsCredentialsToTheRowBeingUpdated(t *testing.T) {
+	for _, bc := range storageBackendCases {
+		t.Run(bc.name, func(t *testing.T) {
+			tc := newBindingCipher(t)
+			mock, r := newStorageRouterWithCipher(t, tc)
+
+			mock.ExpectQuery("SELECT.*FROM storage_config WHERE id").
+				WillReturnRows(sampleStorageCfgRow())
+			mock.ExpectQuery("SELECT storage_configured FROM system_settings").
+				WillReturnRows(sqlmock.NewRows([]string{"storage_configured"}).AddRow(false))
+
+			stored, matchers := recordAll(storageUpdateArgs)
+			mock.ExpectExec("UPDATE storage_config").
+				WithArgs(matchers...).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/storage/configs/"+knownUUID,
+				jsonBody(bc.input)))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+			}
+
+			// Bound to the row actually being written -- sampleStorageCfgRow's
+			// id, which is also the path id.
+			assertStoredCredentials(t, tc, stored, knownUUID, bc.credentials)
+		})
+	}
+}

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -1191,7 +1191,8 @@ func (h *Handlers) buildEncryptedStorageConfig(input *models.StorageConfigInput)
 		cfg.AzureContainerName = toNullString(input.AzureContainerName)
 		cfg.AzureCDNURL = toNullString(input.AzureCDNURL)
 		if input.AzureAccountKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.AzureAccountKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.AzureAccountKey,
+				models.StorageConfigAzureAccountKeyContext(cfg.ID.String()))
 			if err != nil {
 				return nil, err
 			}
@@ -1207,14 +1208,16 @@ func (h *Handlers) buildEncryptedStorageConfig(input *models.StorageConfigInput)
 		cfg.S3ExternalID = toNullString(input.S3ExternalID)
 		cfg.S3WebIdentityTokenFile = toNullString(input.S3WebIdentityTokenFile)
 		if input.S3AccessKeyID != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3AccessKeyID)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3AccessKeyID,
+				models.StorageConfigS3AccessKeyIDContext(cfg.ID.String()))
 			if err != nil {
 				return nil, err
 			}
 			cfg.S3AccessKeyIDEncrypted = toNullString(encrypted)
 		}
 		if input.S3SecretAccessKey != "" {
-			encrypted, err := h.tokenCipher.Seal(input.S3SecretAccessKey)
+			encrypted, err := h.tokenCipher.SealWithContext(input.S3SecretAccessKey,
+				models.StorageConfigS3SecretAccessKeyContext(cfg.ID.String()))
 			if err != nil {
 				return nil, err
 			}
@@ -1227,7 +1230,8 @@ func (h *Handlers) buildEncryptedStorageConfig(input *models.StorageConfigInput)
 		cfg.GCSCredentialsFile = toNullString(input.GCSCredentialsFile)
 		cfg.GCSEndpoint = toNullString(input.GCSEndpoint)
 		if input.GCSCredentialsJSON != "" {
-			encrypted, err := h.tokenCipher.Seal(input.GCSCredentialsJSON)
+			encrypted, err := h.tokenCipher.SealWithContext(input.GCSCredentialsJSON,
+				models.StorageConfigGCSCredentialsJSONContext(cfg.ID.String()))
 			if err != nil {
 				return nil, err
 			}

--- a/backend/internal/api/setup/handlers_test.go
+++ b/backend/internal/api/setup/handlers_test.go
@@ -40,6 +40,9 @@ type testEnv struct {
 	storageMock sqlmock.Sqlmock
 	userMock    sqlmock.Sqlmock
 	orgMock     sqlmock.Sqlmock
+	// cipher is the one the handlers hold, exposed so a test can open what
+	// they sealed rather than re-deriving the key from a literal in this file.
+	cipher *crypto.TokenCipher
 }
 
 func newTestEnv(t *testing.T) *testEnv {
@@ -99,6 +102,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		storageMock: storageMock,
 		userMock:    userMock,
 		orgMock:     orgMock,
+		cipher:      cipher,
 	}
 }
 

--- a/backend/internal/api/setup/storage_binding_test.go
+++ b/backend/internal/api/setup/storage_binding_test.go
@@ -1,0 +1,153 @@
+package setup
+
+import (
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153 — the first-run setup path writes the SAME four
+// storage_config credential columns as the admin CRUD handlers, so it has to
+// bind them the same way.
+//
+// This is the half of the column family that is easy to miss: a reviewer looking
+// at internal/api/admin/storage.go sees every write converted and concludes the
+// column is done, while a fresh install still lands unbound rows here. That is
+// also why registering these columns in the backfill required both writers
+// converted first — a sweep behind an unconverted writer converts rows the next
+// first-run save simply re-creates unbound.
+
+// setupStorageCredential is one encrypted column of the config the builder
+// returns, paired with the context it must be bound to.
+type setupStorageCredential struct {
+	column  string
+	secret  string
+	sealed  func(*models.StorageConfig) string
+	context func(string) []byte
+}
+
+var setupStorageCases = []struct {
+	name        string
+	input       *models.StorageConfigInput
+	credentials []setupStorageCredential
+}{
+	{
+		name: "azure",
+		input: &models.StorageConfigInput{
+			BackendType:        "azure",
+			AzureAccountName:   "acct",
+			AzureContainerName: "ctr",
+			AzureAccountKey:    "dGVzdC1henVyZS1rZXk=",
+		},
+		credentials: []setupStorageCredential{{
+			column:  "azure_account_key_encrypted",
+			secret:  "dGVzdC1henVyZS1rZXk=",
+			sealed:  func(c *models.StorageConfig) string { return c.AzureAccountKeyEncrypted.String },
+			context: models.StorageConfigAzureAccountKeyContext,
+		}},
+	},
+	{
+		name: "s3",
+		input: &models.StorageConfigInput{
+			BackendType:       "s3",
+			S3Bucket:          "bkt",
+			S3Region:          "us-east-1",
+			S3AuthMethod:      "static",
+			S3AccessKeyID:     "AKIAEXAMPLEKEYID",
+			S3SecretAccessKey: "wJalrXUtnFEMI-EXAMPLE-SECRET",
+		},
+		credentials: []setupStorageCredential{
+			{
+				column:  "s3_access_key_id_encrypted",
+				secret:  "AKIAEXAMPLEKEYID",
+				sealed:  func(c *models.StorageConfig) string { return c.S3AccessKeyIDEncrypted.String },
+				context: models.StorageConfigS3AccessKeyIDContext,
+			},
+			{
+				column:  "s3_secret_access_key_encrypted",
+				secret:  "wJalrXUtnFEMI-EXAMPLE-SECRET",
+				sealed:  func(c *models.StorageConfig) string { return c.S3SecretAccessKeyEncrypted.String },
+				context: models.StorageConfigS3SecretAccessKeyContext,
+			},
+		},
+	},
+	{
+		name: "gcs",
+		input: &models.StorageConfigInput{
+			BackendType:        "gcs",
+			GCSBucket:          "bkt",
+			GCSProjectID:       "proj",
+			GCSAuthMethod:      "service_account",
+			GCSCredentialsJSON: `{"type":"service_account","private_key":"-----BEGIN"}`,
+		},
+		credentials: []setupStorageCredential{{
+			column:  "gcs_credentials_json_encrypted",
+			secret:  `{"type":"service_account","private_key":"-----BEGIN"}`,
+			sealed:  func(c *models.StorageConfig) string { return c.GCSCredentialsJSONEncrypted.String },
+			context: models.StorageConfigGCSCredentialsJSONContext,
+		}},
+	},
+}
+
+// setupStorageColumns is the whole family, for the sibling-column assertions.
+var setupStorageColumns = []struct {
+	column  string
+	context func(string) []byte
+}{
+	{"azure_account_key_encrypted", models.StorageConfigAzureAccountKeyContext},
+	{"s3_access_key_id_encrypted", models.StorageConfigS3AccessKeyIDContext},
+	{"s3_secret_access_key_encrypted", models.StorageConfigS3SecretAccessKeyContext},
+	{"gcs_credentials_json_encrypted", models.StorageConfigGCSCredentialsJSONContext},
+}
+
+func TestBuildEncryptedStorageConfig_BindsCredentialsToTheRow(t *testing.T) {
+	for _, sc := range setupStorageCases {
+		t.Run(sc.name, func(t *testing.T) {
+			env := newTestEnv(t)
+
+			cfg, err := env.h.buildEncryptedStorageConfig(sc.input)
+			if err != nil {
+				t.Fatalf("buildEncryptedStorageConfig: %v", err)
+			}
+			// SaveStorageConfig inserts this struct verbatim, so cfg.ID is the
+			// id the row will carry.
+			id := cfg.ID.String()
+
+			for _, cred := range sc.credentials {
+				raw := cred.sealed(cfg)
+				if raw == "" {
+					t.Errorf("%s: nothing was sealed", cred.column)
+					continue
+				}
+
+				got, bound, err := env.cipher.OpenWithContextOrLegacy(raw, cred.context(id))
+				if err != nil {
+					t.Errorf("%s: does not open under its own row context: %v", cred.column, err)
+					continue
+				}
+				if !bound {
+					t.Errorf("%s: opened only via the LEGACY path, so it was sealed WITHOUT a "+
+						"context; a fresh install still writes movable credentials", cred.column)
+				}
+				if got != cred.secret {
+					t.Errorf("%s = %q, want %q", cred.column, got, cred.secret)
+				}
+				if _, err := env.cipher.OpenWithContext(raw, cred.context(otherSetupConfigID)); err == nil {
+					t.Errorf("%s: opened under another config's context; it could be moved "+
+						"between storage configurations", cred.column)
+				}
+				for _, sibling := range setupStorageColumns {
+					if sibling.column == cred.column {
+						continue
+					}
+					if _, err := env.cipher.OpenWithContext(raw, sibling.context(id)); err == nil {
+						t.Errorf("%s: also opened as %s of the SAME row; the two columns are "+
+							"interchangeable", cred.column, sibling.column)
+					}
+				}
+			}
+		})
+	}
+}
+
+const otherSetupConfigID = "99999999-9999-9999-9999-999999999999"

--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -39,23 +39,28 @@ import (
 // unboundSealSites maps a repo-relative file to how many TokenCipher.Seal calls
 // it still contains, with the column and why it has not been converted yet.
 //
-// Converted so far: scm_provider_tokens.access_token (the app-token cache), and
-// the user OAuth access + refresh tokens across scm_oauth.go, scm_linking.go and
-// scm_publisher.go. What remains is the operator-entered material, which needs a
-// backfill per column before its reads can stop accepting the unbound form.
+// Converted so far: scm_provider_tokens.access_token (the app-token cache), the
+// user OAuth access + refresh tokens across scm_oauth.go, scm_linking.go and
+// scm_publisher.go, and the four storage_config credential columns. What remains
+// is the rest of the operator-entered material, which needs a backfill per
+// column before its reads can stop accepting the unbound form.
 //
 // Ordered by recoverability, which is the order the conversion follows: a column
 // whose failure mode is "re-mint" is safe to convert first; one whose failure
 // mode is "an operator re-enters the secret by hand" is converted last, with a
 // verified backfill.
 var unboundSealSites = map[string]int{
-	// Storage-backend credentials: Azure account key, S3 access key id and
-	// secret, GCS credentials JSON. IRREPLACEABLE — an operator re-enters them.
-	"internal/api/admin/storage.go": 8,
-
-	// First-run setup secrets. IRREPLACEABLE, and reached before most of the
-	// service exists, so the conversion needs care about ordering.
-	"internal/api/setup/handlers.go": 6,
+	// First-run setup secrets: the OIDC client secret and the LDAP bind
+	// password. IRREPLACEABLE, and reached before most of the service exists,
+	// so the conversion needs care about ordering.
+	//
+	// Was 6. The other four were this file's half of the storage_config
+	// credential columns — buildEncryptedStorageConfig writes the SAME four
+	// columns as internal/api/admin/storage.go, so they had to convert
+	// together: a column with one converted writer and one unconverted one
+	// cannot be declared bound, and its backfill would be undone by the next
+	// first-run save.
+	"internal/api/setup/handlers.go": 2,
 
 	// SCM client secret and app private key. IRREPLACEABLE.
 	"internal/api/admin/scm_providers.go": 4,

--- a/backend/internal/db/models/aad.go
+++ b/backend/internal/db/models/aad.go
@@ -1,0 +1,71 @@
+package models
+
+// Additional-authenticated-data contexts for the storage-backend credentials
+// held at rest in storage_config.
+//
+// Each binds a ciphertext to the row AND the column it belongs to, so a sealed
+// credential cannot be lifted out of one storage configuration and written into
+// another — or into a different credential column of its own row — by anyone
+// with database write access. Without a context, GCM authenticates that move
+// happily, because nothing in the ciphertext says where it belongs
+// (suite-identity #153).
+//
+// They live here, next to the StorageConfig they describe, because this column
+// family has FOUR call sites in three packages: the admin CRUD handlers
+// (internal/api/admin) and the first-run setup path (internal/api/setup) both
+// write it, internal/services reads it when building a migration's source or
+// target backend, and internal/maintenance re-seals it during the backfill. A
+// hand-built string in four places drifts in one of them, and the failure
+// surfaces as "failed to decrypt s3 secret access key" during a storage
+// migration — long after the change that caused it, against a credential only
+// an operator can restore.
+//
+// The id is the canonical text form of storage_config.id (uuid.UUID.String(),
+// which is what lib/pq also yields when the column is scanned into a string).
+// A string rather than a uuid.UUID so the backfill registry, which reads ids as
+// text out of the database, calls the SAME function the application seals with
+// rather than a parallel one that can disagree.
+//
+// Four functions rather than one taking a column name: the compiler then checks
+// the pairing, and a read site cannot silently ask for the wrong column's
+// context. Distinct contexts WITHIN a row matter here as much as between rows —
+// an S3 access key id and its secret access key live in the same row, and a
+// row-level context alone would let the pair be swapped and still authenticate.
+//
+// Changing a returned format is a breaking change for stored data: every
+// already-bound ciphertext stops opening. It would need the same treatment the
+// original adoption gets — a transition read that accepts both, then a backfill.
+
+// storageConfigContext builds one column's context. The column suffix is the
+// literal database column name, so the binding is legible in a hex dump of the
+// AAD and cannot collide with a differently-named column.
+func storageConfigContext(configID, column string) []byte {
+	return []byte("storage_config:" + configID + ":" + column)
+}
+
+// StorageConfigAzureAccountKeyContext binds an Azure account key to its row.
+func StorageConfigAzureAccountKeyContext(configID string) []byte {
+	return storageConfigContext(configID, "azure_account_key_encrypted")
+}
+
+// StorageConfigS3AccessKeyIDContext binds an S3 access key id to its row.
+func StorageConfigS3AccessKeyIDContext(configID string) []byte {
+	return storageConfigContext(configID, "s3_access_key_id_encrypted")
+}
+
+// StorageConfigS3SecretAccessKeyContext binds an S3 secret access key to its
+// row.
+//
+// Deliberately distinct from StorageConfigS3AccessKeyIDContext for the SAME
+// row: the two halves of one credential pair are stored side by side, and
+// without the column in the context the secret could be written into the
+// access-key-id column of its own row, or the reverse, and still decrypt.
+func StorageConfigS3SecretAccessKeyContext(configID string) []byte {
+	return storageConfigContext(configID, "s3_secret_access_key_encrypted")
+}
+
+// StorageConfigGCSCredentialsJSONContext binds a GCS service-account JSON key
+// to its row.
+func StorageConfigGCSCredentialsJSONContext(configID string) []byte {
+	return storageConfigContext(configID, "gcs_credentials_json_encrypted")
+}

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -12,12 +12,13 @@ import (
 	identitynotify "github.com/sethbacon/terraform-suite-identity/identity/notify"
 
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
 // Converting a column to the row-bound ciphertext form (suite-identity #153)
 // cannot be a SQL migration: AES-GCM re-encryption needs the key, which only
 // exists in the running application. Each converted column therefore needs a
-// sweep, and this service has five more to go.
+// sweep, and this service has several more to go.
 //
 // Rather than five bespoke commands, a column describes itself with three
 // things — how to list its rows, how to derive a row's context, how to write a
@@ -71,11 +72,20 @@ var ErrUnboundRemain = errors.New("maintenance: secrets remain unbound")
 
 // columns is the registry of convertible columns.
 //
-// One entry today. The remaining four (storage credentials, setup secrets, SCM
-// client secret and app private key, SMTP password) are added here as each is
+// The remaining ones (setup's OIDC client secret and LDAP bind password, the SCM
+// client secret and app private key, the SMTP password) are added here as each is
 // converted in the application — the sweep for a column must not exist before
 // the code that writes the bound form, or an operator can convert rows the
-// running service then cannot read.
+// running service then cannot read. "The code" means EVERY writer: the four
+// storage_config entries below were only registrable once both the admin CRUD
+// handlers and the first-run setup path sealed with a context, since otherwise
+// the next first-run save would re-introduce an unbound row behind the sweep.
+//
+// Each entry derives its context by calling the same exported function the
+// application seals with, never by rebuilding the string here. That is the whole
+// reason those functions are exported: a second copy of the format in this file
+// would drift from the first, and the symptom is an operator credential that no
+// longer decrypts.
 var columns = []column{
 	{
 		name:    "notification_channels.encrypted_target",
@@ -91,6 +101,44 @@ var columns = []column{
 			return err
 		},
 	},
+	storageConfigColumn("azure_account_key_encrypted", models.StorageConfigAzureAccountKeyContext),
+	storageConfigColumn("s3_access_key_id_encrypted", models.StorageConfigS3AccessKeyIDContext),
+	storageConfigColumn("s3_secret_access_key_encrypted", models.StorageConfigS3SecretAccessKeyContext),
+	storageConfigColumn("gcs_credentials_json_encrypted", models.StorageConfigGCSCredentialsJSONContext),
+}
+
+// storageConfigColumn describes one of the four storage_config credential
+// columns.
+//
+// A constructor rather than four literals because these four differ only in
+// which column they name, and a copy-paste of a twelve-line literal is how a
+// query ends up selecting one column and writing back another — a bug that
+// would move a credential between columns, which is the exact class this whole
+// change exists to prevent. The column name is interpolated into the SQL, which
+// is safe here and only here: the four call sites are literals in this file, not
+// input.
+//
+// Both clauses of the WHERE matter. The empty-string test excludes a column
+// left blank, which is "unset" rather than "unbound" and is not a conversion
+// candidate; IS NOT NULL is what keeps a NULL out of the sealedRow.sealed string
+// scan, since these columns are nullable — only the backend actually in use has
+// its credentials populated.
+func storageConfigColumn(dbColumn string, contextFor func(string) []byte) column {
+	return column{
+		name:    "storage_config." + dbColumn,
+		context: contextFor,
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			return listRows(ctx, db, fmt.Sprintf(
+				`SELECT id, %s FROM storage_config WHERE %s IS NOT NULL AND %s <> ''`,
+				dbColumn, dbColumn, dbColumn))
+		},
+		update: func(ctx context.Context, db *sql.DB, id, bound string) error {
+			_, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE storage_config SET %s = $2, updated_at = now() WHERE id = $1`, dbColumn),
+				id, bound)
+			return err
+		},
+	}
 }
 
 // listRows runs a two-column (id, ciphertext) query and drains it.

--- a/backend/internal/maintenance/bindsecrets_test.go
+++ b/backend/internal/maintenance/bindsecrets_test.go
@@ -10,6 +10,7 @@ import (
 	identitynotify "github.com/sethbacon/terraform-suite-identity/identity/notify"
 
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
 // suite-identity #153 backfill. The properties an operator relies on when
@@ -48,6 +49,32 @@ func channelRows(pairs ...[2]string) *sqlmock.Rows {
 
 const chanCol = "notification_channels.encrypted_target"
 
+// drive queues sqlmock expectations for a whole sweep while only one column
+// actually has rows: own() runs at that column's position in the registry, and
+// every other column gets an empty result.
+//
+// BindSecrets deliberately sweeps the entire registry, so a test naming only its
+// own column leaves the rest as unexpected queries — which sqlmock fails,
+// turning "a column was registered" into a pile of unrelated failures in tests
+// that have nothing to do with it. Walking `columns` rather than hard-coding a
+// count also keeps the expectation ORDER correct wherever a new column is
+// inserted.
+func drive(t *testing.T, mock sqlmock.Sqlmock, name string, own func()) {
+	t.Helper()
+	found := false
+	for _, c := range columns {
+		if c.name == name {
+			found = true
+			own()
+			continue
+		}
+		mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "sealed"}))
+	}
+	if !found {
+		t.Fatalf("column %q is not registered; the test drives nothing", name)
+	}
+}
+
 func TestBindSecrets_ConvertsAnUnboundRow(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -60,13 +87,14 @@ func TestBindSecrets_ConvertsAnUnboundRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
-		WillReturnRows(channelRows([2]string{"chan-1", legacy}))
-
 	var stored string
-	mock.ExpectExec("UPDATE notification_channels").
-		WithArgs(sqlmock.AnyArg(), capturedArg{got: &stored}).
-		WillReturnResult(sqlmock.NewResult(0, 1))
+	drive(t, mock, chanCol, func() {
+		mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+			WillReturnRows(channelRows([2]string{"chan-1", legacy}))
+		mock.ExpectExec("UPDATE notification_channels").
+			WithArgs(sqlmock.AnyArg(), capturedArg{got: &stored}).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	})
 
 	res, err := BindSecrets(context.Background(), db, tc, false)
 	if err != nil {
@@ -99,8 +127,10 @@ func TestBindSecrets_SkipsAnAlreadyBoundRow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
-		WillReturnRows(channelRows([2]string{"chan-1", bound}))
+	drive(t, mock, chanCol, func() {
+		mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+			WillReturnRows(channelRows([2]string{"chan-1", bound}))
+	})
 
 	res, err := BindSecrets(context.Background(), db, tc, false)
 	if err != nil {
@@ -126,12 +156,14 @@ func TestBindSecrets_OneUndecryptableRowDoesNotAbortTheSweep(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
-		WillReturnRows(channelRows(
-			[2]string{"chan-bad", "not-a-valid-ciphertext"},
-			[2]string{"chan-good", good},
-		))
-	mock.ExpectExec("UPDATE notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+	drive(t, mock, chanCol, func() {
+		mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+			WillReturnRows(channelRows(
+				[2]string{"chan-bad", "not-a-valid-ciphertext"},
+				[2]string{"chan-good", good},
+			))
+		mock.ExpectExec("UPDATE notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+	})
 
 	res, err := BindSecrets(context.Background(), db, tc, false)
 	if err != nil {
@@ -155,8 +187,10 @@ func TestBindSecrets_VerifyWritesNothingAndFailsWhileUnboundRemain(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
-		WillReturnRows(channelRows([2]string{"chan-1", legacy}))
+	drive(t, mock, chanCol, func() {
+		mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+			WillReturnRows(channelRows([2]string{"chan-1", legacy}))
+	})
 
 	res, err := BindSecrets(context.Background(), db, tc, true)
 	if !errors.Is(err, ErrUnboundRemain) {
@@ -183,8 +217,10 @@ func TestBindSecrets_VerifySucceedsWhenAllBound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
-		WillReturnRows(channelRows([2]string{"chan-1", bound}))
+	drive(t, mock, chanCol, func() {
+		mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+			WillReturnRows(channelRows([2]string{"chan-1", bound}))
+	})
 
 	if _, err := BindSecrets(context.Background(), db, tc, true); err != nil {
 		t.Fatalf("verify with everything bound must succeed, got %v", err)
@@ -212,5 +248,145 @@ func TestRegisteredColumns_ContextsAreRowScoped(t *testing.T) {
 		if string(col.context("row-a")) == string(col.context("row-b")) {
 			t.Errorf("%s derives the same context for different rows; its binding is vacuous", col.name)
 		}
+	}
+}
+
+// The other axis, and the one the storage columns made real: four credential
+// columns now share a row, so a context that varies only by row id would let an
+// S3 secret access key be written into the access-key-id column of its OWN row
+// and still authenticate. Row-scoping alone does not catch that — this does.
+func TestRegisteredColumns_ContextsAreColumnDistinct(t *testing.T) {
+	const row = "11111111-1111-1111-1111-111111111111"
+	seen := map[string]string{}
+	for _, col := range columns {
+		ctx := string(col.context(row))
+		if other, dup := seen[ctx]; dup {
+			t.Errorf("%s and %s derive the SAME context for one row; a value could be moved "+
+				"between the two columns undetected", other, col.name)
+			continue
+		}
+		seen[ctx] = col.name
+	}
+}
+
+// ---------------------------------------------------------------------------
+// storage_config credential columns (suite-identity #153)
+// ---------------------------------------------------------------------------
+
+// storageConfigCases pairs each registered storage column with the context
+// function the APPLICATION seals and opens with. Deriving the expectation from
+// models rather than from col.context is the point: this asserts the sweep and
+// the running service agree, which is the failure that would leave an operator
+// re-entering a cloud credential by hand.
+var storageConfigCases = []struct {
+	column  string
+	dbCol   string
+	context func(string) []byte
+}{
+	{"storage_config.azure_account_key_encrypted", "azure_account_key_encrypted",
+		models.StorageConfigAzureAccountKeyContext},
+	{"storage_config.s3_access_key_id_encrypted", "s3_access_key_id_encrypted",
+		models.StorageConfigS3AccessKeyIDContext},
+	{"storage_config.s3_secret_access_key_encrypted", "s3_secret_access_key_encrypted",
+		models.StorageConfigS3SecretAccessKeyContext},
+	{"storage_config.gcs_credentials_json_encrypted", "gcs_credentials_json_encrypted",
+		models.StorageConfigGCSCredentialsJSONContext},
+}
+
+func TestBindSecrets_ConvertsEveryStorageCredentialColumn(t *testing.T) {
+	const configID = "22222222-2222-2222-2222-222222222222"
+
+	for _, sc := range storageConfigCases {
+		t.Run(sc.dbCol, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tc := newCipher(t)
+
+			secret := "secret-for-" + sc.dbCol
+			legacy, err := tc.Seal(secret)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var stored string
+			drive(t, mock, sc.column, func() {
+				mock.ExpectQuery("SELECT id, " + sc.dbCol + " FROM storage_config").
+					WillReturnRows(sqlmock.NewRows([]string{"id", sc.dbCol}).AddRow(configID, legacy))
+				mock.ExpectExec("UPDATE storage_config SET "+sc.dbCol).
+					WithArgs(sqlmock.AnyArg(), capturedArg{got: &stored}).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			})
+
+			res, err := BindSecrets(context.Background(), db, tc, false)
+			if err != nil {
+				t.Fatalf("BindSecrets: %v", err)
+			}
+			if got := res[sc.column]; got.Converted != 1 || got.Failed != 0 {
+				t.Fatalf("result = %s; want one conversion", got)
+			}
+
+			// Opens under the context the application uses...
+			got, err := tc.OpenWithContext(stored, sc.context(configID))
+			if err != nil || got != secret {
+				t.Fatalf("converted value does not open under the application's context: (%q, %v)", got, err)
+			}
+			// ...and no longer without one.
+			if _, err := tc.Open(stored); err == nil {
+				t.Error("converted value still opens WITHOUT a context; it was not bound")
+			}
+			// ...nor as a different column of the same row, which is the move a
+			// row-only binding would still authenticate.
+			for _, other := range storageConfigCases {
+				if other.dbCol == sc.dbCol {
+					continue
+				}
+				if _, err := tc.OpenWithContext(stored, other.context(configID)); err == nil {
+					t.Errorf("converted value opened as %s of the same row; the columns are not distinguished",
+						other.dbCol)
+				}
+			}
+		})
+	}
+}
+
+// The sweep must write back to the column it read. A constructor shared by four
+// columns makes "select one column, update another" a single typo away, and the
+// result would be a credential silently moved between columns — the exact defect
+// this change exists to prevent.
+func TestBindSecrets_StorageColumnWritesBackToTheColumnItRead(t *testing.T) {
+	const configID = "33333333-3333-3333-3333-333333333333"
+
+	for _, sc := range storageConfigCases {
+		t.Run(sc.dbCol, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tc := newCipher(t)
+
+			legacy, err := tc.Seal("a-credential")
+			if err != nil {
+				t.Fatal(err)
+			}
+			drive(t, mock, sc.column, func() {
+				mock.ExpectQuery("SELECT id, " + sc.dbCol + " FROM storage_config").
+					WillReturnRows(sqlmock.NewRows([]string{"id", sc.dbCol}).AddRow(configID, legacy))
+				// A regexp anchored on this column name only: sqlmock fails the
+				// exec if the UPDATE names any other column.
+				mock.ExpectExec(`UPDATE storage_config SET ` + sc.dbCol + ` = \$2`).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			})
+
+			if _, err := BindSecrets(context.Background(), db, tc, false); err != nil {
+				t.Fatalf("BindSecrets: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("the UPDATE did not target %s: %v", sc.dbCol, err)
+			}
+		})
 	}
 }

--- a/backend/internal/services/storage_binding_test.go
+++ b/backend/internal/services/storage_binding_test.go
@@ -1,0 +1,177 @@
+package services
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153, read side. buildStorageFromConfig is the only consumer
+// that decrypts the storage_config credential columns, so it is where a wrong or
+// missing context surfaces — and it surfaces as an operator's storage migration
+// failing on a credential they cannot recover, long after the change.
+//
+// The cases below are the four things the read has to get right, and each one
+// fails if the read is written differently:
+//
+//	bound          -- reads the new form (fails if the context is omitted)
+//	legacy         -- still reads the old form (fails if OpenWithContext is used
+//	                  instead of OpenWithContextOrLegacy, which would break every
+//	                  row written before the backfill)
+//	other row      -- refuses a ciphertext lifted from another configuration
+//	sibling column -- refuses one lifted from another column of the SAME row
+//
+// The last two are what make the first two more than a round-trip: the legacy
+// fallback accepts any no-AAD ciphertext, so if it also accepted a bound one
+// from elsewhere the binding would buy nothing.
+
+// storageReadColumn is one encrypted column: how to place a ciphertext on the
+// model, and the context the read side must use for it.
+type storageReadColumn struct {
+	name        string
+	backendType string
+	place       func(*models.StorageConfig, string)
+	context     func(string) []byte
+}
+
+var storageReadColumns = []storageReadColumn{
+	{
+		name:        "azure_account_key_encrypted",
+		backendType: "azure",
+		place: func(sc *models.StorageConfig, ct string) {
+			sc.AzureAccountName = sql.NullString{String: "acct", Valid: true}
+			sc.AzureContainerName = sql.NullString{String: "ctr", Valid: true}
+			sc.AzureAccountKeyEncrypted = sql.NullString{String: ct, Valid: true}
+		},
+		context: models.StorageConfigAzureAccountKeyContext,
+	},
+	{
+		name:        "s3_access_key_id_encrypted",
+		backendType: "s3",
+		place: func(sc *models.StorageConfig, ct string) {
+			sc.S3Bucket = sql.NullString{String: "bkt", Valid: true}
+			sc.S3Region = sql.NullString{String: "us-east-1", Valid: true}
+			sc.S3AccessKeyIDEncrypted = sql.NullString{String: ct, Valid: true}
+		},
+		context: models.StorageConfigS3AccessKeyIDContext,
+	},
+	{
+		name:        "s3_secret_access_key_encrypted",
+		backendType: "s3",
+		place: func(sc *models.StorageConfig, ct string) {
+			sc.S3Bucket = sql.NullString{String: "bkt", Valid: true}
+			sc.S3Region = sql.NullString{String: "us-east-1", Valid: true}
+			sc.S3SecretAccessKeyEncrypted = sql.NullString{String: ct, Valid: true}
+		},
+		context: models.StorageConfigS3SecretAccessKeyContext,
+	},
+	{
+		name:        "gcs_credentials_json_encrypted",
+		backendType: "gcs",
+		place: func(sc *models.StorageConfig, ct string) {
+			sc.GCSBucket = sql.NullString{String: "bkt", Valid: true}
+			sc.GCSProjectID = sql.NullString{String: "proj", Valid: true}
+			sc.GCSCredentialsJSONEncrypted = sql.NullString{String: ct, Valid: true}
+		},
+		context: models.StorageConfigGCSCredentialsJSONContext,
+	},
+}
+
+// decryptFailed reports whether err came from the decrypt step rather than from
+// the backend constructor.
+//
+// buildStorageFromConfig ends in storage.NewStorage, which needs credentials
+// this test does not have and generally fails; the plaintext never escapes the
+// function. The decrypt failures are the only ones this test can and should
+// distinguish, and each carries its own "failed to decrypt <column>" message.
+func decryptFailed(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "failed to decrypt")
+}
+
+func newStorageReadCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 23)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return tc
+}
+
+func TestBuildStorageFromConfig_ReadsBoundAndLegacyCredentials(t *testing.T) {
+	tc := newStorageReadCipher(t)
+	svc := NewStorageMigrationService(nil, nil, nil, nil, tc, &config.Config{})
+
+	configID := uuid.New()
+	otherID := uuid.New()
+
+	for _, col := range storageReadColumns {
+		// sibling is any other column of the same family, for the
+		// move-within-one-row case.
+		var sibling storageReadColumn
+		for _, other := range storageReadColumns {
+			if other.name != col.name {
+				sibling = other
+				break
+			}
+		}
+
+		cases := []struct {
+			name string
+			// seal produces the ciphertext stored in col's column.
+			seal       func() (string, error)
+			wantUsable bool
+		}{
+			{
+				name:       "bound to its own row and column",
+				seal:       func() (string, error) { return tc.SealWithContext("cred", col.context(configID.String())) },
+				wantUsable: true,
+			},
+			{
+				name:       "legacy unbound ciphertext still readable",
+				seal:       func() (string, error) { return tc.Seal("cred") },
+				wantUsable: true,
+			},
+			{
+				name:       "bound to a different storage config",
+				seal:       func() (string, error) { return tc.SealWithContext("cred", col.context(otherID.String())) },
+				wantUsable: false,
+			},
+			{
+				name:       "bound to a sibling column of the same row",
+				seal:       func() (string, error) { return tc.SealWithContext("cred", sibling.context(configID.String())) },
+				wantUsable: false,
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(col.name+"/"+tt.name, func(t *testing.T) {
+				ct, err := tt.seal()
+				if err != nil {
+					t.Fatalf("seal: %v", err)
+				}
+
+				sc := &models.StorageConfig{ID: configID, BackendType: col.backendType}
+				col.place(sc, ct)
+
+				_, buildErr := svc.buildStorageFromConfig(sc)
+				if got := !decryptFailed(buildErr); got != tt.wantUsable {
+					if tt.wantUsable {
+						t.Fatalf("%s: the credential could not be decrypted: %v", col.name, buildErr)
+					}
+					t.Fatalf("%s: a ciphertext that does not belong to this row+column was "+
+						"accepted; the binding is not enforced on read", col.name)
+				}
+			})
+		}
+	}
+}

--- a/backend/internal/services/storage_migration.go
+++ b/backend/internal/services/storage_migration.go
@@ -250,7 +250,8 @@ func (s *StorageMigrationService) buildStorageFromConfig(sc *models.StorageConfi
 			CDNURL:        sc.AzureCDNURL.String,
 		}
 		if sc.AzureAccountKeyEncrypted.Valid && sc.AzureAccountKeyEncrypted.String != "" {
-			key, err := s.tokenCipher.Open(sc.AzureAccountKeyEncrypted.String)
+			key, _, err := s.tokenCipher.OpenWithContextOrLegacy(sc.AzureAccountKeyEncrypted.String,
+				models.StorageConfigAzureAccountKeyContext(sc.ID.String()))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt azure account key: %w", err)
 			}
@@ -270,14 +271,16 @@ func (s *StorageMigrationService) buildStorageFromConfig(sc *models.StorageConfi
 			WebIdentityTokenFile: sc.S3WebIdentityTokenFile.String,
 		}
 		if sc.S3AccessKeyIDEncrypted.Valid && sc.S3AccessKeyIDEncrypted.String != "" {
-			v, err := s.tokenCipher.Open(sc.S3AccessKeyIDEncrypted.String)
+			v, _, err := s.tokenCipher.OpenWithContextOrLegacy(sc.S3AccessKeyIDEncrypted.String,
+				models.StorageConfigS3AccessKeyIDContext(sc.ID.String()))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt s3 access key id: %w", err)
 			}
 			scfg.AccessKeyID = v
 		}
 		if sc.S3SecretAccessKeyEncrypted.Valid && sc.S3SecretAccessKeyEncrypted.String != "" {
-			v, err := s.tokenCipher.Open(sc.S3SecretAccessKeyEncrypted.String)
+			v, _, err := s.tokenCipher.OpenWithContextOrLegacy(sc.S3SecretAccessKeyEncrypted.String,
+				models.StorageConfigS3SecretAccessKeyContext(sc.ID.String()))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt s3 secret access key: %w", err)
 			}
@@ -294,7 +297,8 @@ func (s *StorageMigrationService) buildStorageFromConfig(sc *models.StorageConfi
 			Endpoint:        sc.GCSEndpoint.String,
 		}
 		if sc.GCSCredentialsJSONEncrypted.Valid && sc.GCSCredentialsJSONEncrypted.String != "" {
-			v, err := s.tokenCipher.Open(sc.GCSCredentialsJSONEncrypted.String)
+			v, _, err := s.tokenCipher.OpenWithContextOrLegacy(sc.GCSCredentialsJSONEncrypted.String,
+				models.StorageConfigGCSCredentialsJSONContext(sc.ID.String()))
 			if err != nil {
 				return nil, fmt.Errorf("failed to decrypt gcs credentials json: %w", err)
 			}


### PR DESCRIPTION
Part of the suite-identity #153 adoption: `TokenCipher.Seal` produces a
ciphertext with no binding to the row or column it belongs to, so a sealed value
can be moved between rows -- or between columns of one row -- by anyone with
database write access, and AES-GCM authenticates the move.

This converts the `storage_config` credential columns: the Azure account key, the
S3 access key id, the S3 secret access key, and the GCS service-account JSON.
They are irreplaceable -- a failure here means an operator re-enters a cloud
credential by hand -- which is why they are converted with a read that still
accepts the old form and a registered backfill rather than a flag day.

## What changed

- `internal/db/models/aad.go` (new): four context functions, one per column,
  each naming `storage_config`, the row id and the database column.
- `internal/api/admin/storage.go`: all 8 writes (create and update x four
  columns) now `SealWithContext`.
- `internal/api/setup/handlers.go`: the 4 storage writes on the first-run path
  now `SealWithContext`. Its other two Seal calls (OIDC client secret, LDAP bind
  password) are untouched.
- `internal/services/storage_migration.go`: all 4 reads now
  `OpenWithContextOrLegacy`. This is the only consumer that decrypts these
  columns.
- `internal/maintenance/bindsecrets.go`: the four columns are registered, via a
  shared constructor rather than four near-identical literals.
- `internal/crypto/unbound_seal_sweep_test.go`: `internal/api/admin/storage.go`
  drops out of the inventory; `internal/api/setup/handlers.go` goes 6 -> 2.

## Two decisions worth arguing with

**The context names the column, not just the row.** The S3 access key id and its
secret access key live in one row. A row-level context alone would let the
secret be written into the access-key-id column of its own row and still
decrypt, handing a credential to a path expecting the other half of the pair.
`TestRegisteredColumns_ContextsAreColumnDistinct` now asserts that no two
registered columns derive the same context for one row -- the second axis
alongside the existing row-scoping test.

**Both writers convert together, so this PR is wider than one file.**
`buildEncryptedStorageConfig` in `internal/api/setup` writes the same four
columns as the admin handlers. Converting only the admin file would have
declared the column bound while a fresh install kept writing unbound rows behind
the backfill. Registering the column in `bind-secrets` requires every writer
converted, so the setup half is here rather than in the next PR.

## Not done, on purpose

The reads still accept unbound ciphertexts. Retiring that is gated on
`registry bind-secrets verify` exiting zero against a real deployment, and no
data is re-encrypted automatically -- an operator runs the sweep. The GCS
credentials-file path, the S3 role/OIDC fields and the local base path are not
secrets and are not sealed at all, so they are untouched.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test ./...` all clean. gosec on the touched
packages reports 0 issues in `internal/api/admin`, `internal/api/setup`,
`internal/db/models` and `internal/maintenance`; the one G304 in
`internal/services` is pre-existing in `scm_publisher.go`, which this PR does not
touch.

Every behavioural claim was mutation-verified -- the fix reverted one site at a
time, restored from a backup copy, and the named test confirmed to fail:

| reverted | test that caught it |
| --- | --- |
| admin create seals azure with no context | `TestCreateStorageConfig_BindsCredentialsToTheNewRow/azure` |
| admin update seals the S3 secret under the access-key-id context | `TestUpdateStorageConfig_BindsCredentialsToTheRowBeingUpdated/s3` |
| first-run setup seals azure with no context | `TestBuildEncryptedStorageConfig_BindsCredentialsToTheRow/azure` |
| read uses a sibling column's context | `TestBuildStorageFromConfig_ReadsBoundAndLegacyCredentials` |
| read drops the legacy fallback | `.../legacy_unbound_ciphertext_still_readable` |
| backfill UPDATE writes a column other than the one it read | `TestBindSecrets_StorageColumnWritesBackToTheColumnItRead` |
| two context functions return the same string | `TestRegisteredColumns_ContextsAreColumnDistinct` |
| one write reverts to `Seal` | `TestNoNewUnboundSealSites` |

The existing `bindsecrets` tests were reworked rather than left alone: they now
queue expectations for the whole registry through a `drive` helper, because
`BindSecrets` sweeps every column and a test naming only its own would fail on
unexpected queries as soon as a column is added. No assertion was weakened.

Refs #153
