### PR TITLE
fix(authz): re-check organization membership on three cross-tenant read paths

### DIFF
--- a/backend/internal/api/admin/cross_org_authz_test.go
+++ b/backend/internal/api/admin/cross_org_authz_test.go
@@ -1,0 +1,246 @@
+package admin
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Cross-organization authorization gaps found while mapping #652.
+//
+// All three routes below were gated ONLY by the flat, org-less scope union in
+// the session JWT. That union is the documented, deliberate design — it is safe
+// precisely because "per-org membership is re-checked server-side on every
+// org-scoped route", which is the claim written at internal/auth/jwt.go and
+// repeated at every mint site. These three routes did not re-check, so on them
+// the claim was false and a scope held in ANY organization read data from
+// EVERY organization.
+//
+// The severity comes from which templates grant the scopes: mirrors:read is on
+// the seeded `viewer` template — the lowest-privilege role in the product — and
+// scanning:read is on `devops` and `auditor`.
+
+// --- POST /admin/policies/evaluate -----------------------------------------
+//
+// Its sibling GET /:id in the same route block carries
+// RequireOrgScopeForResource. This route took organization_id off the query
+// string and evaluated against it with no caller check of any kind.
+
+func newPolicyEvaluateRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewRBACHandlers(repositories.NewRBACRepository(sqlx.NewDb(db, "sqlmock")), nil, nil).
+		WithOrgRepo(repositories.NewOrganizationRepository(db))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeMirrorsRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.POST("/evaluate", h.EvaluatePolicy)
+	return mock, r
+}
+
+const evaluateBody = `{"registry":"registry.terraform.io","namespace":"hashicorp","provider":"aws"}`
+
+func TestEvaluatePolicy_ForeignOrg_Denied(t *testing.T) {
+	mock, r := newPolicyEvaluateRouter(t)
+
+	// Member of alpha only. Asking about beta must not reach the policy query.
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
+			[]byte(`["mirrors:read"]`),
+		))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/evaluate?organization_id="+orgBeta, strings.NewReader(evaluateBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	// Assert the SPECIFIC denial status. `!= 200` would also be satisfied by a
+	// 500 from a broken mock, which is how this very test first passed while
+	// the handler was erroring out before it ever reached the guard.
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for a caller with no membership in beta, got %d: %s", w.Code, w.Body.String())
+	}
+	// The decisive assertion: no policy query was issued at all. A handler that
+	// queried and then filtered would still have read the row.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet/extra expectations — the policy query must never run: %v", err)
+	}
+}
+
+// Positive control. Without this, a handler that denied EVERYTHING would pass
+// the test above.
+func TestEvaluatePolicy_OwnOrg_Allowed(t *testing.T) {
+	mock, r := newPolicyEvaluateRouter(t)
+
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
+			[]byte(`["mirrors:read"]`),
+		))
+	mock.ExpectQuery("(?s)FROM mirror_policies").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "organization_id", "name", "description", "policy_type",
+			"registry_pattern", "namespace_pattern", "provider_pattern",
+			"action", "priority", "requires_approval", "created_at", "updated_at",
+			"organization_name",
+		}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/evaluate?organization_id="+orgAlpha, strings.NewReader(evaluateBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("member of alpha was denied its own organization: %d %s", w.Code, w.Body.String())
+	}
+}
+
+// Omitting organization_id stays open to everyone: ListMirrorPolicies then
+// matches only `organization_id IS NULL`, the global policies, which no tenant
+// owns. Pinned so the fix cannot drift into requiring a parameter the route
+// never required.
+func TestEvaluatePolicy_NoOrgParam_NeedsNoMembership(t *testing.T) {
+	mock, r := newPolicyEvaluateRouter(t)
+
+	mock.ExpectQuery("(?s)FROM mirror_policies").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "organization_id", "name", "description", "policy_type",
+			"registry_pattern", "namespace_pattern", "provider_pattern",
+			"action", "priority", "requires_approval", "created_at", "updated_at",
+			"organization_name",
+		}))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/evaluate", strings.NewReader(evaluateBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("global-only evaluation was refused: %d %s", w.Code, w.Body.String())
+	}
+}
+
+// --- GET /admin/scanning/stats ---------------------------------------------
+//
+// Three queries, none of which carried an organization predicate. Two did not
+// even join to a table that has the column.
+
+func TestScanningStats_NonAdmin_EveryQueryCarriesTheTenantPredicate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "rt-devops", time.Now(), "devops", "DevOps",
+			[]byte(`["scanning:read"]`),
+		))
+
+	// Each of the three queries must join through to modules AND constrain
+	// m.organization_id. `= ANY` is what OrgScope.SQL emits for a bounded set;
+	// asserting on it means a fix that dropped the predicate (emitting bare
+	// TRUE) fails here.
+	tenantPredicate := "(?s)JOIN modules m .*m.organization_id = ANY"
+	mock.ExpectQuery(tenantPredicate).
+		WillReturnRows(sqlmock.NewRows([]string{"total", "pending", "scanning", "clean", "findings", "error_count"}).
+			AddRow(0, 0, 0, 0, 0, 0))
+	mock.ExpectQuery(tenantPredicate).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(tenantPredicate).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "version", "name", "namespace", "system", "scanner", "status",
+			"critical_count", "high_count", "medium_count", "low_count",
+			"scanned_at", "created_at",
+		}))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeScanningRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/stats", GetScanningStatsHandler(sqlx.NewDb(db, "sqlmock"), repositories.NewOrganizationRepository(db)))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stats", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("a scanning-stats query ran without the tenant predicate: %v", err)
+	}
+}
+
+// --- GET /modules/:ns/:name/:system/versions/:v/scan ------------------------
+//
+// Resolved the DEFAULT organization regardless of caller, so scanning:read held
+// anywhere read the default org's findings.
+
+func TestModuleScanByVersion_CallerOutsideDefaultOrg_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	// Caller belongs to alpha; the default organization is beta.
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "rt-devops", time.Now(), "devops", "DevOps",
+			[]byte(`["scanning:read"]`),
+		))
+	mock.ExpectQuery("(?s)FROM organizations").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}).
+			AddRow(orgBeta, "default", "Beta", nil, nil, time.Now(), time.Now()))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeScanningRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/modules/:namespace/:name/:system/versions/:version/scan", GetModuleScanHandler(db))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/modules/hashicorp/vpc/aws/versions/1.0.0/scan", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for a caller outside the default org, got %d: %s", w.Code, w.Body.String())
+	}
+	// 404 must come from the guard, not from a module lookup that ran anyway.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the module lookup must never run for an out-of-scope caller: %v", err)
+	}
+}
+
+// Guard the guard: if the harness stopped reaching these handlers the tests
+// above would pass vacuously. Each asserts a real database conversation, so a
+// silent no-op is caught by ExpectationsWereMet — except the compile-time shape
+// of the handlers themselves, pinned here.
+var (
+	_                                                                      = GetModuleScanHandler
+	_ func(*sqlx.DB, *repositories.OrganizationRepository) gin.HandlerFunc = GetScanningStatsHandler
+	_ *sql.DB
+)

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -1163,11 +1163,26 @@ func (h *RBACHandlers) EvaluatePolicy(c *gin.Context) {
 		return
 	}
 
