### PR TITLE
feat(scm): bind the provider client secret and App private key to their row

### DIFF
--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -128,7 +128,8 @@ func (h *SCMOAuthHandlers) InitiateOAuth(c *gin.Context) {
 	}
 
 	// Decrypt client secret
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return
@@ -300,7 +301,8 @@ func (h *SCMOAuthHandlers) HandleOAuthCallback(c *gin.Context) {
 	}
 
 	// Decrypt client secret for token exchange
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return
@@ -499,7 +501,8 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 	}
 
 	// Decrypt client secret
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return
@@ -784,7 +787,8 @@ func (h *SCMOAuthHandlers) ListRepositories(c *gin.Context) {
 	}
 
 	// Decrypt client secret
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return
@@ -1154,7 +1158,8 @@ func (h *SCMOAuthHandlers) buildConnectorWithToken(ctx context.Context, provider
 	}
 
 	// Decrypt client secret
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to decrypt client secret")
 	}
@@ -1228,7 +1233,8 @@ func (h *SCMOAuthHandlers) buildConnectorWithSharedToken(ctx context.Context, pr
 		return nil, nil, nil, fmt.Errorf("failed to mint shared token: %w", err)
 	}
 
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to decrypt client secret")
 	}

--- a/backend/internal/api/admin/scm_provider_binding_test.go
+++ b/backend/internal/api/admin/scm_provider_binding_test.go
@@ -1,0 +1,230 @@
+package admin
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// suite-identity #153 — an SCM provider's OAuth client secret and its GitHub App
+// private key are bound to the scm_providers row and the column they belong to.
+//
+// The App private key is the sharpest case in this service. It authenticates as
+// the installation itself, and unbound it could be copied into any other
+// provider row — including one an attacker with database write access had just
+// created in their own organization — and used to mint installation tokens for
+// the victim's repositories.
+
+// scmProviderInsertArgs and scmProviderUpdateArgs are the positional-parameter
+// counts of SCMRepository's INSERT and UPDATE. sqlmock needs one matcher per
+// parameter; a mismatch fails with both counts and points back here.
+const (
+	scmProviderInsertArgs = 16
+	scmProviderUpdateArgs = 13
+)
+
+// scmSecret is one encrypted column: the plaintext the request carried and the
+// context the stored ciphertext must be bound to.
+type scmSecret struct {
+	column  string
+	secret  string
+	context func(string) []byte
+}
+
+// allSCMProviderContexts is the column family, for the sibling assertions.
+var allSCMProviderContexts = []scmSecret{
+	{column: "client_secret_encrypted", context: scm.ProviderClientSecretContext},
+	{column: "encrypted_app_private_key", context: scm.ProviderAppPrivateKeyContext},
+}
+
+// assertBoundToProvider checks each secret against the values that reached the
+// database.
+//
+// The negative assertions carry the weight: opening under the right context only
+// shows the seal round-trips, while the failures — no context, another provider
+// row, the sibling column of the same row — are what show the binding is real.
+// The sibling case is not hypothetical here: both columns sit in one row, so
+// without it an App private key could be written into the client-secret column
+// of its own provider and still decrypt.
+func assertBoundToProvider(
+	t *testing.T,
+	tc *crypto.TokenCipher,
+	stored []driver.Value,
+	providerID string,
+	secrets []scmSecret,
+) {
+	t.Helper()
+
+	for _, s := range secrets {
+		raw := findSealed(t, tc, stored, s.context(providerID))
+		if raw == "" {
+			t.Errorf("%s: no stored value opens under the row+column context; "+
+				"it was not bound to provider %s", s.column, providerID)
+			continue
+		}
+
+		got, err := tc.OpenWithContext(raw, s.context(providerID))
+		if err != nil || got != s.secret {
+			t.Errorf("%s: stored value = (%q, %v), want %q", s.column, got, err, s.secret)
+		}
+		if _, err := tc.Open(raw); err == nil {
+			t.Errorf("%s: stored value still opens WITHOUT a context; it was not bound", s.column)
+		}
+		if _, err := tc.OpenWithContext(raw, s.context(otherProviderID)); err == nil {
+			t.Errorf("%s: stored value opened under another provider's context; it could be "+
+				"copied into a provider row the attacker controls", s.column)
+		}
+		for _, sibling := range allSCMProviderContexts {
+			if sibling.column == s.column {
+				continue
+			}
+			if _, err := tc.OpenWithContext(raw, sibling.context(providerID)); err == nil {
+				t.Errorf("%s: stored value also opened as %s of the SAME row; "+
+					"the two columns are interchangeable", s.column, sibling.column)
+			}
+		}
+	}
+}
+
+const otherProviderID = "88888888-8888-8888-8888-888888888888"
+
+func TestCreateSCMProvider_BindsSecretsToTheNewRow(t *testing.T) {
+	keyPEM := testRSAKeyPEM(t)
+
+	cases := []struct {
+		name    string
+		body    map[string]interface{}
+		secrets []scmSecret
+	}{
+		{
+			name: "oauth_user client secret",
+			body: map[string]interface{}{
+				"provider_type": "github",
+				"name":          "gh-oauth",
+				"client_id":     "client-id",
+				"client_secret": "s3cr3t-oauth-client-secret",
+			},
+			secrets: []scmSecret{
+				{"client_secret_encrypted", "s3cr3t-oauth-client-secret",
+					scm.ProviderClientSecretContext},
+			},
+		},
+		{
+			// github_app seals BOTH columns on one request, which is the shape
+			// that makes the sibling-column assertion meaningful. The client
+			// secret is the handler's own "not-applicable" placeholder: those
+			// columns are NOT NULL and unused in this auth mode, and the
+			// placeholder is sealed like anything else.
+			name: "github_app private key and placeholder secret",
+			body: map[string]interface{}{
+				"provider_type":          "github",
+				"name":                   "gh-app",
+				"auth_mode":              "github_app",
+				"github_app_id":          "12345",
+				"github_installation_id": "67890",
+				"app_private_key":        keyPEM,
+			},
+			secrets: []scmSecret{
+				{"client_secret_encrypted", "not-applicable",
+					scm.ProviderClientSecretContext},
+				{"encrypted_app_private_key", keyPEM,
+					scm.ProviderAppPrivateKeyContext},
+			},
+		},
+	}
+
+	for _, tc2 := range cases {
+		t.Run(tc2.name, func(t *testing.T) {
+			mock, r := newSCMProviderRouter(t)
+			tc := testTokenCipher(t)
+			expectDefaultOrgAndNoDuplicate(mock)
+
+			stored, matchers := recordAll(scmProviderInsertArgs)
+			mock.ExpectExec("INSERT INTO scm_providers").
+				WithArgs(matchers...).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/scm-providers", jsonBody(tc2.body)))
+			if w.Code != http.StatusCreated {
+				t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+			}
+
+			// The id the handler minted, as stored. Both secrets on this path
+			// are sealed BEFORE the struct literal that used to mint the id, so
+			// this is the assertion that the id moved rather than being
+			// generated twice.
+			var resp struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || resp.ID == "" {
+				t.Fatalf("create response carried no id: %v (body=%s)", err, w.Body.String())
+			}
+			if !idIsStored(stored, resp.ID) {
+				t.Fatalf("the id in the response (%s) is not the id inserted; the secrets are "+
+					"bound to a row that does not exist", resp.ID)
+			}
+
+			assertBoundToProvider(t, tc, stored, resp.ID, tc2.secrets)
+		})
+	}
+}
+
+// idIsStored reports whether id appears among the INSERT's arguments.
+//
+// Without this the create test would still pass if the handler minted one uuid
+// for the seals and a different one for the row: the response would report the
+// row's id, nothing would open under it, and the failure would read as "not
+// bound" rather than "bound to the wrong row".
+func idIsStored(stored []driver.Value, id string) bool {
+	for _, v := range stored {
+		if s, ok := v.(string); ok && s == id {
+			return true
+		}
+		if u, ok := v.([]byte); ok && string(u) == id {
+			return true
+		}
+		if str, ok := v.(interface{ String() string }); ok && str.String() == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUpdateSCMProvider_BindsSecretsToTheRowBeingUpdated(t *testing.T) {
+	mock, r := newSCMProviderRouter(t)
+	tc := testTokenCipher(t)
+	keyPEM := testRSAKeyPEM(t)
+
+	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
+		WillReturnRows(sampleSCMProviderRow())
+
+	stored, matchers := recordAll(scmProviderUpdateArgs)
+	mock.ExpectExec("UPDATE scm_providers SET").
+		WithArgs(matchers...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/scm-providers/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"client_secret":   "rotated-client-secret",
+			"app_private_key": keyPEM,
+		})))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	// Bound to the row being written — the fixture's id, which is also the path
+	// id — not to a fresh uuid.
+	assertBoundToProvider(t, tc, stored, knownUUID, []scmSecret{
+		{"client_secret_encrypted", "rotated-client-secret", scm.ProviderClientSecretContext},
+		{"encrypted_app_private_key", keyPEM, scm.ProviderAppPrivateKeyContext},
+	})
+}

