### PR TITLE
refactor(scm): share the OAuth exchange, JSON request, and pagination clamp across connectors

### DIFF
--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -137,24 +137,6 @@ func (c *AzureDevOpsConnector) CompleteAuthorization(ctx context.Context, authCo
 	data.Set("client_id", c.clientID)
 	data.Set("client_secret", c.clientSecret)
 
-	tokenURL := fmt.Sprintf(entraTokenURLTemplate, c.tenantID)
-	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("azuredevops: create token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
-		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
-	}
-
 	var result struct {
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
@@ -163,8 +145,9 @@ func (c *AzureDevOpsConnector) CompleteAuthorization(ctx context.Context, authCo
 		Scope        string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("azuredevops: decode token response: %w", err)
+	tokenURL := fmt.Sprintf(entraTokenURLTemplate, c.tenantID)
+	if err := scm.ExchangeOAuthForm(ctx, tokenURL, data, "", &result); err != nil {
+		return nil, err
 	}
 
 	expiresAt := time.Now().Add(time.Duration(result.ExpiresIn) * time.Second)
@@ -280,23 +263,10 @@ func (c *AzureDevOpsConnector) FetchRepository(ctx context.Context, creds *scm.A
 		return nil, fmt.Errorf("azuredevops: create repo request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrRepoNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch repository", nil)
-	}
 
 	var adoRepo adoRepo
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&adoRepo); err != nil {
-		return nil, fmt.Errorf("azuredevops: decode repository: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch repository", scm.ErrRepoNotFound, &adoRepo); err != nil {
+		return nil, err
 	}
 
 	return c.convertRepo(&adoRepo, ownerName), nil
@@ -332,16 +302,6 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 		return nil, fmt.Errorf("azuredevops: create branches request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch branches", nil)
-	}
 
 	var result struct {
 		Value []struct {
@@ -350,8 +310,8 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 		} `json:"value"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("azuredevops: decode branches: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch branches", nil, &result); err != nil {
+		return nil, err
 	}
 
 	branches := make([]*scm.GitBranch, len(result.Value))
@@ -448,19 +408,6 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 		return nil, fmt.Errorf("azuredevops: create commit request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrCommitNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch commit", nil)
-	}
 
 	var adoCommit struct {
 		CommitID string `json:"commitId"`
@@ -473,8 +420,8 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 		RemoteURL string `json:"remoteUrl"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&adoCommit); err != nil {
-		return nil, fmt.Errorf("azuredevops: decode commit: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch commit", scm.ErrCommitNotFound, &adoCommit); err != nil {
+		return nil, err
 	}
 
 	return &scm.GitCommit{
@@ -610,23 +557,15 @@ func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds
 		return "", "", fmt.Errorf("create request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G107 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return "", "", scm.WrapRemoteError(0, "failed to fetch repository IDs", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", "", scm.WrapRemoteError(resp.StatusCode, "failed to fetch repository IDs", nil)
-	}
+
 	var result struct {
 		ID      string `json:"id"`
 		Project struct {
 			ID string `json:"id"`
 		} `json:"project"`
 	}
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return "", "", fmt.Errorf("decode repository: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch repository IDs", nil, &result); err != nil {
+		return "", "", err
 	}
 	return result.Project.ID, result.ID, nil
 }

--- a/backend/internal/scm/bitbucket/connector.go
+++ b/backend/internal/scm/bitbucket/connector.go
@@ -55,14 +55,7 @@ func (c *BitbucketDCConnector) RenewToken(ctx context.Context, refreshToken stri
 
 // FetchRepositories lists repositories accessible to the authenticated user
 func (c *BitbucketDCConnector) FetchRepositories(ctx context.Context, creds *scm.AccessToken, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	limit := pagination.PageSize
-	if limit < 1 || limit > 100 {
-		limit = 25
-	}
-	start := (pagination.PageNum - 1) * limit
-	if start < 0 {
-		start = 0
-	}
+	limit, start := clampWindow(pagination)
 
 	endpoint := fmt.Sprintf("%s/rest/api/1.0/repos?limit=%d&start=%d", c.baseURL, limit, start)
 
@@ -102,14 +95,7 @@ func (c *BitbucketDCConnector) FetchRepository(ctx context.Context, creds *scm.A
 
 // SearchRepositories finds repositories matching a query
 func (c *BitbucketDCConnector) SearchRepositories(ctx context.Context, creds *scm.AccessToken, searchTerm string, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	limit := pagination.PageSize
-	if limit < 1 || limit > 100 {
-		limit = 25
-	}
-	start := (pagination.PageNum - 1) * limit
-	if start < 0 {
-		start = 0
-	}
+	limit, start := clampWindow(pagination)
 
 	endpoint := fmt.Sprintf("%s/rest/api/1.0/repos?name=%s&limit=%d&start=%d", c.baseURL, searchTerm, limit, start)
 
@@ -137,14 +123,7 @@ func (c *BitbucketDCConnector) SearchRepositories(ctx context.Context, creds *sc
 
 // FetchBranches lists branches in a repository
 func (c *BitbucketDCConnector) FetchBranches(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitBranch, error) {
-	limit := pagination.PageSize
-	if limit < 1 || limit > 100 {
-		limit = 25
-	}
-	start := (pagination.PageNum - 1) * limit
-	if start < 0 {
-		start = 0
-	}
+	limit, start := clampWindow(pagination)
 
 	endpoint := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/branches?limit=%d&start=%d", c.baseURL, ownerName, repoName, limit, start)
 
@@ -176,14 +155,7 @@ func (c *BitbucketDCConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 
 // FetchTags lists tags in a repository
 func (c *BitbucketDCConnector) FetchTags(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitTag, error) {
-	limit := pagination.PageSize
-	if limit < 1 || limit > 100 {
-		limit = 25
-	}
-	start := (pagination.PageNum - 1) * limit
-	if start < 0 {
-		start = 0
-	}
+	limit, start := clampWindow(pagination)
 
 	endpoint := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/tags?limit=%d&start=%d", c.baseURL, ownerName, repoName, limit, start)
 
@@ -439,6 +411,23 @@ func (c *BitbucketDCConnector) VerifyDeliverySignature(payloadBytes []byte, sign
 func (c *BitbucketDCConnector) setAuthHeaders(req *http.Request, creds *scm.AccessToken) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", creds.AccessToken))
 	req.Header.Set("Accept", "application/json")
+}
+
+// clampWindow converts a page-number/page-size Pagination into the limit/start window the
+// Bitbucket Data Center REST API pages with, which is why this is not scm.ClampPagination:
+// that helper returns page/per_page for GitHub and GitLab and defaults to 30, whereas this
+// API is offset-based and defaults to 25. A page size outside the accepted 1..100 range
+// falls back to 25, and a page number of zero or less resolves to the first window.
+func clampWindow(pagination scm.Pagination) (limit, start int) {
+	limit = pagination.PageSize
+	if limit < 1 || limit > 100 {
+		limit = 25
+	}
+	start = (pagination.PageNum - 1) * limit
+	if start < 0 {
+		start = 0
+	}
+	return limit, start
 }
 
 func (c *BitbucketDCConnector) doJSON(ctx context.Context, creds *scm.AccessToken, method, endpoint string, body io.Reader, result interface{}) error {

--- a/backend/internal/scm/connector.go
+++ b/backend/internal/scm/connector.go
@@ -74,9 +74,33 @@ type Pagination struct {
 	PageSize int
 }
 
+// Pagination bounds for the SCM APIs addressed by page number and page size.
+const (
+	defaultPageSize = 30
+	maxPageSize     = 100
+)
+
 // DefaultPagination returns standard pagination settings
 func DefaultPagination() Pagination {
-	return Pagination{PageNum: 1, PageSize: 30}
+	return Pagination{PageNum: 1, PageSize: defaultPageSize}
+}
+
+// ClampPagination normalises a Pagination for the SCM APIs that page with page/per_page
+// query parameters (GitHub and GitLab): the page number is forced to at least 1, and a
+// page size outside the 1..100 range both APIs accept falls back to the default of 30.
+//
+// Bitbucket Data Center pages with limit/start instead and defaults to 25, so it clamps
+// its own window; Azure DevOps does not paginate its repository APIs at all.
+func ClampPagination(p Pagination) (page, perPage int) {
+	page = p.PageNum
+	if page < 1 {
+		page = 1
+	}
+	perPage = p.PageSize
+	if perPage < 1 || perPage > maxPageSize {
+		perPage = defaultPageSize
+	}
+	return page, perPage
 }
 
 // RepoListResult contains paginated repository results

--- a/backend/internal/scm/egress_guard_test.go
+++ b/backend/internal/scm/egress_guard_test.go
@@ -1,0 +1,218 @@
+// egress_guard_test.go statically enforces that every outbound HTTP path in internal/scm
+// still goes through the SSRF-safe egress client (internal/httpsafe).
+//
+// The connectors used to repeat the send/status/decode sequence at ~39 call sites, each
+// carrying its own copy of `scm.HTTPClient.Do(req)`. Now that most of them delegate to the
+// shared DoJSON/ExchangeOAuthForm helpers, nothing in the type system stops a new connector
+// (or a future edit to an existing one) from reaching for http.DefaultClient or building a
+// bare &http.Client{} instead — which would silently route that call around the
+// resolve-and-pin private-range deny-list and the per-hop redirect re-validation. These
+// tests parse the whole internal/scm tree and fail when that happens.
+package scm
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scmTreeRoot is the directory walked by every guard below: internal/scm and its connector
+// subpackages, relative to this package's directory.
+const scmTreeRoot = "."
+
+// Non-empty-universe floors. A guard that certifies an empty file set is worse than no
+// guard, so the walk has to actually find the tree it claims to police.
+const (
+	minScannedFiles = 8
+	minDoCallSites  = 5
+)
+
+// allowedDoReceivers maps every expression permitted to receive a .Do(...) call in
+// internal/scm to the reason it is safe. Adding a connector that calls .Do on anything else
+// fails TestEgressGuard_DoCallsUseTheSharedClient; the map is also checked in the other
+// direction, so an entry that stops being used has to be deleted rather than left to rot
+// into a standing permission for whatever later takes that name.
+var allowedDoReceivers = map[string]string{
+	"HTTPClient":     "package scm's own httpsafe-backed client (httpclient.go)",
+	"scm.HTTPClient": "the shared httpsafe-backed client, called from a connector subpackage",
+	"m.httpClient":   "appcreds.Minter's client, pinned to httpsafe.NewClient by TestEgressGuard_HTTPClientFieldsComeFromHTTPSafe",
+}
+
+// forbiddenExprs are net/http entry points that use the unguarded, timeout-less
+// http.DefaultClient.
+var forbiddenExprs = map[string]string{
+	"http.DefaultClient": "http.DefaultClient has no timeout and no egress guard",
+	"http.Get":           "http.Get uses http.DefaultClient",
+	"http.Post":          "http.Post uses http.DefaultClient",
+	"http.PostForm":      "http.PostForm uses http.DefaultClient",
+	"http.Head":          "http.Head uses http.DefaultClient",
+}
+
+type parsedFile struct {
+	path string
+	file *ast.File
+	fset *token.FileSet
+}
+
+// parseSCMTree parses every non-test .go file under internal/scm.
+func parseSCMTree(t *testing.T) []parsedFile {
+	t.Helper()
+
+	var out []parsedFile
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(scmTreeRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return perr
+		}
+		out = append(out, parsedFile{path: path, file: f, fset: fset})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", scmTreeRoot, err)
+	}
+
+	if len(out) < minScannedFiles {
+		t.Fatalf("scanned %d files under %s, want at least %d — the guard is looking at the wrong tree",
+			len(out), scmTreeRoot, minScannedFiles)
+	}
+	return out
+}
+
+func (p parsedFile) pos(n ast.Node) string {
+	return p.fset.Position(n.Pos()).String()
+}
+
+// TestEgressGuard_NoUnguardedHTTPConstructs fails when any connector reaches for
+// http.DefaultClient, one of net/http's package-level request helpers, or rolls its own
+// http.Client / http.Transport instead of the httpsafe-backed client.
+func TestEgressGuard_NoUnguardedHTTPConstructs(t *testing.T) {
+	for _, pf := range parseSCMTree(t) {
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.SelectorExpr:
+				if why, bad := forbiddenExprs[types.ExprString(node)]; bad {
+					t.Errorf("%s: %s — route the request through scm.HTTPClient (%s)",
+						pf.pos(node), types.ExprString(node), why)
+				}
+			case *ast.CompositeLit:
+				switch types.ExprString(node.Type) {
+				case "http.Client", "http.Transport":
+					t.Errorf("%s: constructs a bare %s — build it with httpsafe.NewClient so the "+
+						"egress guard applies", pf.pos(node), types.ExprString(node.Type))
+				}
+			case *ast.CallExpr:
+				if id, ok := node.Fun.(*ast.Ident); ok && id.Name == "new" && len(node.Args) == 1 {
+					if types.ExprString(node.Args[0]) == "http.Client" {
+						t.Errorf("%s: constructs a bare http.Client — build it with httpsafe.NewClient",
+							pf.pos(node))
+					}
+				}
+			}
+			return true
+		})
+	}
+}
+
+// TestEgressGuard_DoCallsUseTheSharedClient fails when a .Do(...) call is made on anything
+// other than a known httpsafe-backed client, and fails just as loudly when an entry in
+// allowedDoReceivers no longer corresponds to any call site.
+func TestEgressGuard_DoCallsUseTheSharedClient(t *testing.T) {
+	seen := map[string]bool{}
+	total := 0
+
+	for _, pf := range parseSCMTree(t) {
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Do" {
+				return true
+			}
+			receiver := types.ExprString(sel.X)
+			total++
+			if _, allowed := allowedDoReceivers[receiver]; !allowed {
+				t.Errorf("%s: %s.Do(...) does not use an httpsafe-backed client; send through "+
+					"scm.HTTPClient (or scm.DoJSON / scm.ExchangeOAuthForm)", pf.pos(call), receiver)
+				return true
+			}
+			seen[receiver] = true
+			return true
+		})
+	}
+
+	if total < minDoCallSites {
+		t.Fatalf("found %d .Do(...) call sites under %s, want at least %d — the guard is not "+
+			"seeing the connectors it is meant to police", total, scmTreeRoot, minDoCallSites)
+	}
+	for receiver := range allowedDoReceivers {
+		if !seen[receiver] {
+			t.Errorf("allowedDoReceivers still permits %q but nothing calls it any more — delete "+
+				"the entry rather than leaving a standing exemption", receiver)
+		}
+	}
+}
+
+// TestEgressGuard_HTTPClientFieldsComeFromHTTPSafe pins the one indirection the receiver
+// allow-list depends on: appcreds.Minter holds its own *http.Client, so that field must only
+// ever be built by httpsafe.NewClient. Without this, allowing "m.httpClient" above would
+// permit any client at all to be smuggled in behind that name.
+func TestEgressGuard_HTTPClientFieldsComeFromHTTPSafe(t *testing.T) {
+	assignments := 0
+
+	isHTTPSafeClient := func(e ast.Expr) bool {
+		call, ok := e.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		return types.ExprString(call.Fun) == "httpsafe.NewClient"
+	}
+
+	for _, pf := range parseSCMTree(t) {
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.KeyValueExpr:
+				if id, ok := node.Key.(*ast.Ident); ok && id.Name == "httpClient" {
+					assignments++
+					if !isHTTPSafeClient(node.Value) {
+						t.Errorf("%s: httpClient is initialised from %s, not httpsafe.NewClient",
+							pf.pos(node), types.ExprString(node.Value))
+					}
+				}
+			case *ast.AssignStmt:
+				for i, lhs := range node.Lhs {
+					sel, ok := lhs.(*ast.SelectorExpr)
+					if !ok || sel.Sel.Name != "httpClient" || i >= len(node.Rhs) {
+						continue
+					}
+					assignments++
+					if !isHTTPSafeClient(node.Rhs[i]) {
+						t.Errorf("%s: httpClient is assigned from %s, not httpsafe.NewClient",
+							pf.pos(node), types.ExprString(node.Rhs[i]))
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if assignments == 0 {
+		t.Fatal("found no httpClient field initialisation — either appcreds stopped holding its " +
+			"own client (drop the \"m.httpClient\" entry from allowedDoReceivers) or this guard " +
+			"has stopped matching it")
+	}
+}

--- a/backend/internal/scm/egress_testmain_test.go
+++ b/backend/internal/scm/egress_testmain_test.go
@@ -1,0 +1,18 @@
+package scm
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain widens the shared connector client's (HTTPClient) egress policy to an explicit
+// loopback allow-list for this test binary only, so the DoJSON/ExchangeOAuthForm tests can
+// talk to an httptest.Server (which binds to 127.0.0.1). Production callers get the strict
+// default (see httpclient.go); only this test binary's egress policy changes. Mirrors the
+// TestMain each connector subpackage already installs.
+func TestMain(m *testing.M) {
+	if err := ConfigureEgress([]string{"127.0.0.1", "::1"}); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/scm/github/connector.go
+++ b/backend/internal/scm/github/connector.go
@@ -79,32 +79,15 @@ func (c *GitHubConnector) CompleteAuthorization(ctx context.Context, authCode st
 	data.Set("code", authCode)
 	data.Set("redirect_uri", c.callbackURL)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/login/oauth/access_token", strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("github: create token request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
-		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
-	}
-
 	var result struct {
 		AccessToken string `json:"access_token"`
 		TokenType   string `json:"token_type"`
 		Scope       string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("github: decode token response: %w", err)
+	// GitHub returns a form-encoded token response unless JSON is explicitly requested.
+	if err := scm.ExchangeOAuthForm(ctx, c.baseURL+"/login/oauth/access_token", data, "application/json", &result); err != nil {
+		return nil, err
 	}
 
 	scopes := []string{}
@@ -126,14 +109,7 @@ func (c *GitHubConnector) RenewToken(ctx context.Context, refreshToken string) (
 
 // FetchRepositories lists repositories the user can access
 func (c *GitHubConnector) FetchRepositories(ctx context.Context, creds *scm.AccessToken, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/user/repos?page=%d&per_page=%d&sort=updated&affiliation=owner,collaborator", c.apiURL, page, perPage)
 	repos, err := c.fetchRepoList(ctx, creds, endpoint)
@@ -158,22 +134,9 @@ func (c *GitHubConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch repository", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrRepoNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch repository", nil)
-	}
-
 	var ghRepo githubRepo
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghRepo); err != nil {
-		return nil, fmt.Errorf("github: decode repository: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch repository", scm.ErrRepoNotFound, &ghRepo); err != nil {
+		return nil, err
 	}
 
 	return c.convertRepo(&ghRepo), nil
@@ -181,14 +144,7 @@ func (c *GitHubConnector) FetchRepository(ctx context.Context, creds *scm.Access
 
 // SearchRepositories finds repositories matching a query
 func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.AccessToken, searchTerm string, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	query := url.QueryEscape(fmt.Sprintf("%s in:name user:@me", searchTerm))
 	endpoint := fmt.Sprintf("%s/search/repositories?q=%s&page=%d&per_page=%d", c.apiURL, query, page, perPage)
@@ -199,23 +155,13 @@ func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "search failed", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "search failed", nil)
-	}
-
 	var result struct {
 		TotalCount int          `json:"total_count"`
 		Items      []githubRepo `json:"items"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("github: decode search results: %w", err)
+	if err := scm.DoJSON(req, "search failed", nil, &result); err != nil {
+		return nil, err
 	}
 
 	repos := make([]*scm.SourceRepo, len(result.Items))
@@ -233,14 +179,7 @@ func (c *GitHubConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 
 // FetchBranches lists branches in a repository
 func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitBranch, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/branches?page=%d&per_page=%d", c.apiURL, ownerName, repoName, page, perPage)
 
@@ -250,16 +189,6 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch branches", nil)
-	}
-
 	var ghBranches []struct {
 		Name   string `json:"name"`
 		Commit struct {
@@ -268,8 +197,8 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 		Protected bool `json:"protected"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghBranches); err != nil {
-		return nil, fmt.Errorf("github: decode branches: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch branches", nil, &ghBranches); err != nil {
+		return nil, err
 	}
 
 	branches := make([]*scm.GitBranch, len(ghBranches))
@@ -286,14 +215,7 @@ func (c *GitHubConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 
 // FetchTags lists tags in a repository
 func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitTag, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/tags?page=%d&per_page=%d", c.apiURL, ownerName, repoName, page, perPage)
 
@@ -303,16 +225,6 @@ func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch tags", nil)
-	}
-
 	var ghTags []struct {
 		Name   string `json:"name"`
 		Commit struct {
@@ -321,8 +233,8 @@ func (c *GitHubConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghTags); err != nil {
-		return nil, fmt.Errorf("github: decode tags: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch tags", nil, &ghTags); err != nil {
+		return nil, err
 	}
 
 	tags := make([]*scm.GitTag, len(ghTags))
@@ -346,19 +258,6 @@ func (c *GitHubConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrTagNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch tag", nil)
-	}
-
 	var ref struct {
 		Ref    string `json:"ref"`
 		Object struct {
@@ -368,8 +267,8 @@ func (c *GitHubConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 		} `json:"object"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ref); err != nil {
-		return nil, fmt.Errorf("github: decode tag ref: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch tag", scm.ErrTagNotFound, &ref); err != nil {
+		return nil, err
 	}
 
 	return &scm.GitTag{
@@ -388,19 +287,6 @@ func (c *GitHubConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrCommitNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch commit", nil)
-	}
-
 	var ghCommit struct {
 		SHA     string `json:"sha"`
 		HTMLURL string `json:"html_url"`
@@ -414,8 +300,8 @@ func (c *GitHubConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghCommit); err != nil {
-		return nil, fmt.Errorf("github: decode commit: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch commit", scm.ErrCommitNotFound, &ghCommit); err != nil {
+		return nil, err
 	}
 
 	return &scm.GitCommit{
@@ -608,19 +494,9 @@ func (c *GitHubConnector) fetchRepoList(ctx context.Context, creds *scm.AccessTo
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch repositories", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch repositories", nil)
-	}
-
 	var ghRepos []githubRepo
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&ghRepos); err != nil {
-		return nil, fmt.Errorf("github: decode repo list: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch repositories", nil, &ghRepos); err != nil {
+		return nil, err
 	}
 
 	repos := make([]*scm.SourceRepo, len(ghRepos))

--- a/backend/internal/scm/gitlab/connector.go
+++ b/backend/internal/scm/gitlab/connector.go
@@ -81,23 +81,6 @@ func (c *GitLabConnector) CompleteAuthorization(ctx context.Context, authCode st
 	data.Set("grant_type", "authorization_code")
 	data.Set("redirect_uri", c.callbackURL)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/oauth/token", strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("gitlab: create token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to exchange code", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(scm.LimitErrorBody(resp.Body))
-		return nil, scm.WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
-	}
-
 	var result struct {
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
@@ -106,8 +89,8 @@ func (c *GitLabConnector) CompleteAuthorization(ctx context.Context, authCode st
 		Scope        string `json:"scope"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("gitlab: decode token response: %w", err)
+	if err := scm.ExchangeOAuthForm(ctx, c.baseURL+"/oauth/token", data, "", &result); err != nil {
+		return nil, err
 	}
 
 	expiresAt := time.Now().Add(time.Duration(result.ExpiresIn) * time.Second)
@@ -172,14 +155,7 @@ func (c *GitLabConnector) RenewToken(ctx context.Context, refreshToken string) (
 
 // FetchRepositories lists projects the user can access
 func (c *GitLabConnector) FetchRepositories(ctx context.Context, creds *scm.AccessToken, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/projects?membership=true&page=%d&per_page=%d&order_by=last_activity_at", c.apiURL, page, perPage)
 
@@ -189,19 +165,9 @@ func (c *GitLabConnector) FetchRepositories(ctx context.Context, creds *scm.Acce
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch projects", nil)
-	}
-
 	var glProjects []gitlabProject
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProjects); err != nil {
-		return nil, fmt.Errorf("gitlab: decode projects: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch projects", nil, &glProjects); err != nil {
+		return nil, err
 	}
 
 	repos := make([]*scm.SourceRepo, len(glProjects))
@@ -228,22 +194,9 @@ func (c *GitLabConnector) FetchRepository(ctx context.Context, creds *scm.Access
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch project", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrRepoNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch project", nil)
-	}
-
 	var glProject gitlabProject
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProject); err != nil {
-		return nil, fmt.Errorf("gitlab: decode project: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch project", scm.ErrRepoNotFound, &glProject); err != nil {
+		return nil, err
 	}
 
 	return c.convertProject(&glProject), nil
@@ -251,14 +204,7 @@ func (c *GitLabConnector) FetchRepository(ctx context.Context, creds *scm.Access
 
 // SearchRepositories searches for projects matching a query
 func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.AccessToken, searchTerm string, pagination scm.Pagination) (*scm.RepoListResult, error) {
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/projects?membership=true&search=%s&page=%d&per_page=%d",
 		c.apiURL, url.QueryEscape(searchTerm), page, perPage)
@@ -269,19 +215,9 @@ func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "search failed", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "search failed", nil)
-	}
-
 	var glProjects []gitlabProject
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glProjects); err != nil {
-		return nil, fmt.Errorf("gitlab: decode search results: %w", err)
+	if err := scm.DoJSON(req, "search failed", nil, &glProjects); err != nil {
+		return nil, err
 	}
 
 	repos := make([]*scm.SourceRepo, len(glProjects))
@@ -299,14 +235,7 @@ func (c *GitLabConnector) SearchRepositories(ctx context.Context, creds *scm.Acc
 // FetchBranches lists branches in a project
 func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitBranch, error) {
 	projectPath := url.PathEscape(fmt.Sprintf("%s/%s", ownerName, repoName))
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/projects/%s/repository/branches?page=%d&per_page=%d", c.apiURL, projectPath, page, perPage)
 
@@ -315,16 +244,6 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 		return nil, fmt.Errorf("gitlab: create branches request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch branches", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch branches", nil)
-	}
 
 	var glBranches []struct {
 		Name   string `json:"name"`
@@ -335,8 +254,8 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 		Default   bool `json:"default"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glBranches); err != nil {
-		return nil, fmt.Errorf("gitlab: decode branches: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch branches", nil, &glBranches); err != nil {
+		return nil, err
 	}
 
 	branches := make([]*scm.GitBranch, len(glBranches))
@@ -355,14 +274,7 @@ func (c *GitLabConnector) FetchBranches(ctx context.Context, creds *scm.AccessTo
 // FetchTags lists tags in a project
 func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken, ownerName, repoName string, pagination scm.Pagination) ([]*scm.GitTag, error) {
 	projectPath := url.PathEscape(fmt.Sprintf("%s/%s", ownerName, repoName))
-	page := pagination.PageNum
-	if page < 1 {
-		page = 1
-	}
-	perPage := pagination.PageSize
-	if perPage < 1 || perPage > 100 {
-		perPage = 30
-	}
+	page, perPage := scm.ClampPagination(pagination)
 
 	endpoint := fmt.Sprintf("%s/projects/%s/repository/tags?page=%d&per_page=%d", c.apiURL, projectPath, page, perPage)
 
@@ -371,16 +283,6 @@ func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 		return nil, fmt.Errorf("gitlab: create tags request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch tags", nil)
-	}
 
 	var glTags []struct {
 		Name    string `json:"name"`
@@ -393,8 +295,8 @@ func (c *GitLabConnector) FetchTags(ctx context.Context, creds *scm.AccessToken,
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glTags); err != nil {
-		return nil, fmt.Errorf("gitlab: decode tags: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch tags", nil, &glTags); err != nil {
+		return nil, err
 	}
 
 	tags := make([]*scm.GitTag, len(glTags))
@@ -422,19 +324,6 @@ func (c *GitLabConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch tag", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrTagNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch tag", nil)
-	}
-
 	var glTag struct {
 		Name    string `json:"name"`
 		Message string `json:"message"`
@@ -444,8 +333,8 @@ func (c *GitLabConnector) FetchTagByName(ctx context.Context, creds *scm.AccessT
 		} `json:"commit"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glTag); err != nil {
-		return nil, fmt.Errorf("gitlab: decode tag: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch tag", scm.ErrTagNotFound, &glTag); err != nil {
+		return nil, err
 	}
 
 	return &scm.GitTag{
@@ -467,19 +356,6 @@ func (c *GitLabConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 	}
 	c.setAuthHeaders(req, creds)
 
-	resp, err := scm.HTTPClient.Do(req) // #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch commit", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, scm.ErrCommitNotFound
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, scm.WrapRemoteError(resp.StatusCode, "failed to fetch commit", nil)
-	}
-
 	var glCommit struct {
 		ID            string    `json:"id"`
 		Title         string    `json:"title"`
@@ -490,8 +366,8 @@ func (c *GitLabConnector) FetchCommit(ctx context.Context, creds *scm.AccessToke
 		WebURL        string    `json:"web_url"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&glCommit); err != nil {
-		return nil, fmt.Errorf("gitlab: decode commit: %w", err)
+	if err := scm.DoJSON(req, "failed to fetch commit", scm.ErrCommitNotFound, &glCommit); err != nil {
+		return nil, err
 	}
 
 	return &scm.GitCommit{

--- a/backend/internal/scm/httpclient.go
+++ b/backend/internal/scm/httpclient.go
@@ -1,10 +1,16 @@
-// httpclient.go provides the shared HTTP client and response-body size caps used by all
-// SCM connectors (GitHub, GitLab, Bitbucket Data Center, Azure DevOps) for API calls and
-// OAuth token exchanges.
+// httpclient.go provides the shared HTTP client, response-body size caps, and the two
+// request helpers (DoJSON, ExchangeOAuthForm) used by all SCM connectors (GitHub, GitLab,
+// Bitbucket Data Center, Azure DevOps) for API calls and OAuth token exchanges.
 package scm
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
@@ -59,4 +65,82 @@ func LimitBody(r io.Reader) io.Reader {
 // io.ReadAll on a non-2xx SCM API response consumed only for an error message.
 func LimitErrorBody(r io.Reader) io.Reader {
 	return io.LimitReader(r, MaxErrorBodyBytes)
+}
+
+// DoJSON sends req through the shared SSRF-safe egress client (HTTPClient) and decodes a
+// 200 OK JSON response body into out.
+//
+// The caller builds req, so the method, URL, and headers — including the Authorization
+// header — stay entirely under the caller's control. DoJSON owns only the part every
+// connector repeats identically: routing through HTTPClient (never a bare http.Client,
+// which would bypass the egress guard), closing the body, mapping the response status
+// onto an error, and size-capping the decoded body with LimitBody.
+//
+// reason is the message carried by the *APIError returned for a transport failure
+// (StatusCode 0, wrapping the transport error) or for an unexpected status. Passing a
+// non-nil notFound makes HTTP 404 return that sentinel verbatim, so each call site keeps
+// its own (ErrRepoNotFound, ErrTagNotFound, ErrCommitNotFound); pass nil where 404 has no
+// special meaning. Response bodies are never copied into the returned error: an SCM
+// response can carry repository content and these errors reach registry API clients.
+func DoJSON(req *http.Request, reason string, notFound error, out any) error {
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return WrapRemoteError(0, reason, err)
+	}
+	defer resp.Body.Close()
+
+	if notFound != nil && resp.StatusCode == http.StatusNotFound {
+		return notFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return WrapRemoteError(resp.StatusCode, reason, nil)
+	}
+
+	if err := json.NewDecoder(LimitBody(resp.Body)).Decode(out); err != nil {
+		return fmt.Errorf("%s: decode response: %w", reason, err)
+	}
+	return nil
+}
+
+// ExchangeOAuthForm posts form to tokenURL as application/x-www-form-urlencoded through
+// the shared SSRF-safe egress client and decodes the JSON token response into out. It is
+// the OAuth authorization-code exchange shared by the GitHub, GitLab, and Azure DevOps
+// (Microsoft Entra ID) connectors.
+//
+// acceptHeader, when non-empty, is sent as the Accept request header. GitHub returns a
+// form-encoded token response unless the caller asks for JSON, whereas GitLab and Entra ID
+// return JSON regardless and send no Accept header — so the header stays a caller
+// decision rather than something this helper imposes on every provider.
+//
+// Unlike DoJSON, a non-200 response here carries a size-capped snippet of the response
+// body (LimitErrorBody) in the returned *APIError: the OAuth error body is the provider's
+// machine-readable failure reason (invalid_client, redirect_uri_mismatch, ...) and is what
+// makes a misconfigured app registration diagnosable.
+func ExchangeOAuthForm(ctx context.Context, tokenURL string, form url.Values, acceptHeader string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("create token request: %w", err)
+	}
+	if acceptHeader != "" {
+		req.Header.Set("Accept", acceptHeader)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return WrapRemoteError(0, "failed to exchange code", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(LimitErrorBody(resp.Body))
+		return WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
+	}
+
+	if err := json.NewDecoder(LimitBody(resp.Body)).Decode(out); err != nil {
+		return fmt.Errorf("decode token response: %w", err)
+	}
+	return nil
 }

--- a/backend/internal/scm/httpclient_test.go
+++ b/backend/internal/scm/httpclient_test.go
@@ -1,0 +1,248 @@
+package scm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestClampPagination(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          Pagination
+		wantPage    int
+		wantPerPage int
+	}{
+		{"zero value falls back to page 1, size 30", Pagination{}, 1, 30},
+		{"negative page number clamps to the first page", Pagination{PageNum: -3, PageSize: 50}, 1, 50},
+		{"page size above the API maximum falls back", Pagination{PageNum: 2, PageSize: 101}, 2, 30},
+		{"page size at the API maximum is preserved", Pagination{PageNum: 2, PageSize: 100}, 2, 100},
+		{"page size of one is preserved", Pagination{PageNum: 7, PageSize: 1}, 7, 1},
+		{"negative page size falls back", Pagination{PageNum: 3, PageSize: -1}, 3, 30},
+		{"defaults pass through unchanged", DefaultPagination(), 1, 30},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			page, perPage := ClampPagination(tc.in)
+			if page != tc.wantPage || perPage != tc.wantPerPage {
+				t.Errorf("ClampPagination(%+v) = (%d, %d), want (%d, %d)",
+					tc.in, page, perPage, tc.wantPage, tc.wantPerPage)
+			}
+		})
+	}
+}
+
+func TestDoJSON_DecodesSuccessfulResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Errorf("Authorization = %q, want the caller's header to survive untouched", got)
+		}
+		_, _ = w.Write([]byte(`{"name":"mod"}`))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer tok")
+
+	var out struct {
+		Name string `json:"name"`
+	}
+	if err := DoJSON(req, "failed to fetch repository", ErrRepoNotFound, &out); err != nil {
+		t.Fatalf("DoJSON error: %v", err)
+	}
+	if out.Name != "mod" {
+		t.Errorf("Name = %q, want %q", out.Name, "mod")
+	}
+}
+
+func TestDoJSON_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		notFound   error
+		wantErr    error // expected via errors.Is, when non-nil
+		wantStatus int   // expected APIError.StatusCode, when wantErr is nil
+	}{
+		{"404 returns the caller's sentinel", http.StatusNotFound, ErrTagNotFound, ErrTagNotFound, 0},
+		{"404 without a sentinel stays an APIError", http.StatusNotFound, nil, nil, http.StatusNotFound},
+		{"401 keeps its status for the token-refresh path", http.StatusUnauthorized, ErrRepoNotFound, nil, http.StatusUnauthorized},
+		{"403 keeps its status", http.StatusForbidden, nil, nil, http.StatusForbidden},
+		{"500 keeps its status", http.StatusInternalServerError, nil, nil, http.StatusInternalServerError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte("s3cr3t-repository-content"))
+			}))
+			defer srv.Close()
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+
+			var out map[string]any
+			err = DoJSON(req, "failed to fetch repository", tc.notFound, &out)
+			if err == nil {
+				t.Fatal("DoJSON error = nil, want an error")
+			}
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("DoJSON error = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+
+			var apiErr *APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("DoJSON error = %v (%T), want an *APIError", err, err)
+			}
+			if apiErr.StatusCode != tc.wantStatus {
+				t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, tc.wantStatus)
+			}
+			// The registry surfaces these errors to API clients, so an SCM response body
+			// must never be copied into them.
+			if strings.Contains(err.Error(), "s3cr3t-repository-content") {
+				t.Errorf("error %q leaks the SCM response body", err.Error())
+			}
+		})
+	}
+}
+
+func TestDoJSON_TransportFailureKeepsStatusZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // nothing is listening any more
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	var out map[string]any
+	err = DoJSON(req, "failed to fetch repository", ErrRepoNotFound, &out)
+	if err == nil {
+		t.Fatal("DoJSON error = nil, want a transport error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("DoJSON error = %v (%T), want an *APIError", err, err)
+	}
+	if apiErr.StatusCode != 0 {
+		t.Errorf("StatusCode = %d, want 0 for a transport failure", apiErr.StatusCode)
+	}
+	if apiErr.Message != "failed to fetch repository" {
+		t.Errorf("Message = %q, want the caller's reason", apiErr.Message)
+	}
+}
+
+// TestDoJSON_RefusesGuardedTarget is the runtime half of the egress guarantee: DoJSON must
+// send through the httpsafe client, which refuses link-local/metadata targets at dial time.
+// A DoJSON rewritten to use a bare http.Client would reach the dial and fail differently
+// (or, on a cloud host, succeed).
+func TestDoJSON_RefusesGuardedTarget(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"http://169.254.169.254/latest/meta-data/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	var out map[string]any
+	err = DoJSON(req, "failed to fetch repository", nil, &out)
+	if err == nil {
+		t.Fatal("DoJSON reached the metadata endpoint; the egress guard is not on this path")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 0 {
+		t.Fatalf("DoJSON error = %v, want a transport-level *APIError from the egress guard", err)
+	}
+}
+
+func TestExchangeOAuthForm_PostsFormAndDecodes(t *testing.T) {
+	tests := []struct {
+		name         string
+		acceptHeader string
+		wantAccept   string
+	}{
+		{"GitHub asks for a JSON token response", "application/json", "application/json"},
+		{"GitLab and Entra ID send no Accept header", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotContentType, gotAccept, gotCode string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotContentType = r.Header.Get("Content-Type")
+				gotAccept = r.Header.Get("Accept")
+				_ = r.ParseForm()
+				gotCode = r.Form.Get("code")
+				_, _ = w.Write([]byte(`{"access_token":"at","token_type":"bearer"}`))
+			}))
+			defer srv.Close()
+
+			form := url.Values{}
+			form.Set("code", "auth-code")
+
+			var result struct {
+				AccessToken string `json:"access_token"`
+				TokenType   string `json:"token_type"`
+			}
+			if err := ExchangeOAuthForm(context.Background(), srv.URL, form, tc.acceptHeader, &result); err != nil {
+				t.Fatalf("ExchangeOAuthForm error: %v", err)
+			}
+
+			if gotMethod != http.MethodPost {
+				t.Errorf("method = %q, want POST", gotMethod)
+			}
+			if gotContentType != "application/x-www-form-urlencoded" {
+				t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", gotContentType)
+			}
+			if gotAccept != tc.wantAccept {
+				t.Errorf("Accept = %q, want %q", gotAccept, tc.wantAccept)
+			}
+			if gotCode != "auth-code" {
+				t.Errorf("code = %q, want the submitted form value", gotCode)
+			}
+			if result.AccessToken != "at" || result.TokenType != "bearer" {
+				t.Errorf("result = %+v, want the decoded token response", result)
+			}
+		})
+	}
+}
+
+func TestExchangeOAuthForm_NonOKCarriesStatusAndBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+	}))
+	defer srv.Close()
+
+	var result struct{}
+	err := ExchangeOAuthForm(context.Background(), srv.URL, url.Values{}, "", &result)
+	if err == nil {
+		t.Fatal("ExchangeOAuthForm error = nil, want an error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v (%T), want an *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	// Unlike the repository APIs, the OAuth failure reason is what makes a misconfigured
+	// app registration diagnosable, so it is deliberately carried in the error.
+	if !strings.Contains(err.Error(), "invalid_client") {
+		t.Errorf("error = %q, want it to carry the provider's failure reason", err.Error())
+	}
+}


### PR DESCRIPTION
Closes #745

## What the audit claimed, and what the code actually says

The issue is right that the boilerplate exists, but its counts are off in both directions. Verified against the code before changing anything:

| Claim | Reality |
|---|---|
| pagination clamp "recurs 4x in github and 4x in gitlab" | **Correct — 8 byte-identical sites**, but across **2** files, not the 4 the title claims |
| bitbucket has the same clamp | **No.** Bitbucket has its own 4 copies of a *different* clamp: offset-based `limit`/`start`, default **25** not 30 |
| azuredevops has the same clamp | **No.** ADO ignores pagination entirely — `FetchRepositories`, `SearchRepositories`, `FetchBranches` and `FetchTags` all accept a `scm.Pagination` and never read it |
| "4 near-identical files" duplicate the OAuth exchange | **3, not 4.** Bitbucket Data Center is PAT-based; its `CompleteAuthorization` just returns `ErrPATRequired` and makes no HTTP call at all |
| no shared `doJSON` | Correct. **18** call sites open-code send/status/decode (github 7, gitlab 7, ADO 4); bitbucket's private one has a *different* error policy |

## What was extracted

Three helpers, no configuration knobs beyond what an existing caller already needs:

- **`scm.ClampPagination`** — the 8 identical page/per_page clamps. Bitbucket's 4 copies collapse into a package-private `clampWindow`; it stays separate because that API is offset-based with a different default, and merging them would have meant inventing a knob.
- **`scm.DoJSON(req, reason, notFound, out)`** — the 18 send/close/status-map/size-capped-decode blocks. The **caller still builds the request**, so no URL, method, or header (including `Authorization`) can drift as a side effect. The 404 sentinel is a per-call-site argument, so `ErrRepoNotFound` / `ErrTagNotFound` / `ErrCommitNotFound` keep their exact existing mapping.
- **`scm.ExchangeOAuthForm`** — the 3 identical OAuth code exchanges. GitHub's `Accept: application/json` (which it needs, or GitHub replies form-encoded) stays a caller argument rather than being imposed on GitLab and Entra ID, which send no `Accept` today.

Net: −397/+185 lines; the four connectors drop from 2,920 to 2,600 lines.

## Behaviour preservation

Every request URL, method, header, pagination bound, status-to-error mapping and `APIError.StatusCode` is unchanged. `StatusCode` is load-bearing — `internal/api/admin/scm_oauth.go` drives its silent token-refresh retry off 401/403/203 — so the new tests assert it directly rather than trusting the reading.

The one intentional change is error *text*: a decode failure now reads `"<reason>: decode response: …"` instead of `"<pkg>: decode <thing>: …"`. Nothing matched on those strings (checked every test and caller). `DoJSON` also deliberately does **not** copy response bodies into errors — these errors reach registry API clients, and an SCM body can carry repository content.

Tests were green before and after; full `go build ./... && go vet ./... && gofmt -l . && go test ./...` is clean (64 packages).

## Security: the guard is still on every path

Deduplication that routes a call around `httpsafe` would be the opposite of the point, so `egress_guard_test.go` parses the whole `internal/scm` tree and fails when:

1. any file uses `http.DefaultClient`, `http.Get/Post/PostForm/Head`, or hand-builds an `http.Client` / `http.Transport`;
2. a `.Do()` receiver is not on the allow-list of httpsafe-backed clients;
3. an allow-list entry has gone **stale** (checked in both directions, so an exemption can't outlive its call site);
4. `appcreds.Minter.httpClient` is initialised from anything but `httpsafe.NewClient` — the indirection rule 2's `m.httpClient` entry depends on;
5. the walk finds an empty universe.

`TestDoJSON_RefusesGuardedTarget` covers the runtime half: a request to `169.254.169.254` must be refused at dial time.

### Mutation table

Each guard was broken and watched to fail, then restored from a `cp` backup:

| # | Mutation | Result |
|---|---|---|
| M1 | `github`: `scm.HTTPClient.Do` → `http.DefaultClient.Do` | ✅ FAIL ×2 — `NoUnguardedHTTPConstructs` + `DoCallsUseTheSharedClient` |
| M2 | `gitlab`: `scm.HTTPClient.Do` → `(&http.Client{}).Do` | ✅ FAIL ×2 — bare-client literal + unknown `.Do` receiver |
| M3 | `appcreds`: `httpsafe.NewClient(…)` → `&http.Client{Timeout: …}` | ✅ FAIL ×2 — `HTTPClientFieldsComeFromHTTPSafe` + literal rule |
| M4 | `appcreds`: last `m.httpClient.Do` call site removed | ✅ FAIL — stale allow-list entry reported (reverse direction) |
| M5 | guard pointed at an empty directory | ✅ FAIL ×3 — all three guards refuse to certify 0 files |

Restored tree re-verified green.

## Found but deliberately not changed

Pre-existing, unrelated to deduplication, and each would have been a behaviour change smuggled in as "refactor":

- **`azuredevops.FetchRepositories` never checks `resp.StatusCode`** before decoding each project's repo list — a non-200 (including the HTML sign-in page ADO returns as **203** for an expired token) is swallowed by `continue`, producing a silently short repo list instead of an error. The 203→401 normalisation exists in `fetchProjects` and `FetchTags` but in no other ADO method. Worth its own issue.
- **ADO ignores the `pagination` argument** in all four listing methods.
- **`azuredevops.FetchTags` has a stray `fmt.Printf("[FetchTags] GET %s\n", …)`** debug print to stdout.
- **Bitbucket's `doJSON` maps 401/403 to `ErrRepoAccessDenied`**, discarding the status code — so the `scm_oauth.go` refresh-on-401 path can never fire for Bitbucket. Harmless today (PAT auth, no refresh token) and precisely why that helper was not folded into `DoJSON`.
- **GitLab/ADO `RenewToken`** return the bare `ErrTokenRefreshFailed` sentinel on non-200 rather than an `*APIError`; folding them into `ExchangeOAuthForm` would have required an `errors.As` dance at both call sites for no net saving.
- **GitLab sets `Content-Type: application/json` on GET requests** — a harmless quirk, preserved verbatim.