+	// GUARD policy-evaluate-tenant-scope: the write axis of this route block is
+	// admin-gated and the by-id read axis carries RequireOrgScopeForResource,
+	// but this one took organization_id straight off the query string and
+	// evaluated against it with no caller check. mirrors:read is granted by the
+	// seeded `viewer` template -- the lowest-privilege role in the product -- so
+	// the result (matched policy name, allow/deny, requires_approval) was
+	// readable across tenants by any member of any organization.
+	//
+	// Omitting organization_id stays open to every caller: ListMirrorPolicies
+	// then matches only `organization_id IS NULL`, the global policies, which
+	// are not owned by any tenant. It is supplying someone else's id that has to
+	// be earned, so the check hangs off the parameter rather than the route.
 	var orgID *uuid.UUID
 	if orgIDStr := c.Query("organization_id"); orgIDStr != "" {
 		id, err := uuid.Parse(orgIDStr)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid organization ID"})
+			return
+		}
+		if !requireTenantScopeForOrg(c, h.orgRepo, auth.ScopeMirrorsRead, id.String()) {
 			return
 		}
 		orgID = &id

--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 )
 
@@ -120,7 +122,7 @@ func GetScanningConfigHandler(cfg *config.ScanningConfig) gin.HandlerFunc {
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/scanning/stats [get]
-func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
+func GetScanningStatsHandler(db *sqlx.DB, orgRepo *repositories.OrganizationRepository) gin.HandlerFunc {
 	validStatuses := map[string]bool{
 		"pending":  true,
 		"scanning": true,
@@ -131,6 +133,22 @@ func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
+
+		// GUARD scanning-stats-tenant-scope: every query below ran with no
+		// organization predicate at all, so scanning:read -- held by the seeded
+		// `devops` and `auditor` templates -- enumerated EVERY organization's
+		// module namespace/name/system together with its critical/high/medium/low
+		// counts, 100 rows at a time. The aggregate counts leaked the platform's
+		// totals on top of that.
+		//
+		// module_version_scans carries no organization_id of its own; a scan is
+		// organization-owned transitively through module_versions -> modules,
+		// which is why two of these three queries did not even join to a table
+		// that had the column. The joins below exist to reach it.
+		scope, ok := resolveTenantScope(c, orgRepo, auth.ScopeScanningRead)
+		if !ok {
+			return
+		}
 
 		// Parse query parameters.
 		statusFilter := c.Query("status")
@@ -155,17 +173,21 @@ func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
 
 		var stats ScanningStatsResponse
 
-		// Aggregate counts by status (always unfiltered).
-		err := db.QueryRowContext(ctx, `
+		// Aggregate counts by status (always unfiltered by status, never by tenant).
+		aggWhere, aggArgs := scope.OrgScope().SQL("m.organization_id", 1)
+		err := db.QueryRowContext(ctx, fmt.Sprintf(`
 			SELECT
 				COUNT(*) AS total,
-				COUNT(*) FILTER (WHERE status = 'pending') AS pending,
-				COUNT(*) FILTER (WHERE status = 'scanning') AS scanning,
-				COUNT(*) FILTER (WHERE status = 'clean') AS clean,
-				COUNT(*) FILTER (WHERE status = 'findings') AS findings,
-				COUNT(*) FILTER (WHERE status = 'error') AS error_count
-			FROM module_version_scans
-		`).Scan(
+				COUNT(*) FILTER (WHERE s.status = 'pending') AS pending,
+				COUNT(*) FILTER (WHERE s.status = 'scanning') AS scanning,
+				COUNT(*) FILTER (WHERE s.status = 'clean') AS clean,
+				COUNT(*) FILTER (WHERE s.status = 'findings') AS findings,
+				COUNT(*) FILTER (WHERE s.status = 'error') AS error_count
+			FROM module_version_scans s
+			JOIN module_versions mv ON mv.id = s.module_version_id
+			JOIN modules m ON m.id = mv.module_id
+			WHERE %s
+		`, aggWhere), aggArgs...).Scan(
 			&stats.Total,
 			&stats.Pending,
 			&stats.Scanning,
@@ -178,19 +200,29 @@ func GetScanningStatsHandler(db *sqlx.DB) gin.HandlerFunc {
 			return
 		}
 
-		// Build filtered recent scans query.
-		var whereClause string
+		// Build filtered recent scans query. The tenant predicate is part of the
+		// shared WHERE rather than appended per query, so the count and the page
+		// below cannot diverge -- a filtered count taken over a wider set than
+		// the rows it describes is its own disclosure.
 		var args []interface{}
 		argIdx := 1
 
+		orgWhere, orgArgs := scope.OrgScope().SQL("m.organization_id", argIdx)
+		args = append(args, orgArgs...)
+		argIdx += len(orgArgs)
+		whereClause := " WHERE " + orgWhere
+
 		if statusFilter != "" {
-			whereClause = fmt.Sprintf(" WHERE s.status = $%d", argIdx)
+			whereClause += fmt.Sprintf(" AND s.status = $%d", argIdx)
 			args = append(args, statusFilter)
 			argIdx++
 		}
 
-		// Get total count for filtered results.
-		countQuery := `SELECT COUNT(*) FROM module_version_scans s` + whereClause
+		// The count must traverse the same joins as the page: module_version_scans
+		// alone cannot express the tenant predicate.
+		countQuery := `SELECT COUNT(*) FROM module_version_scans s
+			JOIN module_versions mv ON mv.id = s.module_version_id
+			JOIN modules m ON m.id = mv.module_id` + whereClause
 		if err := db.QueryRowContext(ctx, countQuery, args...).Scan(&stats.TotalFiltered); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query filtered count"})
 			return

--- a/backend/internal/api/admin/scanning_admin_test.go
+++ b/backend/internal/api/admin/scanning_admin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
 // ---------------------------------------------------------------------------
@@ -146,7 +147,7 @@ func TestGetScanningStatsHandler_Success(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	r := gin.New()
-	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB, repositories.NewOrganizationRepository(db)))
 
 	// Mock aggregate counts
 	mock.ExpectQuery("module_version_scans").
@@ -213,7 +214,7 @@ func TestGetScanningStatsHandler_WithStatusFilter(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	r := gin.New()
-	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB, repositories.NewOrganizationRepository(db)))
 
 	// Mock aggregate counts
 	mock.ExpectQuery("module_version_scans").
@@ -273,7 +274,7 @@ func TestGetScanningStatsHandler_InvalidStatusFilter(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	r := gin.New()
-	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB, repositories.NewOrganizationRepository(db)))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/scanning/stats?status=invalid", nil)
@@ -294,7 +295,7 @@ func TestGetScanningStatsHandler_CountQueryError(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	r := gin.New()
-	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB, repositories.NewOrganizationRepository(db)))
 
 	mock.ExpectQuery("module_version_scans").
 		WillReturnError(&scanTestDBErr{"query failed"})
