### PR TITLE
feat(maintenance): add rekey-secrets so a key rotation can be completed

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -124,8 +124,24 @@ func run() error {
 		// bind-secrets [verify] — convert stored secrets to the row-bound
 		// ciphertext form, or report what remains without writing.
 		return runBindSecrets(cfg, len(os.Args) > 2 && os.Args[2] == "verify")
+	case "rekey-secrets":
+		// rekey-secrets [verify] — re-encrypt stored secrets under the current
+		// ENCRYPTION_KEY, or report what still needs the previous one.
+		//
+		// An unrecognised argument is rejected rather than ignored: this
+		// command's default mode REWRITES every credential in the database, and
+		// silently reading `verfiy` as "no argument" would run the writing mode
+		// on a typo of the read-only one.
+		verify := false
+		if len(os.Args) > 2 {
+			if os.Args[2] != "verify" {
+				return fmt.Errorf("usage: %s rekey-secrets [verify]", os.Args[0])
+			}
+			verify = true
+		}
+		return runRekeySecrets(cfg, verify)
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker, bind-secrets", command)
+		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker, bind-secrets, rekey-secrets", command)
 	}
 }
 
@@ -999,6 +1015,47 @@ func runBindSecrets(cfg *config.Config, verify bool) error {
 	}
 	for name, res := range results {
 		slog.Info("bind-secrets column complete", "mode", mode, "column", name, "result", res.String())
+	}
+	return err
+}
+
+// runRekeySecrets re-encrypts every stored secret under the current
+// ENCRYPTION_KEY, or with "verify" reports what still requires
+// ENCRYPTION_KEY_PREVIOUS without writing anything.
+//
+// This is what finishes a key rotation. bind-secrets deliberately skips a row it
+// can already open under its own context, and that open falls back to the
+// previous key — so once secrets are row-bound, bind-secrets re-encrypts nothing
+// and the previous key can never be retired (#848).
+//
+// The verify form is the exit criterion, and the reason it takes the key rather
+// than only the cipher: a cipher with a fallback cannot tell "opened with the
+// current key" from "opened with the previous one", so it cannot answer the
+// question the gate asks. It exits non-zero while any row still needs the
+// previous key, which is what a runbook step gates the deletion on.
+func runRekeySecrets(cfg *config.Config, verify bool) error {
+	database, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	cipher, err := api.BuildTokenCipherFromEnv()
+	if err != nil {
+		return fmt.Errorf("rekey-secrets needs the encryption key the server uses: %w", err)
+	}
+	currentKey, err := api.CurrentEncryptionKeyFromEnv()
+	if err != nil {
+		return fmt.Errorf("rekey-secrets needs the encryption key the server uses: %w", err)
+	}
+
+	results, err := maintenance.RekeySecrets(context.Background(), database, cipher, currentKey, verify)
+	mode := "re-encrypt"
+	if verify {
+		mode = "verify"
+	}
+	for name, res := range results {
+		slog.Info("rekey-secrets column complete", "mode", mode, "column", name, "result", res.String())
 	}
 	return err
 }