--- a/backend/internal/api/admin/scm_providers.go
+++ b/backend/internal/api/admin/scm_providers.go
@@ -129,6 +129,15 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 		authMode = scm.AuthModeOAuthUser
 	}
 
+	// The row id is minted HERE rather than at the struct literal below, because
+	// both secrets on this path are sealed against it (suite-identity #153) and
+	// the seals happen earlier than the insert. The alternative — insert
+	// unbound, then re-seal against the returned id — is what
+	// notification_channels has to do, and only because its repository takes no
+	// caller-supplied id. This one does, so the row can be bound from the first
+	// write and never exists in the unbound form.
+	providerID := uuid.New()
+
 	// app_private_key, when supplied for github_app, is encrypted separately.
 	var encryptedAppPrivateKey *string
 
@@ -194,7 +203,8 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 			req.ClientID = "github-app"
 		}
 		req.ClientSecret = "not-applicable"
-		enc, encErr := h.tokenCipher.Seal(req.AppPrivateKey)
+		enc, encErr := h.tokenCipher.SealWithContext(req.AppPrivateKey,
+			scm.ProviderAppPrivateKeyContext(providerID.String()))
 		if encErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt app private key"})
 			return
@@ -217,7 +227,8 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 	}
 
 	// Encrypt client secret