@@ -318,7 +319,7 @@ func TestGetScanningStatsHandler_RecentQueryError(t *testing.T) {
 	sqlxDB := sqlx.NewDb(db, "sqlmock")
 
 	r := gin.New()
-	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB))
+	r.GET("/scanning/stats", GetScanningStatsHandler(sqlxDB, repositories.NewOrganizationRepository(db)))
 
 	// Aggregate succeeds
 	mock.ExpectQuery("module_version_scans").

--- a/backend/internal/api/admin/scans.go
+++ b/backend/internal/api/admin/scans.go
@@ -36,9 +36,28 @@ func GetModuleScanHandler(db *sql.DB) gin.HandlerFunc {
 		system := c.Param("system")
 		version := c.Param("version")
 
+		// GUARD scan-byversion-tenant-scope: the by-id sibling below resolves the
+		// caller's tenant scope; this axis resolved the DEFAULT organization
+		// regardless of who was asking, so scanning:read held anywhere read the
+		// default org's vulnerability findings. Same class as #783, missed
+		// because addressing a module by namespace/name/system hides the fact
+		// that the lookup needs an organization at all.
+		//
+		// 404 rather than 403, matching the by-id axis: the body is another
+		// tenant's findings, so confirming the module exists is itself the
+		// disclosure.
+		scope, ok := resolveTenantScope(c, orgRepo, auth.ScopeScanningRead)
+		if !ok {
+			return
+		}
+
 		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
 		if err != nil || org == nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get organization context"})
+			return
+		}
+		if !scope.Permits(org.ID) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "scan not found"})
 			return
 		}
 

