### PR TITLE
feat(setup): bind the OIDC client secret to its oidc_config row

### DIFF
--- a/backend/internal/api/oidc_secret_binding_test.go
+++ b/backend/internal/api/oidc_secret_binding_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// suite-identity #153, read side for oidc_config.client_secret_encrypted.
+//
+// applyPersistedOIDCProvider is the ONLY consumer of this column, and it runs at
+// startup. A wrong or missing context here does not fail a build or a test that
+// only round-trips through the writer; it fails the first time the service boots
+// after the backfill, as SSO silently not being configured.
+//
+// The function is deliberately non-fatal — every failure is logged and the app
+// serves without OIDC — so the decrypt outcome is observed through its log line
+// rather than a return value. That is also the honest thing to assert: "SSO went
+// missing and something was written to the log" is exactly what an operator
+// would be looking at.
+
+const decryptFailureLog = "Failed to decrypt OIDC client secret from database"
+
+// oidcConfigCols is the column set identity's GetActiveOIDCConfig scans.
+var oidcConfigCols = []string{
+	"id", "name", "provider_type", "issuer_url", "client_id",
+	"client_secret_encrypted", "redirect_url", "scopes", "is_active",
+	"extra_config", "created_at", "updated_at", "created_by", "updated_by",
+}
+
+func TestApplyPersistedOIDCProvider_ClientSecretBinding(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 59)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+
+	id := uuid.New()
+	other := uuid.New()
+	const secret = "s3cr3t-oidc-client-secret"
+
+	seal := func(ctx []byte) string {
+		s, sErr := tc.SealWithContext(secret, ctx)
+		if sErr != nil {
+			t.Fatalf("SealWithContext: %v", sErr)
+		}
+		return s
+	}
+	legacy, err := tc.Seal(secret)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		ciphertext     string
+		wantDecryptErr bool
+	}{
+		{"bound to its own row", seal(models.OIDCConfigClientSecretContext(id.String())), false},
+		{"legacy unbound ciphertext still readable", legacy, false},
+		{"bound to a different oidc_config row", seal(models.OIDCConfigClientSecretContext(other.String())), true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, mock, dbErr := sqlmock.New()
+			if dbErr != nil {
+				t.Fatal(dbErr)
+			}
+			defer db.Close()
+
+			mock.ExpectQuery("SELECT.*FROM oidc_config WHERE is_active").
+				WillReturnRows(sqlmock.NewRows(oidcConfigCols).AddRow(
+					id, "default", "generic_oidc", "https://issuer.invalid", "client-id",
+					c.ciphertext, "https://app/callback", []byte(`["openid"]`), true,
+					[]byte(`{}`), time.Now(), time.Now(), nil, nil,
+				))
+			repo := repositories.NewOIDCConfigRepository(sqlx.NewDb(db, "sqlmock"))
+
+			logged := captureLogs(t, func() {
+				// authHandlers is only touched once a live provider is built,
+				// which needs the issuer to be reachable; nil is safe because
+				// every path before that point is what this test exercises.
+				applyPersistedOIDCProvider(nil, repo, tc)
+			})
+
+			failed := strings.Contains(logged, decryptFailureLog)
+			if failed != c.wantDecryptErr {
+				if c.wantDecryptErr {
+					t.Fatalf("a secret belonging to another oidc_config row was accepted; "+
+						"the binding is not enforced on read. log=%s", logged)
+				}
+				t.Fatalf("the client secret could not be decrypted: %s", logged)
+			}
+		})
+	}
+}
+
+// captureLogs redirects slog for the duration of fn and returns what was
+// written, restoring the previous logger afterwards.
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}

--- a/backend/internal/api/router_startup.go
+++ b/backend/internal/api/router_startup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/auth/oidc"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -162,7 +163,9 @@ func applyPersistedOIDCProvider(authHandlers *admin.AuthHandlers, repo *reposito
 	if oidcErr != nil || activeOIDCCfg == nil {
 		return
 	}
