### PR TITLE
feat(auth): platform-admin carrier outside organization_members

### DIFF
--- a/backend/internal/api/platform_admin_carrier_test.go
+++ b/backend/internal/api/platform_admin_carrier_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/middleware"
+)
+
+// The platform-admin carrier, end to end through the REAL route tree (issue
+// #766, PR 1).
+//
+// The middleware tests assert the elevation lands in the request context. This
+// asserts the point of the whole design: because the elevation happens at ONE
+// insertion point, an existing, untouched `auth.HasScope(scopes,
+// auth.ScopeAdmin)` site starts answering from the carrier with no edit of its
+// own.
+//
+// The site under test is api/admin/dev.go:161 — deliberately, because the
+// design calls it out by name: "Dev login / impersonation must consult the
+// carrier, or DEV_MODE becomes a way to mint platform-admin without a grant."
+// It consults it here through the same middleware every other site does, which
+// is why dev.go itself needed no change.
+//
+// The session presented below carries NO scopes at all. Every route in this
+// tree is reached with an org-less scope union that would have refused it
+// before the carrier existed.
+
+// carrierDevRouter mounts the real /api/v1 route tree in DEV_MODE with a
+// carrier repository wired in, and returns the engine plus the identity mock
+// (userRepo + the dev handlers' own repositories share it) and the carrier
+// mock.
+func carrierDevRouter(t *testing.T) (*gin.Engine, sqlmock.Sqlmock, sqlmock.Sqlmock) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	t.Setenv("DEV_MODE", "true")
+	t.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	idDB, idMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (identity): %v", err)
+	}
+	t.Cleanup(func() { idDB.Close() })
+
+	paDB, paMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (platform_admins): %v", err)
+	}
+	t.Cleanup(func() { paDB.Close() })
+
+	limiter := middleware.NewRateLimiter(middleware.RateLimitConfig{
+		RequestsPerMinute: 600, BurstSize: 600, CleanupInterval: time.Minute,
+	})
+	t.Cleanup(limiter.Stop)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	registerAPIV1Routes(r, &apiV1RouteDeps{
+		cfg:                &config.Config{},
+		db:                 idDB,
+		identityDB:         idDB,
+		userRepo:           repositories.NewUserRepository(idDB),
+		orgRepo:            repositories.NewOrganizationRepository(idDB),
+		platformAdminRepo:  repositories.NewPlatformAdminRepository(paDB),
+		generalRateLimiter: limiter,
+		orgRateLimiter:     limiter,
+	})
+	return r, idMock, paMock
+}
+
+// expectSessionUserLoad queues AuthMiddleware's user load for the JWT path.
+func expectSessionUserLoad(mock sqlmock.Sqlmock, userID string) {
+	mock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}).
+			AddRow(userID, "carrier@example.com", "Carrier Admin", nil, time.Now(), time.Now()))
+}
+
+func carrierDevRequest(t *testing.T, r *gin.Engine, userID string) *httptest.ResponseRecorder {
+	t.Helper()
+	// No scopes whatsoever: the union side of the OR grants nothing here, so
+	// anything that succeeds does so because of the carrier.
+	token, err := auth.GenerateJWT(userID, "carrier@example.com", []string{}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dev/users", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// A carrier grant admits the caller at an admin check that was not edited.
+func TestPlatformAdminCarrier_AdmitsAtAnUneditedHasScopeSite(t *testing.T) {
+	r, idMock, paMock := carrierDevRouter(t)
+
+	expectSessionUserLoad(idMock, "user-carrier")
+	paMock.ExpectQuery("SELECT EXISTS.*FROM platform_admins").
+		WithArgs("user-carrier").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	// Past the gate, ListUsersForImpersonationHandler lists users. An empty
+	// page is a complete, successful answer and keeps the assertion on the
+	// authorization outcome rather than on fixture data.
+	idMock.ExpectQuery("SELECT COUNT").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	idMock.ExpectQuery("SELECT id, email, name, oidc_sub").
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"id", "email", "name", "oidc_sub", "created_at", "updated_at"}))
+
+	if w := carrierDevRequest(t, r, "user-carrier"); w.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/dev/users = %d, want 200: a carrier grant did not reach "+
+			"the untouched admin check at api/admin/dev.go:161. body=%s", w.Code, w.Body.String())
+	}
+	if err := paMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the carrier was not consulted on the session path: %v", err)
+	}
+}
+
+// The negative control, and the reason the test above proves anything: the
+// SAME request with no carrier row is refused with exactly 403 — the status
+// dev.go answers with — not a 500 from an incidental mock miss.
+func TestPlatformAdminCarrier_WithoutAGrantTheSameRequestIsRefused(t *testing.T) {
+	r, idMock, paMock := carrierDevRouter(t)
+
+	expectSessionUserLoad(idMock, "user-plain")
+	paMock.ExpectQuery("SELECT EXISTS.*FROM platform_admins").
+		WithArgs("user-plain").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	w := carrierDevRequest(t, r, "user-plain")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("GET /api/v1/dev/users = %d, want 403 (no carrier row, no admin scope): body=%s",
+			w.Code, w.Body.String())
+	}
+	if err := idMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet identity expectations: %v", err)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -198,6 +198,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// the shared identity schema, or a separate identity database (issue #559
 	// finding [9]).
 	userTokenRevocationRepo := repositories.NewUserTokenRevocationRepository(db)
+	// platformAdminRepo is the carrier for platform-admin authority outside
+	// organization_members (issue #766, migration 000051). Same connection and
+	// same reasoning as userTokenRevocationRepo above: no FK dependency on the
+	// identity schema, so it works unchanged whether identity data is in the
+	// app's public schema, the shared identity schema, or a separate identity
+	// database.
+	platformAdminRepo := repositories.NewPlatformAdminRepository(db)
 
 	// Namespace ownership claims back the object-level authorization on every
 	// module/provider mutation route (issue #555, CWE-639): a namespace binds
@@ -487,6 +494,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		orgRepo:                 orgRepo,
 		tokenRepo:               tokenRepo,
 		userTokenRevocationRepo: userTokenRevocationRepo,
+		platformAdminRepo:       platformAdminRepo,
 		auditRepo:               auditRepo,
 		pullThroughSvc:          pullThroughSvc,
 		tfBinariesHandler:       tfBinariesHandler,
@@ -703,6 +711,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		orgRepo:                     orgRepo,
 		tokenRepo:                   tokenRepo,
 		userTokenRevocationRepo:     userTokenRevocationRepo,