-	clientSecretEncrypted, err := h.tokenCipher.Seal(req.ClientSecret)
+	clientSecretEncrypted, err := h.tokenCipher.SealWithContext(req.ClientSecret,
+		scm.ProviderClientSecretContext(providerID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt secret"})
 		return
@@ -267,7 +278,7 @@ func (h *SCMProviderHandlers) CreateProvider(c *gin.Context) {
 	}
 
 	provider := &scm.SCMProviderRecord{
-		ID:                     uuid.New(),
+		ID:                     providerID,
 		OrganizationID:         orgID,
 		ProviderType:           req.ProviderType,
 		Name:                   req.Name,
@@ -476,7 +487,8 @@ func (h *SCMProviderHandlers) UpdateProvider(c *gin.Context) {
 		provider.ClientID = *req.ClientID
 	}
 	if req.ClientSecret != nil {
-		encryptedSecret, err := h.tokenCipher.Seal(*req.ClientSecret)
+		encryptedSecret, err := h.tokenCipher.SealWithContext(*req.ClientSecret,
+			scm.ProviderClientSecretContext(provider.ID.String()))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt secret"})
 			return
@@ -520,7 +532,8 @@ func (h *SCMProviderHandlers) UpdateProvider(c *gin.Context) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "app_private_key is not a valid RSA private key (PKCS#1 or PKCS#8 PEM)"})
 				return
 			}
-			enc, encErr := h.tokenCipher.Seal(*req.AppPrivateKey)
+			enc, encErr := h.tokenCipher.SealWithContext(*req.AppPrivateKey,
+				scm.ProviderAppPrivateKeyContext(provider.ID.String()))
 			if encErr != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt app private key"})
 				return

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -53,7 +53,8 @@ func (h *SCMLinkingHandler) WithMinter(minter appcreds.SharedMinter) *SCMLinking
 // for the user, the returned token is nil (with a nil error) so best-effort
 // callers can treat the operation as a no-op.
 func (h *SCMLinkingHandler) connectorAndToken(ctx context.Context, provider *scm.SCMProviderRecord, userID uuid.UUID) (scm.Connector, *scm.OAuthToken, error) {
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decrypt client secret")
 	}
@@ -572,7 +573,8 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 	}
 
 	// Decrypt client secret
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return

--- a/backend/internal/api/webhooks/scm_webhook.go
+++ b/backend/internal/api/webhooks/scm_webhook.go
@@ -151,7 +151,8 @@ func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
 	if provider.BaseURL != nil {
 		baseURL = *provider.BaseURL
 	}
-	clientSecret, err := h.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := h.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decrypt client secret"})
 		return