--- a/backend/internal/api/admin/scans_test.go
+++ b/backend/internal/api/admin/scans_test.go
@@ -42,6 +42,13 @@ func newScanAdminRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	}
 	t.Cleanup(func() { db.Close() })
 	r := gin.New()
+	// Platform admin: tenantscope.Resolve short-circuits to the whole platform,
+	// so these pre-existing cases keep asserting handler behaviour rather than
+	// tenancy. The tenancy case is in cross_org_authz_test.go.
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", "admin-user")
+	})
 	r.GET("/modules/:namespace/:name/:system/versions/:version/scan",
 		GetModuleScanHandler(db))
 	return mock, r

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -728,7 +728,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				admin.GetScanningConfigHandler(&cfg.Scanning))
 			authenticatedGroup.GET("/admin/scanning/stats",
 				middleware.RequireScope(auth.ScopeScanningRead),
-				admin.GetScanningStatsHandler(sqlxDB))
+				admin.GetScanningStatsHandler(sqlxDB, orgRepo))
 			authenticatedGroup.GET("/admin/scanning/scans/:id",
 				middleware.RequireScope(auth.ScopeScanningRead),
 				admin.GetScanByIDHandler(db, orgRepo))


### PR DESCRIPTION
Found while mapping #652. **Does not close it** — see the last section.

