### PR TITLE
test(db): fail when a migration is undocumented or its README row is stale

### DIFF
--- a/backend/internal/db/migrations_test.go
+++ b/backend/internal/db/migrations_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -23,5 +24,68 @@ func TestMigrationFilesAreConsistent(t *testing.T) {
 	}
 	if upCount != downCount {
 		t.Errorf("migration up/down count mismatch: %d up, %d down", upCount, downCount)
+	}
+}
+
+// migrations/README.md is the rollback reference an operator reads during an
+// incident, and it is maintained by hand. It has already drifted once: it sat
+// at 46 rows while the directory held 49 migrations, so the four newest had no
+// documented rollback behaviour at exactly the moment someone would need it,
+// and nothing failed. Drift is invisible in review because the row and the file
+// live in different diffs.
+//
+// The check is BIDIRECTIONAL by number and by name. Undocumented migrations are
+// the reported failure, but a stale row (documenting a migration that no longer
+// exists, or naming one that was renamed) is just as wrong and fails here too --
+// a one-way check would let the table rot in the other direction.
+func TestMigrationsAreDocumented(t *testing.T) {
+	entries, err := os.ReadDir("migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	onDisk := map[string]string{} // number -> name
+	for _, e := range entries {
+		name, ok := strings.CutSuffix(e.Name(), ".up.sql")
+		if !ok {
+			continue
+		}
+		num, rest, ok := strings.Cut(name, "_")
+		if !ok {
+			t.Errorf("migration %q is not <number>_<name>.up.sql", e.Name())
+			continue
+		}
+		onDisk[num] = rest
+	}
+	if len(onDisk) == 0 {
+		// Guard the guard: a bad path or a changed filename convention would
+		// make every assertion below vacuously true.
+		t.Fatal("no .up.sql migrations found - this test would pass vacuously")
+	}
+
+	readme, err := os.ReadFile("migrations/README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// | 000001 | `initial_schema` | ...
+	row := regexp.MustCompile("(?m)^\\|\\s*(\\d{6})\\s*\\|\\s*`([^`]+)`")
+	documented := map[string]string{}
+	for _, m := range row.FindAllStringSubmatch(string(readme), -1) {
+		documented[m[1]] = m[2]
+	}
+
+	for num, name := range onDisk {
+		got, ok := documented[num]
+		if !ok {
+			t.Errorf("migration %s_%s is not documented in migrations/README.md - add a row with its rollback behaviour", num, name)
+			continue
+		}
+		if got != name {
+			t.Errorf("migrations/README.md documents %s as %q, but the migration on disk is %q", num, got, name)
+		}
+	}
+	for num, name := range documented {
+		if _, ok := onDisk[num]; !ok {
+			t.Errorf("migrations/README.md documents %s (%q), which does not exist on disk - remove the stale row", num, name)
+		}
 	}
 }


### PR DESCRIPTION
`migrations/README.md` is the rollback reference an operator reads during an incident, and it is maintained by hand.

It has already drifted once: it sat at 46 rows while the directory held 49 migrations, so the four newest had no documented rollback behaviour at exactly the moment someone would need it — and nothing failed. #829 backfilled the rows, but nothing stopped it happening again. Drift is invisible in review because the migration and the README row land in different diffs.

Follow-up flagged while verifying #761: the DR doc can no longer drift (it now reads the version from the running database), but the README still could.

## The check

Bidirectional, by number **and** by name:

- an **undocumented migration** is the reported failure mode
- a **stale row** — documenting a migration that no longer exists, or naming one that was renamed — is equally wrong and fails here too

A one-way check would let the table rot in the other direction.

It lives in the existing `migrations_test.go`, which already reads the migrations directory and asserts up/down parity, rather than as a parallel shell or CI check.

## Mutation verification

| Mutation | Result |
| --- | --- |
| New migration on disk, no README row | FAIL — names `000051_probe_guard` |
| README row for a migration not on disk | FAIL — names `000099 ("ghost_migration")` as stale |
| README name drifted from the file | FAIL — `documents 000013 as "jwt_revocation_renamed", but the migration on disk is "jwt_revocation"` |
| README row deleted (the drift that actually happened) | FAIL — names `000050_quarantine_orphaned_api_keys` |
| Restored tree | pass |

The empty universe is guarded too: a changed filename convention would otherwise make every assertion vacuously true, so zero parsed migrations is a hard failure rather than a silent pass.

Current state: 50 migrations, 50 documented rows, in sync.

`go build ./... && go vet ./... && gofmt -l . && go test ./...` clean.