### PR TITLE
fix(resilience): fail Azure DevOps listings on non-200 and recover background-goroutine panics

### DIFF
--- a/backend/internal/api/admin/scm_oauth.go
+++ b/backend/internal/api/admin/scm_oauth.go
@@ -532,7 +532,12 @@ func (h *SCMOAuthHandlers) RefreshToken(c *gin.Context) {
 	// token/provider lookups above.
 	newToken, err := connector.RenewToken(c.Request.Context(), refreshToken)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("token refresh failed: %v", err)})
+		// Same reasoning as the OAuth callback above: the connector error can carry the
+		// provider's token-endpoint diagnostics, which belong in the server log rather
+		// than in a response body. slog resolves *scm.APIError via LogValue, so the
+		// upstream failure reason is recorded here in full.
+		slog.Error("oauth token refresh failed", "provider_id", providerID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "token refresh failed"})
 		return
 	}
 

--- a/backend/internal/api/admin/scm_oauth_leak_test.go
+++ b/backend/internal/api/admin/scm_oauth_leak_test.go
@@ -1,0 +1,123 @@
+// scm_oauth_leak_test.go asserts that an SCM provider's raw response detail never reaches an
+// API client through an OAuth handler's JSON body. The connector errors these handlers format
+// can carry the provider's token-endpoint response (see scm.APIError.RemoteBody); the OAuth
+// callback that used to echo one verbatim is routed unauthenticated.
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// upstreamMarker stands in for whatever an SCM/OAuth provider puts in a failure body:
+// internal hostnames, app-registration identifiers, stack detail.
+const upstreamMarker = "upstream-internal-detail-must-not-leak"
+
+// leakyConnector is an scm.Connector whose token operations fail the way a real one does
+// when the provider rejects the exchange — with an *scm.APIError carrying the provider's
+// response body. It is registered against the GitLab kind, which is a valid provider type
+// whose real connector is not linked into this test binary (only github is imported here),
+// so nothing else in the package is affected.
+type leakyConnector struct{ scm.Connector }
+
+func leakyAPIError(message string) error {
+	err := scm.WrapRemoteError(http.StatusBadRequest, message, nil)
+	err.RemoteBody = `{"error":"invalid_client","error_description":"` + upstreamMarker + `"}`
+	return err
+}
+
+func (leakyConnector) Platform() scm.ProviderKind { return scm.ProviderGitLab }
+
+func (leakyConnector) RenewToken(context.Context, string) (*scm.AccessToken, error) {
+	return nil, leakyAPIError("failed to refresh token")
+}
+
+func (leakyConnector) CompleteAuthorization(context.Context, string) (*scm.AccessToken, error) {
+	return nil, leakyAPIError("oauth code exchange failed")
+}
+
+func registerLeakyConnector(t *testing.T) {
+	t.Helper()
+	scm.RegisterConnector(scm.ProviderGitLab, func(*scm.ConnectorSettings) (scm.Connector, error) {
+		return leakyConnector{}, nil
+	})
+}
+
+// TestRefreshToken_DoesNotEchoUpstreamBody drives POST /oauth/refresh to the connector call
+// and asserts the response body carries none of the provider's detail.
+func TestRefreshToken_DoesNotEchoUpstreamBody(t *testing.T) {
+	registerLeakyConnector(t)
+
+	tc := oauthCipher(t)
+	mock, r := newSCMOAuthRouterWithCipher(t, oauthUserUUID, tc)
+
+	encRefresh, err := tc.SealWithContext("stored-refresh-token",
+		scm.UserRefreshTokenContext(mustParseUUID(oauthUserUUID), mustParseUUID(oauthProviderID)))
+	if err != nil {
+		t.Fatalf("SealWithContext: %v", err)
+	}
+
+	// GetUserToken → an OAuth token record with a refresh token.
+	mock.ExpectQuery("SELECT.*FROM scm_oauth_tokens").
+		WillReturnRows(sqlmock.NewRows(scmOAuthTokenCols).AddRow(
+			"00000000-0000-0000-0000-000000000010",
+			oauthUserUUID,
+			oauthProviderID,
+			"access-token-encrypted",
+			encRefresh,
+			"bearer",
+			time.Now().Add(-time.Hour),
+			nil,
+			time.Now().Add(-24*time.Hour),
+			time.Now().Add(-24*time.Hour),
+		))
+
+	// GetProvider → a GitLab provider, which builds the leaky connector above.
+	mock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
+		WillReturnRows(oauthSCMProviderRowEncrypted(t, tc, "gitlab"))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost,
+		"/scm-providers/"+oauthProviderID+"/oauth/refresh", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (the refresh failed): body=%s", w.Code, w.Body.String())
+	}
+	// Pin the exact branch: every earlier failure in this handler (decrypt, connector
+	// build) also answers 500 with a non-empty error, so without this the test would pass
+	// having never reached the connector call it exists to cover.
+	assertNoUpstreamDetail(t, w.Body.String(), "token refresh failed")
+}
+
+// assertNoUpstreamDetail fails when a response body carries the provider's raw detail, and
+// requires the exact generic message the handler is supposed to substitute — which both
+// proves the request reached the branch under test and rejects an empty body that would
+// otherwise "pass" this guard while telling the caller nothing.
+func assertNoUpstreamDetail(t *testing.T, body, wantMessage string) {
+	t.Helper()
+
+	if strings.Contains(body, upstreamMarker) {
+		t.Errorf("response body %q echoes the upstream provider's response detail", body)
+	}
+	if strings.Contains(body, "invalid_client") {
+		t.Errorf("response body %q echoes the upstream provider's error code", body)
+	}
+
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("response body %q is not JSON: %v", body, err)
+	}
+	if payload.Error != wantMessage {
+		t.Fatalf("error = %q, want %q — the request did not reach the branch under test", payload.Error, wantMessage)
+	}
+}

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // maxConsumersResponseBytes bounds the sibling's "/consumers" JSON response
@@ -111,7 +112,7 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 		slog.Error("suite: failed to start sibling discovery client", "sibling_url", cfg.Suite.SiblingURL, "error", err)
 		return nil
 	}
-	go dc.Start(context.Background())
+	safego.Go(func() { dc.Start(context.Background()) })
 	return dc
 }
 