--- a/backend/internal/crypto/unbound_open_sweep_test.go
+++ b/backend/internal/crypto/unbound_open_sweep_test.go
@@ -1,0 +1,129 @@
+package crypto_test
+
+// unbound_open_sweep_test.go is the READ-side companion to
+// unbound_seal_sweep_test.go.
+//
+// The write side has always been the visible half of the suite-identity #153
+// adoption, and it is the half that fails loudly: a Seal that should have been a
+// SealWithContext leaves the inventory count wrong and the sweep test says so.
+//
+// The read side has neither property. `Open` and `OpenWithContextOrLegacy`
+// differ by an argument and a return value, so a converted column whose read is
+// missed still COMPILES, still passes every test that only round-trips through
+// the writer, and fails for the first real user whose credential was written
+// after the conversion — by which point the change that caused it is several
+// merges back. That has already happened once in this migration, on a column
+// where the follow-up write simply errored and the handler returned success
+// anyway.
+//
+// So the reads get the same treatment: an inventory that has to be edited when a
+// column is converted, and that fails when a converted read quietly reverts.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// unboundOpenSites maps a repo-relative file to how many TokenCipher.Open calls
+// it still contains, with the column and why.
+//
+// Every entry here belongs to a column whose WRITE is also still unbound; the
+// two inventories are converted together, per column, and shrink together. An
+// entry that outlives its Seal counterpart is a bug: it means a column is being
+// written bound and read without a context, which fails at runtime for exactly
+// the rows the conversion just created.
+var unboundOpenSites = map[string]int{
+	// The SMTP password (in the notifications JSON config blob) and the OIDC
+	// client secret, both read during router construction.
+	"internal/api/router_startup.go": 2,
+
+	// The SMTP password again, on the admin test-send path.
+	"internal/api/admin/notifications.go": 1,
+}
+
+// isCipherOpen reports whether a call is <something cipher-ish>.Open(...).
+//
+// Matched on the receiver name for the same reason isCipherSeal is: this is a
+// lint-style sweep, not type resolution. Naming the receiver is what keeps
+// sql.Open, os.Open and zip entry Open() — all over this repo — out of the
+// result without an exclusion list that would need maintaining.
+func isCipherOpen(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Open" {
+		return false
+	}
+	var recv string
+	switch x := sel.X.(type) {
+	case *ast.Ident:
+		recv = x.Name
+	case *ast.SelectorExpr:
+		recv = x.Sel.Name
+	default:
+		return false
+	}
+	return strings.Contains(strings.ToLower(recv), "cipher")
+}
+
+func TestNoNewUnboundOpenSites(t *testing.T) {
+	root := backendRoot(t)
+	found := map[string]int{}
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		ast.Inspect(file, func(n ast.Node) bool {
+			if call, ok := n.(*ast.CallExpr); ok && isCipherOpen(call) {
+				found[rel]++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for file, n := range found {
+		want, listed := unboundOpenSites[file]
+		if !listed {
+			t.Errorf("%s has %d unbound Open call(s) and is not in unboundOpenSites.\n"+
+				"Reading a bound column without its context does not fail the build — it fails at "+
+				"runtime for a real user, on a credential only an operator can restore. Use "+
+				"OpenWithContextOrLegacy with the column's context function, or add the file here "+
+				"with the reason it is deferred.", file, n)
+			continue
+		}
+		if n != want {
+			t.Errorf("%s has %d unbound Open call(s), expected %d.\n"+
+				"If a column was converted, lower the count (or remove the entry). If a read was "+
+				"ADDED against a column that is already bound, it needs OpenWithContextOrLegacy.",
+				file, n, want)
+		}
+	}
+
+	for file, want := range unboundOpenSites {
+		if _, ok := found[file]; !ok {
+			t.Errorf("unboundOpenSites lists %s (expecting %d) but it has no unbound Open calls left. "+
+				"Remove the entry — a stale inventory is worse than none.", file, want)
+		}
+	}
+}

--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -41,9 +41,10 @@ import (
 //
 // Converted so far: scm_provider_tokens.access_token (the app-token cache), the
 // user OAuth access + refresh tokens across scm_oauth.go, scm_linking.go and
-// scm_publisher.go, and the four storage_config credential columns. What remains
-// is the rest of the operator-entered material, which needs a backfill per
-// column before its reads can stop accepting the unbound form.
+// scm_publisher.go, the four storage_config credential columns, and the
+// scm_providers client secret + GitHub App private key. What remains is the rest
+// of the operator-entered material, which needs a backfill per column before its
+// reads can stop accepting the unbound form.
 //
 // Ordered by recoverability, which is the order the conversion follows: a column
 // whose failure mode is "re-mint" is safe to convert first; one whose failure
@@ -61,9 +62,6 @@ var unboundSealSites = map[string]int{
 	// cannot be declared bound, and its backfill would be undone by the next
 	// first-run save.
 	"internal/api/setup/handlers.go": 2,
-
-	// SCM client secret and app private key. IRREPLACEABLE.
-	"internal/api/admin/scm_providers.go": 4,
 
 	// This service's own notification channel target is BOUND. The one Seal left
 	// is deliberate and transient: ChannelRepository.Create uses

--- a/backend/internal/jobs/tag_verifier.go
+++ b/backend/internal/jobs/tag_verifier.go
@@ -125,7 +125,8 @@ func (v *TagVerifier) runVerification(ctx context.Context) {
 		if provider.TenantID != nil {
 			tenantID = *provider.TenantID
 		}
-		clientSecret, csErr := v.tokenCipher.Open(provider.ClientSecretEncrypted)
+		clientSecret, _, csErr := v.tokenCipher.OpenWithContextOrLegacy(
+			provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 		if csErr != nil {
 			continue
 		}

--- a/backend/internal/jobs/webhook_retry_job.go
+++ b/backend/internal/jobs/webhook_retry_job.go
@@ -131,7 +131,8 @@ func (j *WebhookRetryJob) retryOne(ctx context.Context, event *scm.SCMWebhookLog
 	}
 
 	// Decrypt the provider's client secret.
-	clientSecret, err := j.tokenCipher.Open(provider.ClientSecretEncrypted)
+	clientSecret, _, err := j.tokenCipher.OpenWithContextOrLegacy(
+		provider.ClientSecretEncrypted, scm.ProviderClientSecretContext(provider.ID.String()))
 	if err != nil {
 		j.failRetry(ctx, event, fmt.Sprintf("failed to decrypt client secret: %v", err))
 		return

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
 )
 
 // Converting a column to the row-bound ciphertext form (suite-identity #153)
@@ -72,8 +73,8 @@ var ErrUnboundRemain = errors.New("maintenance: secrets remain unbound")
 
 // columns is the registry of convertible columns.
 //
-// The remaining ones (setup's OIDC client secret and LDAP bind password, the SCM
-// client secret and app private key, the SMTP password) are added here as each is
+// The remaining ones (setup's OIDC client secret and LDAP bind password, and the
+// SMTP password) are added here as each is
 // converted in the application — the sweep for a column must not exist before
 // the code that writes the bound form, or an operator can convert rows the
 // running service then cannot read. "The code" means EVERY writer: the four
@@ -105,6 +106,37 @@ var columns = []column{
 	storageConfigColumn("s3_access_key_id_encrypted", models.StorageConfigS3AccessKeyIDContext),
 	storageConfigColumn("s3_secret_access_key_encrypted", models.StorageConfigS3SecretAccessKeyContext),
 	storageConfigColumn("gcs_credentials_json_encrypted", models.StorageConfigGCSCredentialsJSONContext),
+	{
+		name:    "scm_providers.client_secret_encrypted",
+		context: scm.ProviderClientSecretContext,
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			return listRows(ctx, db,
+				`SELECT id, client_secret_encrypted FROM scm_providers WHERE client_secret_encrypted <> ''`)
+		},
+		update: func(ctx context.Context, db *sql.DB, id, bound string) error {
+			_, err := db.ExecContext(ctx,
+				`UPDATE scm_providers SET client_secret_encrypted = $2, updated_at = now() WHERE id = $1`,
+				id, bound)
+			return err
+		},
+	},
+	{
+		// Nullable, unlike the client secret: only a github_app provider has
+		// one. IS NOT NULL keeps a NULL out of the sealedRow.sealed scan.
+		name:    "scm_providers.encrypted_app_private_key",
+		context: scm.ProviderAppPrivateKeyContext,
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			return listRows(ctx, db,
+				`SELECT id, encrypted_app_private_key FROM scm_providers
+				 WHERE encrypted_app_private_key IS NOT NULL AND encrypted_app_private_key <> ''`)
+		},
+		update: func(ctx context.Context, db *sql.DB, id, bound string) error {
+			_, err := db.ExecContext(ctx,
+				`UPDATE scm_providers SET encrypted_app_private_key = $2, updated_at = now() WHERE id = $1`,
+				id, bound)
+			return err
+		},
+	},
 }
 
 // storageConfigColumn describes one of the four storage_config credential

--- a/backend/internal/maintenance/bindsecrets_test.go
+++ b/backend/internal/maintenance/bindsecrets_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
 )
 
 // suite-identity #153 backfill. The properties an operator relies on when
@@ -344,6 +345,86 @@ func TestBindSecrets_ConvertsEveryStorageCredentialColumn(t *testing.T) {
 					continue
 				}
 				if _, err := tc.OpenWithContext(stored, other.context(configID)); err == nil {
+					t.Errorf("converted value opened as %s of the same row; the columns are not distinguished",
+						other.dbCol)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scm_providers secret columns (suite-identity #153)
+// ---------------------------------------------------------------------------
+
+// The two scm_providers columns are hand-written entries rather than products of
+// a shared constructor, so each needs its own proof that the sweep converts to
+// the context the application reads with — and that the UPDATE names the column
+// the SELECT read. These two share a row, so getting that wrong would move an
+// App private key into the client-secret column.
+func TestBindSecrets_ConvertsTheSCMProviderSecrets(t *testing.T) {
+	const providerID = "44444444-4444-4444-4444-444444444444"
+
+	cases := []struct {
+		column  string
+		dbCol   string
+		context func(string) []byte
+	}{
+		{"scm_providers.client_secret_encrypted", "client_secret_encrypted",
+			scm.ProviderClientSecretContext},
+		{"scm_providers.encrypted_app_private_key", "encrypted_app_private_key",
+			scm.ProviderAppPrivateKeyContext},
+	}
+
+	for _, c := range cases {
+		t.Run(c.dbCol, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tc := newCipher(t)
+
+			secret := "secret-for-" + c.dbCol
+			legacy, err := tc.Seal(secret)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var stored string
+			drive(t, mock, c.column, func() {
+				mock.ExpectQuery("SELECT id, " + c.dbCol + " FROM scm_providers").
+					WillReturnRows(sqlmock.NewRows([]string{"id", c.dbCol}).AddRow(providerID, legacy))
+				// Anchored on this column name: sqlmock rejects the exec if the
+				// UPDATE names the sibling instead.
+				mock.ExpectExec(`UPDATE scm_providers SET `+c.dbCol+` = \$2`).
+					WithArgs(sqlmock.AnyArg(), capturedArg{got: &stored}).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			})
+
+			res, err := BindSecrets(context.Background(), db, tc, false)
+			if err != nil {
+				t.Fatalf("BindSecrets: %v", err)
+			}
+			if got := res[c.column]; got.Converted != 1 || got.Failed != 0 {
+				t.Fatalf("result = %s; want one conversion", got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("the UPDATE did not target %s: %v", c.dbCol, err)
+			}
+
+			got, err := tc.OpenWithContext(stored, c.context(providerID))
+			if err != nil || got != secret {
+				t.Fatalf("converted value does not open under the application's context: (%q, %v)", got, err)
+			}
+			if _, err := tc.Open(stored); err == nil {
+				t.Error("converted value still opens WITHOUT a context; it was not bound")
+			}
+			for _, other := range cases {
+				if other.dbCol == c.dbCol {
+					continue
+				}
+				if _, err := tc.OpenWithContext(stored, other.context(providerID)); err == nil {
 					t.Errorf("converted value opened as %s of the same row; the columns are not distinguished",
 						other.dbCol)
 				}

--- a/backend/internal/scm/aad.go
+++ b/backend/internal/scm/aad.go
@@ -54,6 +54,36 @@ func UserTokenContext(userID, scmProviderID uuid.UUID) []byte {
 	return []byte("scm_user_tokens:" + userID.String() + ":" + scmProviderID.String() + ":access_token")
 }
 
+// ProviderClientSecretContext binds a provider's OAuth client secret to its row
+// in scm_providers.
+//
+// Note the table: ProviderTokenContext above is keyed by the SAME provider id
+// but names scm_provider_tokens, so the two cannot be confused even though both
+// contexts contain the same uuid. The table prefix is doing real work here, not
+// decoration.
+//
+// This one takes the id as TEXT, unlike the three above. It is a column the
+// bind-secrets sweep converts, and the sweep reads row ids as text out of the
+// database; giving it a uuid.UUID form would mean either a second function or a
+// parse with nowhere to report failure, and two derivations of one context
+// string is exactly the drift that ends with a credential that no longer
+// decrypts. Callers pass provider.ID.String().
+func ProviderClientSecretContext(scmProviderID string) []byte {
+	return []byte("scm_providers:" + scmProviderID + ":client_secret_encrypted")
+}
+
+// ProviderAppPrivateKeyContext binds a GitHub App private key to its provider
+// row in scm_providers.
+//
+// Distinct from ProviderClientSecretContext for the SAME row, for the same
+// reason the access and refresh tokens are distinct: both columns live side by
+// side, and a row-level context alone would let the App private key — which
+// authenticates as the installation itself — be written into the client-secret
+// column of its own row and still decrypt there.
+func ProviderAppPrivateKeyContext(scmProviderID string) []byte {
+	return []byte("scm_providers:" + scmProviderID + ":encrypted_app_private_key")
+}
+
 // UserRefreshTokenContext binds a user's OAuth refresh token to its row.
 //
 // Deliberately distinct from UserTokenContext for the SAME row. Without that, an

--- a/backend/internal/scm/appcreds/minter.go
+++ b/backend/internal/scm/appcreds/minter.go
@@ -158,7 +158,8 @@ func (m *Minter) entraCreds(p *scm.SCMProvider) (EntraCreds, error) {
 	if p.ClientID == "" {
 		return EntraCreds{}, errors.New("appcreds: entra_app provider missing client_id")
 	}
-	secret, err := m.cipher.Open(p.ClientSecretEncrypted)
+	secret, _, err := m.cipher.OpenWithContextOrLegacy(
+		p.ClientSecretEncrypted, scm.ProviderClientSecretContext(p.ID.String()))
 	if err != nil {
 		return EntraCreds{}, fmt.Errorf("appcreds: decrypt client secret: %w", err)
 	}
@@ -179,7 +180,8 @@ func (m *Minter) githubAppCreds(p *scm.SCMProvider) (GitHubAppCreds, error) {
 	if p.EncryptedAppPrivateKey == nil || *p.EncryptedAppPrivateKey == "" {
 		return GitHubAppCreds{}, errors.New("appcreds: github_app provider missing private key")
 	}
-	pemStr, err := m.cipher.Open(*p.EncryptedAppPrivateKey)
+	pemStr, _, err := m.cipher.OpenWithContextOrLegacy(
+		*p.EncryptedAppPrivateKey, scm.ProviderAppPrivateKeyContext(p.ID.String()))
 	if err != nil {
 		return GitHubAppCreds{}, fmt.Errorf("appcreds: decrypt app private key: %w", err)
 	}

--- a/backend/internal/scm/appcreds/provider_secret_binding_test.go
+++ b/backend/internal/scm/appcreds/provider_secret_binding_test.go
@@ -1,0 +1,161 @@
+package appcreds
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// suite-identity #153, read side for the scm_providers secrets.
+//
+// entraCreds and githubAppCreds are where the client secret and the GitHub App
+// private key are decrypted for the shared, admin-managed credential path. They
+// are also the pair that shares a row, so both axes matter here: a ciphertext
+// from another provider must be refused, and so must one from the sibling column
+// of this provider.
+//
+// Each case fails if the read is written differently:
+//
+//	bound          -- reads the new form (fails if the context is dropped)
+//	legacy         -- still reads the old form (fails if OpenWithContext replaces
+//	                  OpenWithContextOrLegacy before the backfill has run)
+//	other provider -- refuses a secret lifted from a different provider row
+//	sibling column -- refuses one lifted from the other column of THIS row
+
+func bindingCipher(t *testing.T) *crypto.TokenCipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 41)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+	return tc
+}
+
+func TestEntraCreds_ClientSecretBinding(t *testing.T) {
+	tc := bindingCipher(t)
+	m := NewMinter(tc, &fakeStore{})
+
+	id := uuid.New()
+	other := uuid.New()
+	tenant := "tenant-1"
+	const secret = "s3cr3t-entra-client-secret"
+
+	for _, c := range secretBindingCases(t, tc, secret,
+		scm.ProviderClientSecretContext(id.String()),
+		scm.ProviderClientSecretContext(other.String()),
+		scm.ProviderAppPrivateKeyContext(id.String()),
+	) {
+		t.Run(c.name, func(t *testing.T) {
+			p := &scm.SCMProvider{
+				ID:                    id,
+				TenantID:              &tenant,
+				ClientID:              "client-id",
+				ClientSecretEncrypted: c.ciphertext,
+			}
+			creds, err := m.entraCreds(p)
+			if c.wantUsable {
+				if err != nil {
+					t.Fatalf("the client secret could not be decrypted: %v", err)
+				}
+				if creds.ClientSecret != secret {
+					t.Fatalf("client secret = %q, want %q", creds.ClientSecret, secret)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("a ciphertext that does not belong to this row+column was accepted; " +
+					"the binding is not enforced on read")
+			}
+			if !strings.Contains(err.Error(), "decrypt client secret") {
+				t.Fatalf("error = %v, want the decrypt failure", err)
+			}
+		})
+	}
+}
+
+func TestGitHubAppCreds_PrivateKeyBinding(t *testing.T) {
+	tc := bindingCipher(t)
+	m := NewMinter(tc, &fakeStore{})
+
+	id := uuid.New()
+	other := uuid.New()
+	appID, instID := "12345", "67890"
+	keyPEM := generateTestKeyPEM(t)
+
+	for _, c := range secretBindingCases(t, tc, keyPEM,
+		scm.ProviderAppPrivateKeyContext(id.String()),
+		scm.ProviderAppPrivateKeyContext(other.String()),
+		scm.ProviderClientSecretContext(id.String()),
+	) {
+		t.Run(c.name, func(t *testing.T) {
+			ct := c.ciphertext
+			p := &scm.SCMProvider{
+				ID:                     id,
+				GitHubAppID:            &appID,
+				GitHubInstallationID:   &instID,
+				EncryptedAppPrivateKey: &ct,
+			}
+			creds, err := m.githubAppCreds(p)
+			if c.wantUsable {
+				if err != nil {
+					t.Fatalf("the app private key could not be decrypted: %v", err)
+				}
+				if creds.PrivateKeyPEM != keyPEM {
+					t.Fatal("the decrypted private key does not match what was sealed")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("a ciphertext that does not belong to this row+column was accepted; " +
+					"an App private key could be replayed from another provider row")
+			}
+			if !strings.Contains(err.Error(), "decrypt app private key") {
+				t.Fatalf("error = %v, want the decrypt failure", err)
+			}
+		})
+	}
+}
+
+type secretBindingCase struct {
+	name       string
+	ciphertext string
+	wantUsable bool
+}
+
+// secretBindingCases builds the four ciphertexts a read has to distinguish:
+// sealed under its own context, sealed unbound (the pre-backfill form), sealed
+// under the same column of ANOTHER row, and sealed under the SIBLING column of
+// this row.
+func secretBindingCases(
+	t *testing.T,
+	tc *crypto.TokenCipher,
+	plaintext string,
+	own, otherRow, siblingColumn []byte,
+) []secretBindingCase {
+	t.Helper()
+	seal := func(ctx []byte) string {
+		s, err := tc.SealWithContext(plaintext, ctx)
+		if err != nil {
+			t.Fatalf("SealWithContext: %v", err)
+		}
+		return s
+	}
+	legacy, err := tc.Seal(plaintext)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	return []secretBindingCase{
+		{"bound to its own row and column", seal(own), true},
+		{"legacy unbound ciphertext still readable", legacy, true},
+		{"bound to a different provider", seal(otherRow), false},
+		{"bound to the sibling column of the same row", seal(siblingColumn), false},
+	}
+}


### PR DESCRIPTION
Part of the suite-identity #153 adoption. Converts the two `scm_providers`
secrets: the OAuth **client secret** and the **GitHub App private key**.

Unbound, either can be copied into another provider row — including one an
attacker with database write access had just created in their own organization —
and AES-GCM authenticates the move. The App private key is the sharper of the
two: it authenticates as the installation itself, so a replayed copy mints
installation tokens for the victim's repositories.

## What changed

- `internal/scm/aad.go`: `ProviderClientSecretContext` and
  `ProviderAppPrivateKeyContext`, alongside the three already there.
- `internal/api/admin/scm_providers.go`: all 4 writes (create and update x both
  columns).
- 13 reads across 6 packages: `internal/scm/appcreds/minter.go` (both columns),
  `internal/api/admin/scm_oauth.go` (6), `internal/api/modules/scm_linking.go`
  (2), `internal/api/webhooks/scm_webhook.go`, `internal/jobs/tag_verifier.go`,
  `internal/jobs/webhook_retry_job.go`.
- `internal/maintenance/bindsecrets.go`: both columns registered.
- `internal/crypto/unbound_seal_sweep_test.go`: `scm_providers.go` drops out of
  the inventory.
- `internal/crypto/unbound_open_sweep_test.go` (**new**, see below).

## Three things worth arguing with

**The create path was restructured, not just call-swapped.** It sealed both
secrets and only afterwards minted the row id in the struct literal, so at seal
time there was no id to bind to. The id is now minted at the top of the handler
and used for both the seals and the insert. The alternative — insert unbound,
then re-seal against the returned id, as `notification_channels` does — exists
only because that repository takes no caller-supplied id. This one does, so the
row never exists in the unbound form at all. A test asserts the id in the
response is among the INSERT's arguments, so "bound to a uuid that was then
thrown away" fails rather than reading as "not bound".

**These two contexts take the row id as `string`, unlike their three
neighbours** which take a `uuid.UUID`. These are columns the `bind-secrets` sweep
converts, and the sweep reads ids as text out of the database. A uuid form would
mean either a second function or a parse with nowhere to report failure, and two
derivations of one context string is exactly the drift that ends in a credential
that no longer decrypts.

**A read-side inventory is added.** This is the one piece of scope beyond the
column, and it is here because this PR is what creates the exposure. The Seal
inventory makes a missed *write* fail loudly. Nothing did that for *reads* —
`Open` and `OpenWithContextOrLegacy` differ by an argument, so a missed read
compiles, passes every test that only round-trips through the writer, and fails
for the first real user whose credential was written after the conversion. This
PR converts 13 reads with nothing keeping them converted.
`unbound_open_sweep_test.go` mirrors the Seal sweep exactly: three unbound reads
remain (the SMTP password x2, the OIDC client secret), and from now on the two
inventories shrink together per column.

## Not done, on purpose

The reads still accept unbound ciphertexts; retiring that is gated on
`registry bind-secrets verify` exiting zero against a real deployment, and no
data is re-encrypted automatically. The `webhook_secret` column in the same table
is stored in plaintext — it is not sealed at all, so it is not in scope here.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test ./...` clean. gosec over every touched
package reports nothing in any file this PR changes; the 9 findings it does
report (`azuredevops/connector.go`, `jobs/mirror_sync.go`,
`jobs/terraform_mirror_sync.go`) are pre-existing in files this PR does not
touch.

Every behavioural claim was mutation-verified — reverted one site at a time,
restored from a backup copy, named test confirmed to fail:

| reverted | test that caught it |
| --- | --- |
| create seals the client secret with no context | `TestCreateSCMProvider_BindsSecretsToTheNewRow` |
| create mints a second uuid for the row | `TestCreateSCMProvider_BindsSecretsToTheNewRow` (the id-is-stored assertion) |
| update binds the App key to the client-secret column of its own row | `TestUpdateSCMProvider_BindsSecretsToTheRowBeingUpdated` |
| minter reads the client secret with no context | `TestEntraCreds_ClientSecretBinding` |
| minter drops the legacy fallback | `TestGitHubAppCreds_PrivateKeyBinding/legacy_...` |
| the two context functions return the same string | `TestRegisteredColumns_ContextsAreColumnDistinct` |
| a converted READ reverts to `Open` | `TestNoNewUnboundOpenSites` |
| a converted WRITE reverts to `Seal` | `TestNoNewUnboundSealSites` |

Refs #153