+		platformAdminRepo:           platformAdminRepo,
 		credSweeper:                 credSweeper,
 		moduleAdminHandlers:         moduleAdminHandlers,
 		providerAdminHandlers:       providerAdminHandlers,

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -62,6 +62,7 @@ type publicRouteDeps struct {
 	orgRepo                 *repositories.OrganizationRepository
 	tokenRepo               *repositories.TokenRepository
 	userTokenRevocationRepo *repositories.UserTokenRevocationRepository
+	platformAdminRepo       *repositories.PlatformAdminRepository
 	auditRepo               *repositories.AuditRepository
 	pullThroughSvc          *services.PullThroughService
 	tfBinariesHandler       *terraform_binaries.Handler
@@ -84,6 +85,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	orgRepo := d.orgRepo
 	tokenRepo := d.tokenRepo
 	userTokenRevocationRepo := d.userTokenRevocationRepo
+	platformAdminRepo := d.platformAdminRepo
 	auditRepo := d.auditRepo
 	pullThroughSvc := d.pullThroughSvc
 	tfBinariesHandler := d.tfBinariesHandler
@@ -294,7 +296,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// These are public endpoints that support optional authentication
 	v1Modules := router.Group("/v1/modules")
 	v1Modules.Use(protocolLimit)
-	v1Modules.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
+	v1Modules.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo, platformAdminRepo))
 	{
 		v1Modules.GET("/:namespace/:name/:system/versions", modules.ListVersionsHandler(db, cfg))
 		v1Modules.GET("/:namespace/:name/:system/:version/download", modules.DownloadHandler(db, storageBackend, cfg, auditRepo))
@@ -307,7 +309,7 @@ func registerPublicRoutes(router *gin.Engine, d *publicRouteDeps) {
 	// These are for the standard Provider Registry Protocol
 	v1Providers := router.Group("/v1/providers")
 	v1Providers.Use(protocolLimit)
-	v1Providers.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
+	v1Providers.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo, platformAdminRepo))
 	{
 		v1Providers.GET("/:namespace/:type/versions", providers.ListVersionsHandler(db, cfg))
 		v1Providers.GET("/:namespace/:type/:version/download/:os/:arch", providers.DownloadHandler(db, storageBackend, cfg, auditRepo))
@@ -363,6 +365,7 @@ type apiV1RouteDeps struct {
 	orgRepo                 *repositories.OrganizationRepository
 	tokenRepo               *repositories.TokenRepository
 	userTokenRevocationRepo *repositories.UserTokenRevocationRepository
+	platformAdminRepo       *repositories.PlatformAdminRepository
 	// credSweeper invalidates every credential family that snapshots a
 	// principal's derived authority when a lifecycle event reduces it
 	// (issues #732, #736). Built once in NewRouter because its two halves
@@ -422,7 +425,7 @@ type apiV1RouteDeps struct {
 // than the pre-#659 hardcoded nils — has a direct regression test
 // (TestRegisterAuthenticatedGroupMiddleware_AuditShipsToRealShipper).
 func registerAuthenticatedGroupMiddleware(authenticatedGroup *gin.RouterGroup, d *apiV1RouteDeps) {
-	authenticatedGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo))
+	authenticatedGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo, d.platformAdminRepo))
 	authenticatedGroup.Use(middleware.CSRFMiddleware(d.cfg)) // double-submit cookie CSRF protection + browser-origin Bearer allowlist
 	authenticatedGroup.Use(middleware.PrincipalRateLimitMiddleware(d.generalRateLimiter, d.principalOverrides))
 	authenticatedGroup.Use(middleware.OrgRateLimitMiddleware(d.generalRateLimiter, d.orgRateLimiter))
@@ -452,6 +455,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 	orgRepo := d.orgRepo
 	tokenRepo := d.tokenRepo
 	userTokenRevocationRepo := d.userTokenRevocationRepo
+	platformAdminRepo := d.platformAdminRepo
 	moduleAdminHandlers := d.moduleAdminHandlers
 	providerAdminHandlers := d.providerAdminHandlers
 	nsAuthz := d.nsAuthz
@@ -553,7 +557,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// header-JWT branch, loosening a check this route already passes.
 			authGroup.POST("/logout",
 				middleware.CSRFMiddleware(cfg),
-				middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo),
+				middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo, platformAdminRepo),
 				authHandlers.LogoutPostHandler())
 			authGroup.GET("/providers", authHandlers.ProvidersHandler())
 
@@ -591,7 +595,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 		// Public detail endpoints — no auth required; optional auth populates user context if a
 		// token is present (used by the frontend to conditionally show management actions).
 		publicDetailGroup := apiV1.Group("")
-		publicDetailGroup.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
+		publicDetailGroup.Use(middleware.OptionalAuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo, platformAdminRepo))
 		publicDetailGroup.Use(middleware.RateLimitMiddleware(generalRateLimiter))
 		{
 			publicDetailGroup.GET("/modules/:namespace/:name/:system", moduleAdminHandlers.GetModule)
@@ -1251,7 +1255,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				// another user with a cross-site POST. The group sits outside
 				// authenticatedGroup, so it does not inherit that protection --
 				// which is exactly why it was missing.
-				devGroup.Use(middleware.AuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo))
+				devGroup.Use(middleware.AuthMiddleware(cfg, userRepo, apiKeyRepo, orgRepo, tokenRepo, userTokenRevocationRepo, platformAdminRepo))
 				devGroup.Use(middleware.CSRFMiddleware(cfg))
 				devGroup.GET("/users", devHandlers.ListUsersForImpersonationHandler())
 				devGroup.POST("/impersonate/:user_id", devHandlers.ImpersonateUserHandler())
@@ -1278,7 +1282,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 // subject to the same abuse protection as admin-initiated mutations.
 func registerSCIMRoutes(router *gin.Engine, d *apiV1RouteDeps) {
 	scimGroup := router.Group("/scim/v2")
-	scimGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo))
+	scimGroup.Use(middleware.AuthMiddleware(d.cfg, d.userRepo, d.apiKeyRepo, d.orgRepo, d.tokenRepo, d.userTokenRevocationRepo, d.platformAdminRepo))
 	scimGroup.Use(middleware.PrincipalRateLimitMiddleware(d.generalRateLimiter, d.principalOverrides))
 	scimGroup.Use(middleware.OrgRateLimitMiddleware(d.generalRateLimiter, d.orgRateLimiter))
 	scimGroup.Use(middleware.AuditMiddleware(d.auditRepo))

