### PR TITLE
feat(admin): audited management API for the platform-admin carrier

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -3076,6 +3076,269 @@
                 }
             }
         },
+        "/api/v1/admin/platform-admins": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "List every platform-admin grant, with its provenance. A grant whose user no longer resolves is returned with user_resolved=false rather than hidden. Requires admin scope.",
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "List platform administrators",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.ListPlatformAdminsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Grant platform-admin authority to a user and record who granted it. Requires admin scope.",
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "Grant platform admin",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/admin.GrantPlatformAdminRequest"
+                            }
+                        }
+                    },
+                    "description": "Grant request",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.PlatformAdminResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "User already holds platform-admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/platform-admins/{user_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Remove a user's platform-admin authority. Refuses to remove the last remaining administrator. Self-revocation is permitted, subject to that same rule. Requires admin scope.",
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "Revoke platform admin",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/admin.MessageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid user ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User does not hold platform-admin",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Cannot revoke the last platform administrator",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/policies": {
             "get": {
                 "security": [
@@ -16996,6 +17259,22 @@
                     }
                 }
             },
+            "admin.GrantPlatformAdminRequest": {
+                "type": "object",
+                "required": [
+                    "user_id"
+                ],
+                "properties": {
+                    "note": {
+                        "description": "Note is a free-text operator note recorded alongside the grant.",
+                        "type": "string"
+                    },
+                    "user_id": {
+                        "description": "UserID is the principal to grant platform-admin authority to.",
+                        "type": "string"
+                    }
+                }
+            },
             "admin.ListAPIKeysResponse": {
                 "type": "object",
                 "properties": {
@@ -17047,6 +17326,17 @@
                     "organizations": {},
                     "pagination": {
                         "$ref": "#/components/schemas/admin.PaginationMeta"
+                    }
+                }
+            },
+            "admin.ListPlatformAdminsResponse": {
+                "type": "object",
+                "properties": {
+                    "platform_admins": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/admin.PlatformAdminItem"
+                        }
                     }
                 }
             },
@@ -17477,6 +17767,44 @@
                     },
                     "total": {
                         "type": "integer"
+                    }
+                }
+            },
+            "admin.PlatformAdminItem": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string"
+                    },
+                    "granted_at": {
+                        "type": "string"
+                    },
+                    "granted_by": {
+                        "description": "GrantedBy is NULL for rows written by migration 000051's backfill —\nnobody granted those, they were inferred from an admin-bearing role\ntemplate, and Note says so.",
+                        "type": "string"
+                    },
+                    "granted_by_email": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "note": {
+                        "type": "string"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    },
+                    "user_resolved": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "admin.PlatformAdminResponse": {
+                "type": "object",
+                "properties": {
+                    "platform_admin": {
+                        "$ref": "#/components/schemas/admin.PlatformAdminItem"
                     }
                 }
             },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2473,6 +2473,213 @@
                 }
             }
         },
+        "/api/v1/admin/platform-admins": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "List every platform-admin grant, with its provenance. A grant whose user no longer resolves is returned with user_resolved=false rather than hidden. Requires admin scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "List platform administrators",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.ListPlatformAdminsResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Grant platform-admin authority to a user and record who granted it. Requires admin scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "Grant platform admin",
+                "parameters": [
+                    {
+                        "description": "Grant request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/admin.GrantPlatformAdminRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/admin.PlatformAdminResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "User already holds platform-admin",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/platform-admins/{user_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Remove a user's platform-admin authority. Refuses to remove the last remaining administrator. Self-revocation is permitted, subject to that same rule. Requires admin scope.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Platform Admins"
+                ],
+                "summary": "Revoke platform admin",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/admin.MessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid user ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — admin scope required",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "User does not hold platform-admin",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "Cannot revoke the last platform administrator",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/policies": {
             "get": {
                 "security": [
@@ -13822,6 +14029,22 @@
                 }
             }
         },
+        "admin.GrantPlatformAdminRequest": {
+            "type": "object",
+            "required": [
+                "user_id"
+            ],
+            "properties": {
+                "note": {
+                    "description": "Note is a free-text operator note recorded alongside the grant.",
+                    "type": "string"
+                },
+                "user_id": {
+                    "description": "UserID is the principal to grant platform-admin authority to.",
+                    "type": "string"
+                }
+            }
+        },
         "admin.ListAPIKeysResponse": {
             "type": "object",
             "properties": {
@@ -13873,6 +14096,17 @@
                 "organizations": {},
                 "pagination": {
                     "$ref": "#/definitions/admin.PaginationMeta"
+                }
+            }
+        },
+        "admin.ListPlatformAdminsResponse": {
+            "type": "object",
+            "properties": {
+                "platform_admins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/admin.PlatformAdminItem"
+                    }
                 }
             }
         },
