### PR TITLE
ci: check out pipeline-task-core for the replay

### DIFF
--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -148,6 +148,15 @@ jobs:
             path: suite/terraform-suite-ui,
             persist-credentials: false,
           }
+      # The shared module both ADO extensions are migrating onto. It is a
+      # checkout rather than an inference: the extensions used to COPY these
+      # modules to each other, and a version pin is only an improvement if
+      # something reads it.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: 4cloudguru/pipeline-task-core
+          path: suite/pipeline-task-core
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           {


### PR DESCRIPTION
Adds the ninth checkout — `4cloudguru/pipeline-task-core` at `suite/pipeline-task-core`.

**Inert on its own, and deliberately so.** Checking out a repo that `SIGNATURE_SCOPE` does not yet name changes nothing about what runs. It has to land *before* `scope.json` names it, because `load_scope` hard-fails a repo in scope that is not checked out — and that failure would hit all nine gates at once, which is exactly the self-inflicted outage `remediation/replay/README.md` records from when `packer-ext` and `terraform-ext` were added.

## Why the package is entering scope

The two ADO extensions used to copy modules to each other; they are now migrating onto `@4cloudguru/pipeline-task-core`. `azure-pipelines-packer`'s `main` already depends on it from two task manifests (`PackerInstallerV1`, `PackerTaskV1`, both `^0.2.0`). A version pin is only an improvement over copy-paste if something reads it — that is check 2 (consumer pin freshness), and it cannot read a repo the replay does not check out.

Registering it runs **no new signatures**: every registered signature declares `appliesToKinds` of `go-backend`/`gomod` or `ado-extension`, and the package is `npm`. Coverage of the code that moved into it is the blind-audit engine's job, and that profile already shipped.

## Verified

`yaml.safe_load` on the result: 11 checkouts, `persist-credentials: false` on every one, exactly one `token:` (still only the private `security-orchestration` checkout).

Follows sethbacon/security-orchestration#33.