--- a/backend/internal/audit/shipper.go
+++ b/backend/internal/audit/shipper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // LogEntry represents a structured audit log entry
@@ -275,7 +276,7 @@ func NewWebhookShipperWithGuard(cfg *WebhookConfig, egress *httpsafe.Guard) (*We
 
 	// Start batch processor if batching is enabled
 	if cfg.BatchSize > 0 {
-		go ws.processBatches()
+		safego.Go(ws.processBatches)
 	}
 
 	return ws, nil

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -21,6 +21,7 @@ import (
 
 	identityauth "github.com/sethbacon/terraform-suite-identity/identity/auth"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // jwtIssuer stamps the iss claim on tokens this service generates.
@@ -305,7 +306,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 
 	stopCh := make(chan struct{})
 
-	go func() {
+	safego.Go(func() {
 		for {
 			select {
 			case event, ok := <-watcher.Events:
@@ -354,7 +355,7 @@ func StartJWTSecretFileWatch(secretFilePath string, overlapDuration time.Duratio
 				return
 			}
 		}
-	}()
+	})
 
 	return func() { close(stopCh) }, nil
 }

--- a/backend/internal/auth/statestore_memory.go
+++ b/backend/internal/auth/statestore_memory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // MemoryStateStore implements StateStore using an in-process map.
@@ -30,7 +32,7 @@ func NewMemoryStateStore(cleanupInterval time.Duration) *MemoryStateStore {
 		entries: make(map[string]*memoryEntry),
 		stopCh:  make(chan struct{}),
 	}
-	go s.cleanup(cleanupInterval)
+	safego.Go(func() { s.cleanup(cleanupInterval) })
 	return s
 }
 

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
@@ -132,7 +133,7 @@ func NewRateLimiter(config RateLimitConfig) *MemoryRateLimiter {
 	}
 
 	// Start cleanup goroutine
-	go rl.cleanup()
+	safego.Go(rl.cleanup)
 
 	return rl
 }

--- a/backend/internal/middleware/ratelimit_probe_test.go
+++ b/backend/internal/middleware/ratelimit_probe_test.go
@@ -1,0 +1,146 @@
+// ratelimit_probe_test.go guards how many times a single request is allowed to probe the
+// rate-limiter backend.
+//
+// For the Redis backend the quota probe is the quota spend: redis_rate's GCRA has no
+// peek-only operation, so RedisRateLimiter.RemainingTokens is implemented as a second
+// Allow() and consumes another unit. When the middleware called Allow() for the decision and
+// then RemainingTokens() for the X-RateLimit-Remaining header, every request cost two units
+// and operators got half the requests-per-minute they configured. The middleware now takes
+// the remaining count from the one Allow() it already made; these tests fail if a second
+// probe — of either kind — comes back.
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// countingRateLimiterBackend records every probe made against it and returns a remaining
+// count that is distinguishable per call, so a header populated from a second probe cannot
+// coincidentally match one populated from the first.
+type countingRateLimiterBackend struct {
+	mu               sync.Mutex
+	allowCalls       int
+	remainingCalls   int
+	allowedResponses []bool // consumed in order; the last value repeats
+}
+
+func (b *countingRateLimiterBackend) Allow(_ context.Context, _ string) (bool, int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.allowCalls++
+	allowed := true
+	if len(b.allowedResponses) > 0 {
+		idx := b.allowCalls - 1
+		if idx >= len(b.allowedResponses) {
+			idx = len(b.allowedResponses) - 1
+		}
+		allowed = b.allowedResponses[idx]
+	}
+	// Remaining shrinks with each probe, exactly as a GCRA bucket does.
+	return allowed, 100 - b.allowCalls, nil
+}
+
+func (b *countingRateLimiterBackend) RemainingTokens(_ context.Context, _ string) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.remainingCalls++
+	return 999, nil
+}
+
+func (b *countingRateLimiterBackend) Close() error { return nil }
+
+func (b *countingRateLimiterBackend) counts() (allow, remaining int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.allowCalls, b.remainingCalls
+}
+
+// TestRateLimitMiddlewares_ProbeTheBackendExactlyOnce covers every middleware that consults a
+// backend, on both the allowed and the rejected path. The rejected path matters as much as
+// the allowed one: a second probe there spends quota on a request that was already refused.
+func TestRateLimitMiddlewares_ProbeTheBackendExactlyOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	middlewares := map[string]func(RateLimiterBackend) gin.HandlerFunc{
+		"RateLimitMiddleware": RateLimitMiddleware,
+		"OrgRateLimitMiddleware": func(b RateLimiterBackend) gin.HandlerFunc {
+			return OrgRateLimitMiddleware(b, nil)
+		},
+		"PrincipalRateLimitMiddleware": func(b RateLimiterBackend) gin.HandlerFunc {
+			return PrincipalRateLimitMiddleware(b, nil)
+		},
+	}
+
+	decisions := map[string][]bool{
+		"allowed":  {true},
+		"rejected": {false},
+	}
+
+	for mwName, build := range middlewares {
+		for decision, responses := range decisions {
+			t.Run(mwName+"/"+decision, func(t *testing.T) {
+				backend := &countingRateLimiterBackend{allowedResponses: responses}
+
+				r := gin.New()
+				r.Use(build(backend))
+				r.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+				allow, remaining := backend.counts()
+				if allow != 1 {
+					t.Errorf("Allow called %d times for one request, want exactly 1 — each extra "+
+						"probe spends another unit of the operator's configured quota", allow)
+				}
+				if remaining != 0 {
+					t.Errorf("RemainingTokens called %d times, want 0 — on the Redis backend it is a "+
+						"second Allow() and consumes quota; use the remaining value Allow already returned",
+						remaining)
+				}
+
+				// The header must come from that single probe. 99 is what the first Allow
+				// returns; 999 is the counting backend's RemainingTokens answer.
+				if got := w.Header().Get("X-RateLimit-Remaining"); got != strconv.Itoa(99) {
+					t.Errorf("X-RateLimit-Remaining = %q, want %q (the value the single Allow probe returned)",
+						got, strconv.Itoa(99))
+				}
+			})
+		}
+	}
+}
+
+// TestOrgRateLimitMiddleware_ProbesEachBucketOnce extends the rule to the two-bucket path:
+// the individual and per-organization limiters are distinct buckets, so one probe each is
+// correct — but neither may be probed twice.
+func TestOrgRateLimitMiddleware_ProbesEachBucketOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	individual := &countingRateLimiterBackend{}
+	org := &countingRateLimiterBackend{}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("organization_id", "org-1"); c.Next() })
+	r.Use(OrgRateLimitMiddleware(individual, org))
+	r.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+
+	for name, backend := range map[string]*countingRateLimiterBackend{"individual": individual, "org": org} {
+		allow, remaining := backend.counts()
+		if allow != 1 {
+			t.Errorf("%s bucket: Allow called %d times, want exactly 1", name, allow)
+		}
+		if remaining != 0 {
+			t.Errorf("%s bucket: RemainingTokens called %d times, want 0", name, remaining)
+		}
+	}
+}