## What was wrong

The session JWT carries a flat, org-less **union** of the caller's scopes across every organization they belong to. That is deliberate and documented, and it is safe only because of the claim written at `internal/auth/jwt.go` and repeated at all six mint sites:

> per-org membership is re-checked server-side on every org-scoped route

On three routes it was not. There, a scope held in **any** organization read data from **every** organization.

| Route | Gate | What was missing |
| --- | --- | --- |
| `POST /admin/policies/evaluate` | `mirrors:read` | Took `organization_id` off the query string and evaluated against it with no caller check of any kind |
| `GET /admin/scanning/stats` | `scanning:read` | Three queries, none with an organization predicate; two did not even join to a table carrying the column |
| `GET /modules/:ns/:name/:system/versions/:v/scan` | `scanning:read` | Resolved the **default** organization regardless of who was asking |

Severity comes from which seeded templates grant those scopes: **`mirrors:read` is on `viewer`**, the lowest-privilege role in the product; `scanning:read` is on `devops` and `auditor`.

Two of the three are the estate's recurring shape — *a closed issue reopening next to its patched sibling*:

- `GET /admin/policies/:id` carries `RequireOrgScopeForResource`. `POST /evaluate` sits **one line below it in the same route block** and never got it.
- `GetScanByIDHandler` resolves the caller's tenant scope (#783). Its by-version sibling did not — addressing a module by `namespace/name/system` hides the fact that the lookup needs an organization at all.

`module_version_scans` carries no `organization_id` of its own; a scan is organization-owned only transitively through `module_versions -> modules`. That is why two of those three queries did not join to a table that had the column, and why the joins added here exist.

## Approach

Uses the tenant-scope resolvers already established by #718/#719/#783 — `resolveTenantScope`, `requireTenantScopeForOrg`, `OrgScope().SQL(...)` — rather than new machinery.

Two deliberate choices:

- **The scan path answers 404, not 403**, matching its by-id sibling: the body is another tenant's vulnerability findings, so confirming the module exists is itself the disclosure.
- **Omitting `organization_id` on `/evaluate` stays open to every caller.** `ListMirrorPolicies` then matches only `organization_id IS NULL` — the global policies, which no tenant owns. It is supplying *someone else's* id that has to be earned, so the check hangs off the parameter rather than the route. Pinned by a test so the fix cannot drift into requiring a parameter the route never required.

## Mutation verification

Each fix reverted independently, with a mutation that **still compiles** — a build failure is not a test result:

| Mutation | Result |
| --- | --- |
| Remove the policy-evaluate tenant check | deny test **and** positive control both fail |
| Scanning-stats predicate → bare `TRUE` | stats test fails |
| Remove the default-org `Permits` check | scan test fails |
| Restored | all 5 pass |

The deny test asserts **403 specifically**, not `!= 200`. It first passed while the handler was erroring out at 500 before ever reaching the guard — `!= 200` would have shipped that as a green guard.

Positive controls included throughout, so a handler that denied everything would not pass.

## Deliberately left

**`GET /admin/stats/dashboard` has no scope guard at all** — it is the one route in this group reachable by any authenticated principal with no scope requirement whatsoever. It returns platform-wide aggregate `COUNT(*)`s (modules, versions, downloads, users, organizations) — no tenant-owned rows, no names. Tenant-scoping it would change what the dashboard *means*, and gating it on `admin` would remove it from every non-admin user who sees it today. That is a product decision, not a defect fix, so it is flagged rather than decided here.

**Not a fix for #652.** Whether the token itself should carry an org binding is still open. What changed is that the disposition it currently turns on is now true on these routes rather than merely asserted.

`go build ./... && go vet ./... && gofmt -l . && go test ./...` clean, except 4 pre-existing `internal/auth` JWT-secret-file-watch failures that reproduce identically on unmodified `main` and are unrelated to this change.