### PR TITLE
feat(settings): bind the SMTP and LDAP passwords to their config-blob fields

### DIFF
--- a/backend/internal/api/admin/notifications.go
+++ b/backend/internal/api/admin/notifications.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/notify"
 )
@@ -312,7 +313,8 @@ func buildNotificationsConfigDB(input notificationsConfigInput, tokenCipher *cry
 	}
 
 	if input.SMTP.Password != "" {
-		encrypted, err := tokenCipher.Seal(input.SMTP.Password)
+		encrypted, err := tokenCipher.SealWithContext(input.SMTP.Password,
+			models.SystemSettingsSMTPPasswordContext())
 		if err != nil {
 			return dbc, err
 		}
@@ -374,7 +376,8 @@ func (h *NotificationsHandler) TestEmail(c *gin.Context) {
 		if raw, err := h.repo.GetNotificationsConfig(ctx); err == nil && raw != nil {
 			var dbc NotificationsConfigDB
 			if json.Unmarshal(raw, &dbc) == nil && dbc.SMTP.PasswordEncrypted != "" {
-				if pw, derr := h.tokenCipher.Open(dbc.SMTP.PasswordEncrypted); derr == nil {
+				if pw, _, derr := h.tokenCipher.OpenWithContextOrLegacy(
+					dbc.SMTP.PasswordEncrypted, models.SystemSettingsSMTPPasswordContext()); derr == nil {
 					tempSMTP.Password = pw
 				}
 			}

--- a/backend/internal/api/admin/notifications_test.go
+++ b/backend/internal/api/admin/notifications_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
@@ -105,12 +106,35 @@ func TestBuildNotificationsConfigDB_SealsNewPassword(t *testing.T) {
 		t.Fatalf("expected a newly sealed ciphertext, got %q", dbc.SMTP.PasswordEncrypted)
 	}
 
-	decrypted, err := tc.Open(dbc.SMTP.PasswordEncrypted)
+	// INVERTED for suite-identity #153. This used to assert that the stored
+	// password opens with a plain tc.Open, i.e. with no additional-authenticated
+	// data — which is precisely the property being retired: a ciphertext that
+	// carries no statement of where it belongs can be moved to another sealed
+	// field and still decrypt. The SMTP password shares the system_settings row
+	// with the LDAP bind password, so "another sealed field" is not theoretical.
+	//
+	// The assertion is therefore reversed rather than dropped: opening WITHOUT a
+	// context must now fail, and opening under this field's own context must
+	// return the password.
+	if _, err := tc.Open(dbc.SMTP.PasswordEncrypted); err == nil {
+		t.Error("the sealed password still opens without a context; it was not bound to its field")
+	}
+
+	decrypted, err := tc.OpenWithContext(dbc.SMTP.PasswordEncrypted,
+		models.SystemSettingsSMTPPasswordContext())
 	if err != nil {
-		t.Fatalf("tc.Open: %v", err)
+		t.Fatalf("the sealed password does not open under its own field context: %v", err)
 	}
 	if decrypted != "hunter2" {
 		t.Errorf("decrypted password = %q, want %q", decrypted, "hunter2")
+	}
+
+	// The binding names the field, not just the blob: an LDAP bind password and
+	// an SMTP password must not be interchangeable in the row they share.
+	if _, err := tc.OpenWithContext(dbc.SMTP.PasswordEncrypted,
+		models.SystemSettingsLDAPBindPasswordContext()); err == nil {
+		t.Error("the sealed SMTP password also opens as the LDAP bind password; " +
+			"the two fields of system_settings are interchangeable")
 	}
 }
 

--- a/backend/internal/api/router_startup.go
+++ b/backend/internal/api/router_startup.go
@@ -125,7 +125,8 @@ func reloadNotificationsConfigFromDB(cfg *config.Config, repo *repositories.OIDC
 	cfg.Notifications.SMTP.From = dbc.SMTP.From
 	cfg.Notifications.SMTP.UseTLS = dbc.SMTP.UseTLS
 	if dbc.SMTP.PasswordEncrypted != "" {
-		if pw, derr := tokenCipher.Open(dbc.SMTP.PasswordEncrypted); derr == nil {
+		if pw, _, derr := tokenCipher.OpenWithContextOrLegacy(
+			dbc.SMTP.PasswordEncrypted, models.SystemSettingsSMTPPasswordContext()); derr == nil {
 			cfg.Notifications.SMTP.Password = pw
 		} else {
 			log.Printf("notifications startup: failed to decrypt persisted smtp password: %v", derr)

--- a/backend/internal/api/setup/handlers.go
+++ b/backend/internal/api/setup/handlers.go
@@ -977,7 +977,8 @@ func (h *Handlers) SaveLDAPConfig(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// Encrypt the bind password before storing
-	encryptedPassword, err := h.tokenCipher.Seal(input.BindPassword)
+	encryptedPassword, err := h.tokenCipher.SealWithContext(input.BindPassword,
+		models.SystemSettingsLDAPBindPasswordContext())
 	if err != nil {
 		slog.Error("setup: failed to encrypt LDAP bind password", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to encrypt bind password"})

--- a/backend/internal/api/setup/ldap_binding_test.go
+++ b/backend/internal/api/setup/ldap_binding_test.go
@@ -1,0 +1,102 @@
+package setup
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153 — the LDAP service-account bind password is bound to its
+// field in the ldap_config blob.
+//
+// Two things about this one are unlike every other secret in this migration, and
+// both are deliberate:
+//
+// It has no row. ldap_config is a JSON blob on the system_settings singleton, so
+// the context names the blob and the field rather than a row id. What that buys
+// is the cross-field move: notifications_config sits in the SAME row, so an SMTP
+// password and this password would otherwise be interchangeable.
+//
+// Nothing reads it. GetLDAPConfig has no callers; the runtime LDAP provider is
+// built from config.LDAPConfig (environment/file), not from this blob. The field
+// is write-only today, so there is no read path to convert and no "the operator
+// re-enters it" failure mode — which is exactly why binding it is worth doing
+// now rather than later: it costs one call and it means a reader added in future
+// inherits a bound value instead of finding an unbound one.
+
+type ldapBlobCapture struct{ into *[]byte }
+
+func (c ldapBlobCapture) Match(v driver.Value) bool {
+	switch x := v.(type) {
+	case []byte:
+		*c.into = append([]byte(nil), x...)
+	case string:
+		*c.into = []byte(x)
+	}
+	return true
+}
+
+func TestSaveLDAPConfig_BindsTheBindPasswordToItsField(t *testing.T) {
+	env := newTestEnv(t)
+	const password = "svc-account-bind-password"
+
+	r := gin.New()
+	r.POST("/ldap", env.h.SaveLDAPConfig)
+
+	var written []byte
+	env.oidcMock.ExpectExec("UPDATE system_settings SET").
+		WithArgs(ldapBlobCapture{into: &written}, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/ldap", jsonBody(map[string]interface{}{
+		"host":          "ldap.example.com",
+		"port":          636,
+		"use_tls":       true,
+		"bind_dn":       "cn=svc,dc=example,dc=com",
+		"bind_password": password,
+		"base_dn":       "dc=example,dc=com",
+		"user_filter":   "(uid=%s)",
+	})))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+
+	var blob map[string]any
+	if err := json.Unmarshal(written, &blob); err != nil {
+		t.Fatalf("the stored ldap_config is not valid JSON: %v (%s)", err, written)
+	}
+	sealed, _ := blob["bind_password_enc"].(string)
+	if sealed == "" {
+		t.Fatal("no bind_password_enc was stored")
+	}
+	if sealed == password {
+		t.Fatal("the bind password was stored in plaintext")
+	}
+
+	got, bound, err := env.cipher.OpenWithContextOrLegacy(sealed,
+		models.SystemSettingsLDAPBindPasswordContext())
+	if err != nil {
+		t.Fatalf("the stored password does not open under its own field context: %v", err)
+	}
+	if !bound {
+		t.Error("the stored password opened only via the LEGACY path, so it was sealed WITHOUT a " +
+			"context and is interchangeable with any other unbound secret")
+	}
+	if got != password {
+		t.Errorf("stored password = %q, want %q", got, password)
+	}
+	// The other secret in the same system_settings row.
+	if _, err := env.cipher.OpenWithContext(sealed,
+		models.SystemSettingsSMTPPasswordContext()); err == nil {
+		t.Error("the stored bind password also opens as the SMTP password; the two fields of " +
+			"system_settings are interchangeable")
+	}
+}

--- a/backend/internal/api/smtp_password_binding_test.go
+++ b/backend/internal/api/smtp_password_binding_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// suite-identity #153, read side for the SMTP password.
+//
+// The password lives in a field of the notifications_config JSON blob on the
+// system_settings singleton, so it has no row to bind to; its context names the
+// blob and the field instead. That is a weaker binding than the row-scoped ones,
+// and this test is about the part it does buy: the LDAP bind password sits in
+// the OTHER blob on the SAME row, so without the field in the context the two
+// would be interchangeable.
+//
+// reloadNotificationsConfigFromDB writes the decrypted password straight onto
+// cfg.Notifications.SMTP.Password, which makes the outcome directly observable —
+// no log scraping needed here.
+
+func TestReloadNotificationsConfigFromDB_SMTPPasswordBinding(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 71)
+	}
+	tc, err := crypto.NewTokenCipher(key)
+	if err != nil {
+		t.Fatalf("NewTokenCipher: %v", err)
+	}
+
+	const password = "hunter2"
+	seal := func(ctx []byte) string {
+		s, sErr := tc.SealWithContext(password, ctx)
+		if sErr != nil {
+			t.Fatalf("SealWithContext: %v", sErr)
+		}
+		return s
+	}
+	legacy, err := tc.Seal(password)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		ciphertext string
+		wantLoaded bool
+	}{
+		{"bound to its own field", seal(models.SystemSettingsSMTPPasswordContext()), true},
+		{"legacy unbound ciphertext still readable", legacy, true},
+		// The move this binding exists to stop: the other secret in the same
+		// system_settings row, pasted into this field.
+		{"bound as the LDAP bind password of the same row",
+			seal(models.SystemSettingsLDAPBindPasswordContext()), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, mock, dbErr := sqlmock.New()
+			if dbErr != nil {
+				t.Fatal(dbErr)
+			}
+			defer db.Close()
+
+			blob := `{"enabled":true,"smtp":{"host":"smtp.example.com","port":587,` +
+				`"smtp_password_encrypted":"` + c.ciphertext + `"}}`
+			mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+				WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(blob)))
+
+			repo := repositories.NewOIDCConfigRepository(sqlx.NewDb(db, "sqlmock"))
+			cfg := &config.Config{}
+			reloadNotificationsConfigFromDB(cfg, repo, tc)
+
+			got := cfg.Notifications.SMTP.Password
+			if c.wantLoaded {
+				if got != password {
+					t.Fatalf("SMTP password = %q, want %q; the stored password could not be decrypted",
+						got, password)
+				}
+				return
+			}
+			if got != "" {
+				t.Fatalf("a ciphertext belonging to another field of the same row was accepted as "+
+					"the SMTP password (%q); the binding is not enforced on read", got)
+			}
+			// The rest of the configuration still loads: a credential that will
+			// not decrypt must not take the whole notifications config with it.
+			if cfg.Notifications.SMTP.Host != "smtp.example.com" {
+				t.Errorf("SMTP host = %q; a failed decrypt should not discard the rest of the config",
+					cfg.Notifications.SMTP.Host)
+			}
+		})
+	}
+}

--- a/backend/internal/crypto/unbound_open_sweep_test.go
+++ b/backend/internal/crypto/unbound_open_sweep_test.go
@@ -37,15 +37,18 @@ import (
 // entry that outlives its Seal counterpart is a bug: it means a column is being
 // written bound and read without a context, which fails at runtime for exactly
 // the rows the conversion just created.
-var unboundOpenSites = map[string]int{
-	// The SMTP password, read out of the notifications JSON config blob during
-	// router construction. Was 2; the OIDC client secret alongside it is now
-	// bound.
-	"internal/api/router_startup.go": 1,
-
-	// The SMTP password again, on the admin test-send path.
-	"internal/api/admin/notifications.go": 1,
-}
+//
+// EMPTY IS THE FINISH LINE, not a broken test. Every read in this service now
+// passes a context. An empty inventory does not make this test vacuous: its job
+// from here is the other direction — any file that gains an unbound Open fails,
+// which is how a new column, or a revert of an old one, gets caught at the point
+// it is written rather than the first time a user's credential will not decrypt.
+//
+// It also stops being a transition tool at that point and becomes a standing
+// rule. Keep it that way: an entry added here now is a claim that a column is
+// deliberately readable without its context, and that claim needs the same
+// justification the transition entries carried.
+var unboundOpenSites = map[string]int{}
 
 // isCipherOpen reports whether a call is <something cipher-ish>.Open(...).
 //

--- a/backend/internal/crypto/unbound_seal_sweep_test.go
+++ b/backend/internal/crypto/unbound_seal_sweep_test.go
@@ -39,32 +39,19 @@ import (
 // unboundSealSites maps a repo-relative file to how many TokenCipher.Seal calls
 // it still contains, with the column and why it has not been converted yet.
 //
-// Converted so far: scm_provider_tokens.access_token (the app-token cache), the
-// user OAuth access + refresh tokens across scm_oauth.go, scm_linking.go and
-// scm_publisher.go, the four storage_config credential columns, and the
-// scm_providers client secret + GitHub App private key. What remains is the rest
-// of the operator-entered material, which needs a backfill per column before its
-// reads can stop accepting the unbound form.
+// Every column this service seals is now converted: the SCM app-token cache, the
+// user OAuth access + refresh tokens, the four storage_config credentials, the
+// scm_providers client secret and GitHub App private key, the OIDC client
+// secret, and the two config-blob passwords (SMTP and LDAP).
 //
-// Ordered by recoverability, which is the order the conversion follows: a column
-// whose failure mode is "re-mint" is safe to convert first; one whose failure
-// mode is "an operator re-enters the secret by hand" is converted last, with a
-// verified backfill.
+// The conversion order was by recoverability: a column whose failure mode is
+// "re-mint" first, one whose failure mode is "an operator re-enters the secret
+// by hand" last, each with a backfill registered in internal/maintenance.
+//
+// One entry remains and it is not a deferral — see below. The test is still
+// live: any NEW file that gains a Seal fails it, which is what stops the class
+// growing back now that the migration is done.
 var unboundSealSites = map[string]int{
-	// The LDAP bind password. IRREPLACEABLE, and deferred with the SMTP
-	// password because it is the same shape: a field inside a JSON config blob
-	// on the system_settings singleton, not a column of a row, so it has no row
-	// axis to bind to and needs the blob-aware handling that column has been
-	// waiting for.
-	//
-	// Was 6, then 2. Four were this file's half of the storage_config
-	// credential columns — buildEncryptedStorageConfig writes the SAME four
-	// columns as internal/api/admin/storage.go, so they had to convert
-	// together: a column with one converted writer and one unconverted one
-	// cannot be declared bound, and its backfill would be undone by the next
-	// first-run save. The fifth was the OIDC client secret.
-	"internal/api/setup/handlers.go": 1,
-
 	// This service's own notification channel target is BOUND. The one Seal left
 	// is deliberate and transient: ChannelRepository.Create uses
 	// `INSERT ... RETURNING` and takes no caller-supplied id, so the row is
@@ -74,10 +61,11 @@ var unboundSealSites = map[string]int{
 	//
 	// Kept in the inventory rather than exempted, so that if the re-seal is ever
 	// removed the count still has to be justified by someone.
+	//
+	// Every other create path in this service mints its own id and binds from
+	// the first write; this one cannot, because the id does not exist until the
+	// INSERT returns.
 	"internal/api/admin/notification_channels.go": 1,
-
-	// SMTP password.
-	"internal/api/admin/notifications.go": 1,
 }
 
 // backendRoot walks up to the module root so the test is runnable from its own

--- a/backend/internal/db/models/aad.go
+++ b/backend/internal/db/models/aad.go
@@ -86,3 +86,39 @@ func StorageConfigGCSCredentialsJSONContext(configID string) []byte {
 func OIDCConfigClientSecretContext(configID string) []byte {
 	return []byte("oidc_config:" + configID + ":client_secret_encrypted")
 }
+
+// The two secrets below have NO row axis, and that is a property of the data
+// rather than an oversight.
+//
+// Both live inside JSON config blobs on system_settings, which is a singleton:
+// there is one row, `WHERE id = 1`, and there will only ever be one. "Bind this
+// to its row" is therefore vacuous for them — every value is already in the only
+// row there is — so what these contexts bind is the PURPOSE: which blob, and
+// which field inside it.
+//
+// That is weaker than the row-scoped contexts above and it is worth being
+// precise about what it does and does not buy. It does not stop anything, since
+// there is nothing to move a value between. What it does stop is the cross-
+// column move: notifications_config and ldap_config sit side by side in the SAME
+// row, so without the blob and field in the context an SMTP password and an LDAP
+// bind password would be interchangeable, as would either of them and any other
+// secret in this service sealed with no context at all. Naming the purpose is
+// the strongest binding available here, and it is strictly better than none.
+//
+// They take no argument on purpose. A parameter that is always ignored reads as
+// though the value varies, and the next person to add a singleton would copy it.
+// The backfill registry adapts them instead, and marks these columns as
+// singletons explicitly so its row-scoping check can tell "deliberately
+// constant" from "accidentally constant".
+
+// SystemSettingsSMTPPasswordContext binds the SMTP password to its field in the
+// notifications_config blob.
+func SystemSettingsSMTPPasswordContext() []byte {
+	return []byte("system_settings:notifications_config:smtp.smtp_password_encrypted")
+}
+
+// SystemSettingsLDAPBindPasswordContext binds the LDAP service-account bind
+// password to its field in the ldap_config blob.
+func SystemSettingsLDAPBindPasswordContext() []byte {
+	return []byte("system_settings:ldap_config:bind_password_enc")
+}

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -5,9 +5,11 @@ package maintenance
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	identitynotify "github.com/sethbacon/terraform-suite-identity/identity/notify"
 
@@ -48,6 +50,19 @@ type column struct {
 	context func(id string) []byte
 	// update writes the converted ciphertext back for one row.
 	update func(ctx context.Context, db *sql.DB, id, bound string) error
+	// singleton marks a secret with no row axis: a field inside a config blob
+	// on system_settings, of which there is exactly one row. Its context binds
+	// the purpose (which blob, which field) rather than a row id, so
+	// TestRegisteredColumns_ContextsAreRowScoped cannot apply and this flag
+	// tells it so.
+	//
+	// The flag is "singleton" rather than the more natural "rowScoped" so that
+	// its ZERO VALUE is the strict setting. A rowScoped field would default to
+	// false in Go, which means a column added without a thought about this
+	// would be silently exempted from the row-scoping check — the guard would
+	// quietly stop guarding exactly when someone was not paying attention.
+	// This way, forgetting the field means being checked.
+	singleton bool
 }
 
 // Result is what one column's sweep did. Total is rows examined, not changed.
@@ -73,10 +88,8 @@ var ErrUnboundRemain = errors.New("maintenance: secrets remain unbound")
 
 // columns is the registry of convertible columns.
 //
-// The remaining ones (the LDAP bind password and the SMTP password, both fields
-// inside a JSON config blob rather than columns of their own) are added here as
-// each is converted in the application — the sweep for a column must not exist
-// before
+// This is now every secret this service seals. The rule that got them all here:
+// the sweep for a column must not exist before
 // the code that writes the bound form, or an operator can convert rows the
 // running service then cannot read. "The code" means EVERY writer: the four
 // storage_config entries below were only registrable once both the admin CRUD
@@ -155,6 +168,131 @@ var columns = []column{
 			return err
 		},
 	},
+	blobField("notifications_config", "smtp_password_encrypted",
+		models.SystemSettingsSMTPPasswordContext, "smtp"),
+	blobField("ldap_config", "bind_password_enc",
+		models.SystemSettingsLDAPBindPasswordContext),
+}
+
+// systemSettingsID is the single row every config blob lives on. It is passed
+// through the sweep as the "row id" so the shared logic needs no special case,
+// but the singleton contexts ignore it.
+const systemSettingsID = "1"
+
+// blobField describes a secret stored as a FIELD inside a JSON config blob on
+// the system_settings singleton, rather than as a column of its own.
+//
+// path is the object nesting above the field ("smtp" for the SMTP password, none
+// for the LDAP bind password). The whole blob is one column, so converting the
+// secret means read-modify-write of the JSON.
+//
+// The rewrite goes through a generic map, NEVER through the typed struct the
+// application unmarshals into. Round-tripping the blob through
+// admin.NotificationsConfigDB would silently DROP every field that struct does
+// not know about — an older key, a newer key written by a replica mid-upgrade,
+// anything hand-added — and turn a credential conversion into config data loss.
+// A map preserves what it does not understand, which is the only safe posture
+// for a tool that runs once against production.
+func blobField(
+	blobColumn, field string,
+	contextFor func() []byte,
+	path ...string,
+) column {
+	name := "system_settings." + blobColumn + ":" + strings.Join(append(path, field), ".")
+	return column{
+		name:      name,
+		singleton: true,
+		context:   func(string) []byte { return contextFor() },
+		list: func(ctx context.Context, db *sql.DB) ([]sealedRow, error) {
+			blob, err := readBlob(ctx, db, blobColumn)
+			if err != nil || blob == nil {
+				return nil, err
+			}
+			sealed, _ := blobLookup(blob, append(path, field))
+			if sealed == "" {
+				return nil, nil // unset, not unbound
+			}
+			return []sealedRow{{id: systemSettingsID, sealed: sealed}}, nil
+		},
+		update: func(ctx context.Context, db *sql.DB, _, bound string) error {
+			blob, err := readBlob(ctx, db, blobColumn)
+			if err != nil {
+				return err
+			}
+			if blob == nil {
+				return fmt.Errorf("maintenance: %s disappeared between read and write", blobColumn)
+			}
+			if err := blobAssign(blob, append(path, field), bound); err != nil {
+				return err
+			}
+			encoded, err := json.Marshal(blob)
+			if err != nil {
+				return err
+			}
+			// The blob column only; notifications_configured / ldap_configured
+			// and their timestamps are untouched, because re-sealing a secret
+			// is not the operator configuring anything.
+			_, err = db.ExecContext(ctx,
+				// #nosec G201 -- blobColumn is one of two literals passed by the registry
+				// below, never caller input; the secret itself is a bound parameter.
+				fmt.Sprintf(`UPDATE system_settings SET %s = $1, updated_at = now() WHERE id = 1`, blobColumn),
+				encoded)
+			return err
+		},
+	}
+}
+
+// readBlob loads one JSON config column from system_settings, or nil when it is
+// absent or empty.
+func readBlob(ctx context.Context, db *sql.DB, blobColumn string) (map[string]any, error) {
+	var raw []byte
+	err := db.QueryRowContext(ctx,
+		// #nosec G201 -- blobColumn is one of two literals passed by the registry, never input
+		fmt.Sprintf(`SELECT %s FROM system_settings WHERE id = 1`, blobColumn),
+	).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) || len(raw) == 0 {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var blob map[string]any
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		return nil, fmt.Errorf("maintenance: %s is not a JSON object: %w", blobColumn, err)
+	}
+	return blob, nil
+}
+
+// blobLookup walks path through nested objects and returns the string at the
+// end, or "" if any step is missing or the wrong shape.
+func blobLookup(blob map[string]any, path []string) (string, bool) {
+	cur := blob
+	for _, step := range path[:len(path)-1] {
+		next, ok := cur[step].(map[string]any)
+		if !ok {
+			return "", false
+		}
+		cur = next
+	}
+	s, ok := cur[path[len(path)-1]].(string)
+	return s, ok
+}
+
+// blobAssign sets the string at path, refusing rather than creating missing
+// parents: the sweep only ever rewrites a field it has already READ, so an
+// absent parent means the blob changed underneath the run and guessing at its
+// shape would corrupt it.
+func blobAssign(blob map[string]any, path []string, value string) error {
+	cur := blob
+	for _, step := range path[:len(path)-1] {
+		next, ok := cur[step].(map[string]any)
+		if !ok {
+			return fmt.Errorf("maintenance: %q is missing from the config blob; it changed during the sweep", step)
+		}
+		cur = next
+	}
+	cur[path[len(path)-1]] = value
+	return nil
 }
 
 // storageConfigColumn describes one of the four storage_config credential

--- a/backend/internal/maintenance/bindsecrets_test.go
+++ b/backend/internal/maintenance/bindsecrets_test.go
@@ -245,10 +245,54 @@ func TestBindSecrets_RequiresACipher(t *testing.T) {
 // context would satisfy the round-trip tests above while making the binding
 // vacuous for that column, and this is the cheapest place to catch it as columns
 // are added.
+//
+// The exception is a singleton: a field inside a config blob on system_settings,
+// where there is one row and "bind it to its row" means nothing. Those are
+// exempted by an explicit flag on the column rather than by softening the
+// assertion, so the exemption is a decision someone made and can be seen in a
+// diff — and so a column that is accidentally constant still fails.
+//
+// The exemption is checked in BOTH directions. A singleton must actually be
+// constant: a column marked singleton whose context varies by row is mismarked,
+// and letting that pass would mean the row-scoping guard had been switched off
+// for a column that has a row axis after all.
 func TestRegisteredColumns_ContextsAreRowScoped(t *testing.T) {
 	for _, col := range columns {
-		if string(col.context("row-a")) == string(col.context("row-b")) {
-			t.Errorf("%s derives the same context for different rows; its binding is vacuous", col.name)
+		constant := string(col.context("row-a")) == string(col.context("row-b"))
+
+		if col.singleton {
+			if !constant {
+				t.Errorf("%s is marked singleton but derives a DIFFERENT context per row; "+
+					"either the flag is wrong or the column has a row axis it should be bound to",
+					col.name)
+			}
+			continue
+		}
+		if constant {
+			t.Errorf("%s derives the same context for different rows; its binding is vacuous. "+
+				"If it genuinely has no row axis, mark it singleton and say why.", col.name)
+		}
+	}
+}
+
+// A singleton's context is weaker than a row-scoped one, so the set of them is
+// worth being able to see at a glance — and worth failing on if it grows by
+// accident. Both entries are fields of a JSON blob on system_settings; anything
+// else claiming to have no row axis should have to justify itself here.
+func TestRegisteredColumns_SingletonsAreOnlyTheConfigBlobs(t *testing.T) {
+	want := map[string]bool{
+		"system_settings.notifications_config:smtp.smtp_password_encrypted": true,
+		"system_settings.ldap_config:bind_password_enc":                     true,
+	}
+	for _, col := range columns {
+		if col.singleton && !want[col.name] {
+			t.Errorf("%s is exempted from row-scoping but is not one of the known config blobs. "+
+				"A column with a row axis must be bound to it; add it here only if it genuinely "+
+				"has none.", col.name)
+		}
+		if !col.singleton && want[col.name] {
+			t.Errorf("%s lost its singleton marking; the row-scoping check will now fail it for "+
+				"being constant, which is not the bug it looks like", col.name)
 		}
 	}
 }

--- a/backend/internal/maintenance/blobsecrets_test.go
+++ b/backend/internal/maintenance/blobsecrets_test.go
@@ -1,0 +1,256 @@
+package maintenance
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// suite-identity #153, the config-blob secrets. These two are not columns: they
+// are FIELDS inside JSON blobs on the system_settings singleton, so converting
+// one is a read-modify-write of the whole blob rather than an UPDATE of a
+// column.
+//
+// That makes the sweep's failure mode different from every other column's. A
+// column conversion can only damage the ciphertext it is converting; a blob
+// conversion rewrites the entire notifications or LDAP configuration, so a
+// mistake in the rewrite loses settings that have nothing to do with
+// cryptography. The tests below are weighted accordingly.
+
+const (
+	smtpCol = "system_settings.notifications_config:smtp.smtp_password_encrypted"
+	ldapCol = "system_settings.ldap_config:bind_password_enc"
+)
+
+func TestBindSecrets_ConvertsTheSMTPPasswordInsideItsBlob(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	legacy, err := tc.Seal("hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := `{"enabled":true,"recipients":["ops@example.com"],` +
+		`"smtp":{"host":"smtp.example.com","port":587,"smtp_password_encrypted":"` + legacy + `"}}`
+
+	var written []byte
+	drive(t, mock, smtpCol, func() {
+		// list reads the blob...
+		mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+			WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(blob)))
+		// ...and update re-reads it before rewriting, so the write is against
+		// what is actually stored rather than a stale copy from the listing.
+		mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+			WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(blob)))
+		mock.ExpectExec("UPDATE system_settings SET notifications_config").
+			WithArgs(blobCapture{into: &written}).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	})
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	if got := res[smtpCol]; got.Converted != 1 || got.Failed != 0 {
+		t.Fatalf("result = %s; want one conversion", got)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(written, &out); err != nil {
+		t.Fatalf("the rewritten blob is not valid JSON: %v", err)
+	}
+
+	smtp, ok := out["smtp"].(map[string]any)
+	if !ok {
+		t.Fatal("the rewritten blob lost its smtp object")
+	}
+	bound, _ := smtp["smtp_password_encrypted"].(string)
+	got, err := tc.OpenWithContext(bound, models.SystemSettingsSMTPPasswordContext())
+	if err != nil || got != "hunter2" {
+		t.Fatalf("converted password does not open under the application's context: (%q, %v)", got, err)
+	}
+	if _, err := tc.Open(bound); err == nil {
+		t.Error("converted password still opens WITHOUT a context; it was not bound")
+	}
+	if _, err := tc.OpenWithContext(bound, models.SystemSettingsLDAPBindPasswordContext()); err == nil {
+		t.Error("converted password also opens as the LDAP bind password; the two fields of " +
+			"system_settings are interchangeable")
+	}
+}
+
+// The one that matters most. The blob is the whole notifications configuration,
+// so rewriting it through the typed struct the application unmarshals into would
+// silently drop every key that struct does not know about — an older setting, a
+// newer one written by a replica mid-upgrade, anything hand-added — and turn a
+// credential conversion into config data loss on a tool that runs once, against
+// production, usually unattended.
+func TestBindSecrets_BlobRewritePreservesUnknownFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	legacy, err := tc.Seal("hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := `{"enabled":true,"a_setting_this_build_has_never_heard_of":{"deep":[1,2,3]},` +
+		`"recipients":["ops@example.com"],` +
+		`"smtp":{"host":"smtp.example.com","port":587,"an_unknown_smtp_key":"keep me",` +
+		`"smtp_password_encrypted":"` + legacy + `"}}`
+
+	var written []byte
+	drive(t, mock, smtpCol, func() {
+		rows := func() *sqlmock.Rows {
+			return sqlmock.NewRows([]string{"notifications_config"}).AddRow([]byte(blob))
+		}
+		mock.ExpectQuery("SELECT notifications_config FROM system_settings").WillReturnRows(rows())
+		mock.ExpectQuery("SELECT notifications_config FROM system_settings").WillReturnRows(rows())
+		mock.ExpectExec("UPDATE system_settings SET notifications_config").
+			WithArgs(blobCapture{into: &written}).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	})
+
+	if _, err := BindSecrets(context.Background(), db, tc, false); err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+
+	var before, after map[string]any
+	if err := json.Unmarshal([]byte(blob), &before); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(written, &after); err != nil {
+		t.Fatalf("the rewritten blob is not valid JSON: %v", err)
+	}
+
+	// Everything except the one field being converted must survive byte-for-byte
+	// in meaning. Comparing re-marshalled JSON of the pruned maps catches a
+	// dropped key, a changed type and a reordered array alike.
+	delete(before["smtp"].(map[string]any), "smtp_password_encrypted")
+	delete(after["smtp"].(map[string]any), "smtp_password_encrypted")
+	b, _ := json.Marshal(before)
+	a, _ := json.Marshal(after)
+	if string(a) != string(b) {
+		t.Errorf("the sweep changed configuration it was not converting.\n before: %s\n  after: %s", b, a)
+	}
+}
+
+// The LDAP password sits at the TOP level of its blob rather than nested under
+// an object, so it exercises the empty-path branch of the same rewrite.
+func TestBindSecrets_ConvertsTheLDAPBindPassword(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	tc := newCipher(t)
+
+	legacy, err := tc.Seal("bind-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := `{"host":"ldap.example.com","port":636,"bind_dn":"cn=svc","bind_password_enc":"` + legacy + `"}`
+
+	var written []byte
+	drive(t, mock, ldapCol, func() {
+		rows := func() *sqlmock.Rows {
+			return sqlmock.NewRows([]string{"ldap_config"}).AddRow([]byte(blob))
+		}
+		mock.ExpectQuery("SELECT ldap_config FROM system_settings").WillReturnRows(rows())
+		mock.ExpectQuery("SELECT ldap_config FROM system_settings").WillReturnRows(rows())
+		mock.ExpectExec("UPDATE system_settings SET ldap_config").
+			WithArgs(blobCapture{into: &written}).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+	})
+
+	res, err := BindSecrets(context.Background(), db, tc, false)
+	if err != nil {
+		t.Fatalf("BindSecrets: %v", err)
+	}
+	if got := res[ldapCol]; got.Converted != 1 || got.Failed != 0 {
+		t.Fatalf("result = %s; want one conversion", got)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(written, &out); err != nil {
+		t.Fatal(err)
+	}
+	bound, _ := out["bind_password_enc"].(string)
+	got, err := tc.OpenWithContext(bound, models.SystemSettingsLDAPBindPasswordContext())
+	if err != nil || got != "bind-secret" {
+		t.Fatalf("converted password does not open under the application's context: (%q, %v)", got, err)
+	}
+	if _, err := tc.OpenWithContext(bound, models.SystemSettingsSMTPPasswordContext()); err == nil {
+		t.Error("converted password also opens as the SMTP password; the two fields are interchangeable")
+	}
+}
+
+// An unset field is not a conversion candidate, and neither is an absent blob.
+// Getting this wrong would report a permanent "1 row failed" against a
+// deployment that simply has no SMTP configured, which is how a verify gate
+// becomes noise people learn to ignore.
+func TestBindSecrets_BlobWithNoSecretIsNotACandidate(t *testing.T) {
+	cases := []struct {
+		name string
+		blob any
+	}{
+		{"field absent", []byte(`{"enabled":false,"smtp":{"host":""}}`)},
+		{"field present but empty", []byte(`{"smtp":{"smtp_password_encrypted":""}}`)},
+		{"smtp object absent", []byte(`{"enabled":false}`)},
+		{"blob column null", nil},
+		{"blob column empty", []byte(``)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tc := newCipher(t)
+
+			drive(t, mock, smtpCol, func() {
+				mock.ExpectQuery("SELECT notifications_config FROM system_settings").
+					WillReturnRows(sqlmock.NewRows([]string{"notifications_config"}).AddRow(c.blob))
+			})
+
+			// verify mode: nothing to convert must mean a clean exit, which is
+			// the signal the whole gate hangs off.
+			res, err := BindSecrets(context.Background(), db, tc, true)
+			if err != nil {
+				t.Fatalf("verify with nothing to convert must succeed, got %v", err)
+			}
+			if got := res[smtpCol]; got.Total != 0 || got.Converted != 0 || got.Failed != 0 {
+				t.Errorf("result = %s; an unset password is not a conversion candidate", got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("no write should have been attempted: %v", err)
+			}
+		})
+	}
+}
+
+// blobCapture records the JSON argument of the rewrite.
+type blobCapture struct{ into *[]byte }
+
+func (b blobCapture) Match(v driver.Value) bool {
+	switch x := v.(type) {
+	case []byte:
+		*b.into = append([]byte(nil), x...)
+	case string:
+		*b.into = []byte(x)
+	}
+	return true
+}


### PR DESCRIPTION
The last of suite-identity #153 in this service. Converts the **SMTP password**
(`system_settings.notifications_config`) and the **LDAP bind password**
(`system_settings.ldap_config`). Every column and field this service encrypts is
now bound.

## These are not columns, and the binding is honestly weaker

`system_settings` is a singleton — one row, `WHERE id = 1` — so "bind it to its
row" is vacuous: every value is already in the only row there is. The context
names the **purpose** instead: which blob, which field.

What that does not buy: there is no row-to-row move to prevent. What it does buy:
the two blobs sit in the **same row**, so without the blob and field in the
context an SMTP password and an LDAP bind password are interchangeable, as is
either of them and any other secret sealed with no context at all. The comment in
`models/aad.go` states both halves rather than overselling it.

## The `singleton` flag — two choices worth challenging

`TestRegisteredColumns_ContextsAreRowScoped` would correctly reject a constant
context, so the `column` struct gains a flag to exempt exactly these two. The test
is not softened.

**It is named for the exemption, not the rule.** The brief suggested
`rowScoped bool` defaulting to true; Go's zero value makes that default *false*,
so a column added later without a thought about this would be silently exempted —
the guard would stop guarding precisely when someone was not paying attention.
`singleton` has the same meaning with the strict setting as its zero value:
forgetting the field means being checked.

**The exemption is checked in both directions.** A column marked `singleton`
whose context actually *varies* by row now fails, because that is a mismarking
that disables row-scoping for a column that has a row axis after all. A second
test, `TestRegisteredColumns_SingletonsAreOnlyTheConfigBlobs`, pins the singleton
set to these two names.

## The blob rewrite is the risky part, not the crypto

Converting a field means read-modify-write of the whole JSON blob. That rewrite
goes through a **generic map, never the typed struct** the application unmarshals
into: `NotificationsConfigDB` does not know every key that can be in that blob (an
older setting, a newer one written by a replica mid-upgrade, anything
hand-added), and a typed round-trip would drop them — turning a credential
conversion into config data loss, on a tool that runs once, against production,
usually unattended. `TestBindSecrets_BlobRewritePreservesUnknownFields` seals a
blob containing keys this build has never heard of and asserts everything except
the converted field survives.

`blobAssign` also refuses to create missing parents rather than guessing: the
sweep only rewrites a field it has already read, so an absent parent means the
blob changed underneath the run.

## An existing test was inverted, not adapted

`TestBuildNotificationsConfigDB_SealsNewPassword` asserted that the stored
password opens with a plain `tc.Open` — no AAD, which is exactly the property
being retired. It now asserts the opposite (no-context open must fail, own-field
context must succeed, LDAP-field context must fail), with the reason in a comment.

## Two things to know

**Nothing reads the LDAP bind password.** `GetLDAPConfig` has no callers, and the
runtime LDAP provider is built from `config.LDAPConfig` (environment/file), not
from the blob. It is write-only today, so there was no read path to convert.
Binding it still costs one call and means a reader added later inherits a bound
value instead of finding an unbound one.

**The read-side inventory is now empty**, and that is the finish line rather than
a broken test. Its job from here is the other direction — any file that gains an
unbound `Open` fails it. The comment says so, because an empty allowlist is the
kind of thing someone deletes. Verified by adding one.

## Verification

`go build`, `go vet`, `gofmt -l`, `go test ./...` clean. gosec reports 0 issues
across `internal/maintenance`, `internal/db/models`, `internal/api`,
`internal/api/setup` and `internal/api/admin`.

Mutation-verified, one site at a time, restored from a backup copy:

| reverted | test that caught it |
| --- | --- |
| SMTP password sealed with no context | `TestBuildNotificationsConfigDB_SealsNewPassword` (the inverted one) |
| LDAP password sealed with no context | `TestSaveLDAPConfig_BindsTheBindPasswordToItsField` |
| the two blob contexts collide | `TestRegisteredColumns_ContextsAreColumnDistinct` |
| SMTP read uses the LDAP field's context | `TestReloadNotificationsConfigFromDB_SMTPPasswordBinding` |
| SMTP read drops the legacy fallback | same test |
| blob rewrite drops unrecognised keys | `TestBindSecrets_BlobRewritePreservesUnknownFields` |
| a row-scoped column marked `singleton` to dodge the guard | `TestRegisteredColumns_ContextsAreRowScoped` + `..._SingletonsAreOnlyTheConfigBlobs` |
| a `singleton` whose context varies by row | `TestRegisteredColumns_ContextsAreRowScoped` |
| a new unbound `Open` against the empty inventory | `TestNoNewUnboundOpenSites` |

## State of #153 in this service after this

Every write is `SealWithContext` and every read is `OpenWithContextOrLegacy`. The
one remaining unbound `Seal` is `notification_channels.go`'s deliberate
seal-insert-reseal, which is in the inventory with its reason.

The reads still accept the unbound form, by design. Retiring that is one step and
it is now unblocked for every column at once: run `registry bind-secrets` against
a deployment, then `registry bind-secrets verify` until it exits zero, then swap
the reads to `OpenWithContext`. I have not done that swap — it needs a real
deployment to have been converted first, which is an operator action, not a code
change.

Refs #153