@@ -14303,6 +14537,44 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "admin.PlatformAdminItem": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "granted_at": {
+                    "type": "string"
+                },
+                "granted_by": {
+                    "description": "GrantedBy is NULL for rows written by migration 000051's backfill —\nnobody granted those, they were inferred from an admin-bearing role\ntemplate, and Note says so.",
+                    "type": "string"
+                },
+                "granted_by_email": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "note": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "user_resolved": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "admin.PlatformAdminResponse": {
+            "type": "object",
+            "properties": {
+                "platform_admin": {
+                    "$ref": "#/definitions/admin.PlatformAdminItem"
                 }
             }
         },

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -895,7 +895,37 @@ func (h *AuthHandlers) MeHandler() gin.HandlerFunc {
 
 		// Calculate combined allowed scopes across all organizations
 		// and provide a "primary" role template (highest privilege) for backward compatibility
-		response["allowed_scopes"] = userWithRoles.GetAllowedScopes() //nolint:staticcheck // SA1019: deliberate suite-wide combined view for this admin display endpoint; narrow legitimate use per the deprecation notice
+		allowedScopes := userWithRoles.GetAllowedScopes() //nolint:staticcheck // SA1019: deliberate suite-wide combined view for this admin display endpoint; narrow legitimate use per the deprecation notice
+
+		// GUARD me-allowed-scopes-carrier (issue #766). GetAllowedScopes reads
+		// the ROLE-TEMPLATE UNION out of the database, which is only one of the
+		// two carriers of platform-admin authority since PR 1 — the other is
+		// the platform_admins table, resolved per request into this request's
+		// effective scopes.
+		//
+		// Without this union, a carrier-only administrator is authorized
+		// server-side at all twelve HasScope(ScopeAdmin) sites and rendered by
+		// the frontend as an ordinary user, because all 43 of its allowedScopes
+		// call sites read THIS field. Today that is invisible (migration 000051
+		// backfilled the carrier from the union, so the two agree); at PR 3,
+		// when the union stops carrying `admin` at all, it would be every
+		// administrator's experience of the product.
+		//
+		// Read from the request's effective scopes rather than querying the
+		// carrier again, so this stays downstream of PR 1's single insertion
+		// point instead of becoming a second, independently-driftable answer to
+		// the same question. It also inherits that point's deliberate exclusion
+		// of API keys: a key never carries the carrier's elevation, so /auth/me
+		// on a key reports the authority the key actually has.
+		if scopesVal, ok := c.Get("scopes"); ok {
+			if effective, ok := scopesVal.([]string); ok &&
+				auth.HasScope(effective, auth.ScopeAdmin) && !auth.HasScope(allowedScopes, auth.ScopeAdmin) {
+				elevated := make([]string, len(allowedScopes), len(allowedScopes)+1)
+				copy(elevated, allowedScopes)
+				allowedScopes = append(elevated, string(auth.ScopeAdmin))
+			}
+		}
+		response["allowed_scopes"] = allowedScopes
 
 		// Include session expiry from JWT claims so the frontend can schedule the
 		// pre-expiry warning dialog for cookie-based sessions. Absent for API-key auth.

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -2573,3 +2573,126 @@ func TestLogoutPost_CSRFMiddlewareRejectsForgedRequest(t *testing.T) {
 		t.Errorf("legitimate logout: status = %d, want 200 (%s)", w.Code, w.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// MeHandler — allowed_scopes and the platform-admin carrier (issue #766)
+// ---------------------------------------------------------------------------
+
+// GUARD me-allowed-scopes-carrier.
+//
+// allowed_scopes was built solely from GetAllowedScopes() — the role-template
+// union read out of the database — while platform-admin authority has had a
+// SECOND carrier since PR 1: the platform_admins table, resolved per request
+// into the request's effective scopes. All 43 frontend allowedScopes call sites
+// read this field, so a carrier-only administrator would be authorized at every
+// one of the twelve server-side HasScope(ScopeAdmin) sites and rendered as an
+// ordinary user. Invisible today (migration 000051 backfilled the carrier from
+// the union, so the two agree); at PR 3 it is every administrator's experience.
+//
+// The elevation is read from the request's effective scopes rather than by
+// querying the carrier again, so this stays downstream of PR 1's single
+// insertion point — including its deliberate exclusion of API keys.
+func TestMeHandler_AllowedScopesUnionsThePlatformAdminCarrier(t *testing.T) {
+	tests := []struct {
+		name string
+		// effectiveScopes is what the auth middleware published on the request.
+		// nil means the key was never set (the mTLS path, and any handler test
+		// that does not set it).
+		effectiveScopes []string
+		setScopes       bool
+		// membershipScopes is the role-template union in the database.
+		membershipScopes string
+		wantAdmin        bool
+	}{
+		{
+			name:             "carrier-only administrator",
+			effectiveScopes:  []string{"modules:read", "admin"},
+			setScopes:        true,
+			membershipScopes: `["modules:read"]`,
+			wantAdmin:        true,
+		},
+		{
+			name:             "ordinary user is not elevated",
+			effectiveScopes:  []string{"modules:read"},
+			setScopes:        true,
+			membershipScopes: `["modules:read"]`,
+			wantAdmin:        false,
+		},
+		{
+			name:             "administrator by role template, unchanged",
+			effectiveScopes:  []string{"admin"},
+			setScopes:        true,
+			membershipScopes: `["admin"]`,
+			wantAdmin:        true,
+		},
+		{
+			name:             "no effective scopes on the request",
+			setScopes:        false,
+			membershipScopes: `["modules:read"]`,
+			wantAdmin:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, _ := sqlmock.New()
+			defer db.Close()
+
+			h, _ := NewAuthHandlers(&config.Config{}, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set("user_id", "user-1")
+				if tt.setScopes {
+					c.Set("scopes", tt.effectiveScopes)
+				}
+				c.Next()
+			})
+			r.GET("/auth/me", h.MeHandler())
+
+			mock.ExpectQuery("SELECT.*FROM users WHERE id").
+				WillReturnRows(sqlmock.NewRows(authUserCols).
+					AddRow("user-1", "me@example.com", "Me User", nil, time.Now(), time.Now()))
+			mock.ExpectQuery("SELECT.*FROM organization_members").
+				WillReturnRows(sqlmock.NewRows(meOrgMembershipCols).
+					AddRow("org-1", "acme", "role-1", time.Now(), "reader", "Reader", tt.membershipScopes))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/me", nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+
+			raw, ok := getJSON(w)["allowed_scopes"].([]interface{})
+			if !ok {
+				t.Fatalf("allowed_scopes missing or not a list: %s", w.Body.String())
+			}
+			admins := 0
+			for _, s := range raw {
+				if s == "admin" {
+					admins++
+				}
+			}
+			if tt.wantAdmin && admins == 0 {
+				t.Errorf("allowed_scopes = %v, want it to carry \"admin\". The frontend renders "+
+					"this field; without the carrier unioned in, a platform administrator is "+
+					"authorized server-side and shown as a non-admin.", raw)
+			}
+			if !tt.wantAdmin && admins != 0 {
+				t.Errorf("allowed_scopes = %v, want NO \"admin\" — the union must not invent authority", raw)
+			}
+			if admins > 1 {
+				t.Errorf("allowed_scopes = %v, \"admin\" appears %d times", raw, admins)
+			}
+			// The rest of the union must survive the elevation.
+			found := false
+			for _, s := range raw {
+				if s == "modules:read" {
+					found = true
+				}
+			}
+			if !found && tt.membershipScopes != `["admin"]` {
+				t.Errorf("allowed_scopes = %v, lost the role-template scopes it is built from", raw)
+			}
+		})
+	}
+}

--- a/backend/internal/api/admin/platform_admins.go
+++ b/backend/internal/api/admin/platform_admins.go
@@ -1,0 +1,428 @@
+// platform_admins.go implements the management surface for the platform-admin
+// carrier — the grant table that holds platform-admin authority outside
+// `organization_members` (issue #766, migration 000051, PR 2 of 3).
+//
+// PR 1 shipped the table and the per-request read that elevates a session's
+// effective scopes from it. Until this file existed the only way to add or
+// remove a row was hand-written SQL, which means the highest privilege in the
+// product could change hands with nothing in the audit trail saying so. Closing
+// that is the point of this PR; the grant/revoke handlers below write an audit
+// entry naming the actor, the target and the moment, in addition to the coarse
+// route-level entry AuditMiddleware already writes.
+//
+// AUTHORIZATION IS THE `admin` SCOPE, NOT THE CARRIER DIRECTLY.
+// These routes are mounted behind middleware.RequireScope(auth.ScopeAdmin),
+// the same gate as /admin/role-templates and the other eleven admin surfaces.
+// After PR 1 that scope already means "carrier OR the role-template union", and
+// at PR 3 — when authority derives from the carrier alone — it will mean
+// "carrier" with no edit here. Gating on the carrier directly instead would
+// have bought no security (during the transition a union-only administrator
+// still holds `admin` at all twelve other sites, including /admin/role-templates
+// where they can mint themselves another one) while creating one real hazard:
+// an administrator added by role template between PR 1 and PR 3 would be locked
+// out of the only surface that can grant them a carrier row, and the recovery
+// would be the SQL this API replaces.
+package admin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+)
+
+// Audit actions written by this file. Dotted, like the rest of the estate's
+// hand-written actions ("mirror.created", "provider.delete").
+const (
+	auditActionPlatformAdminGranted = "platform_admin.granted"
+	auditActionPlatformAdminRevoked = "platform_admin.revoked"
+	auditResourcePlatformAdmin      = "platform_admin"
+)
+
+// maxPlatformAdminNoteLen bounds the operator note. The column is TEXT; the
+// limit is here so an unbounded body cannot be parked in the carrier.
+const maxPlatformAdminNoteLen = 500
+
+// errLastPlatformAdmin is the refusal from the last-standing guard.
+var errLastPlatformAdmin = errors.New("cannot revoke the last platform administrator")
+
+// errIdentityUnavailable marks a failure to resolve a user, as distinct from
+// resolving them to "no such user". The two must not collapse: an identity
+// store that is down would otherwise read as "every remaining grant is an
+// orphan", and the guard would let the final administrator revoke themselves.
+var errIdentityUnavailable = errors.New("identity lookup failed")
+
+// PlatformAdminHandlers serves /api/v1/admin/platform-admins.
+type PlatformAdminHandlers struct {
+	// carrier is the platform_admins table, on the REGISTRY's connection.
+	carrier *repositories.PlatformAdminRepository
+	// userRepo resolves a grant's user_id to a person. It lives on the IDENTITY
+	// connection, which is why the carrier carries no foreign key to users
+	// (migration 000051) and why resolution is a lookup here rather than a join
+	// there.
+	userRepo *repositories.UserRepository
+	// auditRepo writes the grant/revoke trail. Also on the identity connection.
+	auditRepo *repositories.AuditRepository
+}
+
+// NewPlatformAdminHandlers constructs the handlers.
+func NewPlatformAdminHandlers(carrier *repositories.PlatformAdminRepository, userRepo *repositories.UserRepository, auditRepo *repositories.AuditRepository) *PlatformAdminHandlers {
+	return &PlatformAdminHandlers{carrier: carrier, userRepo: userRepo, auditRepo: auditRepo}
+}
+
+// userResolver resolves user ids to people, memoised for the duration of one
+// request so a list whose grants share a grantor does not re-read the same row.
+//
+// A miss is cached as a nil user and reported as (nil, nil) — "resolved to
+// nobody". A FAILURE is never cached and is returned as an error, so the
+// callers can keep the two apart.
+type userResolver struct {
+	repo *repositories.UserRepository
+	seen map[string]*models.User
+}
+
+func newUserResolver(repo *repositories.UserRepository) *userResolver {
+	return &userResolver{repo: repo, seen: map[string]*models.User{}}
+}
+
+func (u *userResolver) get(ctx context.Context, id string) (*models.User, error) {
+	if id == "" {
+		return nil, nil
+	}
+	if cached, ok := u.seen[id]; ok {
+		return cached, nil
+	}
+	if u.repo == nil {
+		return nil, fmt.Errorf("%w: no user repository wired", errIdentityUnavailable)
+	}
+	user, err := u.repo.GetUserByID(ctx, id, repositories.OrgScopeAllOrganizations())
+	if identityerr.Missing(user, err) {
+		u.seen[id] = nil
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errIdentityUnavailable, err)
+	}
+	u.seen[id] = user
+	return user, nil
+}
+
+// toItem renders one grant, resolving the holder and the grantor.
+//
+// ORPHAN GRANTS ARE SHOWN, FLAGGED — not hidden, and not rendered as a nameless
+// ghost. The carrier has no foreign key to users (migration 000051: identity
+// data may live in another schema or another database entirely), so deleting a
+// user leaves the grant row behind. Dropping it from the listing would hide a
+// row from the only surface that can remove it; showing it unlabelled would
+// read as a corrupt record. `user_resolved: false` says exactly what is true —
+// there is a grant, and nobody answers to it — which is the same choice
+// migration 000050 made for orphaned api_keys: keep the row visible to an
+// operator rather than make it disappear.
+func (h *PlatformAdminHandlers) toItem(ctx context.Context, res *userResolver, g repositories.PlatformAdminGrant) (PlatformAdminItem, error) {
+	item := PlatformAdminItem{
+		UserID:    g.UserID,
+		GrantedBy: g.GrantedBy,
+		GrantedAt: g.GrantedAt,
+		Note:      g.Note,
+	}
+	holder, err := res.get(ctx, g.UserID)
+	if err != nil {
+		return PlatformAdminItem{}, err
+	}
+	if holder != nil {
+		item.UserResolved = true
+		item.Email = holder.Email
+		item.Name = holder.Name
+	}
+	if g.GrantedBy != nil {
+		grantor, err := res.get(ctx, *g.GrantedBy)
+		if err != nil {
+			return PlatformAdminItem{}, err
+		}
+		if grantor != nil {
+			item.GrantedByEmail = grantor.Email
+		}
+	}
+	return item, nil
+}
+
+// @Summary      List platform administrators
+// @Description  List every platform-admin grant, with its provenance. A grant whose user no longer resolves is returned with user_resolved=false rather than hidden. Requires admin scope.
+// @Tags         Platform Admins
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  admin.ListPlatformAdminsResponse
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "Forbidden — admin scope required"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/platform-admins [get]
+// ListPlatformAdmins returns every carrier row.
+// GET /api/v1/admin/platform-admins
+func (h *PlatformAdminHandlers) ListPlatformAdmins(c *gin.Context) {
+	grants, err := h.carrier.List(c.Request.Context())
+	if err != nil {
+		slog.Error("failed to list platform admins", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list platform administrators"})
+		return
+	}
+
+	res := newUserResolver(h.userRepo)
+	items := make([]PlatformAdminItem, 0, len(grants))
+	for _, g := range grants {
+		item, err := h.toItem(c.Request.Context(), res, g)
+		if err != nil {
+			slog.Error("failed to resolve platform admin identities", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve platform administrator identities"})
+			return
+		}
+		items = append(items, item)
+	}
+	c.JSON(http.StatusOK, ListPlatformAdminsResponse{PlatformAdmins: items})
+}
+
+// GrantPlatformAdminRequest is the body of POST /api/v1/admin/platform-admins.
+type GrantPlatformAdminRequest struct {
+	// UserID is the principal to grant platform-admin authority to.
+	UserID string `json:"user_id" binding:"required"`
+	// Note is a free-text operator note recorded alongside the grant.
+	Note string `json:"note"`
+}
+
+// @Summary      Grant platform admin
+// @Description  Grant platform-admin authority to a user and record who granted it. Requires admin scope.
+// @Tags         Platform Admins
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        request  body  admin.GrantPlatformAdminRequest  true  "Grant request"
+// @Success      201  {object}  admin.PlatformAdminResponse
+// @Failure      400  {object}  map[string]interface{}  "Invalid request body"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "Forbidden — admin scope required"
+// @Failure      404  {object}  map[string]interface{}  "User not found"
+// @Failure      409  {object}  map[string]interface{}  "User already holds platform-admin"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/platform-admins [post]
+// GrantPlatformAdmin adds a carrier row.
+// POST /api/v1/admin/platform-admins
+func (h *PlatformAdminHandlers) GrantPlatformAdmin(c *gin.Context) {
+	var req GrantPlatformAdminRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body", "details": err.Error()})
+		return
+	}
+	targetID, err := uuid.Parse(strings.TrimSpace(req.UserID))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id must be a UUID"})
+		return
+	}
+	note := strings.TrimSpace(req.Note)
+	if len(note) > maxPlatformAdminNoteLen {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("note must be at most %d characters", maxPlatformAdminNoteLen)})
+		return
+	}
+
+	// GUARD platform-admin-grant-target-exists. Granting to a UUID that resolves
+	// to nobody would mint an orphan row on purpose: inert (the middlewares load
+	// the user before consulting the carrier) but indistinguishable, later, from
+	// a grant whose user was deleted afterwards. Refusing here keeps the orphan
+	// class down to the one cause the schema genuinely cannot prevent.
+	res := newUserResolver(h.userRepo)
+	target, err := res.get(c.Request.Context(), targetID.String())
+	if err != nil {
+		slog.Error("failed to resolve platform-admin grant target", "error", err, "target_user_id", targetID.String())
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve user"})
+		return
+	}
+	if target == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+		return
+	}
+
+	var grantedBy *string
+	if actor := c.GetString("user_id"); actor != "" {
+		grantedBy = &actor
+	}
+	var notePtr *string
+	if note != "" {
+		notePtr = &note
+	}
+
+	grant, err := h.carrier.Grant(c.Request.Context(), targetID.String(), grantedBy, notePtr)
+	if errors.Is(err, repositories.ErrAlreadyPlatformAdmin) {
+		c.JSON(http.StatusConflict, gin.H{"error": "User already holds platform-admin"})
+		return
+	}
+	if err != nil {
+		slog.Error("failed to grant platform admin", "error", err, "target_user_id", targetID.String())
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to grant platform administrator"})
+		return
+	}
+
+	h.writeAudit(c, auditActionPlatformAdminGranted, grant.UserID, map[string]interface{}{
+		"target_user_id":    grant.UserID,
+		"target_user_email": target.Email,
+		"note":              note,
+	})
+
+	item, err := h.toItem(c.Request.Context(), res, *grant)
+	if err != nil {
+		// The grant landed and is audited; only the display enrichment failed.
+		// Report what is certainly true rather than a 500 that invites a retry
+		// which would then 409.
+		slog.Error("granted platform admin but failed to render it", "error", err, "target_user_id", grant.UserID)
+		item = PlatformAdminItem{UserID: grant.UserID, GrantedBy: grant.GrantedBy, GrantedAt: grant.GrantedAt, Note: grant.Note}
+	}
+	c.JSON(http.StatusCreated, PlatformAdminResponse{PlatformAdmin: item})
+}
+
+// @Summary      Revoke platform admin
+// @Description  Remove a user's platform-admin authority. Refuses to remove the last remaining administrator. Self-revocation is permitted, subject to that same rule. Requires admin scope.
+// @Tags         Platform Admins
+// @Security     Bearer
+// @Accept       json
+// @Produce      json
+// @Param        user_id  path  string  true  "User ID"
+// @Success      200  {object}  admin.MessageResponse
+// @Failure      400  {object}  map[string]interface{}  "Invalid user ID"
+// @Failure      401  {object}  map[string]interface{}  "Unauthorized"
+// @Failure      403  {object}  map[string]interface{}  "Forbidden — admin scope required"
+// @Failure      404  {object}  map[string]interface{}  "User does not hold platform-admin"
+// @Failure      409  {object}  map[string]interface{}  "Cannot revoke the last platform administrator"
+// @Failure      500  {object}  map[string]interface{}  "Internal server error"
+// @Router       /api/v1/admin/platform-admins/{user_id} [delete]
+// RevokePlatformAdmin removes a carrier row.
+// DELETE /api/v1/admin/platform-admins/{user_id}
+//
+// SELF-REVOCATION IS ALLOWED, subject to the last-standing guard. Two reasons.
+// The hazard being defended against is a deployment reaching ZERO
+// administrators, and the guard below addresses exactly that, for a self-revoke
+// as for any other — so a separate "not yourself" rule would forbid nothing
+// dangerous. And forbidding it would make standing down require a second live
+// administrator to do it for you, which is the same single-point-of-failure
+// shape in the other direction: an operator who wants to drop a privilege they
+// should no longer hold would have to keep holding it.
+func (h *PlatformAdminHandlers) RevokePlatformAdmin(c *gin.Context) {
+	targetID, err := uuid.Parse(strings.TrimSpace(c.Param("user_id")))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id must be a UUID"})
+		return
+	}
+
+	res := newUserResolver(h.userRepo)
+	grant, err := h.carrier.Revoke(c.Request.Context(), targetID.String(), func(ctx context.Context, remaining []repositories.PlatformAdminGrant) error {
+		return h.requireAnotherExercisableAdmin(ctx, res, remaining)
+	})
+	switch {
+	case errors.Is(err, repositories.ErrNotPlatformAdmin):
+		c.JSON(http.StatusNotFound, gin.H{"error": "User does not hold platform-admin"})
+		return
+	case errors.Is(err, errLastPlatformAdmin):
+		c.JSON(http.StatusConflict, gin.H{
+			"error":   "Cannot revoke the last platform administrator",
+			"details": "Grant platform-admin to another user first; a deployment with no platform administrator cannot be recovered through this API.",
+		})
+		return
+	case errors.Is(err, errIdentityUnavailable):
+		// Deliberately NOT a revocation. The guard could not establish that
+		// another administrator remains, and an unresolved answer must not be
+		// served as a yes.
+		slog.Error("failed to verify remaining platform admins", "error", err, "target_user_id", targetID.String())
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify remaining platform administrators"})
+		return
+	case err != nil:
+		slog.Error("failed to revoke platform admin", "error", err, "target_user_id", targetID.String())
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to revoke platform administrator"})
+		return
+	}
+
+	targetEmail := ""
+	if user, uerr := res.get(c.Request.Context(), grant.UserID); uerr == nil && user != nil {
+		targetEmail = user.Email
+	}
+	h.writeAudit(c, auditActionPlatformAdminRevoked, grant.UserID, map[string]interface{}{
+		"target_user_id":    grant.UserID,
+		"target_user_email": targetEmail,
+		"self_revocation":   c.GetString("user_id") == grant.UserID,
+	})
+
+	c.JSON(http.StatusOK, MessageResponse{Message: "Platform administrator revoked"})
+}
+
+// requireAnotherExercisableAdmin is the last-standing predicate handed to
+// PlatformAdminRepository.Revoke (GUARD platform-admin-last-standing).
+//
+// It accepts as soon as ONE remaining grant resolves to a live user. A grant
+// that resolves to nobody is skipped rather than counted, because it cannot be
+// exercised: both auth middlewares load the user and abort before reaching the
+// carrier, so an orphan row is a record, not an administrator. Counting rows
+// instead would let the final real administrator revoke themselves whenever a
+// deleted colleague's grant was still on the table.
+//
+// A lookup FAILURE aborts rather than skipping. Treating an unreachable
+// identity store as "this one does not count" would turn an outage into the
+// lockout the guard exists to prevent.
+func (h *PlatformAdminHandlers) requireAnotherExercisableAdmin(ctx context.Context, res *userResolver, remaining []repositories.PlatformAdminGrant) error {
+	for _, g := range remaining {
+		user, err := res.get(ctx, g.UserID)
+		if err != nil {
+			return err
+		}
+		if user != nil {
+			return nil
+		}
+	}
+	return errLastPlatformAdmin
+}
+
+// writeAudit records a grant or revoke: who acted, on whom, and when.
+//
+// SYNCHRONOUS, unlike the download-counter audits elsewhere in this package.
+// This is the record the whole design exists to produce, so it is written on
+// the request path where its failure is observable and where a test can assert
+// it was written at all rather than race a goroutine.
+//
+// organization_id is left NULL deliberately: platform-admin is not an
+// organization-owned fact, and audit_logs' platform-wide scope
+// (OrgScopeAllOrganizations, which every platform administrator's audit read
+// uses) admits NULL-owner rows, so the entry is readable by the principals
+// entitled to review it.
+//
+// A failed write does NOT fail the request. The mutation already happened on a
+// different connection and cannot be rolled back with it, and answering 500
+// would invite a retry that then conflicts. It is logged at error level, and
+// AuditMiddleware's own route-level entry for the same request is written
+// independently of this one.
+func (h *PlatformAdminHandlers) writeAudit(c *gin.Context, action, targetUserID string, metadata map[string]interface{}) {
+	if h.auditRepo == nil {
+		slog.Error("platform-admin change not audited: no audit repository wired",
+			"action", action, "target_user_id", targetUserID)
+		return
+	}
+	resourceType := auditResourcePlatformAdmin
+	ip := c.ClientIP()
+	entry := &models.AuditLog{
+		Action:       action,
+		ResourceType: &resourceType,
+		ResourceID:   &targetUserID,
+		IPAddress:    &ip,
+		Metadata:     metadata,
+	}
+	if actor := c.GetString("user_id"); actor != "" {
+		entry.UserID = &actor
+	}
+	if err := h.auditRepo.CreateAuditLog(c.Request.Context(), entry); err != nil {
+		slog.Error("failed to write platform-admin audit entry",
+			"error", err, "action", action, "target_user_id", targetUserID)
+	}
+}

