### PR TITLE
test(security): assert a tenant-scope property over the real API v1 route table (part of #566)

### DIFF
--- a/backend/internal/api/admin/cross_org_authz_test.go
+++ b/backend/internal/api/admin/cross_org_authz_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -244,3 +245,161 @@ var (
 	_ func(*sqlx.DB, *repositories.OrganizationRepository) gin.HandlerFunc = GetScanningStatsHandler
 	_ *sql.DB
 )
+
+// --- GET /admin/stats/dashboard --------------------------------------------
+//
+// Issue #566. Found by orgscope_route_class_test.go, which enumerates the real
+// route table: this route is the one authenticated route in the whole table
+// that carries NO RequireScope at all, so every principal reaches it — and two
+// of its queries read mirror_configurations, which carries organization_id.
+// The recent-sync list emitted `c.name`, another tenant's chosen name for its
+// upstream mirror, to anybody with a session.
+
+// dashboardRouter mounts GET /stats/dashboard with a principal holding
+// mirrors:read and a single membership in alpha.
+func dashboardRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewStatsHandler(sqlx.NewDb(db, "sqlmock")).
+		WithOrgRepo(repositories.NewOrganizationRepository(db))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeMirrorsRead)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/stats/dashboard", h.GetDashboardStats)
+	return mock, r
+}
+
+// TestDashboardStats_MirrorQueriesCarryTheTenantPredicate pins the fix at the
+// SQL level. `= ANY` is what OrgScope.SQL emits for a bounded organization set;
+// the unscoped handler emitted neither that nor any organization_id reference,
+// so the two expectations below would not match and ExpectationsWereMet fails.
+// The assertion is on ExpectationsWereMet, not on a swallowed query error:
+// both statements are best-effort (`_ =`) in the handler, so a bare `err != nil`
+// could never see them at all.
+func TestDashboardStats_MirrorQueriesCarryTheTenantPredicate(t *testing.T) {
+	mock, r := dashboardRouter(t)
+
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
+			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
+			[]byte(`["mirrors:read"]`),
+		))
+
+	opts := defaultStatsOpts()
+	opts.mirrorHealthQuery = "(?s)FROM mirror_configurations.*organization_id = ANY"
+	opts.recentSyncQuery = "(?s)JOIN mirror_configurations c .*c.organization_id = ANY"
+	opts.recentSyncs = []RecentSyncEntry{{
+		MirrorName: "alpha-upstream", MirrorType: "provider", Status: "success",
+		StartedAt: time.Now(), VersionsSynced: 1, TriggeredBy: "scheduler",
+	}}
+	expectStatsQueries(mock, opts)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stats/dashboard", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("a mirror_configurations query ran without the tenant predicate: %v", err)
+	}
+}
+
+// TestDashboardStats_NoMemberships_SelectsNothing is the deny direction. A
+// principal with no qualifying membership resolves to the empty scope, which
+// OrgScope.SQL renders as the constant FALSE — not an absent predicate, and not
+// TRUE. Asserted on the emitted SQL, because an empty result set is also what a
+// correctly-scoped query returns for an empty database: only the predicate
+// distinguishes "you may see nothing" from "there is nothing".
+func TestDashboardStats_NoMemberships_SelectsNothing(t *testing.T) {
+	mock, r := dashboardRouter(t)
+
+	// No membership rows: the caller holds mirrors:read in no organization.
+	mock.ExpectQuery("(?s)FROM organization_members").
+		WillReturnRows(sqlmock.NewRows(membershipCols))
+
+	opts := defaultStatsOpts()
+	opts.provMirrorTotal, opts.provMirrorHealthy, opts.provMirrorFailed = 0, 0, 0
+	opts.mirrorHealthQuery = "(?s)FROM mirror_configurations\\s+WHERE enabled = true AND FALSE"
+	opts.recentSyncQuery = "(?s)JOIN mirror_configurations c .*WHERE FALSE"
+	expectStatsQueries(mock, opts)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stats/dashboard", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the empty scope did not render as FALSE: %v", err)
+	}
+
+	var body struct {
+		ProviderMirrors ProviderMirrorStats `json:"provider_mirrors"`
+		RecentSyncs     []RecentSyncEntry   `json:"recent_syncs"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ProviderMirrors.Total != 0 {
+		t.Errorf("provider_mirrors.total = %d, want 0", body.ProviderMirrors.Total)
+	}
+	if len(body.RecentSyncs) != 0 {
+		t.Errorf("recent_syncs = %v, want none", body.RecentSyncs)
+	}
+}
+
+// TestDashboardStats_PlatformAdmin_SeesEveryTenant is the positive control.
+// Without it, a "fix" that hard-coded FALSE would satisfy both tests above and
+// look correct. A platform admin resolves to OrgScopeAllOrganizations, which
+// renders as TRUE and binds no arguments — and reaches no membership query at
+// all, which is why none is queued here.
+func TestDashboardStats_PlatformAdmin_SeesEveryTenant(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	h := NewStatsHandler(sqlx.NewDb(db, "sqlmock")).
+		WithOrgRepo(repositories.NewOrganizationRepository(db))
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", scopeUserID)
+	})
+	r.GET("/stats/dashboard", h.GetDashboardStats)
+
+	opts := defaultStatsOpts()
+	opts.mirrorHealthQuery = "(?s)FROM mirror_configurations\\s+WHERE enabled = true AND TRUE"
+	opts.recentSyncQuery = "(?s)JOIN mirror_configurations c .*WHERE TRUE"
+	opts.recentSyncs = []RecentSyncEntry{{
+		MirrorName: "beta-upstream", MirrorType: "provider", Status: "success",
+		StartedAt: time.Now(), VersionsSynced: 3, TriggeredBy: "scheduler",
+	}}
+	expectStatsQueries(mock, opts)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/stats/dashboard", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the platform-admin scope did not render as TRUE: %v", err)
+	}
+	if !strings.Contains(w.Body.String(), "beta-upstream") {
+		t.Errorf("platform admin lost the cross-tenant view: %s", w.Body.String())
+	}
+}

--- a/backend/internal/api/admin/stats.go
+++ b/backend/internal/api/admin/stats.go
@@ -2,18 +2,22 @@
 package admin
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 )
 
 // StatsHandler handles stats-related API requests
 type StatsHandler struct {
 	db       *sqlx.DB
 	scanning *config.ScanningConfig
+	orgRepo  *repositories.OrganizationRepository
 }
 
 // NewStatsHandler creates a new stats handler
@@ -24,6 +28,15 @@ func NewStatsHandler(database *sqlx.DB, scanning ...*config.ScanningConfig) *Sta
 	if len(scanning) > 0 {
 		h.scanning = scanning[0]
 	}
+	return h
+}
+
+// WithOrgRepo wires in the organization repository so GetDashboardStats can
+// re-check the caller's per-organization membership before reporting anything
+// derived from mirror_configurations, which is organization-owned. Returns the
+// handler for chaining, matching NewVersionApprovalHandler().WithOrgRepo(...).
+func (h *StatsHandler) WithOrgRepo(orgRepo *repositories.OrganizationRepository) *StatsHandler {
+	h.orgRepo = orgRepo
 	return h
 }
 
@@ -124,6 +137,34 @@ type RecentSyncEntry struct {
 // GetDashboardStats returns dashboard statistics using a single database round-trip.
 func (h *StatsHandler) GetDashboardStats(c *gin.Context) {
 	ctx := c.Request.Context()
+
+	// GUARD dashboard-mirror-tenant-scope (issue #566, same class as #855).
+	//
+	// This route carries no RequireScope at all — every authenticated principal
+	// reaches it, including a `viewer` whose only membership is in an unrelated
+	// organization. Two of the queries below read mirror_configurations, which
+	// carries organization_id, and the recent-sync list emits `c.name` — another
+	// tenant's chosen name for its upstream mirror. Names are the identifying
+	// data here, and they were returned to everyone.
+	//
+	// The predicate is resolved for mirrors:read, the same scope the
+	// /admin/mirrors family requires, so a caller sees exactly the provider
+	// mirrors it could already list there and nothing more. A platform admin
+	// resolves to OrgScopeAllOrganizations and is unaffected.
+	//
+	// DELIBERATELY NOT SCOPED: the aggregate integer counts above/below
+	// (modules, providers, users, organizations, downloads, scm_providers,
+	// module_version_scans). They are a platform census with no tenant-
+	// identifying values in them, and the module/provider rows they count are
+	// already enumerable anonymously through GET /api/v1/modules/search and
+	// /providers/search. Narrowing them would change what the dashboard means
+	// without closing a disclosure.
+	scope, ok := resolveTenantScope(c, h.orgRepo, auth.ScopeMirrorsRead)
+	if !ok {
+		return
+	}
+	mirrorWhere, mirrorArgs := scope.OrgScope().SQL("organization_id", 1)
+	syncWhere, syncArgs := scope.OrgScope().SQL("c.organization_id", 1)
 
 	// Core counts — single round-trip.
 	query := `
@@ -229,15 +270,16 @@ func (h *StatsHandler) GetDashboardStats(c *gin.Context) {
 		}
 	}
 