--- a/backend/internal/db/migrations/000051_platform_admins.down.sql
+++ b/backend/internal/db/migrations/000051_platform_admins.down.sql
@@ -1,0 +1,14 @@
+-- Drops the platform-admin carrier (issue #766, PR 1).
+--
+-- Safe in PR 1, and only in PR 1. Every row this migration created is
+-- DERIVED -- backfilled from an admin-bearing role template -- and effective
+-- admin is `carrier OR the existing scope union`, so dropping the table
+-- restores exactly the authority the deployment had before it. Nobody loses
+-- access.
+--
+-- That stops being true once PR 2 ships the grant API: a grant made through
+-- it has no role-template equivalent, and dropping the table destroys it with
+-- no way to recover the list short of the audit log. Roll back the binary
+-- first and check `SELECT user_id, note FROM platform_admins WHERE note IS
+-- NULL` -- a NULL note is a deliberate grant, not a backfilled row.
+DROP TABLE IF EXISTS platform_admins;

--- a/backend/internal/db/migrations/000051_platform_admins.up.sql
+++ b/backend/internal/db/migrations/000051_platform_admins.up.sql
@@ -1,0 +1,122 @@
+-- 000051_platform_admins
+--
+-- A carrier for platform-admin authority that is NOT an organization
+-- membership (issue #766, PR 1 of 3).
+--
+-- Today the only carrier for the `admin` wildcard is
+-- organization_members.role_template_id joined to an admin-bearing
+-- role_templates row, and the org-less scope union makes that grant
+-- platform-wide the moment it is held anywhere. #850 established the strongest
+-- invariant reachable while that is true (an admin-bearing template becomes a
+-- membership role only where a principal already holding platform-admin
+-- authority put it there) and declined the recommendation to reject
+-- admin-bearing templates on the member API -- because doing so would leave a
+-- deployment unable to have a platform administrator at all.
+--
+-- This table is that missing carrier. PR 1 is deliberately NON-BREAKING:
+-- effective admin is `carrier OR the existing scope union`, and the backfill
+-- below makes the two sides agree on day one.
+--
+-- PROVENANCE, not a boolean. A table rather than users.is_platform_admin
+-- because it records who granted the highest privilege in the product and
+-- when -- exactly what an assessor asks about, and what a boolean throws away.
+--
+-- NO FOREIGN KEYS -- DELIBERATE, AND A DEVIATION FROM THE DESIGN COMMENT.
+--
+-- The design specified `user_id UUID PRIMARY KEY REFERENCES users(id) ON
+-- DELETE CASCADE` and `granted_by UUID REFERENCES users(id) ON DELETE SET
+-- NULL`. Those constraints cannot hold across the identity topologies this
+-- product supports. This table is created by the REGISTRY's migrations on the
+-- registry's own connection (public schema), while identity data may live in:
+--
+--   1. the registry's public schema      -- default; an FK would work
+--   2. a shared `identity` schema        -- TFR_IDENTITY_SCHEMA_ENABLED; the
+--      rows an FK must reference are in identity.users, and public.users
+--      keeps only the pre-cutover copy (docs/identity-schema.md: identity
+--      data is COPIED, not moved, so post-cutover users exist ONLY in
+--      identity.users and an FK to public.users would refuse their grant)
+--   3. a separate identity DATABASE      -- TFR_IDENTITY_DATABASE_*; Postgres
+--      has no cross-database foreign keys at all
+--
+-- This is the same reasoning, and the same conclusion, as migration 000046
+-- (user_token_revocations), which is likewise a per-user auth table on the
+-- registry connection with no FK to users.
+--
+-- What the FKs would have bought is bounded and is handled elsewhere: user
+-- IDs are UUIDs and are never reused, so a row left behind by a deleted user
+-- grants nothing to anyone. Sweeping it belongs with the rest of the
+-- credential lifecycle (internal/credlifecycle), which is where this estate
+-- already does cross-connection cleanup that an FK cannot.
+CREATE TABLE IF NOT EXISTS platform_admins (
+    user_id     UUID PRIMARY KEY,
+    granted_by  UUID,
+    granted_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    note        TEXT
+);
+
+-- BACKFILL -- every user who holds an admin-bearing role template today.
+--
+-- This is what makes PR 1 non-breaking in the other direction too: once PR 3
+-- derives authority ONLY from the carrier, a deployment whose administrators
+-- were never backfilled would have no platform administrator at all. The
+-- cheapest moment to capture them is now, while both sources are still live.
+--
+-- granted_by is left NULL: nobody granted these, they are inferred. The note
+-- says where each row came from so the provenance is not silently invented.
+DO $$
+DECLARE
+  backfilled BIGINT;
+BEGIN
+  -- public.role_templates.scopes is jsonb (000001_initial_schema), so the
+  -- admin-bearing test is jsonb containment.
+  INSERT INTO platform_admins (user_id, note)
+  SELECT DISTINCT om.user_id,
+         'backfilled by migration 000051 from an admin-bearing role template on public.organization_members'
+    FROM public.organization_members om
+    JOIN public.role_templates rt ON rt.id = om.role_template_id
+   WHERE om.user_id IS NOT NULL
+     AND rt.scopes @> '["admin"]'::jsonb
+  ON CONFLICT (user_id) DO NOTHING;
+  GET DIAGNOSTICS backfilled = ROW_COUNT;
+  IF backfilled > 0 THEN
+    RAISE NOTICE 'migration 000051: backfilled % platform admin(s) from public.organization_members', backfilled;
+  END IF;
+
+  -- The identity-schema half. identity.role_templates.scopes is TEXT[], NOT
+  -- jsonb (terraform-suite-identity 000001_identity_schema), so the same test
+  -- is written differently -- and is guarded on the column actually still
+  -- being an array, so a future identity schema change makes this block a
+  -- no-op instead of failing startup.
+  --
+  -- Guarded on the tables existing, like migrations 000038/000045/000050, and
+  -- with the same caveat: the schema literal `identity` is hardcoded, so a
+  -- deployment that sets TFR_IDENTITY_SCHEMA_NAME to something else must edit
+  -- this file or run the statement by hand.
+  IF to_regclass('identity.organization_members') IS NOT NULL
+     AND to_regclass('identity.role_templates') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns
+                  WHERE table_schema = 'identity'
+                    AND table_name = 'role_templates'
+                    AND column_name = 'scopes'
+                    AND data_type = 'ARRAY') THEN
+    INSERT INTO platform_admins (user_id, note)
+    SELECT DISTINCT om.user_id,
+           'backfilled by migration 000051 from an admin-bearing role template on identity.organization_members'
+      FROM identity.organization_members om
+      JOIN identity.role_templates rt ON rt.id = om.role_template_id
+     WHERE om.user_id IS NOT NULL
+       AND 'admin' = ANY(rt.scopes)
+    ON CONFLICT (user_id) DO NOTHING;
+    GET DIAGNOSTICS backfilled = ROW_COUNT;
+    IF backfilled > 0 THEN
+      RAISE NOTICE 'migration 000051: backfilled % platform admin(s) from identity.organization_members', backfilled;
+    END IF;
+  END IF;
+END $$;
+
+-- LIMITATION, stated rather than discovered later: when identity lives in a
+-- SEPARATE DATABASE (TFR_IDENTITY_DATABASE_*), neither backfill above can see
+-- it -- this migration runs on the registry's connection. Those deployments
+-- must populate platform_admins by hand before PR 3 lands. Until then nothing
+-- breaks: effective admin is carrier OR the scope union, and the union still
+-- answers.

--- a/backend/internal/db/migrations/README.md
+++ b/backend/internal/db/migrations/README.md
@@ -57,6 +57,7 @@ This document catalogs all database migrations, their reversibility, and rollbac
 | 000048 | `notification_channels`                | ✅ Yes         | Drops the notification-channel table (CASCADE); configured destinations must be re-added |
 | 000049 | `add_org_owner_provisioner_roles`      | ✅ Yes         | Deletes the `org_owner` and `org_provisioner` system role templates; memberships referencing them are left with a NULL `role_template_id` by the FK's ON DELETE SET NULL, so those members lose their scopes |
 | 000050 | `quarantine_orphaned_api_keys`         | ⚠️ No-op down  | Data-only: expires `api_keys` rows with `user_id IS NULL` (detached by a user deletion under `ON DELETE SET NULL`). The down cannot distinguish them from deliberately expired keys, so re-arming would undo the retirement; restore individual rows by hand. See `docs/upgrade-guide.md` |
+| 000051 | `platform_admins`                      | ✅ Yes         | Drops the platform-admin carrier table. Safe today: every row is backfilled from an admin-bearing role template and effective admin is `carrier OR the existing scope union`, so the rollback changes nobody's authority. It stops being safe once grants are made through the management API (issue #766 PR 2) — those have no role-template equivalent and are lost; a `NULL` `note` identifies them |
 
 ## How to Run Migrations
 

--- a/backend/internal/db/repositories/platform_admin_repository.go
+++ b/backend/internal/db/repositories/platform_admin_repository.go
@@ -1,0 +1,68 @@
+// platform_admin_repository.go reads the platform-admin carrier — the grant
+// table that holds platform-admin authority outside `organization_members`
+// (issue #766, migration 000051).
+//
+// Until this table existed the only carrier for the `admin` wildcard was a
+// membership row pointing at an admin-bearing role template, which the org-less
+// scope union promotes to platform-wide authority the moment it is held
+// anywhere. This repository is the read side of the replacement.
+//
+// PER REQUEST, NOT IN THE TOKEN. The middleware calls this on every
+// user-session request rather than freezing a `platform_admin` claim into the
+// JWT. That is the same decision this estate reached for api_keys' frozen
+// organization_id (#732) and frozen scopes (#733): a 24-hour session would
+// otherwise carry the highest privilege in the product for up to 24 hours
+// after it was revoked. One indexed read on a table with a handful of rows
+// buys immediate revocation.
+//
+// The table lives on the registry's own (public-schema) connection, not the
+// identity connection, so it works unchanged whether identity data is in the
+// app's public schema, the shared identity schema, or a separate identity
+// database — the same placement and the same reasoning as
+// UserTokenRevocationRepository (issue #559 finding [9]).
+//
+// Grant and revoke are deliberately absent: PR 1 ships the carrier and the
+// read path only. The management surface is PR 2.
+package repositories
+
+import (
+	"context"
+	"database/sql"
+)
+
+// PlatformAdminRepository reads the platform-admin carrier.
+type PlatformAdminRepository struct {
+	db *sql.DB
+}
+
+// NewPlatformAdminRepository constructs a PlatformAdminRepository over the
+// registry's domain connection.
+func NewPlatformAdminRepository(db *sql.DB) *PlatformAdminRepository {
+	return &PlatformAdminRepository{db: db}
+}
+
+// IsPlatformAdmin reports whether the user holds platform-admin authority
+// through the carrier.
+//
+// An empty userID answers false WITHOUT querying. Not a micro-optimisation:
+// user_id is UUID, so an empty string reaches Postgres as an invalid-input
+// error, and the caller — an authorization path — must not have to tell a
+// malformed principal apart from a database fault. "No principal" is a clean
+// no, and the fail-closed direction.
+//
+// Any other error is returned rather than swallowed. This is a GRANT-direction
+// lookup, so a failure can only ever withhold authority, never widen it; the
+// callers decide whether an unresolved answer aborts the request or merely
+// leaves the caller unelevated.
+func (r *PlatformAdminRepository) IsPlatformAdmin(ctx context.Context, userID string) (bool, error) {
+	if userID == "" {
+		return false, nil
+	}
+	const query = `SELECT EXISTS(SELECT 1 FROM platform_admins WHERE user_id = $1)`
+	var isAdmin bool
+	err := r.db.QueryRowContext(ctx, query, userID).Scan(&isAdmin)
+	if err != nil {
+		return false, err
+	}
+	return isAdmin, nil
+}

--- a/backend/internal/db/repositories/platform_admin_repository_test.go
+++ b/backend/internal/db/repositories/platform_admin_repository_test.go
@@ -1,0 +1,96 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func newTestPlatformAdminRepo(t *testing.T) (*PlatformAdminRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewPlatformAdminRepository(db), mock
+}
+
+func TestPlatformAdminRepository_IsPlatformAdmin_Granted(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	mock.ExpectQuery("SELECT EXISTS.*FROM platform_admins WHERE user_id").
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	got, err := repo.IsPlatformAdmin(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("IsPlatformAdmin: %v", err)
+	}
+	if !got {
+		t.Error("IsPlatformAdmin = false, want true for a user with a carrier row")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestPlatformAdminRepository_IsPlatformAdmin_NotGranted(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	mock.ExpectQuery("SELECT EXISTS.*FROM platform_admins WHERE user_id").
+		WithArgs("user-2").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	got, err := repo.IsPlatformAdmin(context.Background(), "user-2")
+	if err != nil {
+		t.Fatalf("IsPlatformAdmin: %v", err)
+	}
+	if got {
+		t.Error("IsPlatformAdmin = true, want false for a user with no carrier row")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A lookup failure is REPORTED, never reported as "not an admin". The two are
+// different answers and the callers treat them differently: AuthMiddleware
+// turns the error into a 500 rather than silently serving a platform
+// administrator a downgraded session.
+func TestPlatformAdminRepository_IsPlatformAdmin_DBError(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	sentinel := errors.New("carrier lookup failed")
+	mock.ExpectQuery("SELECT EXISTS.*FROM platform_admins WHERE user_id").
+		WithArgs("user-3").
+		WillReturnError(sentinel)
+
+	got, err := repo.IsPlatformAdmin(context.Background(), "user-3")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the driver's error %v", err, sentinel)
+	}
+	if got {
+		t.Error("IsPlatformAdmin = true on a failed lookup; a fault must never read as a grant")
+	}
+}
+
+// An empty principal answers false without touching the database. The mock is
+// primed with NO expectations, so a query would fail ExpectationsWereMet --
+// this asserts the short-circuit, not just the return value.
+func TestPlatformAdminRepository_IsPlatformAdmin_EmptyUserID_DoesNotQuery(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	got, err := repo.IsPlatformAdmin(context.Background(), "")
+	if err != nil {
+		t.Fatalf("IsPlatformAdmin(\"\"): %v", err)
+	}
+	if got {
+		t.Error("IsPlatformAdmin(\"\") = true, want false")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -35,7 +35,7 @@ import (
 //     originates from a cookie the auth_method is set to "jwt_cookie" so that
 //     downstream middleware (CSRFMiddleware) can distinguish browser-initiated
 //     requests from programmatic ones.
-func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository, tokenRepo *repositories.TokenRepository, userRevocations *repositories.UserTokenRevocationRepository) gin.HandlerFunc {
+func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository, tokenRepo *repositories.TokenRepository, userRevocations *repositories.UserTokenRevocationRepository, platformAdmins *repositories.PlatformAdminRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 		var fromCookie bool
@@ -151,7 +151,19 @@ func AuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, a
 			if scopes == nil {
 				scopes = []string{}
 			}
-			c.Set("scopes", scopes)
+
+			// GUARD platform-admin-carrier (issue #766). THE insertion point:
+			// resolve platform-admin authority once, here, so the twelve
+			// existing auth.HasScope(scopes, auth.ScopeAdmin) sites keep asking
+			// the same question and start getting the answer from the carrier.
+			// A lookup failure aborts, matching how the revocation checks above
+			// treat an unresolved auth question on this middleware.
+			elevated, status, msg := platformAdminScopes(c.Request.Context(), platformAdmins, user.ID, scopes)
+			if status != 0 {
+				c.AbortWithStatusJSON(status, gin.H{"error": msg})
+				return
+			}
+			c.Set("scopes", elevated)
 
 			c.Next()
 			return
@@ -325,8 +337,60 @@ func currentKeyScopes(ctx context.Context, orgRepo *repositories.OrganizationRep
 	return scopes, 0, ""
 }
 
+// platformAdminScopes returns the effective scopes for a USER SESSION,
+// elevated with auth.ScopeAdmin when the principal holds platform-admin
+// authority through the carrier (issue #766, migration 000051).
+//
+// TRANSITION SEMANTICS ARE `OR`, WHICH IS WHAT MAKES PR 1 NON-BREAKING.
+// Effective admin is `carrier OR the existing scope union`. The union still
+// answers exactly as it did, the carrier can only add, and migration 000051
+// backfills the carrier from the union — so day-one behaviour is identical.
+// PR 3 removes the union side; nothing here changes when it does.
+//
+// APPLIED ON THE USER/SESSION PATH ONLY — NEVER TO AN API KEY. Five of the
+// twelve admin checks are in apikeys.go, and a long-lived credential silently
+// carrying the highest privilege in the product is the exact shape of the
+// problem #766 is about. Keys are already org-bound (#732) and their scopes
+// are already re-derived per request from the owner's CURRENT membership
+// (currentKeyScopes); inheriting the owner's platform-admin status on top of
+// that would hand every CI token its owner's wildcard. Neither middleware
+// calls this from its API-key branch, and
+// TestAuthMiddleware_APIKey_DoesNotInheritOwnersPlatformAdmin holds that shut.
+//
+// A nil repository means the subsystem is not wired (unit tests), matching how
+// tokenRepo/userRevocations/orgRepo nil-checks behave on both middlewares.
+//
+// Returns (scopes, 0, "") when the answer resolved, otherwise an HTTP status
+// and message.
+//
+// The elevation copies rather than appending to the caller's slice. `scopes`
+// is claims.Scopes, which is also published on the context as jwt_claims, so
+// appending in place would write through a shared backing array whenever it
+// has spare capacity. Stated as an idiom, not as a tested guarantee: the JWT
+// decoder happens to produce len == cap today, so a mutation to append-in-place
+// is not observable and no test here would catch it.
+func platformAdminScopes(ctx context.Context, platformAdmins *repositories.PlatformAdminRepository, userID string, scopes []string) ([]string, int, string) {
+	if platformAdmins == nil {
+		return scopes, 0, ""
+	}
+	isAdmin, err := platformAdmins.IsPlatformAdmin(ctx, userID)
+	if err != nil {
+		// 500, not "not an admin". An authority question that did not resolve
+		// must not be served as a completed no: that would silently downgrade a
+		// platform administrator to a 403 during exactly the incident in which
+		// they need the admin surface, with nothing in the response saying why.
+		return nil, http.StatusInternalServerError, "Auth check failed"
+	}
+	if !isAdmin || auth.HasScope(scopes, auth.ScopeAdmin) {
+		return scopes, 0, ""
+	}
+	elevated := make([]string, len(scopes), len(scopes)+1)
+	copy(elevated, scopes)
+	return append(elevated, string(auth.ScopeAdmin)), 0, ""
+}
+
 // OptionalAuthMiddleware - same as AuthMiddleware but doesn't abort if no auth
-func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository, tokenRepo *repositories.TokenRepository, userRevocations *repositories.UserTokenRevocationRepository) gin.HandlerFunc {
+func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepository, apiKeyRepo *repositories.APIKeyRepository, orgRepo *repositories.OrganizationRepository, tokenRepo *repositories.TokenRepository, userRevocations *repositories.UserTokenRevocationRepository, platformAdmins *repositories.PlatformAdminRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var token string
 		var fromCookie bool
@@ -389,6 +453,26 @@ func OptionalAuthMiddleware(cfg *config.Config, userRepo *repositories.UserRepos
 					scopes := claims.Scopes
 					if scopes == nil {
 						scopes = []string{}
+					}
+
+					// GUARD platform-admin-carrier (issue #766). Same
+					// elevation as AuthMiddleware, for the same reason the
+					// jwt_claims Set immediately above exists: the two
+					// middlewares must publish the SAME context shape, or a
+					// check behaves differently depending on which group a
+					// route happens to be mounted under — the divergence
+					// tracked as #665 and the bug the jwt_claims comment
+					// records. No route under this middleware consults
+					// ScopeAdmin today; letting that stay true by accident is
+					// not a decision, it is a bet on nobody moving a route.
+					//
+					// A failed lookup leaves the caller UNELEVATED rather than
+					// aborting, matching this middleware's treatment of every
+					// other failed auth lookup (the revocation checks above
+					// swallow their errors too). Fail-closed by construction:
+					// the carrier can only ever add authority.
+					if elevated, status, _ := platformAdminScopes(c.Request.Context(), platformAdmins, user.ID, scopes); status == 0 {
+						scopes = elevated
 					}
 					c.Set("scopes", scopes)
 				}

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -51,7 +51,7 @@ func newAuthRouterWithJWT(t *testing.T, userMock, orgMock sqlmock.Sqlmock,
 	userRepo *repositories.UserRepository, orgRepo *repositories.OrganizationRepository) *gin.Engine {
 	t.Helper()
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return r
 }
@@ -69,7 +69,7 @@ func generateTestJWT(t *testing.T, userID string) string {
 // nil repos are safe for early-exit paths that abort before any repo call.
 func newAuthRouter() *gin.Engine {
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, nil, nil, nil, nil, nil))
+	r.Use(AuthMiddleware(nil, nil, nil, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return r
 }
@@ -77,7 +77,7 @@ func newAuthRouter() *gin.Engine {
 // newOptionalAuthRouter builds a router with OptionalAuthMiddleware using nil repos.
 func newOptionalAuthRouter() *gin.Engine {
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, nil, nil, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, nil, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return r
 }
@@ -138,7 +138,7 @@ func TestAuthMiddleware_CookieAuth_ValidJWT(t *testing.T) {
 
 	r := gin.New()
 	var capturedAuthMethod string
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) {
 		if am, ok := c.Get("auth_method"); ok {
 			capturedAuthMethod = am.(string)
@@ -173,7 +173,7 @@ func TestAuthMiddleware_HeaderTakesPrecedenceOverCookie(t *testing.T) {
 
 	r := gin.New()
 	var capturedAuthMethod string
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) {
 		if am, ok := c.Get("auth_method"); ok {
 			capturedAuthMethod = am.(string)
@@ -334,7 +334,7 @@ func newAuthRouterWithRepos(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 	repo, mock := newTestAPIKeyRepo(t)
 
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, nil, repo, nil, nil, nil))
+	r.Use(AuthMiddleware(nil, nil, repo, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return mock, r
 }
@@ -514,7 +514,7 @@ func TestAuthMiddleware_APIKeyWithUser(t *testing.T) {
 	userRepo := repositories.NewUserRepository(userDB)
 
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, apiKeyRepo, nil, nil, nil))
+	r.Use(AuthMiddleware(nil, userRepo, apiKeyRepo, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := "tfr_apikey_test123"
@@ -553,7 +553,7 @@ func TestOptionalAuthMiddleware_ValidJWT_SetsUser(t *testing.T) {
 	orgRepo, orgMock := newOrgRepo(t)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := generateTestJWT(t, "user-1")
@@ -590,7 +590,7 @@ func TestOptionalAuthMiddleware_JWTRevoked_ContinuesUnauthenticated(t *testing.T
 
 	var userWasSet bool
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, tokenRepo, nil))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, tokenRepo, nil, nil))
 	r.GET("/", func(c *gin.Context) {
 		_, userWasSet = c.Get("user")
 		c.Status(http.StatusOK)
@@ -615,7 +615,7 @@ func TestOptionalAuthMiddleware_ValidJWT_UserNotFound_PassesThrough(t *testing.T
 	orgRepo, _ := newOrgRepo(t)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := generateTestJWT(t, "nonexistent-user")
@@ -644,7 +644,7 @@ func TestOptionalAuthMiddleware_APIKey_Valid_SetsContext(t *testing.T) {
 	userRepo := repositories.NewUserRepository(userDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, apiKeyRepo, nil, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, apiKeyRepo, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := "tfr_optional_test9"
@@ -678,7 +678,7 @@ func TestOptionalAuthMiddleware_APIKey_Expired_PassesThrough(t *testing.T) {
 	apiKeyRepo := repositories.NewAPIKeyRepository(apiKeyDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	token := "tfr_expired_key9"
@@ -710,7 +710,7 @@ func TestOptionalAuthMiddleware_APIKey_NoMatch_PassesThrough(t *testing.T) {
 	apiKeyRepo := repositories.NewAPIKeyRepository(apiKeyDB)
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, apiKeyRepo, nil, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	// Return empty rows — no matching key
@@ -749,7 +749,7 @@ func newAuthRouterWithRevocation(t *testing.T,
 ) *gin.Engine {
 	t.Helper()
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, tokenRepo, nil))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, tokenRepo, nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 	return r
 }
@@ -827,7 +827,7 @@ func TestAuthMiddleware_RevokeAllWatermark_Aborts(t *testing.T) {
 	_ = userMock // user lookup is not expected to run — the watermark check aborts first
 
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	if code := doAuthRequest(r, "Bearer "+token); code != http.StatusUnauthorized {
@@ -847,7 +847,7 @@ func TestAuthMiddleware_RevokeAllWatermark_DBError(t *testing.T) {
 	_ = userMock
 
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	if code := doAuthRequest(r, "Bearer "+token); code != http.StatusInternalServerError {
@@ -869,7 +869,7 @@ func TestAuthMiddleware_RevokeAllWatermark_NotRevoked_PassesThrough(t *testing.T
 			"user-1", "test@example.com", "Test User", nil, time.Now(), time.Now()))
 
 	r := gin.New()
-	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations))
+	r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	if code := doAuthRequest(r, "Bearer "+token); code != http.StatusOK {
@@ -888,7 +888,7 @@ func TestOptionalAuthMiddleware_RevokeAllWatermark_ContinuesUnauthenticated(t *t
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations))
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, orgRepo, nil, userRevocations, nil))
 	var userWasSet bool
 	r.GET("/", func(c *gin.Context) {
 		_, userWasSet = c.Get("user")
@@ -969,7 +969,7 @@ func apiKeyAuthRouter(t *testing.T, handler gin.HandlerFunc) (*gin.Engine, sqlmo
 
 	r := gin.New()
 	r.Use(AuthMiddleware(nil, repositories.NewUserRepository(userDB),
-		repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil))
+		repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil, nil))
 	r.GET("/", handler)
 	return r, apiKeyMock, orgMock
 }
@@ -1095,7 +1095,7 @@ func TestOptionalAuthMiddleware_OrgBoundAPIKey_OwnerRemoved_ContinuesUnauthentic
 
 	var keyWasSet bool
 	r := gin.New()
-	r.Use(OptionalAuthMiddleware(nil, nil, repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil))
+	r.Use(OptionalAuthMiddleware(nil, nil, repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil, nil))
 	r.GET("/", func(c *gin.Context) {
 		_, keyWasSet = c.Get("api_key")
 		c.Status(http.StatusOK)

--- a/backend/internal/middleware/csrf_test.go
+++ b/backend/internal/middleware/csrf_test.go
@@ -322,7 +322,7 @@ func TestCSRF_Integration_CookieSession_HeaderStripped(t *testing.T) {
 		userRepo, userMock := newUserRepo(t)
 		orgRepo, _ := newOrgRepo(t)
 		r := gin.New()
-		r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil))
+		r.Use(AuthMiddleware(nil, userRepo, nil, orgRepo, nil, nil, nil))
 		r.Use(CSRFMiddleware(csrfTestConfig()))
 		r.POST("/api/v1/admin/modules/create", func(c *gin.Context) { c.Status(http.StatusCreated) })
 		return r, userMock

--- a/backend/internal/middleware/platform_admin_test.go
+++ b/backend/internal/middleware/platform_admin_test.go
@@ -1,0 +1,415 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// ---------------------------------------------------------------------------
+// The platform-admin carrier (issue #766, migration 000051).
+//
+// Authority for the `admin` wildcard is resolved ONCE, in the auth
+// middleware, from a grant table that is not an organization membership. The
+// twelve auth.HasScope(scopes, auth.ScopeAdmin) sites are untouched: they keep
+// asking the same question and the answer starts coming from the carrier.
+//
+// PR 1 is non-breaking because the transition semantics are OR — effective
+// admin is `carrier OR the existing scope union` — so all four combinations
+// of the two sources are asserted here explicitly, plus the case the design
+// is most worried about: an API key must NEVER inherit its owner's
+// platform-admin status.
+// ---------------------------------------------------------------------------
+
+func newPlatformAdminRepo(t *testing.T) (*repositories.PlatformAdminRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (platform_admins): %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return repositories.NewPlatformAdminRepository(db), mock
+}
+
+// expectCarrierLookup queues the one indexed read the middleware makes per
+// user-session request.
+func expectCarrierLookup(mock sqlmock.Sqlmock, userID string, granted bool) {
+	mock.ExpectQuery("SELECT EXISTS.*FROM platform_admins").
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(granted))
+}
+
+func generateScopedJWT(t *testing.T, userID string, scopes []string) string {
+	t.Helper()
+	token, err := auth.GenerateJWT(userID, "carrier@example.com", scopes, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateJWT: %v", err)
+	}
+	return token
+}
+
+// carrierJWTRouter wires AuthMiddleware over a mocked user repository and the
+// carrier repository, and captures the effective scopes the handler sees.
+func carrierJWTRouter(t *testing.T, userID string, paRepo *repositories.PlatformAdminRepository, got *[]string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	userRepo, userMock := newUserRepo(t)
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow(userID, "carrier@example.com", "Carrier", nil, time.Now(), time.Now()))
+
+	r := gin.New()
+	r.Use(AuthMiddleware(nil, userRepo, nil, nil, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			*got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func doJWTRequest(r *gin.Engine, token string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func hasAdmin(scopes []string) bool {
+	for _, s := range scopes {
+		if s == string(auth.ScopeAdmin) {
+			return true
+		}
+	}
+	return false
+}
+
+// State 1 of 4 — CARRIER ONLY. The session token carries no admin scope at
+// all; the grant row is the entire source of authority. This is the state PR 3
+// makes the only one, so it must work now.
+func TestAuthMiddleware_PlatformAdminCarrier_ElevatesSessionWithoutAdminScope(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	expectCarrierLookup(paMock, "user-carrier", true)
+
+	var got []string
+	r := carrierJWTRouter(t, "user-carrier", paRepo, &got)
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-carrier", []string{"modules:read"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if !hasAdmin(got) {
+		t.Errorf("scopes = %v, want %q present: a carrier grant is the whole point of #766", got, auth.ScopeAdmin)
+	}
+	// The elevation ADDS; it does not replace what the session already held.
+	if len(got) != 2 || got[0] != "modules:read" {
+		t.Errorf("scopes = %v, want [modules:read admin]", got)
+	}
+	if err := paMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the carrier was not consulted: %v", err)
+	}
+}
+
+// State 2 of 4 — TEMPLATE ONLY. The pre-#766 path: authority arrives in the
+// scope union from an admin-bearing role template, and there is no carrier
+// row. This is the case that makes PR 1 non-breaking, and the assertion is on
+// the EXACT scope set — an elevation that duplicated `admin` would still
+// "contain admin" and pass a weaker check.
+func TestAuthMiddleware_PlatformAdminCarrier_TemplateOnlyStillAdmin(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	expectCarrierLookup(paMock, "user-template", false)
+
+	var got []string
+	r := carrierJWTRouter(t, "user-template", paRepo, &got)
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-template", []string{"admin"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != string(auth.ScopeAdmin) {
+		t.Errorf("scopes = %v, want exactly [admin]: the union side must still answer, and must not be duplicated", got)
+	}
+}
+
+// State 3 of 4 — BOTH. The day-one state for every administrator the
+// migration backfilled: a carrier row AND an admin-bearing role template.
+// Asserting the EXACT set is what makes this different from the two above —
+// the elevation must notice the caller already holds `admin` and add nothing,
+// or every backfilled administrator carries a duplicated scope for the whole
+// transition. Deleting the dedupe leaves all the other cases passing.
+func TestAuthMiddleware_PlatformAdminCarrier_BothSourcesDoNotDuplicateAdmin(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	expectCarrierLookup(paMock, "user-both", true)
+
+	var got []string
+	r := carrierJWTRouter(t, "user-both", paRepo, &got)
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-both", []string{"admin"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != string(auth.ScopeAdmin) {
+		t.Errorf("scopes = %v, want exactly [admin]: carrier AND template must not stack", got)
+	}
+}
+
+// State 4 of 4 — NEITHER. No carrier row, no admin scope. The negative
+// control: without it, a middleware that unconditionally appended `admin`
+// would pass every test above.
+func TestAuthMiddleware_PlatformAdminCarrier_NeitherSourceGrantsAdmin(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	expectCarrierLookup(paMock, "user-plain", false)
+
+	var got []string
+	r := carrierJWTRouter(t, "user-plain", paRepo, &got)
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-plain", []string{"modules:read"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != "modules:read" {
+		t.Errorf("scopes = %v, want exactly [modules:read]", got)
+	}
+}
+
+// A carrier lookup that does not resolve is a 500, not a silent "not an
+// admin". Serving the downgrade would strip a platform administrator of the
+// admin surface with a 403 and nothing saying why, during exactly the
+// database incident in which they need it. Matches how this middleware treats
+// the two revocation lookups above it.
+func TestAuthMiddleware_PlatformAdminCarrier_LookupFailureAborts(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	paMock.ExpectQuery("SELECT EXISTS.*FROM platform_admins").
+		WillReturnError(errors.New("carrier unavailable"))
+
+	var got []string
+	reached := false
+	gin.SetMode(gin.TestMode)
+	userRepo, userMock := newUserRepo(t)
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow("user-err", "carrier@example.com", "Carrier", nil, time.Now(), time.Now()))
+	r := gin.New()
+	r.Use(AuthMiddleware(nil, userRepo, nil, nil, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		reached = true
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-err", []string{"modules:read"})); w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (carrier lookup failed): body=%s", w.Code, w.Body.String())
+	}
+	if reached {
+		t.Errorf("the handler ran with unresolved platform-admin authority; scopes = %v", got)
+	}
+}
+
+// A nil carrier repository means the subsystem is not wired (unit tests), the
+// same convention tokenRepo/userRevocations/orgRepo already use on this
+// middleware. It must pass through, not panic or deny.
+func TestAuthMiddleware_PlatformAdminCarrier_NilRepoPassesThrough(t *testing.T) {
+	var got []string
+	r := carrierJWTRouter(t, "user-nil", nil, &got)
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-nil", []string{"modules:read"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 1 || got[0] != "modules:read" {
+		t.Errorf("scopes = %v, want exactly [modules:read]", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// THE CONSTRAINT THE DESIGN CALLS OUT: an API key must NEVER inherit its
+// owner's platform-admin status.
+//
+// Five of the twelve admin checks are in apikeys.go. Keys are already
+// org-bound (#732) and already have their scopes re-derived per request from
+// the owner's current membership; a long-lived credential silently carrying
+// the highest privilege in the product is the shape of the original problem.
+//
+// The carrier mock is primed to answer TRUE — the owner really is a platform
+// administrator — so a middleware that applied the carrier on this path would
+// produce a CLEAN elevation and fail on the value, not trip over an
+// incidental "unexpected query" error that a bare err != nil check would
+// mistake for a passing test.
+// ---------------------------------------------------------------------------
+func TestAuthMiddleware_APIKey_DoesNotInheritOwnersPlatformAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	apiKeyDB, keyMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (apikey): %v", err)
+	}
+	t.Cleanup(func() { apiKeyDB.Close() })
+	userDB, userMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (user): %v", err)
+	}
+	t.Cleanup(func() { userDB.Close() })
+	orgRepo, orgMock := newOrgRepo(t)
+	paRepo, paMock := newPlatformAdminRepo(t)
+
+	token := "tfr_keyadmn_1"
+	userID := "user-1"
+
+	// The key's owner IS a platform administrator.
+	expectCarrierLookup(paMock, userID, true)
+	// The key itself is an ordinary org-bound publish credential.
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:write"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, []byte(`["modules:write"]`))
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow(userID, "owner@example.com", "Owner", nil, time.Now(), time.Now()))
+
+	var got []string
+	r := gin.New()
+	r.Use(AuthMiddleware(nil, repositories.NewUserRepository(userDB),
+		repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if hasAdmin(got) {
+		t.Errorf("scopes = %v: an API key inherited its owner's platform-admin grant", got)
+	}
+	if len(got) != 1 || got[0] != "modules:write" {
+		t.Errorf("scopes = %v, want exactly [modules:write]", got)
+	}
+	// Structural half of the same claim: the carrier is not merely ignored on
+	// this path, it is never read. An unmet expectation here is the pass.
+	if err := paMock.ExpectationsWereMet(); err == nil {
+		t.Error("the carrier was queried on the API-key path; it must be consulted only for user sessions")
+	}
+}
+
+// The same key, presented to the optionally-authenticated public routes.
+func TestOptionalAuthMiddleware_APIKey_DoesNotInheritOwnersPlatformAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	apiKeyDB, keyMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (apikey): %v", err)
+	}
+	t.Cleanup(func() { apiKeyDB.Close() })
+	orgRepo, orgMock := newOrgRepo(t)
+	paRepo, paMock := newPlatformAdminRepo(t)
+	userRepo, userMock := newUserRepo(t)
+
+	token := "tfr_optadmn_1"
+	userID := "user-1"
+	expectCarrierLookup(paMock, userID, true)
+	expectAPIKeyLookup(keyMock, token, &userID, []byte(`["modules:read"]`))
+	expectKeyOwnerMembership(orgMock, "org-1", userID, []byte(`["modules:read"]`))
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow(userID, "owner@example.com", "Owner", nil, time.Now(), time.Now()))
+
+	var got []string
+	r := gin.New()
+	r.Use(OptionalAuthMiddleware(nil, userRepo, repositories.NewAPIKeyRepository(apiKeyDB), orgRepo, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	if w := doKeyRequest(r, token); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if hasAdmin(got) {
+		t.Errorf("scopes = %v: an API key inherited its owner's platform-admin grant", got)
+	}
+	if err := paMock.ExpectationsWereMet(); err == nil {
+		t.Error("the carrier was queried on the API-key path; it must be consulted only for user sessions")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// OptionalAuthMiddleware — the SAME context shape as AuthMiddleware.
+//
+// No route mounted under it consults ScopeAdmin today. Publishing a different
+// effective scope set anyway is how a check comes to behave differently
+// depending on which group a route sits in — the divergence already recorded
+// in this file's jwt_claims comment, and tracked as #665.
+// ---------------------------------------------------------------------------
+
+func TestOptionalAuthMiddleware_PlatformAdminCarrier_ElevatesSession(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	expectCarrierLookup(paMock, "user-opt", true)
+
+	gin.SetMode(gin.TestMode)
+	userRepo, userMock := newUserRepo(t)
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow("user-opt", "carrier@example.com", "Carrier", nil, time.Now(), time.Now()))
+
+	var got []string
+	r := gin.New()
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, nil, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-opt", []string{"modules:read"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 2 || got[0] != "modules:read" || got[1] != string(auth.ScopeAdmin) {
+		t.Errorf("scopes = %v, want [modules:read admin]", got)
+	}
+}
+
+// A carrier lookup failure here leaves the caller UNELEVATED and the request
+// authenticated, matching how this middleware already swallows its revocation
+// lookups. Fail-closed by construction: the carrier can only add authority.
+func TestOptionalAuthMiddleware_PlatformAdminCarrier_LookupFailureLeavesUnelevated(t *testing.T) {
+	paRepo, paMock := newPlatformAdminRepo(t)
+	paMock.ExpectQuery("SELECT EXISTS.*FROM platform_admins").
+		WillReturnError(errors.New("carrier unavailable"))
+
+	gin.SetMode(gin.TestMode)
+	userRepo, userMock := newUserRepo(t)
+	userMock.ExpectQuery("SELECT.*FROM users WHERE id").
+		WillReturnRows(sqlmock.NewRows(jwtUserCols).
+			AddRow("user-opterr", "carrier@example.com", "Carrier", nil, time.Now(), time.Now()))
+
+	var got []string
+	var userWasSet bool
+	r := gin.New()
+	r.Use(OptionalAuthMiddleware(nil, userRepo, nil, nil, nil, nil, paRepo))
+	r.GET("/", func(c *gin.Context) {
+		_, userWasSet = c.Get("user")
+		if v, ok := c.Get("scopes"); ok {
+			got, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	if w := doJWTRequest(r, generateScopedJWT(t, "user-opterr", []string{"modules:read"})); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (optional auth always passes through): body=%s", w.Code, w.Body.String())
+	}
+	if !userWasSet {
+		t.Error("a carrier lookup failure must not un-authenticate the request")
+	}
+	if len(got) != 1 || got[0] != "modules:read" {
+		t.Errorf("scopes = %v, want exactly [modules:read]: an unresolved carrier must not elevate", got)
+	}
+}


### PR DESCRIPTION
Refs #766 — PR 1 of 3. The issue remains open; it is answered at PR 3, not here.

## What this is

The prerequisite #766 has been blocked on: a carrier for platform-admin authority that is **not** an organization membership.

PR #850 established the strongest invariant reachable while `organization_members.role_template_id` is the only carrier for scopes — *an admin-bearing template becomes a membership role only where a principal already holding platform-admin authority put it there* — and explicitly declined the issue's headline recommendation, because rejecting admin-bearing templates on the member API would leave a deployment unable to have a platform administrator at all. Give platform-admin its own carrier and that recommendation becomes shippable.

This PR ships the carrier and the read path. **It is deliberately non-breaking**: effective admin is `carrier OR the existing scope union`, and the migration backfills the carrier from the union, so day-one behaviour is identical. No token change, no re-mint, no session invalidation, no frontend `allowedScopes` churn.

## What landed

| | |
|---|---|
| **Migration `000051_platform_admins`** | `user_id` PK, `granted_by`, `granted_at`, `note`. A table rather than `users.is_platform_admin` because it carries provenance. |
| **Backfill, same migration** | Every user holding an admin-bearing role template, `ON CONFLICT (user_id) DO NOTHING`, `granted_by` NULL and a `note` naming the source. Both the `public` half (jsonb containment) and the `identity` half (`TEXT[]`, guarded). |
| **`PlatformAdminRepository.IsPlatformAdmin`** | The read side. Grant/revoke are PR 2. |
| **One insertion point** | Both auth middlewares resolve the carrier after authentication establishes the user, and add `admin` to the request's effective scopes. |
| **Twelve `HasScope(…, ScopeAdmin)` sites** | Untouched. They keep asking the same question; the answer starts coming from the carrier. |
| **`internal/db/migrations/README.md`** | Row added — the `TestMigrationsAreDocumented` guard is bidirectional and both directions were mutation-checked. |

### Per request, not a JWT claim

The same decision this estate reached for `api_keys`' frozen `organization_id` (#732) and frozen scopes (#733). Sessions here last 24 hours, so a claim means revoking platform-admin takes up to 24 hours to bite. A per-request lookup makes revocation immediate, and it is one indexed read on a table with a handful of rows — on a path that already does a user load.

### API keys never inherit it

Five of the twelve checks are in `apikeys.go`. Keys are already org-bound and already have their scopes re-derived per request from the owner's *current* membership; a long-lived credential silently carrying the wildcard is the shape of the original problem. Neither middleware calls the carrier from its API-key branch, and a test on **each** middleware primes the carrier to answer *true* for the key's owner and asserts the resulting scope set is exactly the key's own — so a regression produces a clean wrong value, not an incidental mock error.

### Dev mode

`dev.go:90,161` read the middleware-published scopes, so both consult the carrier without an edit of their own. Proved end-to-end against the real route tree: `GET /api/v1/dev/users` with a session carrying **no scopes at all** answers 200 with a carrier row and exactly 403 without one.

### Both middlewares, deliberately

`AuthMiddleware` guards every group in which the twelve sites live. `OptionalAuthMiddleware` guards the public Terraform-protocol and detail reads, where nothing consults `ScopeAdmin` today — but the two middlewares are already required to publish the same context shape, and the `jwt_claims` comment in that file records the bug that appeared last time they diverged (#665). Letting the divergence stay harmless by accident is a bet on nobody moving a route. The elevation runs only when a JWT identity is established, so anonymous CLI traffic is unaffected. Error handling follows each middleware's own idiom: `AuthMiddleware` aborts 500 on an unresolved lookup, `OptionalAuthMiddleware` leaves the caller unelevated — fail-closed either way, since the carrier can only ever add authority.

## Deviation from the design comment

The design specified `user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE` and `granted_by UUID REFERENCES users(id) ON DELETE SET NULL`. **Both foreign keys are omitted.** They cannot hold across the identity topologies this product supports:

- **public schema** (default) — an FK would work.
- **shared `identity` schema** — identity data is *copied*, not moved (`docs/identity-schema.md`), so post-cutover users exist only in `identity.users` and an FK to `public.users` would refuse their grant.
- **separate identity database** (`TFR_IDENTITY_DATABASE_*`) — Postgres has no cross-database foreign keys.

This is the same reasoning and the same conclusion as migration `000046` (`user_token_revocations`), which is likewise a per-user auth table on the registry connection with no FK to `users`. What the FKs would have bought is bounded: user IDs are UUIDs and never reused, so a row left by a deleted user grants nothing, and sweeping it belongs with the rest of the credential lifecycle — where this estate already does cross-connection cleanup an FK cannot. The reasoning is written into the migration.

Consequence, stated rather than discovered later: a deployment whose identity lives in a **separate database** cannot be backfilled by this migration and must populate the table by hand before PR 3. Nothing breaks until then — the union side still answers.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./...` clean; `golangci-lint run ./...` reports 0 issues.

**Migration exercised against a real Postgres 16**, not just parsed: full chain to v51, backfill inserts exactly the admin-template holders (deduplicated across organizations) and nobody else on both the `public` and `identity` halves, re-running inserts nothing new, the `identity` half degrades to a no-op rather than failing startup when the column type changes, and the whole chain reverses and re-applies.

**Every guard mutation-verified** — broken, compiled, watched fail, restored from a `cp` backup:

| # | Mutation | Test that failed |
|---|---|---|
| M1 | `AuthMiddleware` drops the elevation | `…_ElevatesSessionWithoutAdminScope` |
| M1b | same, observed at the untouched `dev.go:161` check | `TestPlatformAdminCarrier_AdmitsAtAnUneditedHasScopeSite` |
| M2 | a failed carrier lookup no longer aborts | `…_LookupFailureAborts` |
| M3 | API key inherits its owner's grant (`AuthMiddleware`) | `TestAuthMiddleware_APIKey_DoesNotInheritOwnersPlatformAdmin` |
| M4 | API key inherits its owner's grant (`OptionalAuthMiddleware`) | `TestOptionalAuthMiddleware_APIKey_DoesNotInheritOwnersPlatformAdmin` |
| M5 | `OptionalAuthMiddleware` drops the elevation | `…_ElevatesSession` |
| M6 | elevate every session regardless of the carrier's answer | `…_NeitherSourceGrantsAdmin` |
| M6b | same, observed at `dev.go:161` | `…_WithoutAGrantTheSameRequestIsRefused` |
| M7 | drop the already-admin dedupe | `…_BothSourcesDoNotDuplicateAdmin` |
| M9 | repository reports a failed lookup as "not an admin" | `…_IsPlatformAdmin_DBError` |
| M9b | same, observed as the lost 500 | `…_LookupFailureAborts` |
| M10 | repository answers true for every principal | `…_IsPlatformAdmin_NotGranted` |
| M11 | drop the empty-principal short-circuit | `…_IsPlatformAdmin_EmptyUserID_DoesNotQuery` |
| M12 | the `000051` README row names the wrong migration | `TestMigrationsAreDocumented` |
| M13 | the `000051` README row is deleted | `TestMigrationsAreDocumented` |

Two guards came back **inert on the first pass** and were dealt with rather than shipped green:

- **M7** originally passed with the dedupe deleted, because the three OR states asserted (carrier-only, template-only, neither) all short-circuit before it. Added the fourth — **both sources**, which is the day-one state of every backfilled administrator — and M7 now fails as required.
- A test asserting the elevation does not write through the claims' backing array passed with the copy replaced by `append(scopes, …)`, because the JWT decoder produces `len == cap`, so the hazard is not reachable. The copy stays as the correct idiom; the inert test was **deleted** rather than left reporting green, and the comment now says it is an idiom rather than a tested guarantee.

Not verified here: the migration's separate-identity-database limitation (no such deployment to test against) and the down migration's data-loss note for grants made after PR 2 (no such grants exist yet).

## Not in this PR

PR 2 is the management surface (`GET/POST/DELETE /api/v1/admin/platform-admins`, audit entries, refusing to remove the last admin, the UI). PR 3 derives authority only from the carrier and is the one breaking change.

One thing from the design's PR 1 bullet is **not** here: a transition guard asserting the two sources agree. It cannot be a CI check — this repo's tests run on `sqlmock`, with no seeded database of real memberships to compare against — and with OR semantics the drift it guards is behaviourally inert until PR 3, where the same assertion is better expressed as that migration's own precondition.
