### PR TITLE
docs: correct the SOC2 P4.1 audit-shipper config key and PII scope (#763)

### DIFF
--- a/docs/compliance/soc2-mapping.md
+++ b/docs/compliance/soc2-mapping.md
@@ -120,7 +120,7 @@ during SOC 2 Type II audits.
 | -------- | --------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
 | P1.1     | Privacy notice        | Privacy policy documentation                         | `PRIVACY.md` (frontend)                              |
 | P3.1     | Collection limitation | Minimal PII collection (email, username from IdP)    | Auth handlers, user model                            |
-| P4.1     | Use limitation        | PII used only for auth/audit; audit destinations are operator-configured and MAY be external — see note below | `security.audit.shippers`, `internal/audit/shipper.go` |
+| P4.1     | Use limitation        | PII used only for auth/audit; audit destinations are operator-configured and MAY be external — see note below | `audit.shippers`, `internal/audit/shipper.go` |
 | P6.1     | Data subject access   | User data export endpoint                            | `/admin/users/:id/export`                            |
 | P8.1     | Data quality          | IdP-sourced attributes; SCIM sync keeps data current | SCIM provisioning                                    |
 
@@ -128,11 +128,17 @@ during SOC 2 Type II audits.
 > externally", evidenced by "audit shipper config (self-hosted destinations only)". The code
 > enforces no such restriction, and the guard it does apply points the other way: audit webhooks
 > are dialled through `internal/httpsafe`, which **denies** loopback/RFC1918/link-local targets and
-> **permits public ones**. So the shipper is, if anything, biased toward external destinations.
+> **permits public ones**. So the shipper is, if anything, biased toward external destinations: a
+> genuinely self-hosted collector on a private address is *rejected* unless the operator adds it to
+> `security.egress.allowlist`.
 >
-> What is actually true: audit records containing user email and identity attributes are sent only
-> to destinations an operator explicitly configures in `security.audit.shippers`, and nowhere by
-> default. That is an operator-controlled disclosure boundary, not a technical guarantee of
+> What is actually true, field by field. The shipped record (`audit.LogEntry`) carries the acting
+> user's **ID**, organization ID, action, resource type/ID, client **IP address**, auth method,
+> status code, and a free-form metadata map whose contents vary by endpoint. It does **not** carry
+> email addresses — email is collected (P3.1) but is not part of the shipped payload, so the
+> identifiers that leave the system are user IDs and client IPs. Those records go only to
+> destinations an operator explicitly configures in `audit.shippers`, and nowhere by default
+> (`shippers: []`). That is an operator-controlled disclosure boundary, not a technical guarantee of
 > non-disclosure. An assessor relying on this row should test the deployed shipper configuration
 > rather than the code.
 


### PR DESCRIPTION
Closes #763. Also resolves #761 — see below; it needed no change.

Both issues are documentation accuracy, hence one branch.

## First finding: both issues were already worked, and neither closed

PR #829 ("docs: correct three inaccurate claims") fixed all three of #760/#761/#763 on 2026-08-09. Its body said `Closes #760, #761, #763.` — GitHub applies a closing keyword only to the **first** reference in such a list, so #760 closed and #761/#763 silently stayed open. That is why these came back around. Worth knowing for the other audit batches: write `Closes #A, closes #B, closes #C`.

## #761 — already fixed, verified, no change made

Verified against the tree rather than the issue text, and the issue is itself stale:

- The DR checklist no longer hardcodes a version. It now says to read it from the running database, precisely so a literal cannot rot again.
- Actual migration count is **50**, not the 49 the issue asserts: 50 `.up.sql`, 50 `.down.sql`, numbering contiguous 000001–000050, highest `000050_quarantine_orphaned_api_keys`.
- The migrations README it defers to covers all 50 rows; a set-difference of README row numbers against the directory listing is empty.

So there is nothing left to correct. Closing with that evidence rather than manufacturing a change.

## #763 — the claim was fixed, but the fix carried two new errors

#829 correctly replaced the inverted "not shared externally / self-hosted destinations only" claim. The replacement then asserted two things the code does not support.

**The cited config key does not exist.** Both the table row and the note said `security.audit.shippers`. `Security` and `Audit` are *sibling* fields of the root config struct — there is no `security.audit`. The list is `AuditConfig.Shippers` (mapstructure `shippers`), read by the router as `cfg.Audit.Shippers`. `config.example.yaml`, `docs/configuration.md`, `docs/suite-audit-federation.md` and `docs/upgrade-guide.md` all already say `audit.shippers`; only the compliance mapping disagreed. There is no viper alias bridging the two. An assessor grepping the cited key finds nothing.

**The stated PII scope was wrong.** The note claimed the shipped records contain "user email". `audit.LogEntry` has no email field — it carries `UserID`, `OrganizationID`, `Action`, `ResourceType`/`ResourceID`, `IPAddress`, `AuthMethod`, `StatusCode`, and a free-form `Metadata` map. No call site puts an email into it. Email *is* collected (P3.1) but does not leave through this path. The note now enumerates the fields, so the claim can be checked against the struct instead of trusted. Overstating what a payload discloses misdescribes the boundary just as much as understating it.

**Added the setting that actually controls the posture.** `internal/httpsafe` denies loopback/RFC1918/link-local and permits public, so a genuinely self-hosted collector on a private address is *rejected* unless the operator adds it to `security.egress.allowlist` (verified: `SecurityConfig.Egress.Allowlist`, wired via `httpsafe.NewGuard(c.Security.Egress.Allowlist)`). Naming it keeps the row from being vague: the doc states the real control and its limit rather than retreating to "it depends".

## What I deliberately did not do

**No regression guard for the migrations README.** #761 asked for the value to be kept from drifting. The DR doc is now structurally safe — it hardcodes no number. The README table, however, is hand-maintained and *did* drift once, sitting at 46 rows while the tree held 50 (#829 backfilled 000046–000049). The in-convention fix is small: `backend/internal/db/migrations_test.go` already reads the migrations directory and asserts up/down parity, and a row-count/number-set assertion against the README belongs right there. That file is Go source under concurrent work by another change in this repo, so I left it rather than cross into it. Flagging it as the cheap follow-up rather than inventing a parallel shell/CI check that would duplicate an existing convention.

**No other rows audited.** Scope was the two issues; the rest of the mapping was not re-verified against code.

## Verification

Docs-only — one file, no Go source touched.

- `ls migrations/*.up.sql | wc -l` → 50; `.down.sql` → 50; contiguous, no gaps
- README row numbers vs directory: `comm -3` empty
- `config.go:41`/`:44` — `Security` and `Audit` are siblings; `:733` `Shippers` under `AuditConfig`; `router.go:167` `cfg.Audit.Shippers`
- `shipper.go:30-41` — `LogEntry` fields; no email
- `httpsafe.go:139-167` `deniedRange`; `config.go:1401` egress allowlist wiring
- No `security.audit` references remain in the tree