--- a/backend/internal/safego/goroutine_guard_test.go
+++ b/backend/internal/safego/goroutine_guard_test.go
@@ -1,0 +1,186 @@
+// goroutine_guard_test.go statically enforces the rule this package exists to serve: a
+// goroutine started anywhere under backend/internal must recover its own panics.
+//
+// Go does not propagate a panic from a goroutine to whoever started it, and gin.Recovery()
+// only guards the request goroutine. An unrecovered panic in any fire-and-forget goroutine
+// or background job — a nil map in an audit payload, an edge case in a scheduled job — takes
+// down the whole OS process and every tenant with it. safego.Go wraps that recover once, but
+// nothing in the type system stops the next `go func(){...}()` from being written bare, which
+// is exactly how the six long-lived background loops this guard was added alongside came to
+// be unprotected. This test parses the whole internal tree and fails when it happens again.
+package safego
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// internalTreeRoot is the directory walked by the guard: backend/internal, relative to this
+// package's directory.
+const internalTreeRoot = ".."
+
+// Non-empty-universe floors. A guard that certifies an empty file set is worse than no guard,
+// so the walk has to actually find the tree it claims to police.
+const (
+	minScannedFiles   = 100
+	minSafegoCallSite = 20
+)
+
+// TestGoroutineGuard_EveryGoStatementRecovers fails when a `go` statement under
+// backend/internal starts work that is not panic-guarded. There are exactly two shapes that
+// pass, and no path-based exemption list — an exemption keyed on a filename becomes a
+// standing permission for whatever else is later written into that file:
+//
+//   - `go func(){ defer func(){ recover() }(); ... }()` — the goroutine recovers inline. This
+//     is what safego.Go itself does, and what a caller must do when it needs the recovered
+//     panic to set a variable the caller reads (see services/storage_migration.go).
+//   - anything else must be launched with safego.Go(...), which emits no `go` statement at
+//     the call site and so is invisible to this walk.
+func TestGoroutineGuard_EveryGoStatementRecovers(t *testing.T) {
+	found := 0
+
+	for _, pf := range parseInternalTree(t) {
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			gostmt, ok := n.(*ast.GoStmt)
+			if !ok {
+				return true
+			}
+			found++
+
+			lit, ok := gostmt.Call.Fun.(*ast.FuncLit)
+			if !ok {
+				t.Errorf("%s: `go %s(...)` starts a goroutine that cannot recover its own panic — "+
+					"launch it with safego.Go(func() { ... }) so a panic is logged instead of "+
+					"killing the process", pf.pos(gostmt), types.ExprString(gostmt.Call.Fun))
+				return true
+			}
+			if !bodyDefersRecover(lit.Body) {
+				t.Errorf("%s: `go func(){...}()` has no deferred recover() — use safego.Go, or "+
+					"defer a recover() as the first thing the literal does if the caller needs "+
+					"the recovered value", pf.pos(gostmt))
+			}
+			return true
+		})
+	}
+
+	if found == 0 {
+		t.Fatalf("found no `go` statements under %s — the guard is not seeing the tree it is "+
+			"meant to police", internalTreeRoot)
+	}
+}
+
+// TestGoroutineGuard_SafegoIsTheEstablishedRoute pins the other half of the rule: the guard
+// above is only meaningful while safego.Go is what background work actually uses. If the
+// helper fell out of use, every `go` statement could vanish from the tree and the guard would
+// pass over a codebase that had simply moved its unguarded goroutines somewhere else.
+func TestGoroutineGuard_SafegoIsTheEstablishedRoute(t *testing.T) {
+	callSites := 0
+
+	for _, pf := range parseInternalTree(t) {
+		if strings.HasSuffix(filepath.ToSlash(pf.path), "safego/safego.go") {
+			continue
+		}
+		ast.Inspect(pf.file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if types.ExprString(call.Fun) == "safego.Go" {
+				callSites++
+			}
+			return true
+		})
+	}
+
+	if callSites < minSafegoCallSite {
+		t.Fatalf("found %d safego.Go call sites under %s, want at least %d — background work has "+
+			"stopped routing through the panic-recovering launcher", callSites, internalTreeRoot, minSafegoCallSite)
+	}
+}
+
+// bodyDefersRecover reports whether block defers a function that calls recover(). Only
+// top-level defers in the goroutine body count: a recover() buried in a nested call runs on
+// that call's stack frame, where it does not stop the goroutine's panic.
+func bodyDefersRecover(block *ast.BlockStmt) bool {
+	if block == nil {
+		return false
+	}
+	for _, stmt := range block.List {
+		deferred, ok := stmt.(*ast.DeferStmt)
+		if !ok {
+			continue
+		}
+		if callsRecover(deferred.Call) {
+			return true
+		}
+	}
+	return false
+}
+
+// callsRecover reports whether call is `recover()` or a function literal containing one.
+func callsRecover(call *ast.CallExpr) bool {
+	if types.ExprString(call.Fun) == "recover" {
+		return true
+	}
+	lit, ok := call.Fun.(*ast.FuncLit)
+	if !ok {
+		return false
+	}
+	found := false
+	ast.Inspect(lit.Body, func(n ast.Node) bool {
+		inner, ok := n.(*ast.CallExpr)
+		if ok && types.ExprString(inner.Fun) == "recover" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+type parsedFile struct {
+	path string
+	file *ast.File
+	fset *token.FileSet
+}
+
+func (p parsedFile) pos(n ast.Node) string {
+	return p.fset.Position(n.Pos()).String()
+}
+
+// parseInternalTree parses every non-test .go file under backend/internal.
+func parseInternalTree(t *testing.T) []parsedFile {
+	t.Helper()
+
+	var out []parsedFile
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(internalTreeRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return perr
+		}
+		out = append(out, parsedFile{path: path, file: f, fset: fset})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", internalTreeRoot, err)
+	}
+
+	if len(out) < minScannedFiles {
+		t.Fatalf("scanned %d files under %s, want at least %d — the guard is looking at the wrong tree",
+			len(out), internalTreeRoot, minScannedFiles)
+	}
+	return out
+}

--- a/backend/internal/scm/azuredevops/connector.go
+++ b/backend/internal/scm/azuredevops/connector.go
@@ -11,6 +11,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -225,24 +226,21 @@ func (c *AzureDevOpsConnector) FetchRepositories(ctx context.Context, creds *scm
 
 		req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("azuredevops: create repositories request for project %q: %w", project.Name, err)
 		}
 		c.setAuthHeaders(req, creds)
-		// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-		resp, err := scm.HTTPClient.Do(req)
-		if err != nil {
-			continue
-		}
 
 		var result struct {
 			Value []adoRepo `json:"value"`
 		}
 
-		if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-			_ = resp.Body.Close()
-			continue
+		// A failure here used to `continue`, which returned the repositories gathered so
+		// far with a nil error — an expired token (ADO answers 203 with an HTML sign-in
+		// page) produced a silently short listing that every caller read as a complete,
+		// successful result. Fail the whole call instead.
+		if err := doJSON(req, "failed to fetch repositories", nil, &result); err != nil {
+			return nil, err
 		}
-		_ = resp.Body.Close()
 
 		for _, adoRepo := range result.Value {
 			allRepos = append(allRepos, c.convertRepo(&adoRepo, project.Name))
@@ -265,7 +263,7 @@ func (c *AzureDevOpsConnector) FetchRepository(ctx context.Context, creds *scm.A
 	c.setAuthHeaders(req, creds)
 
 	var adoRepo adoRepo
-	if err := scm.DoJSON(req, "failed to fetch repository", scm.ErrRepoNotFound, &adoRepo); err != nil {
+	if err := doJSON(req, "failed to fetch repository", scm.ErrRepoNotFound, &adoRepo); err != nil {
 		return nil, err
 	}
 
@@ -310,7 +308,7 @@ func (c *AzureDevOpsConnector) FetchBranches(ctx context.Context, creds *scm.Acc
 		} `json:"value"`
 	}
 
-	if err := scm.DoJSON(req, "failed to fetch branches", nil, &result); err != nil {
+	if err := doJSON(req, "failed to fetch branches", nil, &result); err != nil {
 		return nil, err
 	}
 
@@ -330,30 +328,12 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 	// peelTags=true causes ADO to include peeledObjectId for annotated tags,
 	// which is the actual commit SHA (objectId for annotated tags is the tag object SHA, not the commit).
 	endpoint := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/refs?filter=tags/&peelTags=true&api-version=7.0", c.baseURL, c.organization, ownerName, repoName)
-	fmt.Printf("[FetchTags] GET %s\n", endpoint)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("azuredevops: create tags request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch tags", err)
-	}
-	defer resp.Body.Close()
-
-	// Azure DevOps returns 203 with an HTML sign-in page when the token is expired
-	// instead of a proper 401. Normalise it so retry logic can detect it.
-	actualStatus := resp.StatusCode
-	if actualStatus == http.StatusNonAuthoritativeInfo {
-		actualStatus = http.StatusUnauthorized
-	}
-	if actualStatus != http.StatusOK {
-		body := readErrorBody(resp)
-		return nil, scm.WrapRemoteError(actualStatus, fmt.Sprintf("failed to fetch tags: HTTP %d: %s", resp.StatusCode, body), nil)
-	}
 
 	var result struct {
 		Value []struct {
@@ -363,8 +343,8 @@ func (c *AzureDevOpsConnector) FetchTags(ctx context.Context, creds *scm.AccessT
 		} `json:"value"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("azuredevops: decode tags: %w", err)
+	if err := doJSON(req, "failed to fetch tags", nil, &result); err != nil {
+		return nil, err
 	}
 
 	tags := make([]*scm.GitTag, len(result.Value))
@@ -420,7 +400,7 @@ func (c *AzureDevOpsConnector) FetchCommit(ctx context.Context, creds *scm.Acces
 		RemoteURL string `json:"remoteUrl"`
 	}
 
-	if err := scm.DoJSON(req, "failed to fetch commit", scm.ErrCommitNotFound, &adoCommit); err != nil {
+	if err := doJSON(req, "failed to fetch commit", scm.ErrCommitNotFound, &adoCommit); err != nil {
 		return nil, err
 	}
 
@@ -564,7 +544,7 @@ func (c *AzureDevOpsConnector) fetchRepoAndProjectIDs(ctx context.Context, creds
 			ID string `json:"id"`
 		} `json:"project"`
 	}
-	if err := scm.DoJSON(req, "failed to fetch repository IDs", nil, &result); err != nil {
+	if err := doJSON(req, "failed to fetch repository IDs", nil, &result); err != nil {
 		return "", "", err
 	}
 	return result.Project.ID, result.ID, nil
@@ -736,17 +716,21 @@ func (c *AzureDevOpsConnector) setAuthHeaders(req *http.Request, creds *scm.Acce
 	req.Header.Set("Content-Type", "application/json")
 }
 
-// readErrorBody reads up to 512 bytes from an error response body for inclusion in error messages.
-func readErrorBody(resp *http.Response) string {
-	if resp == nil || resp.Body == nil {
-		return ""
+// doJSON is the single entry point for every Azure DevOps JSON API call. It delegates to
+// scm.DoJSON — the shared SSRF-safe send/status-check/size-capped-decode helper — and then
+// applies the one status quirk that is specific to this provider: Azure DevOps and Microsoft
+// Entra ID answer an expired or invalid bearer token with HTTP 203 Non-Authoritative
+// Information carrying an HTML sign-in page, not the expected 401. Callers
+// (internal/api/admin/scm_oauth.go) decide whether to refresh the OAuth token by comparing
+// APIError.StatusCode, so the code is normalised here, once, rather than in each method that
+// happens to remember to do it.
+func doJSON(req *http.Request, reason string, notFound error, out any) error {
+	err := scm.DoJSON(req, reason, notFound, out)
+	var apiErr *scm.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNonAuthoritativeInfo {
+		apiErr.StatusCode = http.StatusUnauthorized
 	}
-	buf := make([]byte, 512)
-	n, _ := resp.Body.Read(buf)
-	if n == 0 {
-		return ""
-	}
-	return strings.TrimSpace(string(buf[:n]))
+	return err
 }
 
 func (c *AzureDevOpsConnector) fetchProjects(ctx context.Context, creds *scm.AccessToken) ([]adoProject, error) {
@@ -757,30 +741,13 @@ func (c *AzureDevOpsConnector) fetchProjects(ctx context.Context, creds *scm.Acc
 		return nil, fmt.Errorf("azuredevops: create projects request: %w", err)
 	}
 	c.setAuthHeaders(req, creds)
-	// #nosec G704 -- request is routed through the SSRF-safe egress client (internal/httpsafe): scheme allow-list, resolve-and-pin private-range deny-list, per-hop redirect re-validation
-	resp, err := scm.HTTPClient.Do(req)
-	if err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to fetch projects", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		// Azure DevOps / Entra ID returns HTTP 203 Non-Authoritative when the
-		// bearer token is expired or invalid rather than the expected 401.
-		// Normalise 203 to 401 so that callers' token-refresh logic triggers.
-		reportedStatus := resp.StatusCode
-		if reportedStatus == http.StatusNonAuthoritativeInfo {
-			reportedStatus = http.StatusUnauthorized
-		}
-		return nil, scm.WrapRemoteError(reportedStatus, fmt.Sprintf("failed to fetch projects (HTTP %d)", resp.StatusCode), nil)
-	}
 
 	var result struct {
 		Value []adoProject `json:"value"`
 	}
 
-	if err := json.NewDecoder(scm.LimitBody(resp.Body)).Decode(&result); err != nil {
-		return nil, scm.WrapRemoteError(0, "failed to parse project list", err)
+	if err := doJSON(req, "failed to fetch projects", nil, &result); err != nil {
+		return nil, err
 	}
 
 	return result.Value, nil

--- a/backend/internal/scm/azuredevops/connector_status_test.go
+++ b/backend/internal/scm/azuredevops/connector_status_test.go
@@ -1,0 +1,235 @@
+// connector_status_test.go covers the response-status handling every Azure DevOps listing
+// call has to share: a non-200 must become an error (never a silently short result), and the
+// HTTP 203 sign-in page ADO returns instead of 401 for an expired token must be reported as
+// 401 so the callers' token-refresh-and-retry path fires.
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+// adoSignInPage is what Azure DevOps actually returns when the bearer token has expired:
+// HTTP 203 Non-Authoritative Information carrying an HTML sign-in page instead of a 401.
+const adoSignInPage = `<!DOCTYPE html><html><head><title>Sign In</title></head><body>Sign in to Azure DevOps</body></html>`
+
+// listingCall is one Azure DevOps listing method, reduced to a no-result call so the whole
+// class can be driven from one table. Every entry must surface an upstream non-200 as an
+// error rather than an empty or short success.
+type listingCall struct {
+	name string
+	call func(c *AzureDevOpsConnector) error
+}
+
+func listingCalls() []listingCall {
+	ctx := context.Background()
+	return []listingCall{
+		{"FetchRepositories", func(c *AzureDevOpsConnector) error {
+			_, err := c.FetchRepositories(ctx, creds(), scm.DefaultPagination())
+			return err
+		}},
+		{"SearchRepositories", func(c *AzureDevOpsConnector) error {
+			_, err := c.SearchRepositories(ctx, creds(), "terraform", scm.DefaultPagination())
+			return err
+		}},
+		{"FetchRepository", func(c *AzureDevOpsConnector) error {
+			_, err := c.FetchRepository(ctx, creds(), "proj", "repo")
+			return err
+		}},
+		{"FetchBranches", func(c *AzureDevOpsConnector) error {
+			_, err := c.FetchBranches(ctx, creds(), "proj", "repo", scm.DefaultPagination())
+			return err
+		}},
+		{"FetchTags", func(c *AzureDevOpsConnector) error {
+			_, err := c.FetchTags(ctx, creds(), "proj", "repo", scm.DefaultPagination())
+			return err
+		}},
+		{"FetchCommit", func(c *AzureDevOpsConnector) error {
+			_, err := c.FetchCommit(ctx, creds(), "proj", "repo", "deadbeef")
+			return err
+		}},
+	}
+}
+
+// TestListingCalls_ExpiredTokenReportedAs401 pins the 203→401 normalisation across the whole
+// listing surface. The assertion is on the *scm.APIError status code specifically — the
+// handlers in internal/api/admin/scm_oauth.go decide whether to refresh the OAuth token by
+// comparing that code, so "some error was returned" is not enough to keep them working.
+func TestListingCalls_ExpiredTokenReportedAs401(t *testing.T) {
+	for _, lc := range listingCalls() {
+		t.Run(lc.name, func(t *testing.T) {
+			_, c := newTestConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(http.StatusNonAuthoritativeInfo)
+				_, _ = w.Write([]byte(adoSignInPage))
+			})
+
+			err := lc.call(c)
+			if err == nil {
+				t.Fatalf("%s returned nil error for an HTTP 203 sign-in page", lc.name)
+			}
+			var apiErr *scm.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("%s error %v (%T) is not a *scm.APIError; callers cannot detect the expired token",
+					lc.name, err, err)
+			}
+			if apiErr.StatusCode != http.StatusUnauthorized {
+				t.Errorf("%s StatusCode = %d, want %d (ADO's 203 sign-in page must normalise to 401)",
+					lc.name, apiErr.StatusCode, http.StatusUnauthorized)
+			}
+		})
+	}
+}
+
+// TestListingCalls_NonOKStatusIsAnError covers the rest of the status class: any non-200 has
+// to reach the caller as an error carrying the upstream status, not as an empty success.
+func TestListingCalls_NonOKStatusIsAnError(t *testing.T) {
+	statuses := []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+	}
+
+	for _, lc := range listingCalls() {
+		for _, status := range statuses {
+			t.Run(lc.name+"/"+http.StatusText(status), func(t *testing.T) {
+				_, c := newTestConnector(t, func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(`{"message":"upstream failure"}`))
+				})
+
+				err := lc.call(c)
+				if err == nil {
+					t.Fatalf("%s returned nil error for upstream HTTP %d", lc.name, status)
+				}
+				var apiErr *scm.APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("%s error %v (%T) is not a *scm.APIError", lc.name, err, err)
+				}
+				if apiErr.StatusCode != status {
+					t.Errorf("%s StatusCode = %d, want %d", lc.name, apiErr.StatusCode, status)
+				}
+			})
+		}
+	}
+}
+
+// TestFetchRepositories_PerProjectFailureIsNotASilentShortList is the reported defect: the
+// projects call succeeds, then one project's repository listing fails. Returning the repos
+// gathered so far looks like a successful result to every caller, so a browsing user silently
+// sees a subset of their repositories. The call must fail instead.
+func TestFetchRepositories_PerProjectFailureIsNotASilentShortList(t *testing.T) {
+	tests := []struct {
+		name         string
+		writeFailure func(w http.ResponseWriter)
+	}{
+		{"expired token sign-in page", func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusNonAuthoritativeInfo)
+			_, _ = w.Write([]byte(adoSignInPage))
+		}},
+		{"server error", func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}},
+		{"undecodable body", func(w http.ResponseWriter) {
+			_, _ = w.Write([]byte(`{"value": not-json`))
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Two projects: the first lists one repository fine, the second fails.
+			var repoCalls int
+			_, c := newTestConnector(t, func(w http.ResponseWriter, r *http.Request) {
+				if !isRepoListRequest(r) {
+					_ = json.NewEncoder(w).Encode(struct {
+						Value []adoProject `json:"value"`
+					}{Value: []adoProject{{ID: "p1", Name: "project1"}, {ID: "p2", Name: "project2"}}})
+					return
+				}
+				repoCalls++
+				if repoCalls == 1 {
+					_ = json.NewEncoder(w).Encode(struct {
+						Value []adoRepo `json:"value"`
+					}{Value: []adoRepo{{ID: "r1", Name: "terraform-module-network"}}})
+					return
+				}
+				tc.writeFailure(w)
+			})
+
+			result, err := c.FetchRepositories(context.Background(), creds(), scm.DefaultPagination())
+			if err == nil {
+				t.Fatalf("FetchRepositories returned a short list of %d repo(s) with nil error; "+
+					"a truncated listing must be reported as a failure", len(result.Repos))
+			}
+			if result != nil {
+				t.Errorf("FetchRepositories returned %+v alongside an error; callers must not see partial results", result)
+			}
+		})
+	}
+}
+
+// TestFetchRepositories_ErrorsCarryNoUpstreamBody keeps SCM response content out of the error
+// text: these errors are formatted straight into the JSON body of the repository-listing
+// endpoint, so an HTML sign-in page or an upstream diagnostic must not ride along.
+func TestFetchRepositories_ErrorsCarryNoUpstreamBody(t *testing.T) {
+	const marker = "Sign in to Azure DevOps"
+
+	_, c := newTestConnector(t, func(w http.ResponseWriter, r *http.Request) {
+		if !isRepoListRequest(r) {
+			_ = json.NewEncoder(w).Encode(struct {
+				Value []adoProject `json:"value"`
+			}{Value: []adoProject{{ID: "p1", Name: "project1"}}})
+			return
+		}
+		w.WriteHeader(http.StatusNonAuthoritativeInfo)
+		_, _ = w.Write([]byte(adoSignInPage))
+	})
+
+	_, err := c.FetchRepositories(context.Background(), creds(), scm.DefaultPagination())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), marker) {
+		t.Errorf("error text %q embeds the upstream response body", err.Error())
+	}
+}
+
+// TestFetchRepositories_SucceedsAcrossProjects is the happy path the failure cases above must
+// not have broken: every project's repositories are collected and attributed to its project.
+func TestFetchRepositories_SucceedsAcrossProjects(t *testing.T) {
+	_, c := newTestConnector(t, func(w http.ResponseWriter, r *http.Request) {
+		if !isRepoListRequest(r) {
+			_ = json.NewEncoder(w).Encode(struct {
+				Value []adoProject `json:"value"`
+			}{Value: []adoProject{{ID: "p1", Name: "project1"}, {ID: "p2", Name: "project2"}}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(struct {
+			Value []adoRepo `json:"value"`
+		}{Value: []adoRepo{{ID: "r1", Name: "mod"}}})
+	})
+
+	result, err := c.FetchRepositories(context.Background(), creds(), scm.DefaultPagination())
+	if err != nil {
+		t.Fatalf("FetchRepositories error: %v", err)
+	}
+	if len(result.Repos) != 2 {
+		t.Fatalf("Repos len = %d, want 2 (one per project)", len(result.Repos))
+	}
+	if result.Repos[0].FullName != "project1/mod" || result.Repos[1].FullName != "project2/mod" {
+		t.Errorf("unexpected repo names: %q, %q", result.Repos[0].FullName, result.Repos[1].FullName)
+	}
+}
+
+// isRepoListRequest distinguishes the per-project repository listing from the projects
+// listing that FetchRepositories issues first.
+func isRepoListRequest(r *http.Request) bool {
+	return strings.Contains(r.URL.Path, "/_apis/git/repositories")
+}

--- a/backend/internal/scm/azuredevops/connector_test.go
+++ b/backend/internal/scm/azuredevops/connector_test.go
@@ -560,33 +560,6 @@ func TestParseDelivery_InvalidJSON(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// readErrorBody
-// ---------------------------------------------------------------------------
-
-func TestReadErrorBody_NilResponse(t *testing.T) {
-	result := readErrorBody(nil)
-	if result != "" {
-		t.Errorf("result = %q, want empty", result)
-	}
-}
-
-func TestReadErrorBody_EmptyBody(t *testing.T) {
-	resp := &http.Response{Body: io.NopCloser(strings.NewReader(""))}
-	result := readErrorBody(resp)
-	if result != "" {
-		t.Errorf("result = %q, want empty", result)
-	}
-}
-
-func TestReadErrorBody_WithContent(t *testing.T) {
-	resp := &http.Response{Body: io.NopCloser(strings.NewReader("  error message  "))}
-	result := readErrorBody(resp)
-	if result != "error message" {
-		t.Errorf("result = %q, want 'error message'", result)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // redirectTransport redirects all HTTP(S) requests to a fixed base URL,
 // preserving the path and query — used to intercept scm.HTTPClient calls
 // that use hard-coded external URLs (e.g. Entra token endpoint).

--- a/backend/internal/scm/errors.go
+++ b/backend/internal/scm/errors.go
@@ -2,7 +2,10 @@
 // covering configuration, OAuth, PAT, webhook, and repository operation failures.
 package scm
 
-import "errors"
+import (
+	"errors"
+	"log/slog"
+)
 
 var (
 	// Configuration errors
@@ -88,6 +91,15 @@ type APIError struct {
 	StatusCode int
 	Message    string
 	Err        error
+
+	// RemoteBody is a size-capped snippet of the upstream response body, kept out of
+	// Error() on purpose. API handlers routinely format a connector failure straight into
+	// a JSON response (fmt.Sprintf("...: %v", err)), and one of them — the SCM OAuth
+	// callback — is reachable unauthenticated, so anything inside Error() is effectively
+	// public. The body still has to reach the operator, or a misconfigured OAuth app
+	// registration is undiagnosable: read this field deliberately, or log the error as a
+	// slog attribute and let LogValue below include it.
+	RemoteBody string
 }
 
 func (e *APIError) Error() string {
@@ -95,6 +107,23 @@ func (e *APIError) Error() string {
 		return e.Message + ": " + e.Err.Error()
 	}
 	return e.Message
+}
+
+// LogValue renders the error for structured logging, including RemoteBody. slog resolves
+// this when the error is passed as an attribute value (slog.Error("...", "error", err)), so
+// the upstream detail Error() withholds from API clients still lands in the server log.
+func (e *APIError) LogValue() slog.Value {
+	attrs := []slog.Attr{slog.String("message", e.Message)}
+	if e.StatusCode != 0 {
+		attrs = append(attrs, slog.Int("status", e.StatusCode))
+	}
+	if e.Err != nil {
+		attrs = append(attrs, slog.String("cause", e.Err.Error()))
+	}
+	if e.RemoteBody != "" {
+		attrs = append(attrs, slog.String("remote_body", e.RemoteBody))
+	}
+	return slog.GroupValue(attrs...)
 }
 
 func (e *APIError) Unwrap() error {

--- a/backend/internal/scm/httpclient.go
+++ b/backend/internal/scm/httpclient.go
@@ -113,10 +113,12 @@ func DoJSON(req *http.Request, reason string, notFound error, out any) error {
 // return JSON regardless and send no Accept header — so the header stays a caller
 // decision rather than something this helper imposes on every provider.
 //
-// Unlike DoJSON, a non-200 response here carries a size-capped snippet of the response
-// body (LimitErrorBody) in the returned *APIError: the OAuth error body is the provider's
-// machine-readable failure reason (invalid_client, redirect_uri_mismatch, ...) and is what
-// makes a misconfigured app registration diagnosable.
+// Unlike DoJSON, a non-200 response here keeps a size-capped snippet of the response body
+// (LimitErrorBody): the OAuth error body is the provider's machine-readable failure reason
+// (invalid_client, redirect_uri_mismatch, ...) and is what makes a misconfigured app
+// registration diagnosable. It is carried in APIError.RemoteBody rather than in the error
+// text, so an unauthenticated caller of the OAuth callback cannot be handed it by a handler
+// that formats the error into its JSON response; see errors.go.
 func ExchangeOAuthForm(ctx context.Context, tokenURL string, form url.Values, acceptHeader string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
@@ -136,7 +138,9 @@ func ExchangeOAuthForm(ctx context.Context, tokenURL string, form url.Values, ac
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(LimitErrorBody(resp.Body))
-		return WrapRemoteError(resp.StatusCode, "oauth code exchange failed", fmt.Errorf("%s", body))
+		apiErr := WrapRemoteError(resp.StatusCode, "oauth code exchange failed", nil)
+		apiErr.RemoteBody = string(body)
+		return apiErr
 	}
 
 	if err := json.NewDecoder(LimitBody(resp.Body)).Decode(out); err != nil {

--- a/backend/internal/scm/httpclient_test.go
+++ b/backend/internal/scm/httpclient_test.go
@@ -221,7 +221,7 @@ func TestExchangeOAuthForm_PostsFormAndDecodes(t *testing.T) {
 	}
 }
 
-func TestExchangeOAuthForm_NonOKCarriesStatusAndBody(t *testing.T) {
+func TestExchangeOAuthForm_NonOKCarriesStatusAndRemoteBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
@@ -241,8 +241,10 @@ func TestExchangeOAuthForm_NonOKCarriesStatusAndBody(t *testing.T) {
 		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
 	}
 	// Unlike the repository APIs, the OAuth failure reason is what makes a misconfigured
-	// app registration diagnosable, so it is deliberately carried in the error.
-	if !strings.Contains(err.Error(), "invalid_client") {
-		t.Errorf("error = %q, want it to carry the provider's failure reason", err.Error())
+	// app registration diagnosable, so it is deliberately retained — in RemoteBody, which
+	// Error() excludes because handlers format these errors into client responses
+	// (see remotebody_test.go).
+	if !strings.Contains(apiErr.RemoteBody, "invalid_client") {
+		t.Errorf("RemoteBody = %q, want it to carry the provider's failure reason", apiErr.RemoteBody)
 	}
 }

--- a/backend/internal/scm/remotebody_test.go
+++ b/backend/internal/scm/remotebody_test.go
@@ -1,0 +1,121 @@
+// remotebody_test.go pins where an upstream SCM response body is allowed to travel.
+//
+// APIError.Error() is what handlers reach for when they format a connector failure into a
+// JSON response — several do it with fmt.Sprintf("...: %v", err), and the OAuth callback that
+// used to do it is reachable unauthenticated. So the provider's raw token-endpoint body must
+// not be inside Error(). It still has to reach the operator, or a misconfigured app
+// registration becomes undiagnosable, which is what RemoteBody and LogValue are for.
+package scm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAPIError_ErrorTextExcludesRemoteBody(t *testing.T) {
+	const secretish = "upstream-internal-diagnostic"
+
+	apiErr := &APIError{
+		StatusCode: http.StatusBadRequest,
+		Message:    "oauth code exchange failed",
+		Err:        errors.New("wrapped cause"),
+		RemoteBody: secretish,
+	}
+
+	if strings.Contains(apiErr.Error(), secretish) {
+		t.Errorf("Error() = %q, must not embed the upstream response body", apiErr.Error())
+	}
+	// Handlers format errors with %v as often as with .Error(); both go through Error().
+	if got := fmt.Sprintf("%v", error(apiErr)); strings.Contains(got, secretish) {
+		t.Errorf("%%v formatting = %q, must not embed the upstream response body", got)
+	}
+	if !strings.Contains(apiErr.Error(), "oauth code exchange failed") {
+		t.Errorf("Error() = %q, want it to keep the operator-facing message", apiErr.Error())
+	}
+}
+
+// TestAPIError_LogValueCarriesRemoteBody is the other half of the contract: the body has to
+// stay diagnosable server-side. slog resolves LogValue when the error is logged as an attr,
+// so `slog.Error("...", "error", err)` still records the provider's failure reason.
+func TestAPIError_LogValueCarriesRemoteBody(t *testing.T) {
+	apiErr := &APIError{
+		StatusCode: http.StatusBadRequest,
+		Message:    "oauth code exchange failed",
+		RemoteBody: `{"error":"invalid_client"}`,
+	}
+
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	logger.Error("oauth failed", "error", apiErr)
+
+	logged := buf.String()
+	for _, want := range []string{"invalid_client", "oauth code exchange failed", "400"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("log output %q does not contain %q — the upstream failure reason must stay "+
+				"diagnosable server-side", logged, want)
+		}
+	}
+}
+
+// TestExchangeOAuthForm_UpstreamBodyIsNotInTheErrorText drives the one helper that reads an
+// upstream error body, end to end over a real response.
+func TestExchangeOAuthForm_UpstreamBodyIsNotInTheErrorText(t *testing.T) {
+	const body = `{"error":"invalid_client","error_description":"internal-app-registration-detail"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	var result struct{}
+	err := ExchangeOAuthForm(context.Background(), srv.URL, url.Values{}, "", &result)
+	if err == nil {
+		t.Fatal("ExchangeOAuthForm error = nil, want an error")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v (%T), want an *APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if strings.Contains(err.Error(), "internal-app-registration-detail") {
+		t.Errorf("error text %q leaks the provider's token-endpoint response body", err.Error())
+	}
+	if !strings.Contains(apiErr.RemoteBody, "invalid_client") {
+		t.Errorf("RemoteBody = %q, want the provider's failure reason kept for server-side logging",
+			apiErr.RemoteBody)
+	}
+	if len(apiErr.RemoteBody) > MaxErrorBodyBytes {
+		t.Errorf("RemoteBody is %d bytes, want it capped at %d", len(apiErr.RemoteBody), MaxErrorBodyBytes)
+	}
+}
+
+// TestExchangeOAuthForm_RemoteBodyIsSizeCapped keeps the memory bound on the one field that
+// now retains upstream bytes.
+func TestExchangeOAuthForm_RemoteBodyIsSizeCapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(strings.Repeat("A", MaxErrorBodyBytes*4)))
+	}))
+	defer srv.Close()
+
+	var result struct{}
+	err := ExchangeOAuthForm(context.Background(), srv.URL, url.Values{}, "", &result)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v (%T), want an *APIError", err, err)
+	}
+	if len(apiErr.RemoteBody) != MaxErrorBodyBytes {
+		t.Errorf("RemoteBody is %d bytes, want it truncated to %d", len(apiErr.RemoteBody), MaxErrorBodyBytes)
+	}
+}

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/terraform-registry/terraform-registry/internal/safego"
 )
 
 // HTTP metrics — labelled by method, route template, and status code.
@@ -352,7 +353,7 @@ var DBOpenConnections = promauto.NewGauge(
 // StartDBStatsCollector launches a background goroutine that samples sql.DB connection
 // pool statistics every 30 seconds and updates the DBOpenConnections gauge.
 func StartDBStatsCollector(db *sql.DB) {
-	go func() {
+	safego.Go(func() {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
@@ -362,7 +363,7 @@ func StartDBStatsCollector(db *sql.DB) {
 			}
 			DBOpenConnections.Set(float64(db.Stats().OpenConnections))
 		}
-	}()
+	})
 }
 
 // ReleasesKeyRefreshTotal counts attempts by the releases-key refresh job with


### PR DESCRIPTION
Closes #562

Each of the six findings was re-verified against current `main` before anything was changed. Three were already fixed by earlier work; two were partly fixed with a live sibling; one was fully open. A seventh defect, found while extracting the shared SCM helpers in #852 and deliberately left alone at the time, is fixed here as the headline.

## Per-finding verification

| # | Finding | Verdict |
|---|---|---|
| 34 | Fire-and-forget goroutines have no panic recovery | **Partly fixed — 6 sites remained.** `safego.Go` now has ~33 call sites, including all the ones the audit named (`middleware/audit.go`, `middleware/auth.go`, `jobs/registry.go`). But six long-lived background launchers still used a bare `go`. All six converted; AST guard added. |
| 35 | SCM connectors use `http.DefaultClient`, unbounded bodies | **Already fixed** by #852. One shared `scm.HTTPClient` (`httpsafe`, 30s timeout), `LimitBody`/`LimitErrorBody` on every read, and `internal/scm/egress_guard_test.go` already fails the build if a connector reaches for `http.DefaultClient` or builds a bare `http.Client`. Zero `http.DefaultClient` references remain in `internal/`. |
| 41 | OAuth token-exchange duplicated across 4 connectors | **Already fixed** by #852 (`scm.ExchangeOAuthForm`, `scm.DoJSON`, `scm.ClampPagination`). |
| 37 | Redis rate limiter `RemainingTokens` double-consumes GCRA quota | **Already fixed** — `Allow` returns `(allowed, remaining, err)` and all three middlewares use that value; no middleware calls `RemainingTokens`. It had **no regression test**, so one is added. |
| 36 | Raw upstream error body reflected to the unauthenticated OAuth callback | **Reported site already fixed; a sibling was still open.** `HandleOAuthCallback` logs and returns `"OAuth flow failed"`. `RefreshToken` still did `fmt.Sprintf("token refresh failed: %v", err)`. Fixed at the source rather than the site — see below. |
| 38 | Unbounded response reads in the mirror upstream client | **Already fixed**, with caps *and* existing regression tests (`TestDownloadFile_OversizedResponseCapped`, `TestResolveProviderVersionID_OversizedProviderLookupIsCapped`). |

The audit's claim of "21+ call sites using `http.DefaultClient` directly" (finding 41) is **stale**, not wrong at filing time — #852 landed after the audit commit.

## What changed

### Azure DevOps listings fail instead of truncating

`FetchRepositories` never checked `resp.StatusCode`. Each per-project failure hit a bare `continue`, so the repositories gathered so far were returned **with a nil error**. An expired token — which ADO answers with HTTP 203 and an HTML sign-in page, not 401 — produced a silently short repository list that every caller read as a complete, successful result. `SearchRepositories` delegates to it and inherited the same behaviour.

The 203→401 normalisation existed in `fetchProjects` and `FetchTags` but nowhere else, so `FetchRepository`, `FetchBranches` and `FetchCommit` reported 203 verbatim — and `ListRepositories`'s refresh-and-retry, which keys off `APIError.StatusCode == 401 || 403`, never fired.

All six ADO JSON calls now go through one package-local `doJSON` that delegates to `scm.DoJSON` and applies the 203→401 mapping once, replacing three hand-rolled status blocks. `readErrorBody` went with its last caller (it also copied the sign-in page into an error message that reached clients), as did a stray `fmt.Printf("[FetchTags] GET %s")` debug line in the function being rewritten.

### Background goroutines recover

Six launchers converted to `safego.Go`: suite discovery poller, audit webhook batcher, JWT secret file watch, OIDC memory state-store cleanup, rate-limiter cleanup, DB stats collector. A panic in any of them takes the whole process down — Go does not propagate it to the caller and `gin.Recovery()` only guards the request goroutine.

The audit also asked for a lint rule. `internal/safego/goroutine_guard_test.go` walks `backend/internal`, and fails any `go` statement that neither defers a `recover()` inline nor goes through `safego.Go`. **It has no path-based exemption list** — an exemption keyed on a filename becomes a standing permission for whatever is later written into that file. The two remaining bare `go` statements pass on their merits, because they genuinely defer a recover; mutation 4 below deletes one of those recovers and watches the guard catch it.

### Upstream OAuth bodies stop reaching clients

Rather than patching the one remaining handler, the leak is closed at its only producer. `ExchangeOAuthForm` now puts the size-capped token-endpoint body in a new `APIError.RemoteBody` field instead of inside `Err`, and `Error()` excludes it — so no handler, present or future, can echo it by formatting the error with `%v`. A `LogValue` method keeps the provider's failure reason (`invalid_client`, `redirect_uri_mismatch`, …) in the server log, which is what makes a misconfigured app registration diagnosable. `RefreshToken` now logs the detail and answers `"token refresh failed"`.

`TestExchangeOAuthForm_NonOKCarriesStatusAndBody` asserted the old contract and is updated to assert the new one on both halves: absent from `Error()`, present in `RemoteBody`.

## Mutation table

Every guard was broken and watched to fail, then restored from a `cp` backup. Assertions are on sentinel values — `*scm.APIError` status codes, exact response messages, probe counts — never on a bare `err != nil`.

| # | Mutation | Guard | Result |
|---|---|---|---|
| A | Drop the 203→401 mapping from ADO `doJSON` | `TestListingCalls_ExpiredTokenReportedAs401` | FAIL — all 6 methods report `StatusCode = 203, want 401` |
| B | Restore the `continue` in `FetchRepositories` | `TestFetchRepositories_PerProjectFailureIsNotASilentShortList` | FAIL — all 3 cases, "returned a short list of 1 repo(s) with nil error" |
| C | Put `go rl.cleanup()` back as a bare statement | `TestGoroutineGuard_EveryGoStatementRecovers` | FAIL — pinpoints `ratelimit.go:136` |
| D | Delete the inline `recover()` from the one goroutine allowed to keep a bare `go` | `TestGoroutineGuard_EveryGoStatementRecovers` | FAIL — `storage_migration.go:505`, proving the pass was earned, not exempted |
| E | Point the guard's walk at a 1-file directory | both goroutine guards | FAIL — "scanned 1 files, want at least 100" (non-empty-universe floor) |
| F | Re-add `backend.RemainingTokens(...)` after `Allow` | `TestRateLimitMiddlewares_ProbeTheBackendExactlyOnce` | FAIL — allowed *and* rejected paths; header reads `999` instead of the single probe's `99` |
| G | Restore `fmt.Sprintf("token refresh failed: %v", err)` | `TestRefreshToken_DoesNotEchoUpstreamBody` | FAIL — exact-message assertion catches it |
| H | Put the response body back into `APIError.Err` | `TestExchangeOAuthForm_UpstreamBodyIsNotInTheErrorText` | FAIL — "error text … leaks the provider's token-endpoint response body" |
| I | Drop `remote_body` from `LogValue` | `TestAPIError_LogValueCarriesRemoteBody` | FAIL — diagnosability regression caught |

Mutation G is worth a note: under it the marker string still did not appear in the body, because `RemoteBody` was already keeping it out of `Error()`. The guard caught the regression anyway because it asserts the **exact** generic message, not merely the absence of a marker. Every earlier failure branch in that handler also answers 500 with a non-empty error, so a looser assertion would have passed without ever reaching the connector call.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` and `go test ./...` are clean, with one environmental exception: the four `fsnotify`-based tests in `internal/auth` fail locally with `no space left on device`. That is the host's inotify watch budget (65587 watches in use against a 65536 limit), not disk and not this branch — the same four fail identically on a pristine `origin/main` checkout. `golangci-lint` reports 6 staticcheck issues, all pre-existing in untouched test files and identical on `main`.

## Deliberately not done

- **`RateLimiterBackend.RemainingTokens` is left in place.** It is now called by nothing in `internal/`, and on the Redis backend it still consumes quota by design. Removing it from the interface is dead-code deletion beyond this issue's scope; its docstring already warns callers. Worth a follow-up.
- **The ~96 other `gin.H{"error": err.Error()}` sites across `internal/api`** are untouched. Finding 36 is specifically about *upstream SCM response bodies* reaching clients, and that class is now closed at its source. Generic internal-error verbosity is a separate, much larger question that needs a product decision about what registry API errors should say.
- **`cmd/` goroutines** (`cmd/server/main.go`, `cmd/chaos-test`, `cmd/registry-import`) are outside the stated scope of `backend/internal/`, so the guard walks `internal/` only. Server-lifecycle goroutines in `main.go` are also a different case: several of them *should* end the process.