-	// Provider mirror health (mirror_configurations table).
-	_ = h.db.QueryRowContext(ctx, `
+	// Provider mirror health (mirror_configurations table) — tenant-scoped, see
+	// GUARD dashboard-mirror-tenant-scope above.
+	_ = h.db.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT
 			COUNT(*) AS total,
 			COUNT(*) FILTER (WHERE last_sync_status = 'success' OR last_sync_status IS NULL) AS healthy,
 			COUNT(*) FILTER (WHERE last_sync_status = 'failed') AS failed
 		FROM mirror_configurations
-		WHERE enabled = true
-	`).Scan(
+		WHERE enabled = true AND %s
+	`, mirrorWhere), mirrorArgs...).Scan(
 		&stats.ProviderMirrors.Total,
 		&stats.ProviderMirrors.Healthy,
 		&stats.ProviderMirrors.Failed,
@@ -264,7 +306,10 @@ func (h *StatsHandler) GetDashboardStats(c *gin.Context) {
 	)
 
 	// Recent sync activity — last 8 entries unified across both mirror types.
-	recentRows, recentErr := h.db.QueryContext(ctx, `
+	// The provider half is tenant-scoped (it names mirror_configurations rows);
+	// the binary half reads terraform_mirror_configs, which is platform-global
+	// and has no organization_id to scope by.
+	recentRows, recentErr := h.db.QueryContext(ctx, fmt.Sprintf(`
 		SELECT mirror_name, mirror_type, status, started_at, completed_at,
 		       versions_synced, platforms_synced, triggered_by
 		FROM (
@@ -297,12 +342,13 @@ func (h *StatsHandler) GetDashboardStats(c *gin.Context) {
 				'scheduler'                   AS triggered_by
 			FROM mirror_sync_history h
 			JOIN mirror_configurations c ON c.id = h.mirror_config_id
+			WHERE %s
 			ORDER BY h.started_at DESC
 			LIMIT 8
 		) provider_syncs
 		ORDER BY started_at DESC
 		LIMIT 8
-	`)
+	`, syncWhere), syncArgs...)
 	if recentErr == nil {
 		defer recentRows.Close()
 		for recentRows.Next() {

--- a/backend/internal/api/admin/stats_test.go
+++ b/backend/internal/api/admin/stats_test.go
@@ -84,7 +84,11 @@ func expectStatsQueries(mock sqlmock.Sqlmock, opts statsOpts) {
 
 	// 6. Provider mirror health
 	provHealthCols := []string{"total", "healthy", "failed"}
-	mock.ExpectQuery("mirror_configurations").
+	mirrorHealthQuery := opts.mirrorHealthQuery
+	if mirrorHealthQuery == "" {
+		mirrorHealthQuery = "mirror_configurations"
+	}
+	mock.ExpectQuery(mirrorHealthQuery).
 		WillReturnRows(sqlmock.NewRows(provHealthCols).AddRow(
 			opts.provMirrorTotal, opts.provMirrorHealthy, opts.provMirrorFailed,
 		))
@@ -99,7 +103,11 @@ func expectStatsQueries(mock sqlmock.Sqlmock, opts statsOpts) {
 		rows.AddRow(e.MirrorName, e.MirrorType, e.Status, e.StartedAt, e.CompletedAt,
 			e.VersionsSynced, e.PlatformsSynced, e.TriggeredBy)
 	}
-	mock.ExpectQuery("terraform_sync_history").WillReturnRows(rows)
+	recentSyncQuery := opts.recentSyncQuery
+	if recentSyncQuery == "" {
+		recentSyncQuery = "terraform_sync_history"
+	}
+	mock.ExpectQuery(recentSyncQuery).WillReturnRows(rows)
 }
 
 type statsOpts struct {
@@ -115,6 +123,12 @@ type statsOpts struct {
 	bySystem                                                []ModuleSystemCount
 	byTool                                                  []BinaryToolCount
 	recentSyncs                                             []RecentSyncEntry
+	// Optional regexes for the two mirror_configurations-derived queries, so a
+	// caller can require the tenant predicate to be present in the SQL text
+	// rather than merely the table name (see cross_org_authz_test.go). Empty
+	// means "match on the table name only".
+	mirrorHealthQuery string
+	recentSyncQuery   string
 }
 
 func defaultStatsOpts() statsOpts {

--- a/backend/internal/api/orgscope_route_class_test.go
+++ b/backend/internal/api/orgscope_route_class_test.go
@@ -1,0 +1,1052 @@
+package api
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+
+	"github.com/terraform-registry/terraform-registry/internal/api/admin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// Issue #566 — the seven route tests in this package are hand-written tables.
+//
+// Every one of them names the routes it checks, so each is a statement about
+// the routes that existed the day it was written and about nothing else. That
+// is structurally unable to catch the defect that keeps recurring here: a NEW
+// route mounted without the guard its siblings carry. POST
+// /admin/policies/evaluate shipped that way and was fixed in #855 — one line
+// below a sibling in the same block that had RequireOrgScopeForResource — and
+// #718/#719/#783 are the same shape at four earlier addresses.
+//
+// This file asserts an authorization property over the REAL route table
+// instead. It enumerates whatever registerAPIV1Routes actually mounts and
+// requires every AUTHENTICATED route to answer the question the session JWT
+// cannot: the token carries a FLAT, org-less union of the caller's scopes
+// across every organization they belong to (#652), so holding `mirrors:read`
+// proves nothing about WHICH organization's mirrors may be read. Something on
+// the request path has to re-derive that, and this test says what "something"
+// is allowed to be:
+//
+//	1. the route's middleware chain requires the platform-wide `admin` wildcard,
+//	   which deliberately crosses organization boundaries (see the AUTHORITY
+//	   MODEL comment in internal/tenantscope);
+//	2. the chain carries one of the org-resolving guards in internal/middleware;
+//	3. the handler itself reaches a tenant-scope resolver;
+//	4. the route is named in tenantGuardExemptRoutes with a reason.
+//
+// A new route that does none of those fails here, once, on the commit that adds
+// it.
+//
+// TWO TABLES, CROSS-CHECKED. Middleware is not observable from gin's
+// Engine.Routes() — RouteInfo reports only the terminal handler — so the
+// middleware chain is read from the AST of router_routes.go. An AST parse can
+// silently miss a route, which would make the whole check vacuous for exactly
+// the routes most likely to be unusual. So the AST table is required to match
+// the RUNTIME table exactly, in both directions, before anything else is
+// asserted: gin is the oracle for WHICH routes exist, the AST is the oracle for
+// WHAT GUARDS THEM.
+
+// ---------------------------------------------------------------------------
+// The exemption map
+// ---------------------------------------------------------------------------
+
+// tenantGuardExemptRoutes are the authenticated routes that legitimately carry
+// no per-organization check, each with the reason. Keyed "METHOD /path".
+//
+// Checked in BOTH directions. An entry naming a route the table no longer
+// mounts fails the test, so the list cannot rot into a standing permission
+// nobody has re-read — and a renamed route cannot inherit an exemption that was
+// granted to something else.
+//
+// Being a map rather than a prefix or path-pattern rule is the point: a new
+// route cannot join this list by living under a plausible-looking prefix,
+// somebody has to type it here next to a reason.
+var tenantGuardExemptRoutes = map[string]string{
+	// --- Reads over platform-global tables --------------------------------
+	// None of terraform_mirror_configs, terraform_versions,
+	// terraform_version_platforms, terraform_sync_history or releases_gpg_keys
+	// carries an organization_id column, so there is no tenant to scope to and
+	// no per-org guard that could apply. The authority has to come from the
+	// scope itself, which is what platform_mirror_routes_test.go asserts for
+	// this family (and why its mutating half requires mirrors:manage).
+	"GET /api/v1/admin/terraform-mirrors":                                 "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id":                             "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id/status":                      "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id/history":                     "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id/versions":                    "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id/versions/:version":           "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/:id/versions/:version/platforms": "platform-global binary-mirror catalogue; no organization_id on any table it reads",
+	"GET /api/v1/admin/terraform-mirrors/releases-gpg-keys":               "platform-global HashiCorp releases signing keys; releases_gpg_keys has no organization_id",
+	"GET /api/v1/admin/scanning/latest":                                   "reads no table at all — asks the upstream release API which scanner version is current",
+
+	// --- The principal's own data -----------------------------------------
+	// The discriminator on these is the CALLER, resolved from c.Get("user_id")
+	// by the auth middleware. An organization predicate would be the wrong
+	// question: a user is not reachable from an organization by column, only
+	// through organization_members.
+	"GET /api/v1/auth/me":              "returns the calling principal's own identity and scopes",
+	"POST /api/v1/auth/refresh":        "re-mints the calling principal's own token",
+	"GET /api/v1/users/me/memberships": "the caller's own memberships, keyed on the authenticated user_id",
+	"GET /api/v1/apikeys/:id":          "self-service: authorizes on api_keys.user_id == caller (403 otherwise, unless platform admin); the discriminator is the owning user, not organization_id",
+	"DELETE /api/v1/apikeys/:id":       "self-service: authorizes on api_keys.user_id == caller (403 otherwise, unless platform admin); the discriminator is the owning user, not organization_id",
+
+	// --- No organization exists yet, or the table has none -----------------
+	"POST /api/v1/organizations": "creates the organization; there is no membership to check against a row that does not exist yet. The auto-grant of org_owner it performs is the named bootstrapExemption in platform_admin_grant_class_test.go",
+	"POST /api/v1/users":         "the users table carries no organization_id; gated on users:write",
+
+	// --- Proxy, no local table --------------------------------------------
+	"GET /api/v1/suite/modules/:namespace/:name/:system/consumers": "server-side proxy to a sibling suite application (2s timeout, [] on any failure); reads no table in this database",
+
+	// --- SCIM: the IdP-driven platform provisioning surface ----------------
+	// SCIM is how an external identity provider administers the whole
+	// deployment's users and groups; it passes OrgScopeAllOrganizations
+	// explicitly and deliberately, and is gated on scim:provision, which no
+	// seeded per-organization role template grants. Narrowing it to the
+	// caller's memberships would break provisioning of users who have none yet
+	// — which is every user, at the moment they are created.
+	"GET /scim/v2/Users":      "IdP-driven platform provisioning; explicitly OrgScopeAllOrganizations, gated on scim:provision",
+	"GET /scim/v2/Users/:id":  "IdP-driven platform provisioning; explicitly OrgScopeAllOrganizations, gated on scim:provision",
+	"POST /scim/v2/Users":     "IdP-driven platform provisioning; explicitly OrgScopeAllOrganizations, gated on scim:provision",
+	"GET /scim/v2/Groups":     "IdP-driven platform provisioning; explicitly OrgScopeAllOrganizations, gated on scim:provision",
+	"GET /scim/v2/Groups/:id": "IdP-driven platform provisioning; explicitly OrgScopeAllOrganizations, gated on scim:provision",
+
+	// --- Development-only --------------------------------------------------
+	// Not registered at all unless DEV_MODE is set (#740); this test sets it so
+	// the table it checks is the widest one the binary can produce.
+	// dev_routes_test.go asserts they are absent otherwise.
+	"GET /api/v1/dev/users":                 "dev-mode-only impersonation picker; the group is not registered unless DEV_MODE is set (#740)",
+	"POST /api/v1/dev/impersonate/:user_id": "dev-mode-only impersonation; the group is not registered unless DEV_MODE is set (#740)",
+}
+
+// ---------------------------------------------------------------------------
+// The guard vocabularies
+// ---------------------------------------------------------------------------
+
+// orgGuardMiddleware are the middleware that resolve the addressed row's — or
+// the addressed namespace's — owning organization and authorize the caller
+// against THAT organization rather than against the token's org-less union.
+var orgGuardMiddleware = map[string]bool{
+	"nsAuthz.RequireOrgScopeForResource":     true,
+	"nsAuthz.RequireNamespaceAccessFromPath": true,
+	"nsAuthz.RequirePublishAccessFromForm":   true,
+	"nsAuthz.RequirePublishAccessFromJSON":   true,
+	"nsAuthz.RequireModuleAccessByID":        true,
+	"nsAuthz.RequireModuleUpdateAccess":      true,
+	"nsAuthz.RequireProviderAccessByID":      true,
+	"middleware.RequireOrgScopeForPathOrg":   true,
+}
+
+// platformAdminMiddleware is the wildcard that deliberately crosses
+// organization boundaries. A route behind it is not exempt by omission — it is
+// authorized by a scope that no per-organization role template grants.
+const platformAdminMiddleware = "middleware.RequireScope(ScopeAdmin)"
+
+// authMiddleware marks the routes this test is about. Routes reachable without
+// authentication (the Terraform protocol surface, public search, the setup
+// wizard, the login endpoints) answer a different question and are covered by
+// public_routes_ratelimit_test.go and unauth_principal_class_test.go.
+const authMiddleware = "middleware.AuthMiddleware"
+
+// tenantResolverCalls are the handler-side ways to re-derive the caller's
+// per-organization authority. Each one ends at a membership lookup against the
+// identity store: tenantscope.Resolve and its package-local wrappers, the two
+// axis helpers in internal/api/admin, and the two direct per-org membership
+// reads that predate the shared resolver.
+//
+// OrgScopeAllOrganizations is deliberately NOT here: it is the explicit
+// platform-wide widening, the opposite of a check.
+var tenantResolverCalls = map[string]bool{
+	"tenantscope.Resolve":      true,
+	"tenantscope.OwnerOrg":     true,
+	"resolveTenantScope":       true,
+	"callerTenantScope":        true,
+	"requireTenantScopeForOrg": true,
+	"userAxisScope":            true,
+	"auditScope":               true,
+	"GetUserScopesForOrg":      true,
+	"GetMemberWithRole":        true,
+}
+
+// ---------------------------------------------------------------------------
+// AST route table
+// ---------------------------------------------------------------------------
+
+// routeGroup mirrors a gin *RouterGroup: a base path plus the middleware in
+// effect for routes registered on it FROM THIS POINT ON. Middleware is
+// accumulated in source order because gin's Use only applies to routes
+// registered after it — devGroup relies on exactly that, mounting two
+// unauthenticated routes before it attaches AuthMiddleware.
+type routeGroup struct {
+	basePath string
+	mws      []string
+}
+
+// mountedRoute is one row of the route table as read from the AST.
+type mountedRoute struct {
+	method string
+	path   string
+	mws    []string
+	pos    token.Position
+}
+
+func (r mountedRoute) key() string { return r.method + " " + r.path }
+
+var routeHTTPMethods = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "DELETE": true,
+	"PATCH": true, "HEAD": true, "OPTIONS": true,
+}
+
+// joinRoutePaths reproduces gin's joinPaths.
+func joinRoutePaths(base, rel string) string {
+	if rel == "" {
+		return base
+	}
+	final := path.Join(base, rel)
+	if strings.HasSuffix(rel, "/") && !strings.HasSuffix(final, "/") {
+		return final + "/"
+	}
+	if final == "" {
+		return "/"
+	}
+	return final
+}
+
+// callSymbol renders a call's callee as "pkg.Func" / "recv.Method" / "Func".
+func callSymbol(call *ast.CallExpr) string {
+	switch f := call.Fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		if x, ok := f.X.(*ast.Ident); ok {
+			return x.Name + "." + f.Sel.Name
+		}
+		if sel, ok := f.X.(*ast.SelectorExpr); ok {
+			return sel.Sel.Name + "." + f.Sel.Name
+		}
+		return f.Sel.Name
+	}
+	return ""
+}
+
+// middlewareName names a middleware argument. RequireScope's argument is folded
+// into the name because ScopeAdmin is the distinction that matters.
+func middlewareName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.CallExpr:
+		name := callSymbol(v)
+		if len(v.Args) > 0 {
+			if sel, ok := v.Args[0].(*ast.SelectorExpr); ok {
+				return name + "(" + sel.Sel.Name + ")"
+			}
+		}
+		return name + "()"
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return middlewareName(v.X) + "." + v.Sel.Name
+	}
+	return fmt.Sprintf("%T", e)
+}
+
+func middlewareBase(name string) string {
+	if i := strings.Index(name, "("); i >= 0 {
+		return name[:i]
+	}
+	return name
+}
+
+// routeTableReader walks registration functions and collects the route table.
+type routeTableReader struct {
+	fset  *token.FileSet
+	funcs map[string]*ast.FuncDecl
+	// factories are local `f := func(...) gin.HandlerFunc { ... }` middleware
+	// builders. router_routes.go uses four of them (scmProviderOrg,
+	// mirrorConfigOrg, approvalOrg, policyOrg); without expanding them, the
+	// guard they wrap is invisible and 20 correctly-guarded routes would look
+	// unguarded.
+	factories map[string][]string
+	routes    []mountedRoute
+}
+
+// read walks fn in source order. groups binds in-scope identifiers to groups.
+func (rr *routeTableReader) read(fn *ast.FuncDecl, groups map[string]*routeGroup, depth int) {
+	if fn == nil || fn.Body == nil || depth > 4 {
+		return
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			rr.readAssign(node, groups)
+		case *ast.ExprStmt:
+			call, ok := node.X.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// A call into a sibling registration helper — registerSCIMRoutes,
+			// registerAuthenticatedGroupMiddleware — with the group passed as
+			// its first argument. Recursing with the caller's *routeGroup bound
+			// to the parameter name means middleware the helper attaches lands
+			// on the caller's group, exactly as it does at run time.
+			if id, ok := call.Fun.(*ast.Ident); ok {
+				rr.readHelperCall(id, call, groups, depth)
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			recv, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			g := groups[recv.Name]
+			if g == nil {
+				return true
+			}
+			if sel.Sel.Name == "Use" {
+				for _, a := range call.Args {
+					g.mws = append(g.mws, middlewareName(a))
+				}
+				return true
+			}
+			if routeHTTPMethods[sel.Sel.Name] && len(call.Args) >= 2 {
+				rr.readRoute(sel.Sel.Name, call, g)
+			}
+		}
+		return true
+	})
+}
+
+func (rr *routeTableReader) readAssign(node *ast.AssignStmt, groups map[string]*routeGroup) {
+	if len(node.Lhs) != 1 || len(node.Rhs) != 1 {
+		return
+	}
+	lhs, ok := node.Lhs[0].(*ast.Ident)
+	if !ok {
+		return
+	}
+	if lit, ok := node.Rhs[0].(*ast.FuncLit); ok {
+		var inner []string
+		ast.Inspect(lit.Body, func(n ast.Node) bool {
+			if c, ok := n.(*ast.CallExpr); ok {
+				inner = append(inner, callSymbol(c))
+			}
+			return true
+		})
+		rr.factories[lhs.Name] = inner
+		return
+	}
+	call, ok := node.Rhs[0].(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Group" || len(call.Args) < 1 {
+		return
+	}
+	parentIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	parent := groups[parentIdent.Name]
+	if parent == nil {
+		return
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok {
+		return
+	}
+	prefix, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return
+	}
+	g := &routeGroup{basePath: joinRoutePaths(parent.basePath, prefix)}
+	g.mws = append(g.mws, parent.mws...)
+	groups[lhs.Name] = g
+}
+
+func (rr *routeTableReader) readHelperCall(id *ast.Ident, call *ast.CallExpr, groups map[string]*routeGroup, depth int) {
+	helper := rr.funcs[id.Name]
+	if helper == nil || len(call.Args) == 0 || helper.Type.Params == nil || len(helper.Type.Params.List) == 0 {
+		return
+	}
+	argIdent, ok := call.Args[0].(*ast.Ident)
+	if !ok {
+		return
+	}
+	g := groups[argIdent.Name]
+	if g == nil {
+		return
+	}
+	names := helper.Type.Params.List[0].Names
+	if len(names) == 0 {
+		return
+	}
+	rr.read(helper, map[string]*routeGroup{names[0].Name: g}, depth+1)
+}
+
+func (rr *routeTableReader) readRoute(method string, call *ast.CallExpr, g *routeGroup) {
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok {
+		return
+	}
+	rel, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return
+	}
+	r := mountedRoute{
+		method: method,
+		path:   joinRoutePaths(g.basePath, rel),
+		pos:    rr.fset.Position(call.Pos()),
+	}
+	r.mws = append(r.mws, g.mws...)
+	for _, a := range call.Args[1 : len(call.Args)-1] {
+		name := middlewareName(a)
+		if inner, ok := rr.factories[middlewareBase(name)]; ok {
+			r.mws = append(r.mws, inner...)
+			continue
+		}
+		r.mws = append(r.mws, name)
+	}
+	rr.routes = append(rr.routes, r)
+}
+
+// readAPIV1RouteTable parses router_routes.go and returns the route table
+// registerAPIV1Routes mounts, keyed "METHOD /path".
+func readAPIV1RouteTable(t *testing.T, root string) map[string]mountedRoute {
+	t.Helper()
+	fset := token.NewFileSet()
+	src := filepath.Join(root, "internal/api/router_routes.go")
+	f, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+	funcs := map[string]*ast.FuncDecl{}
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv == nil {
+			funcs[fd.Name.Name] = fd
+		}
+	}
+	entry := funcs["registerAPIV1Routes"]
+	if entry == nil || entry.Type.Params == nil || len(entry.Type.Params.List) == 0 ||
+		len(entry.Type.Params.List[0].Names) == 0 {
+		t.Fatal("registerAPIV1Routes not found in internal/api/router_routes.go, or its first " +
+			"parameter is unnamed — this reader is looking at the wrong function and would " +
+			"certify an empty table")
+	}
+	rr := &routeTableReader{fset: fset, funcs: funcs, factories: map[string][]string{}}
+	rr.read(entry, map[string]*routeGroup{entry.Type.Params.List[0].Names[0].Name: {}}, 0)
+
+	table := map[string]mountedRoute{}
+	for _, r := range rr.routes {
+		table[r.key()] = r
+	}
+	return table
+}
+
+// ---------------------------------------------------------------------------
+// Runtime route table
+// ---------------------------------------------------------------------------
+
+// mountRealAPIV1Routes builds the production route table with sparse
+// dependencies. Handlers are never invoked here — only the shape of the table
+// is read — so a nil dependency a handler would have dereferenced is harmless.
+func mountRealAPIV1Routes(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 600, BurstSize: 100, CleanupInterval: time.Minute,
+	})
+	t.Cleanup(limiter.Stop)
+
+	r := gin.New()
+	registerAPIV1Routes(r, &apiV1RouteDeps{
+		cfg:                &config.Config{},
+		db:                 db,
+		identityDB:         db,
+		sqlxDB:             sqlxDB,
+		userRepo:           repositories.NewUserRepository(db),
+		generalRateLimiter: limiter,
+		orgRateLimiter:     limiter,
+		nsAuthz: middleware.NewNamespaceAuthorizer(
+			repositories.NewOrganizationRepository(db),
+			repositories.NewNamespaceClaimRepository(db),
+			repositories.NewModuleRepository(db),
+			repositories.NewProviderRepository(db),
+		),
+		mirrorRepo:       repositories.NewMirrorRepository(sqlxDB),
+		rbacRepo:         repositories.NewRBACRepositoryWithIdentity(sqlxDB, sqlxDB),
+		auditLogHandlers: admin.NewAuditLogHandlers(db),
+	})
+	return r
+}
+
+// ---------------------------------------------------------------------------
+// Handler index and reachability
+// ---------------------------------------------------------------------------
+
+// handlerIndex maps declared functions and methods across the module so a gin
+// handler symbol can be resolved back to source.
+type handlerIndex struct {
+	byMethod map[string]*ast.FuncDecl // "(*Type).Method"
+	byFunc   map[string]*ast.FuncDecl // "pkg.Func"
+	recvType map[*ast.FuncDecl]string
+	pkgName  map[*ast.FuncDecl]string
+}
+
+func buildHandlerIndex(t *testing.T, root string) *handlerIndex {
+	t.Helper()
+	idx := &handlerIndex{
+		byMethod: map[string]*ast.FuncDecl{},
+		byFunc:   map[string]*ast.FuncDecl{},
+		recvType: map[*ast.FuncDecl]string{},
+		pkgName:  map[*ast.FuncDecl]string{},
+	}
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(filepath.Join(root, "internal"), func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if n := d.Name(); n == "vendor" || n == "testdata" || strings.HasPrefix(n, ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".go") || strings.HasSuffix(p, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, p, nil, 0)
+		if perr != nil {
+			return fmt.Errorf("parse %s: %w", p, perr)
+		}
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				continue
+			}
+			idx.pkgName[fd] = f.Name.Name
+			if fd.Recv != nil && len(fd.Recv.List) == 1 {
+				rt := receiverTypeName(fd.Recv.List[0].Type)
+				idx.recvType[fd] = rt
+				idx.byMethod["(*"+rt+")."+fd.Name.Name] = fd
+				continue
+			}
+			idx.byFunc[f.Name.Name+"."+fd.Name.Name] = fd
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("index module: %v", err)
+	}
+	return idx
+}
+
+func receiverTypeName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.StarExpr:
+		return receiverTypeName(v.X)
+	case *ast.Ident:
+		return v.Name
+	case *ast.IndexExpr:
+		return receiverTypeName(v.X)
+	}
+	return ""
+}
+
+// closureSuffix strips the ".funcN" gin appends for a handler that is a closure
+// returned by a constructor, including nested forms like ".func3.1".
+var closureSuffix = regexp.MustCompile(`(\.func\d+)+(\.\d+)*$`)
+
+// resolveHandlerSymbol maps a gin RouteInfo.Handler to the function that
+// declares it. Two shapes occur:
+//
+//	.../internal/api/admin.(*MirrorHandler).GetMirrorConfig-fm
+//	.../internal/api.registerAPIV1Routes.(*APIKeyHandlers).ListAPIKeysHandler.func92
+//
+// The second is a closure the runtime attributes to the package of the
+// ENCLOSING function rather than the declaring one, so a package-qualified
+// lookup fails for it and the bare name is used — rejected if ambiguous rather
+// than guessed.
+func (idx *handlerIndex) resolveHandlerSymbol(sym string) (*ast.FuncDecl, string) {
+	s := closureSuffix.ReplaceAllString(strings.TrimSuffix(sym, "-fm"), "")
+	if i := strings.Index(s, ".(*"); i >= 0 {
+		key := s[i+1:]
+		return idx.byMethod[key], key
+	}
+	parts := strings.Split(s, "/")
+	last := parts[len(parts)-1]
+	if fd := idx.byFunc[last]; fd != nil {
+		return fd, last
+	}
+	segs := strings.Split(last, ".")
+	bare := segs[len(segs)-1]
+	var hit *ast.FuncDecl
+	var hitKey string
+	matches := 0
+	for k, fd := range idx.byFunc {
+		if strings.HasSuffix(k, "."+bare) {
+			matches++
+			hit, hitKey = fd, k
+		}
+	}
+	if matches == 1 {
+		return hit, hitKey
+	}
+	return nil, last
+}
+
+// reachesTenantResolver reports whether fd calls a tenant-scope resolver, or
+// reaches one through a function in its own package or a method on its own
+// receiver. Expansion is deliberately limited to those two edges: both are
+// resolvable from the AST without type information, which keeps the answer
+// exact. A resolver reached only through some other package's type would not be
+// seen — that direction produces a demand for an exemption, never a silent
+// pass, so the failure mode is a test that asks for justification rather than
+// one that grants it.
+func (idx *handlerIndex) reachesTenantResolver(fd *ast.FuncDecl, depth int, seen map[*ast.FuncDecl]bool) (string, bool) {
+	if fd == nil || depth > 4 || seen[fd] {
+		return "", false
+	}
+	seen[fd] = true
+
+	recvIdent := ""
+	if fd.Recv != nil && len(fd.Recv.List) == 1 && len(fd.Recv.List[0].Names) == 1 {
+		recvIdent = fd.Recv.List[0].Names[0].Name
+	}
+	recvType := idx.recvType[fd]
+	pkg := idx.pkgName[fd]
+
+	via := ""
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		if via != "" {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name := callSymbol(call)
+		short := name
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			short = name[i+1:]
+		}
+		if tenantResolverCalls[name] || tenantResolverCalls[short] {
+			via = name
+			return false
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok {
+			if next := idx.byFunc[pkg+"."+id.Name]; next != nil {
+				if v, ok := idx.reachesTenantResolver(next, depth+1, seen); ok {
+					via = v
+					return false
+				}
+			}
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == recvIdent && recvType != "" {
+				if next := idx.byMethod["(*"+recvType+")."+sel.Sel.Name]; next != nil {
+					if v, ok := idx.reachesTenantResolver(next, depth+1, seen); ok {
+						via = v
+						return false
+					}
+				}
+			}
+		}
+		return true
+	})
+	return via, via != ""
+}
+
+// ---------------------------------------------------------------------------
+// Vacuity
+// ---------------------------------------------------------------------------
+
+// These are floors, not counts. The real figures when this landed were 208
+// routes, 170 of them authenticated, 146 of those guarded; the floors sit well
+// below so they only fire when a table stops being enumerated at all. They must
+// never be raised to track the real figures, or every new route becomes a test
+// edit and the floor stops meaning "this is not vacuous".
+const (
+	minAPIV1Routes         = 150
+	minAuthenticatedRoutes = 100
+	minGuardedRoutes       = 60
+)
+
+// checkNotVacuous is the empty-universe guard, factored out as a pure function
+// so it can be falsified directly (TestOrgScopeRouteClass_RefusesAnEmptyUniverse
+// hands it nothing and requires it to complain). Every other assertion in this
+// file iterates a set; if that set is empty they all pass while checking
+// nothing, which is the one failure mode iteration cannot see.
+func checkNotVacuous(routes map[string]mountedRoute, authenticated, guarded int) error {
+	if len(routes) < minAPIV1Routes {
+		return fmt.Errorf("registerAPIV1Routes yielded only %d routes (floor %d): the route "+
+			"table is not being enumerated, so every assertion over it is vacuous",
+			len(routes), minAPIV1Routes)
+	}
+	if authenticated < minAuthenticatedRoutes {
+		return fmt.Errorf("only %d of %d routes were classified as authenticated (floor %d): %q "+
+			"no longer matches the middleware chain, so the routes this test exists for are "+
+			"being skipped", authenticated, len(routes), minAuthenticatedRoutes, authMiddleware)
+	}
+	if guarded < minGuardedRoutes {
+		return fmt.Errorf("only %d authenticated routes resolved a tenant scope (floor %d): the "+
+			"guard vocabularies (orgGuardMiddleware / tenantResolverCalls) have gone stale, so "+
+			"guarded routes are being reported as exempt-or-broken", guarded, minGuardedRoutes)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// The tests
+// ---------------------------------------------------------------------------
+
+// TestOrgScopeRouteClass_ASTTableMatchesTheRealRouter is the prerequisite for
+// everything below it. The middleware chain is only visible in the AST, and the
+// set of routes is only authoritative at run time; if the two disagree, the
+// classification is being applied to a table that is not the one gin serves.
+//
+// Checked in both directions. A route the reader misses would be silently
+// unchecked (the dangerous direction); a route the reader invents would be
+// classified against middleware no request ever runs.
+func TestOrgScopeRouteClass_ASTTableMatchesTheRealRouter(t *testing.T) {
+	// Dev routes are registered only when DEV_MODE is set (#740). Setting it
+	// here makes the runtime table the WIDEST the binary can produce, so the
+	// dev endpoints are classified rather than quietly absent.
+	t.Setenv("DEV_MODE", "true")
+
+	astTable := readAPIV1RouteTable(t, moduleRoot(t))
+	runtimeTable := map[string]string{}
+	for _, ri := range mountRealAPIV1Routes(t).Routes() {
+		runtimeTable[ri.Method+" "+ri.Path] = ri.Handler
+	}
+
+	var onlyRuntime, onlyAST []string
+	for k := range runtimeTable {
+		if _, ok := astTable[k]; !ok {
+			onlyRuntime = append(onlyRuntime, k)
+		}
+	}
+	for k := range astTable {
+		if _, ok := runtimeTable[k]; !ok {
+			onlyAST = append(onlyAST, k)
+		}
+	}
+	sort.Strings(onlyRuntime)
+	sort.Strings(onlyAST)
+
+	if len(onlyRuntime) > 0 {
+		t.Errorf("gin serves %d route(s) the AST reader did not find: %s.\nThese are "+
+			"UNCHECKED by the guard below. Teach readAPIV1RouteTable the registration shape "+
+			"they use — do not narrow the guard to match the reader.",
+			len(onlyRuntime), strings.Join(onlyRuntime, ", "))
+	}
+	if len(onlyAST) > 0 {
+		t.Errorf("the AST reader invented %d route(s) gin does not serve: %s.\nThe "+
+			"classification below would be judging middleware that never runs.",
+			len(onlyAST), strings.Join(onlyAST, ", "))
+	}
+	if len(astTable) < minAPIV1Routes {
+		t.Fatalf("only %d routes read (floor %d) — the table is not being enumerated",
+			len(astTable), minAPIV1Routes)
+	}
+}
+
+// TestOrgScopeRouteClass_EveryAuthenticatedRouteResolvesATenant is the guard.
+func TestOrgScopeRouteClass_EveryAuthenticatedRouteResolvesATenant(t *testing.T) {
+	t.Setenv("DEV_MODE", "true")
+
+	root := moduleRoot(t)
+	astTable := readAPIV1RouteTable(t, root)
+	idx := buildHandlerIndex(t, root)
+
+	runtimeTable := map[string]string{}
+	for _, ri := range mountRealAPIV1Routes(t).Routes() {
+		runtimeTable[ri.Method+" "+ri.Path] = ri.Handler
+	}
+
+	var keys []string
+	for k := range astTable {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	authenticated, guarded := 0, 0
+	claimedExemptions := map[string]bool{}
+
+	for _, key := range keys {
+		route := astTable[key]
+
+		isAuthenticated, isPlatformAdmin := false, false
+		orgGuard := ""
+		for _, mw := range route.mws {
+			base := middlewareBase(mw)
+			switch {
+			case base == authMiddleware:
+				isAuthenticated = true
+			case mw == platformAdminMiddleware:
+				isPlatformAdmin = true
+			case orgGuardMiddleware[base]:
+				orgGuard = base
+			}
+		}
+		if !isAuthenticated {
+			continue
+		}
+		authenticated++
+
+		if isPlatformAdmin || orgGuard != "" {
+			guarded++
+			// An exemption on an already-guarded route is a claim nobody
+			// re-reads; surface it rather than letting it sit.
+			if _, exempt := tenantGuardExemptRoutes[key]; exempt {
+				claimedExemptions[key] = true
+				via := orgGuard
+				if isPlatformAdmin {
+					via = platformAdminMiddleware
+				}
+				t.Errorf("%s carries a guard (%s) AND a tenantGuardExemptRoutes entry — "+
+					"drop the exemption, it is describing something that is no longer true",
+					key, via)
+			}
+			continue
+		}
+
+		sym, ok := runtimeTable[key]
+		if !ok {
+			// The cross-check test reports the mismatch; do not double-report,
+			// but do not certify the route either.
+			t.Errorf("%s is in the AST table but not the runtime table — cannot resolve its "+
+				"handler, so it cannot be certified", key)
+			continue
+		}
+		fd, symKey := idx.resolveHandlerSymbol(sym)
+		if fd == nil {
+			t.Errorf("%s: cannot resolve handler %q (looked for %q) to a declaration. A handler "+
+				"this test cannot read is a handler it cannot certify — teach "+
+				"resolveHandlerSymbol the shape, do not exempt the route.", key, sym, symKey)
+			continue
+		}
+		if via, ok := idx.reachesTenantResolver(fd, 0, map[*ast.FuncDecl]bool{}); ok {
+			guarded++
+			if _, exempt := tenantGuardExemptRoutes[key]; exempt {
+				claimedExemptions[key] = true
+				t.Errorf("%s resolves a tenant scope in its handler (via %s) AND has a "+
+					"tenantGuardExemptRoutes entry — drop the exemption", key, via)
+			}
+			continue
+		}
+		if _, exempt := tenantGuardExemptRoutes[key]; exempt {
+			claimedExemptions[key] = true
+			continue
+		}
+
+		t.Errorf(`%s (%s) is authenticated but re-checks nothing about the caller's organization.
+
+  handler: %s
+  chain:   %s
+
+The session JWT carries a FLAT, org-less union of the caller's scopes across
+every organization they belong to (#652), so passing RequireScope proves the
+caller holds the scope SOMEWHERE, not here. Give the route one of:
+
+  * an org guard in its chain (%s), or
+  * a tenant-scope resolver in the handler (tenantscope.Resolve /
+    resolveTenantScope / requireTenantScopeForOrg), or
+  * an entry in tenantGuardExemptRoutes naming the reason it needs none.
+
+This is the defect #855 fixed at POST /admin/policies/evaluate, which sat one
+line below a sibling that had the guard.`,
+			key, route.pos, symKey, strings.Join(route.mws, " -> "),
+			strings.Join(sortedKeys(orgGuardMiddleware), " / "))
+	}
+
+	if err := checkNotVacuous(astTable, authenticated, guarded); err != nil {
+		t.Fatal(err)
+	}
+
+	// The other direction: an exemption that no longer names an unguarded
+	// authenticated route.
+	var stale []string
+	for key := range tenantGuardExemptRoutes {
+		if !claimedExemptions[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	for _, key := range stale {
+		if _, mounted := astTable[key]; !mounted {
+			t.Errorf("tenantGuardExemptRoutes names %q, which registerAPIV1Routes no longer "+
+				"mounts — remove the entry. An exemption for a route that does not exist is "+
+				"waiting for the next route to take that path and inherit it.", key)
+			continue
+		}
+		t.Errorf("tenantGuardExemptRoutes names %q, which is no longer an unguarded "+
+			"authenticated route — remove the entry.", key)
+	}
+
+	t.Logf("classified %d authenticated routes: %d guarded, %d exempt",
+		authenticated, guarded, len(claimedExemptions))
+}
+
+// TestOrgScopeRouteClass_RefusesAnEmptyUniverse falsifies the vacuity guard.
+// Without this, checkNotVacuous is itself untested: a floor that never fires is
+// indistinguishable from no floor at all.
+func TestOrgScopeRouteClass_RefusesAnEmptyUniverse(t *testing.T) {
+	tests := []struct {
+		name          string
+		routes        map[string]mountedRoute
+		authenticated int
+		guarded       int
+	}{
+		{"no routes at all", map[string]mountedRoute{}, 0, 0},
+		{"nil table", nil, 0, 0},
+		{"table read, but nothing recognised as authenticated",
+			fakeRouteTable(minAPIV1Routes + 10), 0, 0},
+		{"authenticated routes found, but no guard vocabulary matched",
+			fakeRouteTable(minAPIV1Routes + 10), minAuthenticatedRoutes + 10, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := checkNotVacuous(tt.routes, tt.authenticated, tt.guarded); err == nil {
+				t.Fatal("checkNotVacuous certified an empty/degenerate universe — it must " +
+					"refuse rather than pass, or the guard reports green while checking nothing")
+			}
+		})
+	}
+
+	// Positive control: the real shape must still pass, otherwise the floors
+	// above are simply unreachable and the check is a constant failure.
+	if err := checkNotVacuous(fakeRouteTable(minAPIV1Routes+10), minAuthenticatedRoutes+10, minGuardedRoutes+10); err != nil {
+		t.Fatalf("checkNotVacuous rejected a well-formed universe: %v", err)
+	}
+}
+
+// TestOrgScopeRouteClass_ReaderSeesTheGuardsItLooksFor pins the AST reader
+// against the two shapes that would otherwise make it lie by omission: a group
+// whose middleware is attached by a helper function, and a per-route guard
+// built by a local factory closure. Both are used by router_routes.go today,
+// and a reader blind to either reports correctly-guarded routes as unguarded —
+// which pressures whoever hits it into adding exemptions for routes that are
+// fine.
+func TestOrgScopeRouteClass_ReaderSeesTheGuardsItLooksFor(t *testing.T) {
+	t.Setenv("DEV_MODE", "true")
+	astTable := readAPIV1RouteTable(t, moduleRoot(t))
+
+	// Attached by registerAuthenticatedGroupMiddleware, not by a .Use in
+	// registerAPIV1Routes itself.
+	viaHelper, ok := astTable["GET /api/v1/auth/me"]
+	if !ok {
+		t.Fatal("GET /api/v1/auth/me is not in the table")
+	}
+	if !hasMiddlewareBase(viaHelper, authMiddleware) {
+		t.Errorf("the reader did not follow registerAuthenticatedGroupMiddleware: %v", viaHelper.mws)
+	}
+
+	// Built by the local scmProviderOrg closure, which wraps
+	// nsAuthz.RequireOrgScopeForResource.
+	viaFactory, ok := astTable["GET /api/v1/scm-providers/:id"]
+	if !ok {
+		t.Fatal("GET /api/v1/scm-providers/:id is not in the table")
+	}
+	if !hasMiddlewareBase(viaFactory, "nsAuthz.RequireOrgScopeForResource") {
+		t.Errorf("the reader did not expand the scmProviderOrg factory closure: %v", viaFactory.mws)
+	}
+
+	// Ordering within a group: devGroup mounts two routes BEFORE attaching
+	// AuthMiddleware. A reader that hoisted group middleware would mark them
+	// authenticated and demand a tenant guard for an unauthenticated route.
+	preUse, ok := astTable["POST /api/v1/dev/login"]
+	if !ok {
+		t.Fatal("POST /api/v1/dev/login is not in the table (is DEV_MODE set?)")
+	}
+	if hasMiddlewareBase(preUse, authMiddleware) {
+		t.Errorf("the reader hoisted a later .Use onto an earlier route: %v", preUse.mws)
+	}
+	postUse, ok := astTable["GET /api/v1/dev/users"]
+	if !ok {
+		t.Fatal("GET /api/v1/dev/users is not in the table")
+	}
+	if !hasMiddlewareBase(postUse, authMiddleware) {
+		t.Errorf("the reader dropped a .Use that precedes the route: %v", postUse.mws)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod, so the scan covers the whole module however it is invoked.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("abs cwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the test's working directory")
+		}
+		dir = parent
+	}
+}
+
+func hasMiddlewareBase(r mountedRoute, base string) bool {
+	for _, mw := range r.mws {
+		if middlewareBase(mw) == base {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// fakeRouteTable builds n distinct routes for the vacuity falsification tests.
+func fakeRouteTable(n int) map[string]mountedRoute {
+	out := make(map[string]mountedRoute, n)
+	for i := 0; i < n; i++ {
+		r := mountedRoute{method: "GET", path: fmt.Sprintf("/fake/%d", i)}
+		out[r.key()] = r
+	}
+	return out
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -536,7 +536,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	apiKeyHandlers := admin.NewAPIKeyHandlers(cfg, identityDB)
 	userHandlers := admin.NewUserHandlers(cfg, identityDB, admin.WithUserCredentialSweeper(credSweeper))
 	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB, nsClaimRepo, userTokenRevocationRepo)
-	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning)
+	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning).WithOrgRepo(orgRepo)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers
 	mirrorHandlers.SetEgressGuard(egressGuard)


### PR DESCRIPTION
## Per-part verification of #566 — six of seven findings already landed

I verified every finding against current code before writing anything. Findings
[45]–[51] were closed by PR #599 (`dee69b7`) and PR #715 (`bcafd6d`); nothing in
them is a live gap:

| # | Finding | Status in current code |
|---|---|---|
| 45 | Per-package coverage gate omits security-critical packages | **Already covered.** `scripts/check_package_coverage.sh` now floors 13 packages including `db/repositories`(85), `archiver`(80), `api/modules`(65), `api/providers`(80), `mirror`(83), `policy`(80). Verified each is currently above its floor. Gate runs at `ci.yml:156`. |
| 46 | No real-extraction fuzz; decompression cap and non-regular entries untested | **Already covered.** `FuzzExtractTarGz` pipes fuzz bytes through the real `ExtractTarGz` into a `t.TempDir()`; `TestExtractTarGz_ExceedsExtractionCap`, `..._CumulativeSmallEntries`, `..._SymlinkEntryIgnored`, `..._HardlinkEntryIgnored`, `..._EntryResolvingToDestRoot` all exist. |
| 47 | Traversal guard on `GET /v1/files/*filepath` has no attack-payload test | **Already covered.** `TestServeFileHandler_PathTraversal`, `_DoubleSlashTraversal`, `_URLEncodedTraversal`. |
| 48 | No SSRF-rejection tests, and the validator does no SSRF check | **Premise now wrong.** `ValidateRegistryURL` delegates to `internal/httpsafe`; `TestValidateRegistryURL_RejectsSSRFTargets` covers loopback/v6-loopback/169.254.169.254/RFC1918/fc00::/fe80::/0.0.0.0, and `_AllowlistedPrivateTargetPasses` is the positive control for `security.egress.allowlist`. |
| 49 | LDAP `InsecureSkipVerify` untested in either direction | **Already covered.** `TestProvider_TLSConfig_DefaultsToVerify` + `_InsecureSkipVerifyExplicit`. |
| 50 | No adversarial-input test for the `whereClause` `fmt.Sprintf` pattern | **Already covered.** `TestSearchModules_SQLMetacharacterQuery` binds `foo' OR '1'='1` and asserts via `mock.ExpectationsWereMet()` that it arrived as a bound parameter. |
| 51 | `coverage:skip:` marker is self-declared with no CI enforcement | **Already covered.** `coverfilter -list` enumerates every skip-marked function; `ci.yml:169` publishes it to the job summary as the periodic-audit step the finding asked for. |

So the residual value of #566 was the gap the task brief identified, which I confirmed: **no test enumerated the real route table and asserted an authorization property.** The seven existing route tests are hand-written per-family tables — each is a statement about the routes that existed the day it was written, and none can catch a new route that forgets its guard. That is exactly how `POST /admin/policies/evaluate` shipped.

## What this adds

`internal/api/orgscope_route_class_test.go` enumerates whatever `registerAPIV1Routes` actually mounts (208 routes) and requires every **authenticated** one (170) to re-derive the caller's organization, by one of:

1. a platform-admin gate (`RequireScope(ScopeAdmin)`) — the wildcard that deliberately crosses org boundaries;
2. an org-resolving guard in the chain (`RequireOrgScopeForResource`, the `nsAuthz.Require*` family, `RequireOrgScopeForPathOrg`);
3. a tenant-scope resolver reached from the handler (`tenantscope.Resolve` / `resolveTenantScope` / `requireTenantScopeForOrg` / the two per-org membership reads that predate them);
4. a named entry in `tenantGuardExemptRoutes` **with a reason**.

Result today: 146 guarded, 24 exempt, 0 unexplained. The exemption map is checked **bidirectionally** — an entry naming a route the table no longer mounts fails, and so does one naming a route that has since gained a real guard.

**Two tables, cross-checked.** Middleware is invisible to `gin.Engine.Routes()` (`RouteInfo` reports only the terminal handler), so the chain is read from the AST of `router_routes.go`. An AST parse can silently miss a route — which would make the check vacuous for exactly the routes most likely to be unusual — so the AST table must equal the runtime table **exactly, in both directions**, before anything else is asserted. gin is the oracle for *which routes exist*; the AST is the oracle for *what guards them*. `DEV_MODE` is set so the dev endpoints (#740) are classified rather than quietly absent.

The reader is itself pinned (`TestOrgScopeRouteClass_ReaderSeesTheGuardsItLooksFor`) against the three shapes that would make it lie by omission: middleware attached by a helper function, per-route guards built by a local factory closure (four of them in `router_routes.go` — without expansion, 20 correctly-guarded routes look unguarded), and `.Use` ordering within a group (`devGroup` mounts two routes *before* attaching `AuthMiddleware`).

## ⚠️ Vulnerability found and fixed: cross-tenant disclosure on `GET /api/v1/admin/stats/dashboard`

The new guard flagged it on its first run.

- It is the **only** authenticated route in the entire table with **no `RequireScope` at all** — every principal with a session reaches it, including a seeded `viewer` whose only membership is in an unrelated organization.
- Two of its queries read `mirror_configurations`, which carries `organization_id`, with no organization predicate.
- The recent-sync list emitted `c.name` — **another tenant's chosen name for its upstream mirror configuration** — to everyone.

Same class as #855: a route reading an organization-owned table while trusting the flat, org-less scope union the session JWT carries (#652).

**Fix** (`internal/api/admin/stats.go`): both `mirror_configurations`-derived statements are now scoped through `resolveTenantScope(c, orgRepo, auth.ScopeMirrorsRead)` → `Scope.OrgScope().SQL(...)`, the resolver #718/#719/#783 established, rather than new machinery. A caller sees exactly the provider mirrors it could already list at `/admin/mirrors`; a platform admin resolves to `OrgScopeAllOrganizations` and is unaffected; a caller with no qualifying membership gets the constant `FALSE`, not a missing predicate.

**Deliberately not scoped, and recorded at the guard rather than left implicit:** the aggregate integer counts (modules, providers, users, organizations, downloads, `scm_providers`, `module_version_scans`). They carry no tenant-identifying values, and the module/provider rows they count are already enumerable anonymously through `GET /api/v1/modules/search` and `/providers/search`. Narrowing them would change what the dashboard means without closing a disclosure. If you disagree, that is a one-line change at the same call site.

## Mutation table

Every guard was broken with a change that still **compiles** (`_ = scope` added where a removal would otherwise orphan it — a build failure is not a test result) and restored from a `cp` backup. Each of #855's three fixes was reverted **independently**, in both the "remove the check" and "remove the resolver" forms, because those two forms probe different halves of the design.

### PR #855's three fixes, reverted independently

| # | Mutation (compiles) | Route-table class guard | #855 behavioural test |
|---|---|---|---|
| M1 | `rbac.go` — remove the `requireTenantScopeForOrg(...)` block in `EvaluatePolicy` | ❌ names `POST /api/v1/admin/policies/evaluate` | ❌ `TestEvaluatePolicy_ForeignOrg_Denied` + `_OwnOrg_Allowed` |
| M2a | `scanning_admin.go` — both `scope.OrgScope().SQL("m.organization_id", …)` → bare `"TRUE"`, resolve call kept | ⚠️ **passes** (inert — see limitation) | ❌ `TestScanningStats_NonAdmin_EveryQueryCarriesTheTenantPredicate` |
| M2b | `scanning_admin.go` — remove `resolveTenantScope` entirely | ❌ names `GET /api/v1/admin/scanning/stats` | — |
| M3a | `scans.go` — remove the `if !scope.Permits(org.ID)` block, resolve kept | ⚠️ **passes** (inert — see limitation) | ❌ `TestModuleScanByVersion_CallerOutsideDefaultOrg_NotFound` (403/404 assertion, and the "module lookup must never run" expectation) |
| M3b | `scans.go` — remove `resolveTenantScope` entirely | ❌ names both `.../versions/:version/scan` and `/admin/scanning/scans/:id` | — |

Neither inert result is a hole in coverage — both are caught, by the behavioural half where that assertion belongs — but they are the honest boundary of what a *structural* guard can see, and they are documented below rather than papered over.

### The new-route defect the guard exists for

| # | Mutation | Result |
|---|---|---|
| B3 | Mount a NEW authenticated route with `RequireScope` only and a non-resolving handler | ❌ names `GET /api/v1/admin/brand-new-thing` at its source position |
| B4 | Register a route with a computed (non-literal) path, invisible to the AST reader | ❌ cross-check: "gin serves 1 route(s) the AST reader did not find: GET /api/v1/admin/sneaky" |

### Bidirectional exemption map

| # | Mutation | Result |
|---|---|---|
| B1 | Delete an **exempt** route from the table | ❌ "tenantGuardExemptRoutes names …, which registerAPIV1Routes no longer mounts — remove the entry" |
| B2 | Give an **exempt** route a real `RequireScope(ScopeAdmin)` | ❌ "carries a guard (…) AND a tenantGuardExemptRoutes entry — drop the exemption, it is describing something that is no longer true" |

### Empty universe — the guard must refuse, not pass vacuously

| # | Mutation | Result |
|---|---|---|
| E1 | Point the reader at a function that registers **no routes** (empty route set) | ❌ "yielded only 0 routes (floor 150): the route table is not being enumerated, so every assertion over it is vacuous" |
| E2a | Point the handler index at a **missing** directory | ❌ `index module: lstat …/internal/does-not-exist: no such file or directory` |
| E2b | Point the handler index at an **existing but empty** directory | ❌ **59 routes refused** as "cannot resolve handler … a handler this test cannot read is a handler it cannot certify" — it fails closed rather than certifying |
| E3 | Rename the auth-middleware vocabulary | ❌ "only 0 of 208 routes were classified as authenticated (floor 100)" |
| E4 | Empty `tenantResolverCalls` | ❌ "only N authenticated routes resolved a tenant scope (floor 60) … vocabularies have gone stale" |

`checkNotVacuous` is additionally falsified **directly** as a pure function: `TestOrgScopeRouteClass_RefusesAnEmptyUniverse` hands it an empty table, a nil table, a table with zero authenticated routes and one with zero guarded routes, requiring it to refuse each time — with a positive control so the floors are not simply unreachable.

### The AST reader itself

| # | Mutation | Result |
|---|---|---|
| M8 | Reader stops expanding local middleware factory closures | ❌ "did not expand the scmProviderOrg factory closure" |
| M9 | Reader hoists a later `.Use` onto earlier routes | ❌ "hoisted a later .Use onto an earlier route" |

### The dashboard fix

| # | Mutation | Result |
|---|---|---|
| D1 | Widen the mirror-health predicate to all organizations | ❌ `TestDashboardStats_MirrorQueriesCarryTheTenantPredicate` + `_NoMemberships_SelectsNothing` |
| D2 | Widen the recent-sync predicate to all organizations | ❌ same two |

Assertions are on sentinels and exact values throughout: the dashboard tests assert on `mock.ExpectationsWereMet()` against a predicate regex (`= ANY` / `TRUE` / `FALSE`), never on `err != nil` — both mutated statements are best-effort `_ =` in the handler, so a bare error check could never see them at all. `TestDashboardStats_PlatformAdmin_SeesEveryTenant` is the positive control that stops a hard-coded `FALSE` from passing as a fix.

## Known limitation, stated rather than hidden

The route guard asserts that a resolver is **reached**, not that its result is **used** (M2a). Widening a predicate while keeping the resolve call passes it. That half is the behavioural tests' job and they do it — `cross_org_authz_test.go` catches exactly that mutation on both the scanning and dashboard paths. Making the structural guard track dataflow would need whole-program type information; the honest boundary is drawn here instead of implied.

Handler reachability expands through same-package functions and same-receiver methods only — both exactly resolvable from the AST. A resolver reached solely through some other package's type would not be seen; that direction produces a **demand for an exemption**, never a silent pass, so the failure mode is a test that asks for justification rather than one that grants it.

## Verification

`cd backend && go build ./... && go vet ./... && gofmt -l . && go test ./...` all clean — the full suite exits 0, including the `internal/auth` fsnotify tests that intermittently fail on this host when its inotify watch limit is exhausted. `golangci-lint v2.12.2` reports nothing in any file this PR touches.

## Scope left undone

Deliberately NOT closing #566 with a keyword: findings [45]–[51] were already resolved before this PR and I did not re-do them, and #51's "require skip markers to reference a tracked issue / reviewer sign-off" remains a policy decision rather than a code change — the informational audit step it asked for exists. Leaving the issue open so that call can be made explicitly.

Also not attempted: scoping the dashboard's platform-wide aggregate counts (reasoned above), and a structural guard that follows the tenant scope into the SQL it constrains (needs type information; the behavioural tests cover it today).