--- a/backend/internal/api/tokencipher_env.go
+++ b/backend/internal/api/tokencipher_env.go
@@ -27,12 +27,32 @@ import (
 // refusing to convert because the existing key is weak would strand exactly the
 // deployments that most need to re-encrypt.
 func BuildTokenCipherFromEnv() (*crypto.TokenCipher, error) {
+	key, err := CurrentEncryptionKeyFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	if previous := os.Getenv("ENCRYPTION_KEY_PREVIOUS"); previous != "" {
+		return crypto.NewTokenCipherWithPrevious(key, []byte(previous))
+	}
+	return crypto.NewTokenCipher(key)
+}
+
+// CurrentEncryptionKeyFromEnv returns the raw ENCRYPTION_KEY bytes — the key
+// everything is encrypted WITH, without the previous-key decryption fallback.
+//
+// The rekey-secrets maintenance command needs the current key on its own,
+// because a cipher that falls back to the previous key cannot answer the only
+// question that ends a rotation: is this row still encrypted under the key I am
+// about to delete? An open that succeeds through the fallback looks identical to
+// one that did not need it (#848).
+//
+// It reads the key here, beside the cipher constructor, rather than in the
+// command, for the reason above: one key source, so the sweep and the server
+// cannot disagree about what "the current key" is.
+func CurrentEncryptionKeyFromEnv() ([]byte, error) {
 	key := os.Getenv("ENCRYPTION_KEY")
 	if key == "" {
 		return nil, errors.New("ENCRYPTION_KEY must be set")
 	}
-	if previous := os.Getenv("ENCRYPTION_KEY_PREVIOUS"); previous != "" {
-		return crypto.NewTokenCipherWithPrevious([]byte(key), []byte(previous))
-	}
-	return crypto.NewTokenCipher([]byte(key))
+	return []byte(key), nil
 }

--- a/backend/internal/maintenance/bindsecrets.go
+++ b/backend/internal/maintenance/bindsecrets.go
@@ -66,16 +66,36 @@ type column struct {
 }
 
 // Result is what one column's sweep did. Total is rows examined, not changed.
+//
+// The two sweeps share this struct because they answer the same two questions
+// per row — did it need work, and did the work land — and a second
+// near-identical struct would drift from this one exactly the way five bespoke
+// loops would have.
+//
+// They do NOT share a reason for skipping a row, though, and that difference is
+// the whole of #848: bind-secrets skips a row that is already bound, a rekey run
+// skips one that is already on the current key, and a row can be the first
+// without being the second. AlreadyBound therefore carries the count and
+// `skipped` carries what it means, so a rekey run never prints "already-bound"
+// over a row that still needs the key the operator is about to delete.
 type Result struct {
 	Total        int
 	Converted    int
 	AlreadyBound int
 	Failed       int
+
+	// skipped labels AlreadyBound in String(). Empty means the binding sweep's
+	// wording, so a zero Result still prints sensibly.
+	skipped string
 }
 
 func (r Result) String() string {
-	return fmt.Sprintf("examined=%d converted=%d already-bound=%d failed=%d",
-		r.Total, r.Converted, r.AlreadyBound, r.Failed)
+	skipped := r.skipped
+	if skipped == "" {
+		skipped = "already-bound"
+	}
+	return fmt.Sprintf("examined=%d converted=%d %s=%d failed=%d",
+		r.Total, r.Converted, skipped, r.AlreadyBound, r.Failed)
 }
 
 // ErrUnboundRemain is returned by a verify run that found rows still unbound.
@@ -352,6 +372,79 @@ func listRows(ctx context.Context, db *sql.DB, query string) ([]sealedRow, error
 	return out, rows.Err()
 }
 
+// converter decides what a sweep does with one row. needsWork false means the
+// row is already in the target form and must be left alone; otherwise
+// replacement is the ciphertext to store.
+//
+// An error is a row-level failure — reported, stepped over, and counted against
+// the verify gate. It is never a reason to abandon the remaining rows.
+type converter func(col column, row sealedRow) (replacement string, needsWork bool, err error)
+
+// sweep runs one converter over every registered column, writing unless
+// verifyOnly, and reports whether any row needed work or failed.
+//
+// It is shared by BindSecrets and RekeySecrets so that the properties an
+// operator relies on — verify writes nothing, one bad row does not abandon the
+// rest, the whole registry is walked rather than a subset — are implemented once
+// and cannot hold for one command and not the other. `skipped` is only the word
+// the two use for a row they left alone.
+//
+// Writes are per row, not per sweep. A transaction spanning every credential in
+// the database would hold locks for the length of the run and turn a partial
+// failure into an all-or-nothing one; a single-row UPDATE is already atomic, so
+// an interrupted sweep leaves each row either wholly converted or wholly
+// untouched, and both forms still open. That is what makes it resumable.
+func sweep(
+	ctx context.Context,
+	db *sql.DB,
+	verifyOnly bool,
+	skipped string,
+	convert converter,
+) (map[string]Result, bool, error) {
+	results := make(map[string]Result, len(columns))
+	var workRemains bool
+
+	for _, col := range columns {
+		rows, err := col.list(ctx, db)
+		if err != nil {
+			return results, workRemains, fmt.Errorf("maintenance: list %s: %w", col.name, err)
+		}
+
+		res := Result{Total: len(rows), skipped: skipped}
+		for _, row := range rows {
+			replacement, needsWork, err := convert(col, row)
+			if err != nil {
+				res.Failed++
+				slog.Error("secret could not be converted",
+					"column", col.name, "row_id", row.id, "error", err)
+				continue
+			}
+			if !needsWork {
+				res.AlreadyBound++
+				continue
+			}
+			if verifyOnly {
+				res.Converted++ // would convert
+				continue
+			}
+			if err := col.update(ctx, db, row.id, replacement); err != nil {
+				res.Failed++
+				slog.Error("converted secret could not be written",
+					"column", col.name, "row_id", row.id, "error", err)
+				continue
+			}
+			res.Converted++
+		}
+
+		results[col.name] = res
+		if res.Converted > 0 || res.Failed > 0 {
+			workRemains = true
+		}
+	}
+
+	return results, workRemains, nil
+}
+
 // BindSecrets converts every registered column to the row-bound form, or with
 // verifyOnly reports what remains without writing.
 //
@@ -359,6 +452,11 @@ func listRows(ctx context.Context, db *sql.DB, query string) ([]sealedRow, error
 // opening it under its own context — no schema flag can answer this, because the
 // form is a property of the ciphertext, not of the row — and skipped rather than
 // double-sealed.
+//
+// That skip is binding-only, and deliberately so: OpenWithContext falls back to
+// the previous key, so a row bound before a key rotation opens here and is left
+// where it is. Completing a rotation is RekeySecrets' job, not this one's
+// (#848).
 //
 // A row that cannot be decrypted at all is reported and stepped over. That is a
 // pre-existing problem this sweep did not cause and cannot fix, and abandoning
@@ -373,45 +471,16 @@ func BindSecrets(
 		return nil, errors.New("maintenance: no token cipher configured (set ENCRYPTION_KEY)")
 	}
 
-	results := make(map[string]Result, len(columns))
-	var unbound bool
-
-	for _, col := range columns {
-		rows, err := col.list(ctx, db)
-		if err != nil {
-			return results, fmt.Errorf("maintenance: list %s: %w", col.name, err)
-		}
-
-		res := Result{Total: len(rows)}
-		for _, row := range rows {
+	results, unbound, err := sweep(ctx, db, verifyOnly, "already-bound",
+		func(col column, row sealedRow) (string, bool, error) {
 			if _, err := tc.OpenWithContext(row.sealed, col.context(row.id)); err == nil {
-				res.AlreadyBound++
-				continue
+				return "", false, nil
 			}
 			bound, err := tc.ReSealWithContext(row.sealed, col.context(row.id))
-			if err != nil {
-				res.Failed++
-				slog.Error("secret could not be converted",
-					"column", col.name, "row_id", row.id, "error", err)
-				continue
-			}
-			if verifyOnly {
-				res.Converted++ // would convert
-				continue
-			}
-			if err := col.update(ctx, db, row.id, bound); err != nil {
-				res.Failed++
-				slog.Error("converted secret could not be written",
-					"column", col.name, "row_id", row.id, "error", err)
-				continue
-			}
-			res.Converted++
-		}
-
-		results[col.name] = res
-		if res.Converted > 0 || res.Failed > 0 {
-			unbound = true
-		}
+			return bound, true, err
+		})
+	if err != nil {
+		return results, err
 	}
 
 	if verifyOnly && unbound {

--- a/backend/internal/maintenance/rekey_coverage_test.go
+++ b/backend/internal/maintenance/rekey_coverage_test.go
@@ -1,0 +1,227 @@
+package maintenance
+
+// rekey_coverage_test.go is an inventory guard, in the same spirit as
+// internal/crypto/unbound_{seal,open}_sweep_test.go, for the claim
+// `rekey-secrets verify` makes.
+//
+// That claim is load-bearing and unusually expensive to get wrong: a zero exit
+// is what tells an operator ENCRYPTION_KEY_PREVIOUS can be deleted, and deleting
+// it while any secret is still sealed under it destroys that secret. The gate is
+// therefore only as wide as the registry the sweep walks, and the registry is a
+// hand-maintained list — so a new encrypted column added anywhere in this
+// service silently narrows a gate that keeps reporting success.
+//
+// The inventory below is the fix: every AAD context function used by this
+// service must be declared either as swept by a registered column or as
+// deliberately not swept, with a reason. Adding an encrypted column means
+// editing this file, and editing this file is where someone decides whether
+// dropping the previous key can still be called safe.
+//
+// It is checked in BOTH directions, because a one-way check rots. A listed
+// function that no longer exists fails, a registered column no entry claims
+// fails, and an entry claiming a column the registry does not have fails.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sweptAADContexts maps an AAD context function to the registered column whose
+// rows RekeySecrets re-encrypts through it. One entry per column.
+var sweptAADContexts = map[string]string{
+	"TargetContext":                          "notification_channels.encrypted_target",
+	"StorageConfigAzureAccountKeyContext":    "storage_config.azure_account_key_encrypted",
+	"StorageConfigS3AccessKeyIDContext":      "storage_config.s3_access_key_id_encrypted",
+	"StorageConfigS3SecretAccessKeyContext":  "storage_config.s3_secret_access_key_encrypted",
+	"StorageConfigGCSCredentialsJSONContext": "storage_config.gcs_credentials_json_encrypted",
+	"OIDCConfigClientSecretContext":          "oidc_config.client_secret_encrypted",
+	"ProviderClientSecretContext":            "scm_providers.client_secret_encrypted",
+	"ProviderAppPrivateKeyContext":           "scm_providers.encrypted_app_private_key",
+	"SystemSettingsSMTPPasswordContext":      "system_settings.notifications_config:smtp.smtp_password_encrypted",
+	"SystemSettingsLDAPBindPasswordContext":  "system_settings.ldap_config:bind_password_enc",
+}
+
+// unsweptAADContexts are the encrypted columns no sweep touches, and why.
+//
+// These are NOT covered by the rekey gate. Both tables hold credentials that the
+// service can obtain again without an administrator: the shared app token is a
+// cache with an expiry that is re-minted, and a user OAuth token is restored by
+// that user re-linking their account. That is a real difference in blast radius
+// from an OIDC client secret or a cloud storage key, which only a human can
+// re-enter — but it is not "nothing", and docs/secrets-rotation.md says so
+// rather than letting the gate imply a coverage it does not have.
+//
+// They are also not reachable from the registry as it stands: column.context
+// takes one row-id string, and both scm_oauth_tokens contexts are derived from
+// a user id AND a provider id (see internal/scm/aad.go). Widening the registry
+// to carry composite keys is a change to the binding sweep as much as to this
+// one, and belongs to its own issue rather than being smuggled in behind a
+// rotation fix.
+var unsweptAADContexts = map[string]string{
+	"ProviderTokenContext": "scm_provider_tokens.access_token_encrypted is a cache with an expiry; " +
+		"entries are re-minted from the identity provider, so the table converts itself",
+	"UserTokenContext": "scm_oauth_tokens.access_token_encrypted is keyed by user AND provider, " +
+		"which the single-row-id registry cannot express; a lost token is restored by the user re-linking",
+	"UserRefreshTokenContext": "scm_oauth_tokens.refresh_token_encrypted, as above",
+}
+
+// findAADContextFuncs returns every exported *Context function this service
+// passes as the additional-authenticated-data argument of a seal or open.
+//
+// Matched on the argument position of a *WithContext* call rather than on where
+// the function is declared: what matters is that a ciphertext somewhere is bound
+// by it, not which package it lives in. The bare name "Context" is excluded —
+// that is ctx plumbing, not an AAD.
+func findAADContextFuncs(t *testing.T) map[string]string {
+	t.Helper()
+	root := moduleRoot(t)
+	found := map[string]string{}
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // unparseable files are not this test's business
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !strings.Contains(sel.Sel.Name, "WithContext") {
+				return true
+			}
+			for _, arg := range call.Args {
+				inner, ok := arg.(*ast.CallExpr)
+				if !ok {
+					continue
+				}
+				var name string
+				switch fn := inner.Fun.(type) {
+				case *ast.Ident:
+					name = fn.Name
+				case *ast.SelectorExpr:
+					name = fn.Sel.Name
+				}
+				if name == "Context" || !strings.HasSuffix(name, "Context") {
+					continue
+				}
+				if r := name[0]; r < 'A' || r > 'Z' {
+					continue // col.context(...), not an exported AAD derivation
+				}
+				if _, seen := found[name]; !seen {
+					found[name] = rel
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	return found
+}
+
+func TestRekeyCoverage_EveryAADContextIsDeclaredSweptOrNot(t *testing.T) {
+	found := findAADContextFuncs(t)
+	if len(found) == 0 {
+		t.Fatal("the scan found no AAD context functions at all; it has stopped matching " +
+			"and would certify any registry as complete")
+	}
+
+	for name, where := range found {
+		_, swept := sweptAADContexts[name]
+		_, unswept := unsweptAADContexts[name]
+		switch {
+		case swept && unswept:
+			t.Errorf("%s is listed as both swept and unswept", name)
+		case !swept && !unswept:
+			t.Errorf("%s binds a secret (first seen in %s) and is in neither inventory.\n"+
+				"Either register a column for it in bindsecrets.go and add it to sweptAADContexts, "+
+				"or add it to unsweptAADContexts with why a rotation does not need to reach it — "+
+				"and say so in docs/secrets-rotation.md, because `rekey-secrets verify` returning "+
+				"zero is what an operator deletes ENCRYPTION_KEY_PREVIOUS on.", name, where)
+		}
+	}
+
+	for name := range sweptAADContexts {
+		if _, ok := found[name]; !ok {
+			t.Errorf("sweptAADContexts lists %s but nothing seals with it any more. "+
+				"Remove the entry — a stale inventory is worse than none.", name)
+		}
+	}
+	for name := range unsweptAADContexts {
+		if _, ok := found[name]; !ok {
+			t.Errorf("unsweptAADContexts lists %s but nothing seals with it any more. "+
+				"Remove the entry — a stale inventory is worse than none.", name)
+		}
+	}
+}
+
+// The other direction: the swept inventory and the registry must describe the
+// same set of columns. Without this, a column could be dropped from the registry
+// — narrowing the gate — while the inventory above still claimed it was covered.
+func TestRekeyCoverage_SweptInventoryMatchesTheRegistry(t *testing.T) {
+	registered := map[string]bool{}
+	for _, col := range columns {
+		registered[col.name] = true
+	}
+
+	claimed := map[string]string{}
+	for fn, colName := range sweptAADContexts {
+		if !registered[colName] {
+			t.Errorf("sweptAADContexts says %s covers %q, which is not a registered column", fn, colName)
+			continue
+		}
+		if other, dup := claimed[colName]; dup {
+			t.Errorf("%s and %s both claim to cover %q; one column, one entry", other, fn, colName)
+			continue
+		}
+		claimed[colName] = fn
+	}
+
+	for _, col := range columns {
+		if _, ok := claimed[col.name]; !ok {
+			t.Errorf("column %q is registered but no sweptAADContexts entry claims it.\n"+
+				"Every registered column is re-encrypted by RekeySecrets, so it belongs in the "+
+				"inventory the rotation gate's scope is read from.", col.name)
+		}
+	}
+}
+
+// moduleRoot walks up to the module root so the test runs from its own package
+// directory.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatal("could not locate the module root (no go.mod found walking up)")
+	return ""
+}

--- a/backend/internal/maintenance/rekeysecrets.go
+++ b/backend/internal/maintenance/rekeysecrets.go
@@ -1,0 +1,171 @@
+package maintenance
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+)
+
+// Completing a key rotation (#848).
+//
+// bind-secrets converts a ciphertext's FORM — unbound to row-bound — and skips
+// any row it can already open under its own context. OpenWithContext goes
+// through the dual-key path, so a row bound before a rotation opens under
+// ENCRYPTION_KEY_PREVIOUS, counts as done, and is never re-encrypted. Nothing
+// breaks and nothing signals; the previous key simply becomes permanent, which
+// means the rotation never finishes.
+//
+// The two questions are genuinely different and both need answering, so this is
+// a second sweep over the same registry rather than a flag on the first:
+//
+//	bind-secrets   — is every ciphertext bound to its row?
+//	rekey-secrets  — is every ciphertext readable WITHOUT the previous key?
+//
+// The obvious implementation does not work, and it is worth writing down why.
+// Dropping bind-secrets' already-bound short-circuit and always calling
+// ReSealWithContext looks like a one-line fix, but ReSealWithContext opens with
+// NO additional data — it is the unbound-to-bound converter — so it fails
+// outright on an already-bound row. Every row in a converted estate would be
+// reported as a failure. Re-encrypting a bound row means opening it WITH its
+// context and sealing it again with the same context.
+
+// ErrPreviousKeyStillRequired is returned by a verify run that found rows only
+// the previous key can open.
+//
+// It is the exit criterion for the rotation runbook, in the same way
+// ErrUnboundRemain is for the binding migration: while it is returned,
+// ENCRYPTION_KEY_PREVIOUS must stay in place, and a nil error is what says the
+// key can be deleted. A gate that only prints is not a gate — a runbook step
+// needs a non-zero exit to hang off.
+var ErrPreviousKeyStillRequired = errors.New("maintenance: secrets remain encrypted under the previous key")
+
+// ErrEncryptionKeyMismatch is returned when the ENCRYPTION_KEY handed to
+// RekeySecrets is not the key the supplied cipher seals with.
+//
+// A sentinel rather than a bare error so the refusal is distinguishable from
+// "the sweep ran and something went wrong" — by a caller, and by the test that
+// has to prove the check happens before a single row is read.
+var ErrEncryptionKeyMismatch = errors.New("maintenance: ENCRYPTION_KEY is not the key this cipher seals with")
+
+// keyProbeContext is the AAD for the sealing-key probe below. It names no row
+// and protects no stored value; it exists only so the probe goes through the
+// same bound seal/open pair the real rows do.
+var keyProbeContext = []byte("maintenance:rekey:sealing-key-probe")
+
+// RekeySecrets re-encrypts every registered secret under the CURRENT encryption
+// key, or with verifyOnly reports what still requires the previous one without
+// writing.
+//
+// tc is the cipher the server runs with — current key, previous key as the
+// decryption fallback. currentKey is the raw ENCRYPTION_KEY, from which this
+// builds a cipher with NO fallback: that second cipher is the only thing that
+// can answer "which key is this row under", because a successful open on tc
+// cannot distinguish the two. Taking the key bytes rather than a second
+// *TokenCipher is what makes the oracle trustworthy — a caller cannot hand in
+// something that quietly still has a previous key configured, which would make
+// every verify run pass.
+//
+// Safe to re-run: a row already bound under the current key is left untouched,
+// so a second run writes nothing. Safe to interrupt: rows are written one at a
+// time and both keys still open, so a half-finished run is resumed by running
+// it again.
+//
+// It also subsumes binding. A row that is unbound converges to bound-and-current
+// in the same pass, so a deployment that never ran bind-secrets does not need
+// two commands in a particular order.
+//
+// A row that cannot be opened at all — corrupt, or bound to a DIFFERENT row's
+// context — is reported and stepped over, and holds the gate shut. It is never
+// re-sealed into the row it was found in: doing so would mint the valid binding
+// an attacker who moved it could not forge, turning the rotation into the
+// laundering step for exactly the attack the AAD exists to detect.
+func RekeySecrets(
+	ctx context.Context,
+	db *sql.DB,
+	tc *crypto.TokenCipher,
+	currentKey []byte,
+	verifyOnly bool,
+) (map[string]Result, error) {
+	if tc == nil {
+		return nil, errors.New("maintenance: no token cipher configured (set ENCRYPTION_KEY)")
+	}
+	current, err := crypto.NewTokenCipher(currentKey)
+	if err != nil {
+		return nil, fmt.Errorf("maintenance: ENCRYPTION_KEY is not a usable AES-256 key: %w", err)
+	}
+	if err := proveSealingKey(tc, current); err != nil {
+		return nil, err
+	}
+
+	results, remains, err := sweep(ctx, db, verifyOnly, "already-current",
+		func(col column, row sealedRow) (string, bool, error) {
+			aad := col.context(row.id)
+
+			// The only question that matters: does this row still need the
+			// previous key? A cipher holding just the current key answers it;
+			// tc cannot, which is the bug.
+			if _, err := current.OpenWithContext(row.sealed, aad); err == nil {
+				return "", false, nil
+			}
+
+			// Either form, either key. OpenWithContextOrLegacy is what lets one
+			// pass converge a row that is unbound AND on the previous key,
+			// without a separate branch that would need its own proof.
+			//
+			// It widens which FORMATS are accepted, never which contexts: a
+			// value bound to another row fails both attempts and lands in the
+			// error path below, unmodified.
+			plaintext, _, err := tc.OpenWithContextOrLegacy(row.sealed, aad)
+			if err != nil {
+				return "", true, err
+			}
+			resealed, err := tc.SealWithContext(plaintext, aad)
+			if err != nil {
+				return "", true, err
+			}
+
+			// Prove the replacement before it overwrites a live credential.
+			// Everything below the gate depends on this value opening under the
+			// current key alone, and the cost of finding out otherwise is an
+			// administrator re-entering a secret by hand.
+			roundTripped, err := current.OpenWithContext(resealed, aad)
+			if err != nil {
+				return "", true, fmt.Errorf("re-encrypted value does not open under the current key: %w", err)
+			}
+			if roundTripped != plaintext {
+				return "", true, errors.New("re-encrypted value does not match the secret it was made from")
+			}
+			return resealed, true, nil
+		})
+	if err != nil {
+		return results, err
+	}
+
+	if verifyOnly && remains {
+		return results, ErrPreviousKeyStillRequired
+	}
+	return results, nil
+}
+
+// proveSealingKey checks that currentKey really is the key tc seals with, before
+// any row is read or written.
+//
+// Without it, a wrong ENCRYPTION_KEY produces a sweep in which every row appears
+// to need re-encryption and every re-encryption then fails its own read-back —
+// technically fail-closed, but the operator sees "47 rows failed" during a key
+// rotation, which is the worst possible moment to have to work out whether the
+// data or the key is at fault.
+func proveSealingKey(tc, current *crypto.TokenCipher) error {
+	probe, err := tc.SealWithContext("sealing-key-probe", keyProbeContext)
+	if err != nil {
+		return fmt.Errorf("maintenance: could not seal the key probe: %w", err)
+	}
+	if _, err := current.OpenWithContext(probe, keyProbeContext); err != nil {
+		return fmt.Errorf("%w; re-encryption would write values the running service cannot read",
+			ErrEncryptionKeyMismatch)
+	}
+	return nil
+}

--- a/backend/internal/maintenance/rekeysecrets_test.go
+++ b/backend/internal/maintenance/rekeysecrets_test.go
@@ -1,0 +1,534 @@
+package maintenance
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/terraform-registry/terraform-registry/internal/crypto"
+)
+
+// Key rotation completion (#848). bind-secrets skips a row it can already open
+// under its own context, and OpenWithContext falls back to
+// ENCRYPTION_KEY_PREVIOUS — so a row bound BEFORE a rotation stays sealed under
+// the old key forever, and nothing says so. The rotation therefore never ends:
+// the previous key can never be dropped.
+//
+// The properties an operator relies on here are the same ones bind-secrets has
+// to have, against a harder failure mode. A mistake in a binding sweep leaves a
+// readable secret; a mistake here can write a value that only the key you are
+// about to delete could open.
+
+// rotation is the state an operator is actually in mid-rotation: everything at
+// rest was sealed under `previous`, the deployment now runs with `currentKey`
+// and keeps `previous` as the decryption fallback.
+//
+// `current` is the same key as `currentKey` with NO fallback — the oracle the
+// tests use to assert "this row no longer needs the previous key", which is
+// exactly what RekeySecrets builds internally and what the gate means.
+type rotation struct {
+	previous   *crypto.TokenCipher
+	dual       *crypto.TokenCipher
+	current    *crypto.TokenCipher
+	currentKey []byte
+}
+
+func newRotation(t *testing.T) rotation {
+	t.Helper()
+	previousKey, currentKey := make([]byte, 32), make([]byte, 32)
+	for i := range previousKey {
+		previousKey[i] = byte(i + 3)
+		currentKey[i] = byte(200 - i)
+	}
+	previous, err := crypto.NewTokenCipher(previousKey)
+	if err != nil {
+		t.Fatalf("previous cipher: %v", err)
+	}
+	dual, err := crypto.NewTokenCipherWithPrevious(currentKey, previousKey)
+	if err != nil {
+		t.Fatalf("dual cipher: %v", err)
+	}
+	current, err := crypto.NewTokenCipher(currentKey)
+	if err != nil {
+		t.Fatalf("current cipher: %v", err)
+	}
+	return rotation{previous: previous, dual: dual, current: current, currentKey: currentKey}
+}
+
+// rekeyRowID is the row every single-row test serves. A uuid because several
+// context functions are documented as taking one, even though they only
+// concatenate.
+const rekeyRowID = "77777777-7777-7777-7777-777777777777"
+
+// driveColumn primes a whole registry sweep in which `col` is the only column
+// holding a row, serves `sealed` for it, and returns a pointer to whatever
+// ciphertext is written back.
+//
+// It is derived from the column itself rather than from a per-column fixture
+// table, including the config-blob singletons whose listing reads a JSON
+// document and whose write is a read-modify-write of it. That is deliberate:
+// the tests below iterate `columns`, so a column added to the registry is
+// exercised by every one of them without anyone remembering to add a fixture —
+// and the requirement here is that rekeying covers EVERY registered column, not
+// a representative sample of them.
+func driveColumn(t *testing.T, mock sqlmock.Sqlmock, col column, sealed string, expectWrite bool) *string {
+	t.Helper()
+	stored := new(string)
+	for _, c := range columns {
+		if c.name != col.name {
+			mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "sealed"}))
+			continue
+		}
+		if c.singleton {
+			blobColumn, path := blobNameParts(t, c.name)
+			doc := blobDocument(path, sealed)
+			mock.ExpectQuery("SELECT " + blobColumn).
+				WillReturnRows(sqlmock.NewRows([]string{blobColumn}).AddRow(doc))
+			if expectWrite {
+				// The write re-reads the blob so it rewrites what is stored
+				// rather than a stale copy from the listing.
+				mock.ExpectQuery("SELECT " + blobColumn).
+					WillReturnRows(sqlmock.NewRows([]string{blobColumn}).AddRow(doc))
+				mock.ExpectExec("UPDATE system_settings SET " + blobColumn).
+					WithArgs(blobFieldCapture{path: path, into: stored}).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+			continue
+		}
+		mock.ExpectQuery("SELECT").
+			WillReturnRows(sqlmock.NewRows([]string{"id", "sealed"}).AddRow(rekeyRowID, sealed))
+		if expectWrite {
+			mock.ExpectExec("UPDATE").
+				WithArgs(sqlmock.AnyArg(), capturedArg{got: stored}).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+		}
+	}
+	return stored
+}
+
+// blobNameParts splits a singleton column's name back into the blob column and
+// the field path inside it. blobField builds the name from exactly these two
+// pieces, so reading them back keeps the driver honest for any blob field added
+// later rather than hard-coding the two that exist today.
+func blobNameParts(t *testing.T, name string) (string, []string) {
+	t.Helper()
+	blobColumn, dotted, ok := strings.Cut(strings.TrimPrefix(name, "system_settings."), ":")
+	if !ok {
+		t.Fatalf("singleton column %q does not have the system_settings.<blob>:<path> shape "+
+			"the driver relies on", name)
+	}
+	return blobColumn, strings.Split(dotted, ".")
+}
+
+// blobDocument builds a config blob holding `sealed` at `path`.
+func blobDocument(path []string, sealed string) []byte {
+	doc := map[string]any{"an_unrelated_setting": true}
+	cur := doc
+	for _, step := range path[:len(path)-1] {
+		next := map[string]any{"an_unrelated_nested_setting": 1}
+		cur[step] = next
+		cur = next
+	}
+	cur[path[len(path)-1]] = sealed
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}
+
+// blobFieldCapture records the ciphertext a blob rewrite left at `path`.
+type blobFieldCapture struct {
+	path []string
+	into *string
+}
+
+func (b blobFieldCapture) Match(v driver.Value) bool {
+	var raw []byte
+	switch x := v.(type) {
+	case []byte:
+		raw = x
+	case string:
+		raw = []byte(x)
+	default:
+		return false
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return false
+	}
+	s, _ := blobLookup(doc, b.path)
+	*b.into = s
+	return true
+}
+
+// The defect, over the whole registry: a row that is already BOUND but sealed
+// under the previous key must be re-encrypted onto the current one.
+//
+// Iterating `columns` rather than naming a column is the point — the gate this
+// feeds says "the previous key can be deleted", and that claim is only as wide
+// as the set of columns actually swept.
+func TestRekeySecrets_ReEncryptsEveryRegisteredColumnOntoTheCurrentKey(t *testing.T) {
+	for _, col := range columns {
+		t.Run(col.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			r := newRotation(t)
+
+			secret := "secret-for-" + col.name
+			aad := col.context(rekeyRowID)
+			boundUnderPrevious, err := r.previous.SealWithContext(secret, aad)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stored := driveColumn(t, mock, col, boundUnderPrevious, true)
+
+			res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, false)
+			if err != nil {
+				t.Fatalf("RekeySecrets: %v", err)
+			}
+			if got := res[col.name]; got.Converted != 1 || got.Failed != 0 {
+				t.Fatalf("result = %s; want the row re-encrypted", got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("the re-encrypted value was not written back: %v", err)
+			}
+
+			// The whole point of the run: the stored value no longer needs the
+			// previous key.
+			got, err := r.current.OpenWithContext(*stored, aad)
+			if err != nil || got != secret {
+				t.Fatalf("re-encrypted value does not open under the CURRENT key alone: (%q, %v)", got, err)
+			}
+			// ...and the binding survived the re-encryption. A singleton has no
+			// row axis to be moved along, so there is nothing to assert for it.
+			if !col.singleton {
+				if _, err := r.current.OpenWithContext(*stored, col.context("some-other-row")); err == nil {
+					t.Error("re-encrypted value opens under another row's context; the binding was dropped")
+				}
+			}
+		})
+	}
+}
+
+// Re-running must write nothing. A rekey that rewrites every row on every
+// invocation turns a routine verification into a full credential rewrite, and
+// an interrupted run into an unbounded one.
+func TestRekeySecrets_LeavesARowAlreadyOnTheCurrentKeyAlone(t *testing.T) {
+	for _, col := range columns {
+		t.Run(col.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			r := newRotation(t)
+
+			aad := col.context(rekeyRowID)
+			boundUnderCurrent, err := r.current.SealWithContext("already-rotated", aad)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// expectWrite=false: sqlmock fails an UPDATE that was not queued.
+			driveColumn(t, mock, col, boundUnderCurrent, false)
+
+			res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, false)
+			if err != nil {
+				t.Fatalf("RekeySecrets: %v", err)
+			}
+			if got := res[col.name]; got.AlreadyBound != 1 || got.Converted != 0 {
+				t.Fatalf("result = %s; want the row recognised as already on the current key", got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("a row already on the current key must not be rewritten: %v", err)
+			}
+		})
+	}
+}
+
+// A row that is BOTH unbound and on the previous key converges in one pass, so a
+// deployment that never ran bind-secrets is not left needing two commands in a
+// particular order.
+func TestRekeySecrets_ConvergesAnUnboundRowOnThePreviousKey(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	r := newRotation(t)
+
+	col := registeredColumn(t, chanCol)
+	aad := col.context(rekeyRowID)
+	legacy, err := r.previous.Seal("https://hooks.example.com/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stored := driveColumn(t, mock, col, legacy, true)
+
+	res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, false)
+	if err != nil {
+		t.Fatalf("RekeySecrets: %v", err)
+	}
+	if got := res[chanCol]; got.Converted != 1 || got.Failed != 0 {
+		t.Fatalf("result = %s; want one conversion", got)
+	}
+	if got, err := r.current.OpenWithContext(*stored, aad); err != nil || got != "https://hooks.example.com/a" {
+		t.Fatalf("value did not converge to bound-and-current in one pass: (%q, %v)", got, err)
+	}
+	if _, err := r.current.Open(*stored); err == nil {
+		t.Error("the re-encrypted value still opens WITHOUT a context; the rekey dropped the binding")
+	}
+}
+
+// The regression that names the bug. This row is exactly what bind-secrets
+// declares finished — bound, and openable through the dual-key fallback — while
+// still requiring the key the operator is about to delete.
+//
+// Asserting both commands on the SAME row is what makes it a regression test
+// rather than a restatement: bind-secrets verify passing here is correct and
+// must keep passing, and it is precisely why it cannot be the rotation gate.
+func TestRekeyVerify_FailsOnTheRowBindVerifyCallsDone(t *testing.T) {
+	r := newRotation(t)
+	col := registeredColumn(t, chanCol)
+	boundUnderPrevious, err := r.previous.SealWithContext("https://hooks.example.com/a", col.context(rekeyRowID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("bind-secrets verify reports nothing to do", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		driveColumn(t, mock, col, boundUnderPrevious, false)
+
+		if _, err := BindSecrets(context.Background(), db, r.dual, true); err != nil {
+			t.Fatalf("bind verify = %v; the row IS bound, so this must stay clean", err)
+		}
+	})
+
+	t.Run("rekey verify refuses", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		driveColumn(t, mock, col, boundUnderPrevious, false)
+
+		res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, true)
+		if !errors.Is(err, ErrPreviousKeyStillRequired) {
+			t.Fatalf("rekey verify = %v, want ErrPreviousKeyStillRequired so a runbook step can gate on it", err)
+		}
+		if res[chanCol].Converted != 1 {
+			t.Errorf("verify should report what WOULD be re-encrypted; got %s", res[chanCol])
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("verify must not write: %v", err)
+		}
+	})
+}
+
+// The zero that permits dropping ENCRYPTION_KEY_PREVIOUS.
+func TestRekeyVerify_SucceedsOnlyWhenEveryRowIsOnTheCurrentKey(t *testing.T) {
+	for _, col := range columns {
+		t.Run(col.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			r := newRotation(t)
+
+			boundUnderCurrent, err := r.current.SealWithContext("rotated", col.context(rekeyRowID))
+			if err != nil {
+				t.Fatal(err)
+			}
+			driveColumn(t, mock, col, boundUnderCurrent, false)
+
+			if _, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, true); err != nil {
+				t.Fatalf("verify with everything on the current key must succeed, got %v", err)
+			}
+		})
+	}
+}
+
+// A row nothing can decrypt is reported and stepped over, as in the binding
+// sweep — but unlike there it must also HOLD THE GATE SHUT. "One row could not
+// be read" is not evidence that deleting the previous key is safe.
+func TestRekeySecrets_OneUndecryptableRowIsSteppedOverAndBlocksTheGate(t *testing.T) {
+	r := newRotation(t)
+	col := registeredColumn(t, chanCol)
+
+	good, err := r.previous.SealWithContext("https://hooks.example.com/good", col.context("chan-good"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prime := func(mock sqlmock.Sqlmock, expectWrite bool) {
+		for _, c := range columns {
+			if c.name != chanCol {
+				mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "sealed"}))
+				continue
+			}
+			mock.ExpectQuery("SELECT id, encrypted_target FROM notification_channels").
+				WillReturnRows(channelRows(
+					[2]string{"chan-bad", "not-a-valid-ciphertext"},
+					[2]string{"chan-good", good},
+				))
+			if expectWrite {
+				mock.ExpectExec("UPDATE notification_channels").WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+		}
+	}
+
+	t.Run("the good row is still re-encrypted", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		prime(mock, true)
+
+		res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, false)
+		if err != nil {
+			t.Fatalf("RekeySecrets: %v", err)
+		}
+		if got := res[chanCol]; got.Failed != 1 || got.Converted != 1 {
+			t.Errorf("result = %s; want the bad row reported and the good one still re-encrypted", got)
+		}
+	})
+
+	t.Run("verify refuses while it remains", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		prime(mock, false)
+
+		if _, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, true); !errors.Is(err, ErrPreviousKeyStillRequired) {
+			t.Fatalf("verify = %v; an unreadable row is not proof the previous key can go", err)
+		}
+	})
+}
+
+// A ciphertext lifted out of another row must NOT be re-sealed into the row it
+// was planted in. Re-binding it here would launder the move the AAD exists to
+// detect — the rekey would hand an attacker the valid binding they could not
+// forge, and the audit trail would be a routine rotation.
+func TestRekeySecrets_RefusesToReBindAValueMovedFromAnotherRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	r := newRotation(t)
+
+	col := registeredColumn(t, chanCol)
+	// Sealed for a different channel, then written into this row.
+	planted, err := r.previous.SealWithContext("https://attacker.example.com/",
+		col.context("00000000-0000-0000-0000-00000000dead"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driveColumn(t, mock, col, planted, false)
+
+	res, err := RekeySecrets(context.Background(), db, r.dual, r.currentKey, false)
+	if err != nil {
+		t.Fatalf("RekeySecrets: %v", err)
+	}
+	if got := res[chanCol]; got.Failed != 1 || got.Converted != 0 {
+		t.Fatalf("result = %s; a value bound to another row must be reported, never re-bound here", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("nothing should have been written for a moved value: %v", err)
+	}
+}
+
+// The gate is only meaningful if the key it checks against is the key the
+// service seals with. Handed the wrong ENCRYPTION_KEY, the sweep must refuse up
+// front rather than report every row as needing work — or, far worse, re-seal
+// the estate under a key nothing else has.
+func TestRekeySecrets_RefusesAKeyTheCipherDoesNotSealWith(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	r := newRotation(t)
+
+	wrong := make([]byte, 32)
+	for i := range wrong {
+		wrong[i] = byte(i + 11)
+	}
+
+	// Prime the whole sweep as a run with nothing to do. Without this the test
+	// passes on the wrong evidence: sqlmock rejects the first unexpected query,
+	// so ANY failure to check the key still surfaces as "an error was returned".
+	// With it, a missing check produces a clean nil — which is the outcome that
+	// has to fail.
+	for range columns {
+		mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id", "sealed"}))
+	}
+
+	_, err = RekeySecrets(context.Background(), db, r.dual, wrong, false)
+	if !errors.Is(err, ErrEncryptionKeyMismatch) {
+		t.Fatalf("err = %v, want ErrEncryptionKeyMismatch", err)
+	}
+	if mock.ExpectationsWereMet() == nil {
+		t.Error("the sweep read rows before checking the key; the refusal must come first, " +
+			"because the alternative is re-sealing the estate under a key nothing else has")
+	}
+}
+
+func TestRekeySecrets_RequiresACipherAndAKey(t *testing.T) {
+	r := newRotation(t)
+	cases := []struct {
+		name string
+		tc   *crypto.TokenCipher
+		key  []byte
+	}{
+		{"no cipher", nil, r.currentKey},
+		{"no key", r.dual, nil},
+		{"short key", r.dual, []byte("too-short")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			db, _, err := sqlmock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := RekeySecrets(context.Background(), db, c.tc, c.key, false); err == nil {
+				t.Fatal("must be refused, not treated as 'nothing to do'")
+			}
+		})
+	}
+}
+
+// registeredColumn returns a column by name, failing if the registry no longer
+// has it — so a rename shows up as "this test drives nothing" rather than as a
+// silently vacuous pass.
+func registeredColumn(t *testing.T, name string) column {
+	t.Helper()
+	for _, c := range columns {
+		if c.name == name {
+			return c
+		}
+	}
+	t.Fatalf("column %q is not registered; the test drives nothing", name)
+	return column{}
+}

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -146,47 +146,51 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
    - Trigger a tag push or verify the webhook integration is functional.
    - Check logs for decryption errors (there should be none).
 
-6. **(Optional) Re-encrypt every stored secret** with the new key, removing the dependency on the previous key:
+6. **Re-encrypt every stored secret** under the new key, removing the dependency on the previous key:
 
    ```bash
-   terraform-registry bind-secrets
+   terraform-registry rekey-secrets
    ```
 
-   This decrypts through the dual-key path (so rows still on the old key are read via
-   `ENCRYPTION_KEY_PREVIOUS`) and re-encrypts with the **current** key. It covers every
-   encrypted column — SCM provider credentials, user OAuth tokens, storage-backend
-   credentials, the OIDC client secret, SMTP and LDAP passwords — not just
-   `scm_providers`.
+   This is the step that makes the rotation finishable, and it is **not optional** if you
+   intend to reach step 7. It reads each secret through the dual-key path (so rows still
+   on the old key are read via `ENCRYPTION_KEY_PREVIOUS`) and re-seals it with the
+   **current** key, under the same row binding it already had. It covers every swept
+   encrypted column — SCM provider client secrets and GitHub App private keys,
+   storage-backend credentials, the OIDC client secret, notification channel targets,
+   SMTP and LDAP passwords. See [What `rekey-secrets` covers](#what-rekey-secrets-covers)
+   for the two columns it deliberately does not.
 
-   **This only re-encrypts rows that are not yet row-bound.** Read that limitation
-   carefully, because it changes what this step can do for you:
+   A row already on the current key is left untouched, so the command is safe to re-run
+   and cheap to run again after an interruption. A row that is not yet bound to its row
+   is bound *and* re-encrypted in the same pass, so you do not need to run `bind-secrets`
+   first.
 
-   - **If you have not yet run the row-binding migration below** (the usual case on a
-     first rotation after upgrading), every row is unbound, so this one command does
-     both jobs: it binds each secret to its row *and* lands it on the current key.
-   - **If your rows are already bound**, this command detects them as converted and
-     **skips them** — it will not re-encrypt them onto the new key. That detection
-     succeeds via the dual-key fallback, so a bound row sitting on the previous key
-     looks "already done" to it. There is no re-encrypt-only command today; keep
-     `ENCRYPTION_KEY_PREVIOUS` in place, or re-enter those credentials, until one exists.
+   **Do not use `bind-secrets` for this.** It converts a ciphertext's *form* and skips any
+   row it can already open — and that check goes through the dual-key fallback, so a row
+   that is bound but still sealed under the previous key looks finished to it. On a first
+   rotation after upgrading, when nothing is bound yet, it happens to re-encrypt as a side
+   effect; on every rotation after that it re-encrypts nothing.
 
-   Confirm what actually happened before moving to step 7:
+7. **Remove the previous key** — but only once the gate says it is safe:
 
    ```bash
-   terraform-registry bind-secrets verify   # exits non-zero if any row is unbound
+   terraform-registry rekey-secrets verify   # exits non-zero while any row needs the previous key
    ```
 
-   Note this verifies **binding**, not which key a row is encrypted under. It passing
-   does not by itself prove you can safely drop `ENCRYPTION_KEY_PREVIOUS`.
+   **A zero exit from this command is the only thing that authorises removing
+   `ENCRYPTION_KEY_PREVIOUS`.** It writes nothing. It re-checks every swept row against a
+   cipher holding *only* the current key, so unlike `bind-secrets verify` it can tell
+   "opened with the current key" from "opened with the previous one" — which is the
+   question this step actually turns on.
 
-7. **Remove the previous key** once all tokens have been re-encrypted (or after a sufficient grace period).
+   A non-zero exit means at least one row still requires the previous key, or could not be
+   read at all. Both hold the gate shut, and both are logged per column with a row id.
 
-   Be sure step 6 actually re-encrypted, rather than skipping already-bound rows — see
-   the limitation there. Removing `ENCRYPTION_KEY_PREVIOUS` while any row is still
-   encrypted under it makes that secret **permanently unreadable**, by the service and
-   by `bind-secrets` alike, and it has to be re-entered by an administrator. When in
-   doubt, keep the previous key: an extra key in a secrets manager is cheap, and this
-   is not a reversible mistake.
+   Removing `ENCRYPTION_KEY_PREVIOUS` while any row is still encrypted under it makes that
+   secret **permanently unreadable**, by the service and by these commands alike, and it
+   has to be re-entered by an administrator. There is no undo. When the gate is red, keep
+   the previous key: an extra key in a secrets manager is cheap.
 
    ```bash
    kubectl create secret generic registry-secrets \
@@ -198,12 +202,71 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
 
 ### Timeline Recommendation
 
-| Step                             | When                        |
-| -------------------------------- | --------------------------- |
-| Set new key + previous key       | Day 0                       |
-| Rolling restart                  | Day 0                       |
-| Re-encrypt all tokens (optional) | Day 0 - Day 7               |
-| Remove previous key              | Day 7+ (after verification) |
+| Step                                            | When                                |
+| ----------------------------------------------- | ----------------------------------- |
+| Set new key + previous key                      | Day 0                               |
+| Rolling restart                                  | Day 0                               |
+| `rekey-secrets` (re-encrypt everything)         | Day 0 - Day 7                       |
+| `rekey-secrets verify` returns zero             | Before removing the previous key    |
+| Remove previous key                             | Day 7+ (only after the gate is green) |
+
+### Completing a Rotation: `rekey-secrets`
+
+**Why a second command.** `bind-secrets` answers *"is every ciphertext bound to its
+row?"*; `rekey-secrets` answers *"is every ciphertext readable without the previous
+key?"*. Those look like the same question and are not: a row can be bound and still be
+sealed under the key you are about to delete, and the read path will not tell you,
+because it silently falls back.
+
+**Run it:**
+
+```bash
+# Re-encrypt every swept secret under the current ENCRYPTION_KEY.
+terraform-registry rekey-secrets
+
+# Report what still needs ENCRYPTION_KEY_PREVIOUS, writing nothing.
+terraform-registry rekey-secrets verify
+```
+
+In a container the binary is at `/app/terraform-registry`, so:
+
+```bash
+kubectl exec deploy/terraform-registry -- /app/terraform-registry rekey-secrets verify
+```
+
+Both need `ENCRYPTION_KEY` and — until the rotation is complete — `ENCRYPTION_KEY_PREVIOUS`,
+the same values the server runs with. If `ENCRYPTION_KEY` is not the key the service is
+actually sealing with, the command refuses before reading a single row rather than
+re-encrypting your estate under a key nothing else has.
+
+**Safe to re-run and safe to interrupt.** Rows are written one at a time, and a row is
+skipped once it is bound and on the current key, so a second run is a no-op and an
+interrupted run is resumed by running it again. Nothing is written in `verify` mode.
+
+**A row reported as `failed`** could not be decrypted at all, or is bound to a *different*
+row than the one it was found in. Neither is re-sealed into place: doing so would mint a
+valid binding for a value that was moved, which is the exact tampering the binding exists
+to detect. A failed row is logged with its column and row id, and holds the verify gate
+shut — "one row could not be read" is not evidence that the previous key can go.
+
+<a id="what-rekey-secrets-covers"></a>
+
+**What `rekey-secrets` covers.** Every column the maintenance registry sweeps: notification
+channel targets, all four `storage_config` credentials, the OIDC client secret, the
+`scm_providers` client secret and GitHub App private key, and the SMTP and LDAP passwords
+inside `system_settings`. These are the secrets only an administrator could re-enter.
+
+Two encrypted columns are **not** swept, and `rekey-secrets verify` returning zero says
+nothing about them:
+
+| Column                                    | Why it is not swept                                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `scm_provider_tokens.access_token_encrypted` | A cache with an expiry. Entries are re-minted from the identity provider, so the table converts itself.       |
+| `scm_oauth_tokens.access_token_encrypted` / `refresh_token_encrypted` | Per-user OAuth tokens. Rows are re-sealed whenever a token is refreshed; a row that is not refreshed before the previous key is removed becomes unreadable, and that user re-links their SCM account to restore it. |
+
+Neither needs an administrator to recover, which is why the rotation is not blocked on
+them — but if you would rather not have users re-link, leave `ENCRYPTION_KEY_PREVIOUS` in
+place for a token-refresh cycle after the gate goes green.
 
 ### One-Time: Bind Stored Secrets to Their Rows
 
@@ -252,12 +315,17 @@ secret has to be re-entered by an administrator.
 
 **Interaction with key rotation** (this is the non-obvious part): the conversion
 decrypts through the same dual-key path the server uses, then re-encrypts with the
-**current** key. So running `bind-secrets` during a rotation window also completes
-the re-encryption step for every row it touches — the "Re-encrypt all tokens
-(optional)" line in the timeline above. Running it *before* removing
-`ENCRYPTION_KEY_PREVIOUS` is therefore strictly better than running it after: after
-removal, any row still on the old key can no longer be read by anything, including
-this command.
+**current** key — but only for rows it actually converts. A row that is *already*
+bound is skipped, and that skip is decided by an open that falls back to
+`ENCRYPTION_KEY_PREVIOUS`, so a bound row still sealed under the old key looks
+finished here.
+
+The practical consequence: `bind-secrets` re-encrypts as a side effect on the first
+rotation after upgrading (when nothing is bound yet) and on no rotation after that. It
+is not the re-encryption step and `bind-secrets verify` is not the rotation gate — use
+[`rekey-secrets`](#completing-a-rotation-rekey-secrets) for both. Run either one
+*before* removing `ENCRYPTION_KEY_PREVIOUS`: after removal, any row still on the old
+key can no longer be read by anything, including these commands.
 
 **Why `verify` exists.** Until it reports zero, the service must keep accepting
 unbound ciphertexts — which is the weakness being retired. It exits non-zero while


### PR DESCRIPTION
Closes #848

## The defect

`bind-secrets` decides a row needs no work by opening it under its own context:

```go
if _, err := tc.OpenWithContext(row.sealed, col.context(row.id)); err == nil {
    res.AlreadyBound++
    continue
}
```

`OpenWithContext` goes through the dual-key path, so a row that is **already bound but still sealed under `ENCRYPTION_KEY_PREVIOUS`** opens, counts as `AlreadyBound`, and is skipped — permanently. Nothing breaks and nothing signals. The previous key becomes undroppable, so the rotation the dual-key support exists for can never be finished.

Verified against the code before building anything:

| Premise | Result |
| --- | --- |
| A row bound under the previous key opens via the dual cipher's `OpenWithContext` → counted `AlreadyBound` | confirmed |
| A cipher holding only the current key rejects that row → usable as the which-key oracle | confirmed |
| Open-with-dual + `SealWithContext` lands the row on the current key | confirmed |
| Unbound + previous-key converges via `ReSealWithContext` | confirmed |

**The issue's suggested fix does not work.** Dropping the short-circuit and always calling `ReSealWithContext` fails with `ErrDecryptionFailed` on every already-bound row, because `ReSealWithContext` opens with **no** additional data — it is the unbound→bound converter. On a converted estate that mutation reports every row as `failed`. Re-encrypting a bound row means opening it *with* its context and sealing it again with the same context.

## What this adds

```
terraform-registry rekey-secrets          # re-seal every swept secret under ENCRYPTION_KEY
terraform-registry rekey-secrets verify   # non-zero while any row needs the previous key
```

`verify` returning zero is the exit criterion for dropping `ENCRYPTION_KEY_PREVIOUS`, exactly as `bind-secrets verify` is for the binding migration.

Distinguishing "opened with the current key" from "opened with the previous one" needs a cipher with no fallback, so `RekeySecrets` takes the raw `ENCRYPTION_KEY` bytes and builds one itself. Taking key bytes rather than a second `*TokenCipher` is deliberate — a caller cannot hand in something that quietly still has a previous key configured, which would make every verify run pass. A probe proves that key is the one the cipher seals with **before any row is read**.

Properties, each with a test:

- **Covers every column in the registry.** The tests iterate `columns` rather than naming one, so a column added to the registry is exercised by all of them without a fixture being written — including the `system_settings` config-blob singletons, whose listing reads JSON and whose write is a read-modify-write.
- **Idempotent.** A row already bound under the current key is not rewritten; a second run issues no `UPDATE`.
- **Converges in one pass.** A row that is both unbound and on the previous key ends up bound and current, so `bind-secrets` is not a prerequisite.
- **Cannot corrupt a row partway.** Writes are per row, not per sweep; a re-encrypted value is proved to open under the current key with the same plaintext *before* it overwrites a live credential. Mutation M7/M7b below shows that check turning a corrupting write into a reported failure.
- **Does not weaken the AAD.** A value bound to a *different* row is reported and left alone, never re-bound into the row it was found in — re-binding it would mint the valid binding an attacker who moved it could not forge, with a routine rotation as the audit trail. It also holds the gate shut.
- **Fail-closed gate.** An unreadable row blocks verify: "one row could not be read" is not evidence the previous key can go.

The per-row loop is shared with `BindSecrets` rather than copied, so "verify writes nothing", "one bad row does not abandon the rest" and "the whole registry is walked" are implemented once. The two sweeps differ only in the skip test and the conversion.

## Scope guard

`rekey_coverage_test.go` is an inventory guard over every AAD context function in the service: each must be declared either swept by a registered column or deliberately unswept **with a reason**, checked in both directions against the registry. A new encrypted column cannot silently narrow a gate that keeps reporting success.

Two columns stay unswept and are recorded as such, in the guard and in the doc, so the gate does not imply coverage it does not have:

| Column | Why |
| --- | --- |
| `scm_provider_tokens.access_token_encrypted` | Cache with an expiry; re-minted, so the table converts itself. |
| `scm_oauth_tokens.access_token_encrypted` / `refresh_token_encrypted` | Keyed by user **and** provider, which the single-row-id registry cannot express. A lost token is restored by the user re-linking, not by an administrator. |

Neither is reachable without widening `column.context` to carry composite keys, which is a change to the binding sweep as much as to this one and belongs to its own issue.

## Mutation table

Every guard was broken and watched to fail, then restored from a `cp` backup.

| # | Mutation | Expected to fail | Result |
| --- | --- | --- | --- |
| M1 | Skip test uses the **dual** cipher (the original bug) | rekey + verify tests | fired — all 10 columns |
| M2 | `verify` no longer returns `ErrPreviousKeyStillRequired` | gate tests | fired |
| M3 | Re-seal with a nil context (drop the AAD binding) | binding assertions | fired — all 10 columns |
| M4 | Unopenable row treated as "nothing to do" | failure + moved-value tests | fired |
| M5 | Never skip (rewrite every row every run) | idempotency test | fired — all 10 columns |
| M6 | Sealing-key probe removed | key-mismatch test | **INERT at first** — the test accepted any error, and sqlmock's own "unexpected query" error satisfied it. Fixed: sentinel `ErrEncryptionKeyMismatch` + the sweep primed as a clean no-op run, so a missing check returns nil. Re-run: fired. |
| M7 | Read-back proof removed **and** re-seal context mis-derived | corruption assertion | fired — and a corrupt value **was written** |
| M7b | Read-back proof kept, same mis-derived context | same | fired — the `UPDATE` was never issued; the row was reported and left intact |
| M8 | A column deleted from the registry | coverage guard | fired |
| M9 | An unswept declaration deleted | coverage guard | fired |
| M10 | A swept declaration deleted | coverage guard | fired (both directions) |
| M11 | Shared sweep never writes | existing bind-secrets tests | fired |
| M12 | Shared sweep counts a row failure as a skip | bind + rekey tests | fired |

M6 is the reason the rule exists: that guard was inert as first written and would have shipped looking green.

## Docs

`docs/secrets-rotation.md`: step 6 is now `rekey-secrets` and is no longer optional, step 7 is gated on `rekey-secrets verify` returning zero, the timeline reflects both, and a new section covers the command, what it sweeps and what it does not. The `bind-secrets` section now says plainly that it re-encrypts as a side effect on the first rotation after upgrading and on **no** rotation after that.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` all clean; `golangci-lint run` (v2.12.2, the CI pin) reports 0 issues on the changed packages.