-	clientSecret, decErr := tokenCipher.Open(activeOIDCCfg.ClientSecretCiphertext)
+	clientSecret, _, decErr := tokenCipher.OpenWithContextOrLegacy(
+		activeOIDCCfg.ClientSecretCiphertext,
+		models.OIDCConfigClientSecretContext(activeOIDCCfg.ID.String()))
 	if decErr != nil {
 		slog.Error("Failed to decrypt OIDC client secret from database", "error", decErr)
 		return

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -228,8 +228,15 @@ func (h *Handlers) SaveOIDCConfig(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	// Encrypt the client secret
-	encryptedSecret, err := h.tokenCipher.Seal(input.ClientSecret)
+	// The row id is minted here rather than at the struct literal below, because
+	// the client secret is sealed against it (suite-identity #153) and the seal
+	// happens first. CreateOIDCConfig takes the id from the caller, so the row
+	// can be bound from its only write and never exists in the unbound form.
+	oidcConfigID := uuid.New()
+
+	// Encrypt the client secret, bound to the row it will live in
+	encryptedSecret, err := h.tokenCipher.SealWithContext(input.ClientSecret,
+		models.OIDCConfigClientSecretContext(oidcConfigID.String()))
 	if err != nil {
 		slog.Error("setup: failed to encrypt OIDC client secret", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt client secret"})
@@ -267,7 +274,7 @@ func (h *Handlers) SaveOIDCConfig(c *gin.Context) {
 	// non-atomic calls that this transaction is designed to close.
 	now := time.Now()
 	oidcCfg := &models.OIDCConfig{
-		ID:                     uuid.New(),
+		ID:                     oidcConfigID,
 		Name:                   name,
 		ProviderType:           input.ProviderType,
 		IssuerURL:              input.IssuerURL,

--- a/backend/internal/api/setup/oidc_binding_test.go
+++ b/backend/internal/api/setup/oidc_binding_test.go
@@ -1,0 +1,121 @@
+package setup
+
+import (
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153 — the OIDC client secret is bound to its oidc_config row.
+//
+// oidc_config keeps every configuration ever saved, not only the active one, so
+// the row axis is the one that matters: unbound, a secret from a retired row
+// could be promoted onto the active row, pointing the service's SSO at an issuer
+// of someone else's choosing without touching the setup API at all.
+//
+// This asserts the value REACHING the database against the id in the same
+// INSERT. SaveOIDCConfig seals BEFORE the struct literal that used to mint the
+// id, so a test of the seal alone would pass even with the row inserted under a
+// different uuid.
+
+// oidcInsertArgs is the positional-parameter count of the identity module's
+// oidc_config INSERT, with id as $1. sqlmock needs one matcher per parameter and
+// fails with both counts if the module's column list changes.
+const oidcInsertArgs = 14
+
+type oidcRecordArg struct {
+	into []driver.Value
+	idx  int
+}
+
+func (r oidcRecordArg) Match(v driver.Value) bool {
+	r.into[r.idx] = v
+	return true
+}
+
+func recordOIDCArgs() ([]driver.Value, []driver.Value) {
+	seen := make([]driver.Value, oidcInsertArgs)
+	matchers := make([]driver.Value, oidcInsertArgs)
+	for i := range matchers {
+		matchers[i] = oidcRecordArg{into: seen, idx: i}
+	}
+	return seen, matchers
+}
+
+func TestSaveOIDCConfig_BindsTheClientSecretToTheNewRow(t *testing.T) {
+	env := newTestEnv(t)
+	const secret = "s3cr3t-oidc-client-secret"
+
+	r := gin.New()
+	r.POST("/oidc", env.h.SaveOIDCConfig)
+
+	stored, matchers := recordOIDCArgs()
+	env.oidcMock.ExpectBegin()
+	env.oidcMock.ExpectExec("UPDATE oidc_config SET is_active = false").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	env.oidcMock.ExpectExec("INSERT INTO oidc_config").
+		WithArgs(matchers...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	env.oidcMock.ExpectCommit()
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/oidc", jsonBody(map[string]string{
+		"provider_type": "generic_oidc",
+		"issuer_url":    "https://issuer.example.com",
+		"client_id":     "test-client",
+		"client_secret": secret,
+		"redirect_url":  "https://app/callback",
+	})))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	// $1 is the row id. Deriving the context from the value actually INSERTED,
+	// rather than from anything the handler reported, is what makes "sealed
+	// against one uuid and inserted under another" a failure.
+	rowID := argString(t, stored[0])
+	ct := argString(t, stored[5])
+
+	got, bound, err := env.cipher.OpenWithContextOrLegacy(ct,
+		models.OIDCConfigClientSecretContext(rowID))
+	if err != nil {
+		t.Fatalf("the stored secret does not open under its own row context: %v", err)
+	}
+	if !bound {
+		t.Error("the stored secret opened only via the LEGACY path, so it was sealed WITHOUT a " +
+			"context and can be moved onto another oidc_config row")
+	}
+	if got != secret {
+		t.Errorf("stored secret = %q, want %q", got, secret)
+	}
+	if _, err := env.cipher.OpenWithContext(ct,
+		models.OIDCConfigClientSecretContext(otherOIDCConfigID)); err == nil {
+		t.Error("the stored secret opened under another config's context; a retired row's secret " +
+			"could be promoted onto the active row")
+	}
+}
+
+const otherOIDCConfigID = "77777777-7777-7777-7777-777777777777"
+
+// argString renders a recorded driver argument as the text the database would
+// store. A uuid.UUID arrives as its own type rather than a string, so the
+// comparison has to go through Stringer rather than a type assertion.
+func argString(t *testing.T, v driver.Value) string {
+	t.Helper()
+	switch x := v.(type) {
+	case string:
+		return x
+	case []byte:
+		return string(x)
+	case interface{ String() string }:
+		return x.String()
+	}
+	t.Fatalf("unexpected argument type %T", v)
+	return ""
+}

--- a/backend/internal/crypto/unbound_open_sweep_test.go
+++ b/backend/internal/crypto/unbound_open_sweep_test.go
@@ -38,9 +38,10 @@ import (
 // written bound and read without a context, which fails at runtime for exactly
 // the rows the conversion just created.
 var unboundOpenSites = map[string]int{
-	// The SMTP password (in the notifications JSON config blob) and the OIDC
-	// client secret, both read during router construction.
-	"internal/api/router_startup.go": 2,
+	// The SMTP password, read out of the notifications JSON config blob during
+	// router construction. Was 2; the OIDC client secret alongside it is now
+	// bound.
+	"internal/api/router_startup.go": 1,
 
 	// The SMTP password again, on the admin test-send path.
 	"internal/api/admin/notifications.go": 1,

--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -51,17 +51,19 @@ import (
 // mode is "an operator re-enters the secret by hand" is converted last, with a
 // verified backfill.
 var unboundSealSites = map[string]int{
-	// First-run setup secrets: the OIDC client secret and the LDAP bind
-	// password. IRREPLACEABLE, and reached before most of the service exists,
-	// so the conversion needs care about ordering.
+	// The LDAP bind password. IRREPLACEABLE, and deferred with the SMTP
+	// password because it is the same shape: a field inside a JSON config blob
+	// on the system_settings singleton, not a column of a row, so it has no row
+	// axis to bind to and needs the blob-aware handling that column has been
+	// waiting for.
 	//
-	// Was 6. The other four were this file's half of the storage_config
+	// Was 6, then 2. Four were this file's half of the storage_config
 	// credential columns — buildEncryptedStorageConfig writes the SAME four
 	// columns as internal/api/admin/storage.go, so they had to convert
 	// together: a column with one converted writer and one unconverted one
 	// cannot be declared bound, and its backfill would be undone by the next
-	// first-run save.
-	"internal/api/setup/handlers.go": 2,
+	// first-run save. The fifth was the OIDC client secret.
+	"internal/api/setup/handlers.go": 1,
 
 	// This service's own notification channel target is BOUND. The one Seal left
 	// is deliberate and transient: ChannelRepository.Create uses

--- a/backend/internal/db/models/aad.go
+++ b/backend/internal/db/models/aad.go
@@ -69,3 +69,20 @@ func StorageConfigS3SecretAccessKeyContext(configID string) []byte {
 func StorageConfigGCSCredentialsJSONContext(configID string) []byte {
 	return storageConfigContext(configID, "gcs_credentials_json_encrypted")
 }
+
+// OIDCConfigClientSecretContext binds an OIDC provider's client secret to its
+// row in oidc_config.
+//
+// The row is the unit that matters here even though only one config is active at
+// a time: oidc_config holds every configuration ever saved, active or not, and
+// without a binding a secret could be moved from a retired row onto the active
+// one — which is a way to make the service authenticate to an issuer of
+// someone else's choosing without ever touching the setup API.
+//
+// It lives here rather than in the identity module, unlike notify.TargetContext,
+// because the identity module performs no cryptography on this column: it stores
+// and returns ClientSecretCiphertext opaquely, and both the seal (the setup
+// wizard) and the open (router startup) are this service's own code.
+func OIDCConfigClientSecretContext(configID string) []byte {
+	return []byte("oidc_config:" + configID + ":client_secret_encrypted")
+}

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -73,9 +73,10 @@ var ErrUnboundRemain = errors.New("maintenance: secrets remain unbound")
 
 // columns is the registry of convertible columns.
 //
-// The remaining ones (setup's OIDC client secret and LDAP bind password, and the
-// SMTP password) are added here as each is
-// converted in the application — the sweep for a column must not exist before
+// The remaining ones (the LDAP bind password and the SMTP password, both fields
+// inside a JSON config blob rather than columns of their own) are added here as
+// each is converted in the application — the sweep for a column must not exist
+// before
 // the code that writes the bound form, or an operator can convert rows the
 // running service then cannot read. "The code" means EVERY writer: the four
 // storage_config entries below were only registrable once both the admin CRUD
@@ -106,6 +107,23 @@ var columns = []column{
 	storageConfigColumn("s3_access_key_id_encrypted", models.StorageConfigS3AccessKeyIDContext),
 	storageConfigColumn("s3_secret_access_key_encrypted", models.StorageConfigS3SecretAccessKeyContext),
 	storageConfigColumn("gcs_credentials_json_encrypted", models.StorageConfigGCSCredentialsJSONContext),
+	{
+		// Every saved configuration, not just the active one. A retired row's
+		// secret is exactly what an attacker would promote onto the active row,
+		// so leaving inactive rows unconverted would leave the move available.
+		name:    "oidc_config.client_secret_encrypted",
+		context: models.OIDCConfigClientSecretContext,
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			return listRows(ctx, db,
+				`SELECT id, client_secret_encrypted FROM oidc_config WHERE client_secret_encrypted <> ''`)
+		},
+		update: func(ctx context.Context, db *sql.DB, id, bound string) error {
+			_, err := db.ExecContext(ctx,
+				`UPDATE oidc_config SET client_secret_encrypted = $2, updated_at = now() WHERE id = $1`,
+				id, bound)
+			return err
+		},
+	},
 	{
 		name:    "scm_providers.client_secret_encrypted",
 		context: scm.ProviderClientSecretContext,

--- a/backend/internal/maintenance/bindsecrets_test.go
+++ b/backend/internal/maintenance/bindsecrets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
@@ -351,6 +352,96 @@ func TestBindSecrets_ConvertsEveryStorageCredentialColumn(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// oidc_config.client_secret_encrypted (suite-identity #153)
+// ---------------------------------------------------------------------------
+
+// The sweep must convert EVERY saved configuration, not only the active one: a
+// retired row's secret is what an attacker would promote onto the active row, so
+// a WHERE is_active filter would leave the move available on exactly the rows
+// nobody looks at.
+//
+// That claim cannot be made with rows alone. sqlmock returns whatever the
+// expectation was primed with regardless of the real WHERE clause, so a test
+// that only counts conversions passes just as happily with the filter added —
+// verified by reverting it. The SELECT's own text therefore has to be asserted,
+// which is what recordSQL is for.
+func TestBindSecrets_ConvertsEveryOIDCConfigRow(t *testing.T) {
+	var seen []string
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(recordSQL(&seen)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	const activeID, retiredID = "55555555-5555-5555-5555-555555555555", "66666666-6666-6666-6666-666666666666"
+	legacy, err := tc.Seal("oidc-client-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	drive(t, mock, "oidc_config.client_secret_encrypted", func() {
+		mock.ExpectQuery("SELECT id, client_secret_encrypted FROM oidc_config").
+			WillReturnRows(sqlmock.NewRows([]string{"id", "client_secret_encrypted"}).
+				AddRow(activeID, legacy).
+				AddRow(retiredID, legacy))
+		mock.ExpectExec("UPDATE oidc_config SET client_secret_encrypted").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectExec("UPDATE oidc_config SET client_secret_encrypted").
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	})
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	if got := res["oidc_config.client_secret_encrypted"]; got.Converted != 2 || got.Failed != 0 {
+		t.Fatalf("result = %s; want both the active and the retired row converted", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("both rows should have been written: %v", err)
+	}
+
+	// The listing query must select on nothing but "holds a secret". Any other
+	// predicate narrows the sweep to a subset of rows and silently leaves the
+	// rest unbound — while verify, running the same query, reports success.
+	sel := findSelect(t, seen, "client_secret_encrypted FROM oidc_config")
+	for _, forbidden := range []string{"is_active", "limit", "created_at"} {
+		if strings.Contains(strings.ToLower(sel), forbidden) {
+			t.Errorf("the oidc_config listing query narrows the sweep with %q: %s", forbidden, sel)
+		}
+	}
+}
+
+// recordSQL is a QueryMatcher that appends every query the driver is asked to
+// match, while keeping the default regexp matching behaviour.
+func recordSQL(into *[]string) sqlmock.QueryMatcher {
+	return sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		*into = append(*into, actualSQL)
+		return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+	})
+}
+
+// findSelect returns the one recorded statement containing substr, failing if
+// there is not exactly one. Recorded queries can repeat (the matcher is
+// consulted per candidate expectation), so they are de-duplicated first.
+func findSelect(t *testing.T, seen []string, substr string) string {
+	t.Helper()
+	uniq := map[string]bool{}
+	var hits []string
+	for _, q := range seen {
+		if strings.Contains(q, substr) && !uniq[q] {
+			uniq[q] = true
+			hits = append(hits, q)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly one distinct statement containing %q, got %d: %v", substr, len(hits), hits)
+	}
+	return hits[0]
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of the suite-identity #153 adoption. Converts
`oidc_config.client_secret_encrypted`.

`oidc_config` keeps **every** configuration ever saved, not only the active one,
which makes the unbound form a specific move rather than an abstract one: promote
a retired row's secret onto the active row and the service authenticates to an
issuer of someone else's choosing at its next boot — no call to the setup API,
nothing in an audit log.

## What changed

- `internal/db/models/aad.go`: `OIDCConfigClientSecretContext`.
- `internal/api/setup/handlers.go`: `SaveOIDCConfig` seals with a context, and
  mints the row id first (it sealed before the struct literal that used to mint
  it — same shape as the SCM provider create path, and fixed the same way).
- `internal/api/router_startup.go`: `applyPersistedOIDCProvider`, the only
  consumer, reads with `OpenWithContextOrLegacy`.
- `internal/maintenance/bindsecrets.go`: registered.
- Both inventories shrink: `setup/handlers.go` 2 → 1 Seal, `router_startup.go`
  2 → 1 Open.

The context lives here rather than upstream beside `notify.TargetContext`
because the identity module stores `ClientSecretCiphertext` opaquely and performs
no cryptography on it — both halves are this service's code.

## Scope correction — please read

This was planned as "the setup secrets": the OIDC client secret **and** the LDAP
bind password. **The LDAP bind password is not a row column.**
`SaveLDAPConfig` seals it into the `bind_password_enc` field of the `ldap_config`
JSON blob on the `system_settings` singleton — the same shape as the SMTP
password, which is already deferred as the blob case. The two blobs live on the
same row, so a context naming only the row would still let a value move between
`ldap_config` and `notifications_config`; they need the column in the context and
they need the same singleton exemption. Doing them together writes the blob-aware
`list`/`update` and the `rowScoped` exemption once instead of twice, so the LDAP
password moves to that change and this PR is the OIDC secret alone.

One thing worth knowing before that change is written: **nothing decrypts the
LDAP bind password.** `GetLDAPConfig` has no callers anywhere in the repo, and
the runtime LDAP provider is built from `config.LDAPConfig` (environment/file),
not from the stored blob. It is write-only today. That does not make binding it
pointless — it is cheap and it forecloses the cross-blob move — but there is no
"an operator re-enters the secret" failure mode to weigh against it, which is a
different risk calculation from every other column in this migration.

## A test that certified nothing, caught and fixed

The first version of `TestBindSecrets_ConvertsEveryOIDCConfigRow` asserted only
that both primed rows converted. sqlmock returns whatever the expectation was
primed with regardless of the real `WHERE` clause, so adding `is_active = true`
to the sweep's query left it green — confirmed by trying it. It now records and
asserts the SELECT's own text, and that mutation fails it. Flagging this because
it is the same failure mode the #840 create test had, in a different disguise.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test ./...` clean. gosec reports 0 issues
across `internal/api`, `internal/api/setup`, `internal/db/models` and
`internal/maintenance`.

Mutation-verified, one site at a time, restored from a backup copy:

| reverted | test that caught it |
| --- | --- |
| seal with no context | `TestSaveOIDCConfig_BindsTheClientSecretToTheNewRow` |
| the row gets a different uuid from the one sealed against | same test |
| read derives the context from the wrong id | `TestApplyPersistedOIDCProvider_ClientSecretBinding` |
| read drops the legacy fallback | same test |
| sweep narrows to active rows only | `TestBindSecrets_ConvertsEveryOIDCConfigRow` |
| the context collides with a `storage_config` column | `TestRegisteredColumns_ContextsAreColumnDistinct` |
| the write reverts to `Seal` | `TestNoNewUnboundSealSites` |

Reverting the read to plain `Open` leaves an unused import, i.e. a build break
rather than a test result, so it was replaced by the two read mutations above.

## Remaining after this

Two unbound writes and two unbound reads, all belonging to the SMTP password and
the LDAP bind password — both JSON-blob fields on the `system_settings`
singleton, and the last of #153 in this service.

Refs #153
