### PR TITLE
fix(ci): point the suite-ui checkout at its new owner

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -104,9 +104,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           {
-            repository: sethbacon/terraform-suite-ui,
+            # Moved out of the sethbacon org and renamed (2026-08-11), which is
+            # what broke this checkout with "Not Found" on every PR in every
+            # repo running this gate.
+            #
+            # The checkout PATH is deliberately unchanged: the replay tool keys
+            # off it, and renaming the working directory would bundle a second,
+            # riskier change into a one-line ownership fix.
+            #
+            # No token: the repo is public now, so SUITE_READ_TOKEN adds nothing
+            # here — and if it is a fine-grained PAT scoped to sethbacon-owned
+            # repos, keeping it is exactly what would leave this still failing.
+            repository: 4cloudguru/cloud-suite-ui,
             path: suite/terraform-suite-ui,
-            token: "${{ secrets.SUITE_READ_TOKEN }}",
             persist-credentials: false,
           }
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Companion to terraform-state-manager-backend#363 — same one-line ownership fix.

`terraform-suite-ui` moved out of the `sethbacon` org and was renamed to **`4cloudguru/cloud-suite-ui`** on 2026-08-11. This job still asked for the old path, so `actions/checkout` returned `Not Found` and the gate failed on **every PR in every repo that runs it**.

The failure was misleading: the job died **in checkout, before any signature ran**, and reported zero findings — so it read as a signature failure when it was an ownership one.

**The checkout path stays `suite/terraform-suite-ui`** — the replay tool keys off it, and renaming the directory would bundle a riskier change into a one-line fix.

**The token is dropped, not repointed.** The repo is public now, so `SUITE_READ_TOKEN` adds nothing — and if it's a fine-grained PAT scoped to sethbacon repos, keeping it is exactly what would leave this failing even after the name was fixed.

Not addressed here: this repo has no npm dependency on the moved package. The two **frontends** do (`@sethbacon/terraform-suite-ui@0.8.1`), and whether that still resolves under the old scope needs checking separately.