--- a/backend/internal/api/admin/platform_admins_test.go
+++ b/backend/internal/api/admin/platform_admins_test.go
@@ -1,0 +1,592 @@
+package admin
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// Issue #766, PR 2 — the management surface for the platform-admin carrier.
+//
+// Three properties are load-bearing here and each is asserted on an EXACT
+// status and an EXACT payload, never on "not 200":
+//
+//  1. the last remaining platform administrator cannot be revoked, and an
+//     ORPHANED grant does not count as one that remains;
+//  2. grant and revoke write an audit entry naming the actor, the target and
+//     the time — that entry IS the gap this design exists to close;
+//  3. a grant whose user no longer resolves is listed and labelled, not hidden.
+
+const (
+	paCaller = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	paTarget = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	paThird  = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+)
+
+var paGrantCols = []string{"user_id", "granted_by", "granted_at", "note"}
+
+// capturedJSONArg matches any bound argument and keeps it, so a test can assert on
+// a value (the audit metadata JSON) that is built inside the handler.
+type capturedJSONArg struct{ value driver.Value }
+
+func (c *capturedJSONArg) Match(v driver.Value) bool {
+	c.value = v
+	return true
+}
+
+func (c *capturedJSONArg) metadata(t *testing.T) map[string]interface{} {
+	t.Helper()
+	raw, ok := c.value.([]byte)
+	if !ok {
+		t.Fatalf("audit metadata argument was %T (%v), want JSON bytes", c.value, c.value)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("audit metadata is not JSON: %v (%s)", err, raw)
+	}
+	return out
+}
+
+// newPlatformAdminRouter mounts the three routes with callerID as the acting
+// principal. All three repositories share one mocked connection, which is also
+// what makes sqlmock's ORDERED matching meaningful across them: the carrier
+// read, the identity resolution and the audit write have to happen in the order
+// the handler claims they do.
+func newPlatformAdminRouter(t *testing.T, callerID string) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewPlatformAdminHandlers(
+		repositories.NewPlatformAdminRepository(db),
+		repositories.NewUserRepository(db),
+		repositories.NewAuditRepository(db),
+	)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("user_id", callerID)
+		// The route gate is middleware.RequireScope(ScopeAdmin) in
+		// router_routes.go; these tests exercise the handlers behind it, and
+		// internal/api/platform_admin_routes_test.go owns the gate itself.
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Next()
+	})
+	r.GET("/platform-admins", h.ListPlatformAdmins)
+	r.POST("/platform-admins", h.GrantPlatformAdmin)
+	r.DELETE("/platform-admins/:user_id", h.RevokePlatformAdmin)
+	return mock, r
+}
+
+// expectUserLookup primes one GetUserByID. found=false returns no rows, which
+// is how a grant whose user was deleted resolves.
+func expectUserLookup(mock sqlmock.Sqlmock, userID, email string, found bool) {
+	q := mock.ExpectQuery("(?s)FROM users WHERE id").WithArgs(userID)
+	if !found {
+		q.WillReturnRows(sqlmock.NewRows(authUserCols))
+		return
+	}
+	q.WillReturnRows(sqlmock.NewRows(authUserCols).
+		AddRow(userID, email, "Name "+email, nil, time.Now(), time.Now()))
+}
+
+// expectAuditWrite primes the audit INSERT and returns the metadata capture.
+//
+// The actor, action, resource type and resource id are matched EXACTLY: an
+// audit row that records the wrong target, or attributes the change to nobody,
+// is the same defect as no row at all. organization_id is asserted NULL because
+// platform-admin is not an organization-owned fact and the platform-wide audit
+// scope is what makes NULL-owner rows readable.
+func expectAuditWrite(mock sqlmock.Sqlmock, actor, action, targetID string) *capturedJSONArg {
+	meta := &capturedJSONArg{}
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			actor,            // user_id
+			nil,              // organization_id
+			action,
+			"platform_admin", // resource_type
+			targetID,         // resource_id
+			meta,             // metadata
+			sqlmock.AnyArg(), // ip_address
+			sqlmock.AnyArg(), // created_at
+			nil,              // actor_email (filled by COALESCE in SQL)
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"actor_email"}).AddRow(nil))
+	return meta
+}
+
+func paDo(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func paJSON(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var out map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("response is not JSON: %v (%s)", err, w.Body.String())
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// List — the orphan decision
+// ---------------------------------------------------------------------------
+
+// A grant whose user no longer resolves is SHOWN and LABELLED. Dropping it
+// would hide a live row from the only surface that can remove it; showing it
+// unlabelled would read as a corrupt record.
+func TestListPlatformAdmins_OrphanGrantIsListedAndFlagged(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	granted := time.Date(2026, 8, 12, 9, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnRows(sqlmock.NewRows(paGrantCols).
+			AddRow(paCaller, nil, granted, nil).
+			AddRow(paTarget, paCaller, granted.Add(time.Hour), "on call"))
+	expectUserLookup(mock, paCaller, "caller@example.com", true)
+	expectUserLookup(mock, paTarget, "", false) // deleted user: the orphan
+	// paTarget's grantor is paCaller, already resolved and memoised — a second
+	// lookup here would be an unexpected query and fail ExpectationsWereMet.
+
+	w := paDo(t, r, http.MethodGet, "/platform-admins", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	items, ok := paJSON(t, w)["platform_admins"].([]interface{})
+	if !ok || len(items) != 2 {
+		t.Fatalf("platform_admins = %v, want 2 entries — an orphan must not be dropped", paJSON(t, w)["platform_admins"])
+	}
+
+	live := items[0].(map[string]interface{})
+	if live["user_id"] != paCaller {
+		t.Errorf("items[0].user_id = %v, want %s", live["user_id"], paCaller)
+	}
+	if live["user_resolved"] != true {
+		t.Errorf("items[0].user_resolved = %v, want true", live["user_resolved"])
+	}
+	if live["email"] != "caller@example.com" {
+		t.Errorf("items[0].email = %v, want caller@example.com", live["email"])
+	}
+
+	orphan := items[1].(map[string]interface{})
+	if orphan["user_id"] != paTarget {
+		t.Errorf("items[1].user_id = %v, want %s", orphan["user_id"], paTarget)
+	}
+	if orphan["user_resolved"] != false {
+		t.Errorf("items[1].user_resolved = %v, want false — an unresolvable grant must say so", orphan["user_resolved"])
+	}
+	if _, present := orphan["email"]; present {
+		t.Errorf("items[1] carries an email (%v) for a user that does not resolve", orphan["email"])
+	}
+	if orphan["granted_by_email"] != "caller@example.com" {
+		t.Errorf("items[1].granted_by_email = %v, want caller@example.com — the provenance survives the holder", orphan["granted_by_email"])
+	}
+	if orphan["note"] != "on call" {
+		t.Errorf("items[1].note = %v, want \"on call\"", orphan["note"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestListPlatformAdmins_CarrierReadFails(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnError(errDB)
+
+	w := paDo(t, r, http.MethodGet, "/platform-admins", "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "Failed to list platform administrators" {
+		t.Errorf("error = %v, want the carrier-read message", got)
+	}
+}
+
+// An identity-store FAILURE is not "this user does not exist". Serving a
+// partial list, in which the unreachable rows look like orphans, would
+// misreport who holds the highest privilege in the product.
+func TestListPlatformAdmins_IdentityFailureIsNotAnOrphan(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnRows(sqlmock.NewRows(paGrantCols).AddRow(paCaller, nil, time.Now(), nil))
+	mock.ExpectQuery("(?s)FROM users WHERE id").WithArgs(paCaller).WillReturnError(errDB)
+
+	w := paDo(t, r, http.MethodGet, "/platform-admins", "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "Failed to resolve platform administrator identities" {
+		t.Errorf("error = %v, want the identity-resolution message", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grant
+// ---------------------------------------------------------------------------
+
+func TestGrantPlatformAdmin_WritesGrantAndAuditEntry(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	granted := time.Date(2026, 8, 12, 13, 0, 0, 0, time.UTC)
+	expectUserLookup(mock, paTarget, "target@example.com", true)
+	mock.ExpectQuery("INSERT INTO platform_admins").
+		WithArgs(paTarget, paCaller, "incident 42").
+		WillReturnRows(sqlmock.NewRows(paGrantCols).AddRow(paTarget, paCaller, granted, "incident 42"))
+	meta := expectAuditWrite(mock, paCaller, "platform_admin.granted", paTarget)
+	expectUserLookup(mock, paCaller, "caller@example.com", true) // grantor, for the rendered row
+
+	w := paDo(t, r, http.MethodPost, "/platform-admins",
+		`{"user_id":"`+paTarget+`","note":"incident 42"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body.String())
+	}
+
+	item, ok := paJSON(t, w)["platform_admin"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response has no platform_admin object: %s", w.Body.String())
+	}
+	if item["user_id"] != paTarget {
+		t.Errorf("user_id = %v, want %s", item["user_id"], paTarget)
+	}
+	if item["granted_by"] != paCaller {
+		t.Errorf("granted_by = %v, want the acting principal %s", item["granted_by"], paCaller)
+	}
+	if item["granted_at"] != granted.Format(time.RFC3339) {
+		t.Errorf("granted_at = %v, want %v", item["granted_at"], granted.Format(time.RFC3339))
+	}
+
+	md := meta.metadata(t)
+	if md["target_user_id"] != paTarget {
+		t.Errorf("audit metadata target_user_id = %v, want %s", md["target_user_id"], paTarget)
+	}
+	if md["target_user_email"] != "target@example.com" {
+		t.Errorf("audit metadata target_user_email = %v, want target@example.com", md["target_user_email"])
+	}
+	if md["note"] != "incident 42" {
+		t.Errorf("audit metadata note = %v, want \"incident 42\"", md["note"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// Granting to a UUID nobody answers to would mint an orphan on purpose. The
+// mock is primed with NO carrier INSERT, so a write would be an unexpected
+// query — this asserts the refusal, not just the status.
+func TestGrantPlatformAdmin_UnknownUser(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+	expectUserLookup(mock, paTarget, "", false)
+
+	w := paDo(t, r, http.MethodPost, "/platform-admins", `{"user_id":"`+paTarget+`"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "User not found" {
+		t.Errorf("error = %v, want \"User not found\"", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (was a grant written for a nonexistent user?): %v", err)
+	}
+}
+
+// A re-grant leaves the original provenance alone and says so, rather than
+// reporting a success that rewrote who conferred the privilege.
+func TestGrantPlatformAdmin_AlreadyGranted(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+	expectUserLookup(mock, paTarget, "target@example.com", true)
+	mock.ExpectQuery("INSERT INTO platform_admins").
+		WillReturnRows(sqlmock.NewRows(paGrantCols)) // ON CONFLICT DO NOTHING
+
+	w := paDo(t, r, http.MethodPost, "/platform-admins", `{"user_id":"`+paTarget+`"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "User already holds platform-admin" {
+		t.Errorf("error = %v, want the already-granted message", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (an audit entry for a grant that did not happen?): %v", err)
+	}
+}
+
+func TestGrantPlatformAdmin_RejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"not a uuid", `{"user_id":"not-a-uuid"}`, "user_id must be a UUID"},
+		{"missing user_id", `{"note":"x"}`, "Invalid request body"},
+		{"note too long", `{"user_id":"` + paTarget + `","note":"` + string(make([]byte, 0)) + longNote() + `"}`,
+			"note must be at most 500 characters"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, r := newPlatformAdminRouter(t, paCaller)
+			w := paDo(t, r, http.MethodPost, "/platform-admins", tt.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+			}
+			if got := paJSON(t, w)["error"]; got != tt.want {
+				t.Errorf("error = %v, want %q", got, tt.want)
+			}
+			// Nothing was primed: a 400 must be decided before any query.
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unmet expectations: %v", err)
+			}
+		})
+	}
+}
+
+func longNote() string {
+	b := make([]byte, maxPlatformAdminNoteLen+1)
+	for i := range b {
+		b[i] = 'x'
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// Revoke — the last-standing guard
+// ---------------------------------------------------------------------------
+
+// expectRevokeLock primes BEGIN + the locking read with the given carrier rows.
+func expectRevokeLock(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
+	mock.ExpectBegin()
+	mock.ExpectQuery("(?s)FROM platform_admins.*FOR UPDATE").WillReturnRows(rows)
+}
+
+func TestRevokePlatformAdmin_WritesAuditEntry(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	now := time.Now()
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, now, nil).
+		AddRow(paTarget, paCaller, now, nil))
+	expectUserLookup(mock, paCaller, "caller@example.com", true) // the remaining admin
+	mock.ExpectExec("DELETE FROM platform_admins WHERE user_id").
+		WithArgs(paTarget).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	expectUserLookup(mock, paTarget, "target@example.com", true) // for the audit metadata
+	meta := expectAuditWrite(mock, paCaller, "platform_admin.revoked", paTarget)
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paTarget, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["message"]; got != "Platform administrator revoked" {
+		t.Errorf("message = %v, want the revoked message", got)
+	}
+
+	md := meta.metadata(t)
+	if md["target_user_id"] != paTarget {
+		t.Errorf("audit metadata target_user_id = %v, want %s", md["target_user_id"], paTarget)
+	}
+	if md["target_user_email"] != "target@example.com" {
+		t.Errorf("audit metadata target_user_email = %v, want target@example.com", md["target_user_email"])
+	}
+	if md["self_revocation"] != false {
+		t.Errorf("audit metadata self_revocation = %v, want false", md["self_revocation"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// SELF-REVOCATION IS ALLOWED while another administrator remains. The hazard
+// the guard defends against is reaching ZERO administrators, which is a
+// different question from who is asking.
+func TestRevokePlatformAdmin_SelfRevocationAllowedWhenAnotherRemains(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	now := time.Now()
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, now, nil).
+		AddRow(paTarget, paCaller, now, nil))
+	expectUserLookup(mock, paTarget, "target@example.com", true) // the remaining admin
+	mock.ExpectExec("DELETE FROM platform_admins WHERE user_id").
+		WithArgs(paCaller).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	expectUserLookup(mock, paCaller, "caller@example.com", true)
+	meta := expectAuditWrite(mock, paCaller, "platform_admin.revoked", paCaller)
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paCaller, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (self-revocation is permitted): %s", w.Code, w.Body.String())
+	}
+	if md := meta.metadata(t); md["self_revocation"] != true {
+		t.Errorf("audit metadata self_revocation = %v, want true", md["self_revocation"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// GUARD platform-admin-last-standing. No DELETE and no audit entry are primed,
+// so a revocation that slipped through would be an unexpected query as well as
+// a wrong status.
+func TestRevokePlatformAdmin_RefusesTheLastAdministrator(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, time.Now(), nil))
+	mock.ExpectRollback()
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paCaller, "")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+	body := paJSON(t, w)
+	if body["error"] != "Cannot revoke the last platform administrator" {
+		t.Errorf("error = %v, want the last-administrator refusal", body["error"])
+	}
+	if body["details"] == nil || body["details"] == "" {
+		t.Error("the refusal carries no details saying how to proceed")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (was the last administrator deleted?): %v", err)
+	}
+}
+
+// An ORPHANED grant is not an administrator. Both auth middlewares load the
+// user before consulting the carrier, so a deleted user's row elevates nobody
+// — counting it would let the last real administrator revoke themselves
+// against a count of two.
+func TestRevokePlatformAdmin_OrphanGrantDoesNotCountAsTheRemainingAdmin(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	now := time.Now()
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, now, nil).
+		AddRow(paThird, nil, now, "grant left behind by a deleted user"))
+	expectUserLookup(mock, paThird, "", false)
+	mock.ExpectRollback()
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paCaller, "")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 — an orphan grant is a row, not an administrator: %s",
+			w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "Cannot revoke the last platform administrator" {
+		t.Errorf("error = %v, want the last-administrator refusal", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// An identity store that cannot answer must not be read as "every other grant
+// is an orphan". That would turn an outage into the lockout the guard exists to
+// prevent, which is why the resolver keeps failure and absence apart.
+func TestRevokePlatformAdmin_IdentityFailureBlocksTheRevocation(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	now := time.Now()
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, now, nil).
+		AddRow(paTarget, nil, now, nil))
+	mock.ExpectQuery("(?s)FROM users WHERE id").WithArgs(paTarget).WillReturnError(errDB)
+	mock.ExpectRollback()
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paCaller, "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "Failed to verify remaining platform administrators" {
+		t.Errorf("error = %v, want the verification-failure message (NOT the last-admin refusal, "+
+			"and NOT a success)", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (was anything deleted?): %v", err)
+	}
+}
+
+func TestRevokePlatformAdmin_NotAnAdministrator(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	expectRevokeLock(mock, sqlmock.NewRows(paGrantCols).
+		AddRow(paCaller, nil, time.Now(), nil))
+	mock.ExpectRollback()
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/"+paTarget, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "User does not hold platform-admin" {
+		t.Errorf("error = %v, want the not-an-admin message", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRevokePlatformAdmin_InvalidUserID(t *testing.T) {
+	mock, r := newPlatformAdminRouter(t, paCaller)
+
+	w := paDo(t, r, http.MethodDelete, "/platform-admins/not-a-uuid", "")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "user_id must be a UUID" {
+		t.Errorf("error = %v, want the UUID message", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A handler constructed without a user repository cannot resolve anyone, so
+// every grant would look like an orphan. It answers 500 instead — the same
+// fail-closed direction as an identity outage, and the reason the nil check in
+// userResolver.get is a branch rather than a comment.
+func TestListPlatformAdmins_NoUserRepositoryFailsClosed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewPlatformAdminHandlers(repositories.NewPlatformAdminRepository(db), nil, nil)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("user_id", paCaller); c.Next() })
+	r.GET("/platform-admins", h.ListPlatformAdmins)
+
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnRows(sqlmock.NewRows(paGrantCols).AddRow(paCaller, nil, time.Now(), nil))
+
+	w := paDo(t, r, http.MethodGet, "/platform-admins", "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 — an unresolvable listing must not be served as a "+
+			"complete one: %s", w.Code, w.Body.String())
+	}
+	if got := paJSON(t, w)["error"]; got != "Failed to resolve platform administrator identities" {
+		t.Errorf("error = %v, want the identity-resolution message", got)
+	}
+}

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -346,6 +346,39 @@ type NamespaceOwnershipResponse struct {
 	OwnerOrganizationIDs []string   `json:"owner_organization_ids,omitempty"`
 }
 
+// PlatformAdminItem is one platform-admin grant in list/get responses
+// (issue #766).
+//
+// UserResolved is the orphan flag. The carrier carries no foreign key to users
+// (migration 000051 — identity data may live in another schema or another
+// database), so a deleted user leaves the grant row behind. Such a row is
+// returned with UserResolved false and no Email/Name, rather than dropped: it
+// is inert authority-wise but it is still a row, and the listing is the only
+// place an operator can see it in order to remove it.
+type PlatformAdminItem struct {
+	UserID       string `json:"user_id"`
+	Email        string `json:"email,omitempty"`
+	Name         string `json:"name,omitempty"`
+	UserResolved bool   `json:"user_resolved"`
+	// GrantedBy is NULL for rows written by migration 000051's backfill —
+	// nobody granted those, they were inferred from an admin-bearing role
+	// template, and Note says so.
+	GrantedBy      *string   `json:"granted_by"`
+	GrantedByEmail string    `json:"granted_by_email,omitempty"`
+	GrantedAt      time.Time `json:"granted_at"`
+	Note           *string   `json:"note"`
+}
+
+// ListPlatformAdminsResponse is returned by GET /api/v1/admin/platform-admins.
+type ListPlatformAdminsResponse struct {
+	PlatformAdmins []PlatformAdminItem `json:"platform_admins"`
+}
+
+// PlatformAdminResponse is returned by POST /api/v1/admin/platform-admins.
+type PlatformAdminResponse struct {
+	PlatformAdmin PlatformAdminItem `json:"platform_admin"`
+}
+
 // AuditLogResponse represents a single audit log entry in list or get responses.
 type AuditLogResponse struct {
 	ID             string                 `json:"id"`

--- a/backend/internal/api/platform_admin_routes_test.go
+++ b/backend/internal/api/platform_admin_routes_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+// Issue #766, PR 2 — the gate on /api/v1/admin/platform-admins.
+//
+// These routes confer and remove the highest privilege in the product, so the
+// authority question is the whole point: only a principal holding `admin` may
+// reach them. After PR 1 that scope means "the platform_admins carrier OR the
+// role-template union", and at PR 3 it will mean the carrier alone — with no
+// edit to the routes, which is why the gate is the SCOPE and not the carrier
+// read directly (see the package comment in internal/api/admin/platform_admins.go).
+//
+// Written the same way as TestPlatformTerraformMirrorRoutes_Authority, over the
+// real registerAPIV1Routes wiring rather than a hand-mounted group, so a route
+// that loses its gate — or is moved to a group that does not carry one — fails
+// here rather than in a test that describes routes as they were the day it was
+// written.
+
+// platformAdminTargetID is an arbitrary well-formed UUID. The gate decides
+// before any row is read, so no grant needs to exist for it to be observable.
+const platformAdminTargetID = "9f1d1f8e-2b7a-4c53-8f0e-6a1b2c3d4e5f"
+
+var platformAdminRoutes = []struct {
+	name   string
+	method string
+	path   string
+}{
+	{"list platform admins", http.MethodGet, "/api/v1/admin/platform-admins"},
+	{"grant platform admin", http.MethodPost, "/api/v1/admin/platform-admins"},
+	{"revoke platform admin", http.MethodDelete, "/api/v1/admin/platform-admins/" + platformAdminTargetID},
+}
+
+func TestPlatformAdminRoutes_RequireTheAdminScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	os.Setenv("TFR_JWT_SECRET", "test-jwt-secret-that-is-32-chars!!")
+
+	principals := []struct {
+		name        string
+		scopes      []string
+		wantAllowed bool
+	}{
+		{
+			// The seeded org_owner: every organization-level scope the product
+			// grants through membership, and none of them is `admin`.
+			name: "organization owner",
+			scopes: []string{
+				string(auth.ScopeModulesWrite), string(auth.ScopeProvidersWrite),
+				string(auth.ScopeMirrorsManage), string(auth.ScopeUsersWrite),
+				string(auth.ScopeAuditRead),
+			},
+			wantAllowed: false,
+		},
+		{
+			name:        "reader",
+			scopes:      []string{string(auth.ScopeModulesRead)},
+			wantAllowed: false,
+		},
+		{
+			name:        "platform admin",
+			scopes:      []string{string(auth.ScopeAdmin)},
+			wantAllowed: true,
+		},
+	}
+
+	for _, p := range principals {
+		for _, rt := range platformAdminRoutes {
+			t.Run(p.name+"/"+rt.name, func(t *testing.T) {
+				code := platformRouteCase(t, rt.method, rt.path, p.scopes)
+
+				if code == http.StatusNotFound {
+					t.Fatalf("%s %s: 404 — the route is not registered", rt.method, rt.path)
+				}
+				// The deps handed to platformRouteCase carry no
+				// PlatformAdminHandlers, so an AUTHORIZED caller falls through
+				// to a nil handler and gin.Recovery answers 500. The signal is
+				// exactly "403 or not", which is the authority decision.
+				gotAllowed := code != http.StatusForbidden
+				if gotAllowed != p.wantAllowed {
+					verb := "allowed"
+					if !p.wantAllowed {
+						verb = "refused"
+					}
+					t.Errorf("%s %s as %s: status %d, want the caller to be %s.\n"+
+						"These routes grant and revoke platform-admin; a principal without the "+
+						"`admin` scope must not reach them.",
+						rt.method, rt.path, p.name, code, verb)
+				}
+			})
+		}
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -577,6 +577,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Initialize audit log handlers
 	auditLogHandlers := admin.NewAuditLogHandlers(identityDB)
 
+	// Platform-admin management (issue #766, PR 2). Spans both connections by
+	// construction: the carrier is on the registry's own connection (see
+	// platformAdminRepo above, and migration 000051 for why it carries no FK),
+	// while the users it names and the audit trail it writes live on the
+	// identity connection.
+	platformAdminHandlers := admin.NewPlatformAdminHandlers(platformAdminRepo, userRepo, auditRepo)
+
 	// Shared app-credential minter (Entra app / GitHub App) for providers opted
 	// into an app auth mode; scmRepo provides the token-cache store. Uses the
 	// shared egress guard for parity with the other SCM outbound paths (#676).
@@ -741,6 +748,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		tfMirrorAdminHandler:        tfMirrorAdminHandler,
 		releasesGPGKeysAdminHandler: releasesGPGKeysAdminHandler,
 		rbacHandlers:                rbacHandlers,
+		platformAdminHandlers:       platformAdminHandlers,
 		versionApprovalHandler:      versionApprovalHandler,
 		storageHandlers:             storageHandlers,
 		storageConfigRepo:           storageConfigRepo,

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -399,21 +399,23 @@ type apiV1RouteDeps struct {
 	tfMirrorAdminHandler        *admin.TerraformMirrorHandler
 	releasesGPGKeysAdminHandler *admin.ReleasesGPGKeysHandler
 	rbacHandlers                *admin.RBACHandlers
-	platformAdminHandlers       *admin.PlatformAdminHandlers
-	versionApprovalHandler      *admin.VersionApprovalHandler
-	storageHandlers             *admin.StorageHandlers
-	storageConfigRepo           *repositories.StorageConfigRepository
-	moduleRepo                  *repositories.ModuleRepository
-	providerRepo                *repositories.ProviderRepository
-	tokenCipher                 *crypto.TokenCipher
-	oidcAdminHandlers           *admin.OIDCConfigAdminHandlers
-	auditLogHandlers            *admin.AuditLogHandlers
-	policyAdminHandler          *admin.PolicyHandler
-	cvePollJob                  *jobs.CVEPollJob
-	statsHandlers               *admin.StatsHandler
-	scmWebhookHandler           *webhooks.SCMWebhookHandler
-	approvalWebhookHandler      *webhooks.ApprovalHandler
-	egressGuard                 *httpsafe.Guard
+	// platformAdminHandlers serves the management surface for the
+	// platform-admin carrier (issue #766).
+	platformAdminHandlers  *admin.PlatformAdminHandlers
+	versionApprovalHandler *admin.VersionApprovalHandler
+	storageHandlers        *admin.StorageHandlers
+	storageConfigRepo      *repositories.StorageConfigRepository
+	moduleRepo             *repositories.ModuleRepository
+	providerRepo           *repositories.ProviderRepository
+	tokenCipher            *crypto.TokenCipher
+	oidcAdminHandlers      *admin.OIDCConfigAdminHandlers
+	auditLogHandlers       *admin.AuditLogHandlers
+	policyAdminHandler     *admin.PolicyHandler
+	cvePollJob             *jobs.CVEPollJob
+	statsHandlers          *admin.StatsHandler
+	scmWebhookHandler      *webhooks.SCMWebhookHandler
+	approvalWebhookHandler *webhooks.ApprovalHandler
+	egressGuard            *httpsafe.Guard
 }
 
 // registerAuthenticatedGroupMiddleware wires the middleware stack applied to

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -399,6 +399,7 @@ type apiV1RouteDeps struct {
 	tfMirrorAdminHandler        *admin.TerraformMirrorHandler
 	releasesGPGKeysAdminHandler *admin.ReleasesGPGKeysHandler
 	rbacHandlers                *admin.RBACHandlers
+	platformAdminHandlers       *admin.PlatformAdminHandlers
 	versionApprovalHandler      *admin.VersionApprovalHandler
 	storageHandlers             *admin.StorageHandlers
 	storageConfigRepo           *repositories.StorageConfigRepository
@@ -479,6 +480,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 	tfMirrorAdminHandler := d.tfMirrorAdminHandler
 	releasesGPGKeysAdminHandler := d.releasesGPGKeysAdminHandler
 	rbacHandlers := d.rbacHandlers
+	platformAdminHandlers := d.platformAdminHandlers
 	versionApprovalHandler := d.versionApprovalHandler
 	storageHandlers := d.storageHandlers
 	storageConfigRepo := d.storageConfigRepo
@@ -1080,6 +1082,27 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 				roleTemplatesGroup.POST("", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.CreateRoleTemplate)
 				roleTemplatesGroup.PUT("/:id", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.UpdateRoleTemplate)
 				roleTemplatesGroup.DELETE("/:id", middleware.RequireScope(auth.ScopeAdmin), rbacHandlers.DeleteRoleTemplate)
+			}
+
+			// Platform administrators (issue #766) — the carrier for
+			// platform-admin authority OUTSIDE organization_members. Mounted
+			// next to role-templates because it is the other half of the same
+			// question: this is where the platform-wide wildcard is conferred
+			// once PR 3 removes it from the role templates.
+			//
+			// Gated on RequireScope(ScopeAdmin) like every other /admin surface,
+			// NOT on the carrier directly — see the package comment in
+			// internal/api/admin/platform_admins.go for why. That also means
+			// these routes are classified as guarded by
+			// orgscope_route_class_test.go's platform-admin branch and need no
+			// tenantGuardExemptRoutes entry: they are authorized by a scope no
+			// per-organization role template grants, which is the same standing
+			// the other eleven admin surfaces have.
+			platformAdminsGroup := authenticatedGroup.Group("/admin/platform-admins")
+			{
+				platformAdminsGroup.GET("", middleware.RequireScope(auth.ScopeAdmin), platformAdminHandlers.ListPlatformAdmins)
+				platformAdminsGroup.POST("", middleware.RequireScope(auth.ScopeAdmin), platformAdminHandlers.GrantPlatformAdmin)
+				platformAdminsGroup.DELETE("/:user_id", middleware.RequireScope(auth.ScopeAdmin), platformAdminHandlers.RevokePlatformAdmin)
 			}
 
 			// Mirror Approval Requests

--- a/backend/internal/db/repositories/platform_admin_repository.go
+++ b/backend/internal/db/repositories/platform_admin_repository.go
@@ -161,6 +161,36 @@ func (r *PlatformAdminRepository) Grant(ctx context.Context, userID string, gran
 	return g, nil
 }
 
+// lockCarrier reads every grant inside tx under FOR UPDATE, separating the one
+// addressed by userID (nil when there is none) from the ones that would remain
+// after it is removed.
+func lockCarrier(ctx context.Context, tx *sql.Tx, userID string) (*PlatformAdminGrant, []PlatformAdminGrant, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT `+grantColumns+` FROM platform_admins ORDER BY granted_at ASC, user_id ASC FOR UPDATE`)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+
+	var target *PlatformAdminGrant
+	var remaining []PlatformAdminGrant
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			return nil, nil, err
+		}
+		if g.UserID == userID {
+			target = g
+			continue
+		}
+		remaining = append(remaining, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return target, remaining, nil
+}
+
 // Revoke removes userID's carrier row, but only if keepsAnAdmin accepts the
 // grants that would REMAIN afterwards.
 //
@@ -194,30 +224,10 @@ func (r *PlatformAdminRepository) Revoke(ctx context.Context, userID string, kee
 	// only the Commit error is reported.
 	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.QueryContext(ctx,
-		`SELECT `+grantColumns+` FROM platform_admins ORDER BY granted_at ASC, user_id ASC FOR UPDATE`)
+	target, remaining, err := lockCarrier(ctx, tx, userID)
 	if err != nil {
 		return nil, err
 	}
-	var target *PlatformAdminGrant
-	var remaining []PlatformAdminGrant
-	for rows.Next() {
-		g, err := scanGrant(rows)
-		if err != nil {
-			rows.Close()
-			return nil, err
-		}
-		if g.UserID == userID {
-			target = g
-			continue
-		}
-		remaining = append(remaining, *g)
-	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return nil, err
-	}
-	rows.Close()
 
 	if target == nil {
 		return nil, ErrNotPlatformAdmin

--- a/backend/internal/db/repositories/platform_admin_repository.go
+++ b/backend/internal/db/repositories/platform_admin_repository.go
@@ -21,16 +21,44 @@
 // database — the same placement and the same reasoning as
 // UserTokenRevocationRepository (issue #559 finding [9]).
 //
-// Grant and revoke are deliberately absent: PR 1 ships the carrier and the
-// read path only. The management surface is PR 2.
+// PR 2 (issue #766) adds the write side — List/Grant/Revoke — behind the
+// management API in internal/api/admin/platform_admins.go. The read path above
+// is unchanged by it.
 package repositories
 
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+	"time"
 )
 
-// PlatformAdminRepository reads the platform-admin carrier.
+// Sentinels for the two carrier states a caller has to tell apart from a
+// database fault. Returned as values, not as "zero rows and a nil error", so a
+// handler cannot map a silent no-op onto a success.
+var (
+	// ErrAlreadyPlatformAdmin is returned by Grant when the user already holds
+	// a carrier row. The existing row is left ALONE rather than overwritten:
+	// granted_by/granted_at/note are the provenance this table exists to keep,
+	// and a re-grant that rewrote them would erase who originally conferred the
+	// highest privilege in the product.
+	ErrAlreadyPlatformAdmin = errors.New("user already holds platform-admin")
+
+	// ErrNotPlatformAdmin is returned by Revoke when there is no carrier row to
+	// remove.
+	ErrNotPlatformAdmin = errors.New("user does not hold platform-admin")
+)
+
+// PlatformAdminGrant is one row of the carrier.
+type PlatformAdminGrant struct {
+	UserID    string
+	GrantedBy *string
+	GrantedAt time.Time
+	Note      *string
+}
+
+// PlatformAdminRepository reads and writes the platform-admin carrier.
 type PlatformAdminRepository struct {
 	db *sql.DB
 }
@@ -65,4 +93,158 @@ func (r *PlatformAdminRepository) IsPlatformAdmin(ctx context.Context, userID st
 		return false, err
 	}
 	return isAdmin, nil
+}
+
+// grantColumns is the projection every accessor below reads, in one place so
+// the three scan sites cannot drift apart.
+const grantColumns = `user_id, granted_by, granted_at, note`
+
+func scanGrant(s interface{ Scan(...any) error }) (*PlatformAdminGrant, error) {
+	g := &PlatformAdminGrant{}
+	if err := s.Scan(&g.UserID, &g.GrantedBy, &g.GrantedAt, &g.Note); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// List returns every carrier row, oldest grant first.
+//
+// UNFILTERED, AND THAT IS THE POINT. A grant whose user no longer resolves is
+// still returned: the caller (internal/api/admin/platform_admins.go) labels it
+// rather than dropping it. Filtering here would make a live row invisible to
+// the only surface that can remove it, which is the failure mode migration
+// 000050 was written to clean up after on api_keys.
+func (r *PlatformAdminRepository) List(ctx context.Context) ([]PlatformAdminGrant, error) {
+	query := `SELECT ` + grantColumns + ` FROM platform_admins ORDER BY granted_at ASC, user_id ASC`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	grants := make([]PlatformAdminGrant, 0)
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return grants, nil
+}
+
+// Grant records platform-admin authority for userID.
+//
+// Returns ErrAlreadyPlatformAdmin when the user already holds a carrier row —
+// ON CONFLICT DO NOTHING, so the original provenance survives a re-grant. The
+// caller turns that into a 409 rather than a silent success, because "already
+// an admin" and "granted just now, by you" are different facts about who is
+// accountable for the privilege.
+//
+// grantedBy is the acting principal, nil for a grant with no attributable
+// actor (the backfill in migration 000051 writes its rows that way).
+func (r *PlatformAdminRepository) Grant(ctx context.Context, userID string, grantedBy, note *string) (*PlatformAdminGrant, error) {
+	query := `INSERT INTO platform_admins (user_id, granted_by, note)
+	          VALUES ($1, $2, $3)
+	          ON CONFLICT (user_id) DO NOTHING
+	          RETURNING ` + grantColumns
+	g, err := scanGrant(r.db.QueryRowContext(ctx, query, userID, grantedBy, note))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAlreadyPlatformAdmin
+	}
+	if err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// Revoke removes userID's carrier row, but only if keepsAnAdmin accepts the
+// grants that would REMAIN afterwards.
+//
+// GUARD platform-admin-last-standing (issue #766). A deployment that revokes
+// its final platform administrator has no recovery path short of hand-written
+// SQL against platform_admins — which is precisely the operation this API
+// exists to replace. The predicate is the caller's because "an admin that
+// remains" is not answerable from this table alone: a grant whose user no
+// longer resolves is inert (both middlewares load the user BEFORE consulting
+// the carrier, so a deleted user's row elevates nobody), and counting it would
+// let the last REAL administrator revoke themselves against a count of two.
+//
+// UNDER A LOCK, NOT CHECK-THEN-DELETE. The read takes FOR UPDATE and the
+// delete runs in the same transaction, so two administrators revoking each
+// other concurrently serialise: the second one's read blocks, then sees a set
+// with the first's row already gone. Without the lock both would see the other
+// still present, both would pass the predicate, and the deployment would end
+// with zero administrators — the exact outcome the guard exists to prevent,
+// reachable by two well-formed requests.
+//
+// Returns ErrNotPlatformAdmin when there is no row to remove, the predicate's
+// own error when it refuses, and the driver's error otherwise. Nothing is
+// deleted in any of those cases.
+func (r *PlatformAdminRepository) Revoke(ctx context.Context, userID string, keepsAnAdmin func(ctx context.Context, remaining []PlatformAdminGrant) error) (*PlatformAdminGrant, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Rolled back unconditionally; a Rollback after a successful Commit is a
+	// no-op returning sql.ErrTxDone, which is why the error is dropped here and
+	// only the Commit error is reported.
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx,
+		`SELECT `+grantColumns+` FROM platform_admins ORDER BY granted_at ASC, user_id ASC FOR UPDATE`)
+	if err != nil {
+		return nil, err
+	}
+	var target *PlatformAdminGrant
+	var remaining []PlatformAdminGrant
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if g.UserID == userID {
+			target = g
+			continue
+		}
+		remaining = append(remaining, *g)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	if target == nil {
+		return nil, ErrNotPlatformAdmin
+	}
+	if keepsAnAdmin != nil {
+		if err := keepsAnAdmin(ctx, remaining); err != nil {
+			return nil, err
+		}
+	}
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM platform_admins WHERE user_id = $1`, userID)
+	if err != nil {
+		return nil, err
+	}
+	// The row was present under FOR UPDATE moments ago, so zero rows here means
+	// the lock did not hold what it is supposed to hold. Refusing to commit is
+	// the only safe reading: reporting a revocation that did not happen would
+	// leave an administrator the operator believes is gone.
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, err
+	}
+	if affected != 1 {
+		return nil, fmt.Errorf("revoking platform-admin for %s removed %d rows, want 1", userID, affected)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return target, nil
 }

--- a/backend/internal/db/repositories/platform_admin_repository_test.go
+++ b/backend/internal/db/repositories/platform_admin_repository_test.go
@@ -3,7 +3,9 @@ package repositories
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
@@ -92,5 +94,289 @@ func TestPlatformAdminRepository_IsPlatformAdmin_EmptyUserID_DoesNotQuery(t *tes
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR 2 (issue #766) — the write side
+// ---------------------------------------------------------------------------
+
+var grantCols = []string{"user_id", "granted_by", "granted_at", "note"}
+
+const (
+	adminA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	adminB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+)
+
+func TestPlatformAdminRepository_List(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	granted := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	note := "on-call rotation"
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins ORDER BY").
+		WillReturnRows(sqlmock.NewRows(grantCols).
+			AddRow(adminA, nil, granted, nil).
+			AddRow(adminB, adminA, granted.Add(time.Hour), note))
+
+	got, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(List) = %d, want 2", len(got))
+	}
+	if got[0].UserID != adminA || got[0].GrantedBy != nil || got[0].Note != nil {
+		t.Errorf("got[0] = %+v, want the backfilled shape (%s, nil grantor, nil note)", got[0], adminA)
+	}
+	if !got[0].GrantedAt.Equal(granted) {
+		t.Errorf("got[0].GrantedAt = %v, want %v", got[0].GrantedAt, granted)
+	}
+	if got[1].GrantedBy == nil || *got[1].GrantedBy != adminA {
+		t.Errorf("got[1].GrantedBy = %v, want %s", got[1].GrantedBy, adminA)
+	}
+	if got[1].Note == nil || *got[1].Note != note {
+		t.Errorf("got[1].Note = %v, want %q", got[1].Note, note)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// An empty carrier lists as an empty slice, not nil: the handler renders it as
+// `[]` rather than `null`.
+func TestPlatformAdminRepository_List_Empty(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnRows(sqlmock.NewRows(grantCols))
+
+	got, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got == nil {
+		t.Fatal("List returned nil on an empty carrier; want an empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("len(List) = %d, want 0", len(got))
+	}
+}
+
+func TestPlatformAdminRepository_List_DBError(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+	sentinel := errors.New("list failed")
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnError(sentinel)
+
+	got, err := repo.List(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the driver's error %v", err, sentinel)
+	}
+	if got != nil {
+		t.Errorf("List = %v on a failed read, want nil", got)
+	}
+}
+
+func TestPlatformAdminRepository_Grant(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	granted := time.Date(2026, 8, 12, 11, 0, 0, 0, time.UTC)
+	note := "promoted by ops"
+	mock.ExpectQuery("INSERT INTO platform_admins").
+		WithArgs(adminB, adminA, note).
+		WillReturnRows(sqlmock.NewRows(grantCols).AddRow(adminB, adminA, granted, note))
+
+	grantor := adminA
+	got, err := repo.Grant(context.Background(), adminB, &grantor, &note)
+	if err != nil {
+		t.Fatalf("Grant: %v", err)
+	}
+	if got.UserID != adminB {
+		t.Errorf("UserID = %q, want %q", got.UserID, adminB)
+	}
+	if got.GrantedBy == nil || *got.GrantedBy != adminA {
+		t.Errorf("GrantedBy = %v, want %q — the provenance is the reason this is a table and not a boolean", got.GrantedBy, adminA)
+	}
+	if !got.GrantedAt.Equal(granted) {
+		t.Errorf("GrantedAt = %v, want %v", got.GrantedAt, granted)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ON CONFLICT DO NOTHING returns no row. That must surface as the sentinel, not
+// as a nil grant with a nil error, and the EXISTING row must be left alone —
+// overwriting it would erase who originally conferred the privilege.
+func TestPlatformAdminRepository_Grant_AlreadyGranted(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	mock.ExpectQuery("INSERT INTO platform_admins").
+		WithArgs(adminB, nil, nil).
+		WillReturnRows(sqlmock.NewRows(grantCols)) // conflict: nothing returned
+
+	got, err := repo.Grant(context.Background(), adminB, nil, nil)
+	if !errors.Is(err, ErrAlreadyPlatformAdmin) {
+		t.Fatalf("err = %v, want ErrAlreadyPlatformAdmin", err)
+	}
+	if got != nil {
+		t.Errorf("Grant = %+v on a conflict, want nil", got)
+	}
+}
+
+func TestPlatformAdminRepository_Grant_DBError(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+	sentinel := errors.New("insert failed")
+	mock.ExpectQuery("INSERT INTO platform_admins").WillReturnError(sentinel)
+
+	got, err := repo.Grant(context.Background(), adminB, nil, nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the driver's error %v", err, sentinel)
+	}
+	if errors.Is(err, ErrAlreadyPlatformAdmin) {
+		t.Error("a driver failure was reported as ErrAlreadyPlatformAdmin")
+	}
+	if got != nil {
+		t.Errorf("Grant = %+v on failure, want nil", got)
+	}
+}
+
+// expectRevokeRead primes the locking read Revoke performs.
+func expectRevokeRead(mock sqlmock.Sqlmock, rows *sqlmock.Rows) {
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins .*FOR UPDATE").
+		WillReturnRows(rows)
+}
+
+func TestPlatformAdminRepository_Revoke(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	granted := time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)
+	expectRevokeRead(mock, sqlmock.NewRows(grantCols).
+		AddRow(adminA, nil, granted, nil).
+		AddRow(adminB, adminA, granted, nil))
+	mock.ExpectExec("DELETE FROM platform_admins WHERE user_id").
+		WithArgs(adminB).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	var sawRemaining []PlatformAdminGrant
+	got, err := repo.Revoke(context.Background(), adminB, func(_ context.Context, remaining []PlatformAdminGrant) error {
+		sawRemaining = remaining
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if got.UserID != adminB {
+		t.Errorf("Revoke returned %q, want the revoked grant %q", got.UserID, adminB)
+	}
+	// The predicate must be handed the set that would REMAIN — the target
+	// excluded. Handing it the whole set would make "one admin left" read as
+	// "two", which is the guard failing open.
+	if len(sawRemaining) != 1 || sawRemaining[0].UserID != adminA {
+		t.Errorf("predicate saw %+v, want exactly the non-target grant %q", sawRemaining, adminA)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The predicate's refusal aborts the transaction: no DELETE is issued at all.
+// sqlmock is ordered and primed with no Exec, so an attempted delete fails the
+// expectations rather than merely being rolled back.
+func TestPlatformAdminRepository_Revoke_PredicateRefuses_DoesNotDelete(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	expectRevokeRead(mock, sqlmock.NewRows(grantCols).
+		AddRow(adminA, nil, time.Now(), nil))
+	mock.ExpectRollback()
+
+	refusal := errors.New("last one standing")
+	got, err := repo.Revoke(context.Background(), adminA, func(_ context.Context, remaining []PlatformAdminGrant) error {
+		if len(remaining) != 0 {
+			t.Errorf("remaining = %+v, want empty for a sole administrator", remaining)
+		}
+		return refusal
+	})
+	if !errors.Is(err, refusal) {
+		t.Fatalf("err = %v, want the predicate's own error %v", err, refusal)
+	}
+	if got != nil {
+		t.Errorf("Revoke = %+v after a refusal, want nil", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (a DELETE was issued despite the refusal?): %v", err)
+	}
+}
+
+func TestPlatformAdminRepository_Revoke_NotAnAdmin(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	expectRevokeRead(mock, sqlmock.NewRows(grantCols).
+		AddRow(adminA, nil, time.Now(), nil))
+	mock.ExpectRollback()
+
+	called := false
+	got, err := repo.Revoke(context.Background(), adminB, func(context.Context, []PlatformAdminGrant) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrNotPlatformAdmin) {
+		t.Fatalf("err = %v, want ErrNotPlatformAdmin", err)
+	}
+	if got != nil {
+		t.Errorf("Revoke = %+v for a non-admin, want nil", got)
+	}
+	if called {
+		t.Error("the last-standing predicate ran for a user who holds no grant; there is nothing to protect")
+	}
+}
+
+// A DELETE that matches nothing after the row was read under FOR UPDATE must
+// not commit and must not report success.
+func TestPlatformAdminRepository_Revoke_DeleteMatchedNothing(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	expectRevokeRead(mock, sqlmock.NewRows(grantCols).
+		AddRow(adminA, nil, time.Now(), nil).
+		AddRow(adminB, nil, time.Now(), nil))
+	mock.ExpectExec("DELETE FROM platform_admins WHERE user_id").
+		WithArgs(adminB).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	got, err := repo.Revoke(context.Background(), adminB, nil)
+	if err == nil {
+		t.Fatal("Revoke reported success for a DELETE that removed no rows")
+	}
+	if !strings.Contains(err.Error(), "removed 0 rows") {
+		t.Errorf("err = %v, want it to name the row count", err)
+	}
+	if got != nil {
+		t.Errorf("Revoke = %+v, want nil", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (did it commit?): %v", err)
+	}
+}
+
+func TestPlatformAdminRepository_Revoke_ReadError(t *testing.T) {
+	repo, mock := newTestPlatformAdminRepo(t)
+
+	sentinel := errors.New("locking read failed")
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT user_id, granted_by, granted_at, note FROM platform_admins").
+		WillReturnError(sentinel)
+	mock.ExpectRollback()
+
+	got, err := repo.Revoke(context.Background(), adminA, nil)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the driver's error %v", err, sentinel)
+	}
+	if errors.Is(err, ErrNotPlatformAdmin) {
+		t.Error("a failed read was reported as ErrNotPlatformAdmin — a fault must not read as an absent grant")
+	}
+	if got != nil {
+		t.Errorf("Revoke = %+v on a failed read, want nil", got)
 	}
 }

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -189,6 +189,12 @@ func getResourceType(c *gin.Context) string {
 		return "storage"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/roles"):
 		return "role"
+	// The platform-admin carrier (issue #766). The grant/revoke handlers write
+	// their own entries naming the target; this labels the coarse route-level
+	// entry this middleware writes for the same request, which would otherwise
+	// fall through to "unknown".
+	case strings.HasPrefix(fullPath, "/api/v1/admin/platform-admins"):
+		return "platform_admin"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/scm-providers"):
 		return "scm_provider"
 	case strings.HasPrefix(fullPath, "/api/v1/admin/webhooks"):

--- a/backend/internal/middleware/audit_test.go
+++ b/backend/internal/middleware/audit_test.go
@@ -241,6 +241,12 @@ func TestAuditMiddleware_ResourceTypeDetection(t *testing.T) {
 		// /api/v1) and must be audited distinctly rather than falling through
 		// to "unknown" — see issue #666.
 		{"/scim/v2/Users", "scim_provisioning"},
+		// The platform-admin carrier's management surface (issue #766). Its
+		// handlers write their own per-target entries; this labels the coarse
+		// route-level entry, which would otherwise read "unknown" for the route
+		// that confers the highest privilege in the product.
+		{"/api/v1/admin/platform-admins", "platform_admin"},
+		{"/api/v1/admin/platform-admins/some-id", "platform_admin"},
 		{"/other/z", "unknown"},
 	}
 


### PR DESCRIPTION
PR 2 of 3 for the platform-admin carrier. Refs #766.

PR 1 (#860) shipped `platform_admins` (migration 000051) and the per-request
read that elevates a session's effective scopes from it. This adds the surface
that manages it. **#766 remains open, and closes at PR 3**, which makes the
carrier the only source of authority.

Additive only — no `BREAKING CHANGE:` footer.

## API

| Route | Gate | Notes |
| --- | --- | --- |
| `GET /api/v1/admin/platform-admins` | `RequireScope(admin)` | every grant with its provenance; orphans flagged, not hidden |
| `POST /api/v1/admin/platform-admins` | `RequireScope(admin)` | `{user_id, note}` → **201**; **404** unknown user, **409** already granted |
| `DELETE /api/v1/admin/platform-admins/{user_id}` | `RequireScope(admin)` | **404** not an admin, **409** last administrator |

Shapes follow the `/admin/role-templates` idiom next to which they are mounted:
a group off `authenticatedGroup`, per-route `middleware.RequireScope`, handler
methods, response structs in `responses.go`, full Swagger annotations
(`docs/swagger.json` and `docs/openapi3.json` regenerated).

## The audit trail

`platform_admin.granted` / `platform_admin.revoked`, `resource_type =
platform_admin`, `resource_id` = the target, `user_id` = the actor, metadata
carrying the target's email and — on revoke — whether it was a self-revocation.

Written **synchronously** on the request path, unlike the async download audits
elsewhere in the package. This is the record the whole design exists to
produce: its failure should be observable, and a test should be able to assert
it was written rather than race a goroutine. `organization_id` is left NULL
deliberately — platform-admin is not an organization-owned fact, and
`OrgScopeAllOrganizations` (what every platform administrator's audit read
uses) admits NULL-owner rows, so the entry is readable by the people entitled
to review it.

A failed audit write does **not** fail the request: the mutation already
happened on a different connection and cannot be rolled back with it, and a 500
would invite a retry that then conflicts. It logs at error level, and
`AuditMiddleware`'s own route-level entry for the same request is written
independently (that route now labels as `platform_admin` rather than falling
through to `unknown`).

## Refusing to remove the last administrator

Under a **lock**, not check-then-delete. The read takes `FOR UPDATE` and the
`DELETE` runs in the same transaction. Without it, two administrators revoking
each other concurrently both see the other still present, both pass the guard,
and the deployment ends with zero administrators — reachable by two well-formed
requests.

Falsified against a real Postgres 16 container, deterministically (one
transaction parks inside the predicate while the other attempts its revoke):

| | outcome, 3/3 runs |
| --- | --- |
| with `FOR UPDATE` | 1 revocation succeeds, 1 refused, **1 administrator left** |
| without `FOR UPDATE` | both succeed, **0 administrators left** |

The same container run also exercised the rest of the new SQL — the migration's
backfill, `ON CONFLICT DO NOTHING RETURNING` (re-grant preserves the original
provenance), the `granted_at` default, and rollback on refusal — since PR CI
does not run migrations.

## Decisions

**Gated on the scope, not on the carrier.** `RequireScope(auth.ScopeAdmin)`,
like every other `/admin` surface. After PR 1 that scope already means "carrier
OR the role-template union", and at PR 3 it becomes "carrier" with no edit here.
Gating on the carrier directly would have bought no security — during the
transition a union-only administrator still holds `admin` at all twelve other
`HasScope(ScopeAdmin)` sites, including `/admin/role-templates` where they can
mint themselves another one — while creating a real hazard: an administrator
added by role template between PR 1 and PR 3 would be locked out of the only
surface that could give them a carrier row, and the recovery would be the SQL
this API replaces.

**Orphan grants are listed and labelled.** The carrier has no FK to `users`
(migration 000051: identity data may live in another schema or another
database), so a deleted user leaves a row behind. It is returned with
`user_resolved: false` and no email/name. Dropping it would hide a live row
from the only surface that can remove it; showing it unlabelled would read as a
corrupt record. Same choice migration 000050 made for orphaned `api_keys` —
keep the row visible to an operator rather than make it disappear.

**An orphan is not an administrator that remains.** Both middlewares load the
user *before* consulting the carrier, so an orphan row elevates nobody.
Counting rows instead would let the last real administrator revoke themselves
whenever a deleted colleague's grant was still on the table. An identity lookup
that *fails* is kept distinct from one that resolves to nobody, so an outage
cannot be read as "every other grant is an orphan" — that would turn a blip
into the lockout the guard exists to prevent.

**Granting to a nonexistent user is refused (404).** It would mint an orphan on
purpose, indistinguishable later from one caused by a deletion.

**Self-revocation is permitted, subject to the last-standing rule.** The hazard
is a deployment reaching *zero* administrators, and that rule covers it exactly
— for a self-revoke as for any other. A separate "not yourself" rule would
forbid nothing dangerous, and would make standing down require a second live
administrator to do it for you: the same single-point-of-failure shape in the
other direction, where an operator who should no longer hold a privilege has to
keep holding it.

## `/auth/me`

`allowed_scopes` was built solely from `GetAllowedScopes()`, the role-template
union read out of the database, while platform-admin has had a second carrier
since PR 1. All 43 frontend `allowedScopes` sites read that field, so at PR 3 a
carrier-only administrator would be authorized at every server-side check and
rendered as an ordinary user. The carrier is unioned in from the request's
effective scopes rather than by querying it again, keeping this downstream of
PR 1's single insertion point — including its deliberate exclusion of API keys.

## Mutation table

20 mutations, each applied to a `cp` backup, compiled, and required to fail the
named tests. **20/20 caught.**

| # | Mutation | Caught by |
| --- | --- | --- |
| M1 | last-standing guard never refuses | `TestRevokePlatformAdmin_RefusesTheLastAdministrator`, `_OrphanGrantDoesNotCount…` |
| M2 | an orphan grant resolves to a user | `TestListPlatformAdmins_OrphanGrantIsListedAndFlagged`, `TestRevokePlatformAdmin_OrphanGrant…` |
| M3 | identity lookup failure skipped instead of aborting | `TestRevokePlatformAdmin_IdentityFailureBlocksTheRevocation` |
| M4 | the target counted among the grants that would remain | 4 revoke tests + `TestPlatformAdminRepository_Revoke` |
| M5 | the last-standing predicate never consulted | 4 revoke tests |
| M6 | revoke read drops `FOR UPDATE` | 4 `TestPlatformAdminRepository_Revoke*` |
| M6b | `FOR UPDATE` removed, **real Postgres** | deterministic race → 0 administrators left |
| M7 | grant writes no audit entry | `TestGrantPlatformAdmin_WritesGrantAndAuditEntry` |
| M8 | revoke writes no audit entry | `TestRevokePlatformAdmin_WritesAuditEntry`, `_SelfRevocation…` |
| M9 | audit entry does not record who acted | grant + both revoke audit tests |
| M10 | audit entry records the actor as the target | grant + revoke audit tests |
| M11 | `/auth/me` drops the carrier union | `…AllowedScopesUnionsThePlatformAdminCarrier/carrier-only_administrator` |
| M12 | `/auth/me` reports admin for everyone | `…/ordinary_user_is_not_elevated` |
| M13 | grant route gated on `users:write` | `TestPlatformAdminRoutes_RequireTheAdminScope/organization_owner/grant` |
| M14 | granting to a nonexistent user allowed | `TestGrantPlatformAdmin_UnknownUser` |
| M15 | a `DELETE` that removed nothing still commits | `TestPlatformAdminRepository_Revoke_DeleteMatchedNothing` |
| M16 | a re-grant reported as success, not conflict | `TestGrantPlatformAdmin_AlreadyGranted` |
| M17 | audit route label falls back to `unknown` | `TestAuditMiddleware_ResourceTypeDetection` |
| M18 | note-length bound dropped | `TestGrantPlatformAdmin_RejectsBadInput/note_too_long` |
| M19 | revoke accepts a non-UUID path parameter | `TestRevokePlatformAdmin_InvalidUserID` |
| M20 | nil user repository resolves silently | `TestListPlatformAdmins_NoUserRepositoryFailsClosed` |

No inert guard was found, and no test short-circuited before the code under
test — every mutation failed at least one assertion on an exact status or an
exact value. Every assertion here is on a sentinel or an exact status/payload;
none is a bare `err != nil` or "not 200".

## Route-class guard (#856)

The three routes carry `middleware.RequireScope(ScopeAdmin)`, which
`orgscope_route_class_test.go` classifies as **guarded** via its platform-admin
branch. They therefore need **no** `tenantGuardExemptRoutes` entry — and adding
one would fail the test, which errors on a route that carries a guard *and* an
exemption. The classifier's own counts move from 170/146 to 173/149
authenticated/guarded, with the exemption list unchanged at 24.

## Untouched

The twelve existing `HasScope(…, ScopeAdmin)` sites, PR 1's middleware
elevation and its tests, and the seeded role templates.

## Verification

`go build ./... && go vet ./... && gofmt -l . && go test ./...` clean.
(`internal/auth`'s four `StartJWTSecretFileWatch` tests fail on this host with
`inotify: too many open files`; identical failure on `origin/main`, unrelated.)
