### PR TITLE
ci(replay): check out the GitHub-Actions family and drift-contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
 
@@ -572,6 +572,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:go

--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -157,6 +157,36 @@ jobs:
           persist-credentials: false
           repository: 4cloudguru/pipeline-task-core
           path: suite/pipeline-task-core
+      # The GitHub-Actions family plus the drift payload contract they share with
+      # the ADO TerraformDriftReport task. In SIGNATURE_SCOPE and absent here is
+      # exit 2 for the whole job, not a quieter run. Note drift-contract is owned
+      # by 4cloudguru, not sethbacon; each path basename must equal that repo's
+      # `dir` in scope.json, which is what `--repos-root suite` resolves against.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: sethbacon/setup-terraform-hardened
+          path: suite/setup-terraform-hardened
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-provider-mirror
+          path: suite/terraform-provider-mirror
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-drift-report
+          path: suite/terraform-drift-report
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: sethbacon/terraform-module-publish
+          path: suite/terraform-module-publish
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: 4cloudguru/terraform-drift-contract
+          path: suite/terraform-drift-contract
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           {

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -225,7 +225,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
 
@@ -234,7 +234,7 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:go
 


### PR DESCRIPTION
`security-orchestration#36` widened `SIGNATURE_SCOPE` with four recorded signatures for the GitHub-Actions family, plus the drift payload contract they share with the ADO TerraformDriftReport task. Repos in scope that are not checked out make the gate **exit 2** ΓÇö a signature that cannot run is never read as a pass ΓÇö so `replay` fails on every PR here until these five checkouts exist.

Adds:

| repo | path |
| --- | --- |
| `sethbacon/setup-terraform-hardened` | `suite/setup-terraform-hardened` |
| `sethbacon/terraform-provider-mirror` | `suite/terraform-provider-mirror` |
| `sethbacon/terraform-drift-report` | `suite/terraform-drift-report` |
| `sethbacon/terraform-module-publish` | `suite/terraform-module-publish` |
| `4cloudguru/terraform-drift-contract` | `suite/terraform-drift-contract` |

`drift-contract` is in the **4cloudguru** org, not `sethbacon` ΓÇö the slug is not interchangeable. Both are public, so the job own `GITHUB_TOKEN` still reads them. Each `path` basename equals that repo `dir` in `scope.json`, which is what `--repos-root suite` resolves against.

### Consistency

Matches the canonical `remediation/replay/workflows/signature-replay.yml` in security-orchestration, and the shape already merged in `azure-pipelines-packer` and `terraform-state-manager-frontend`. Reuses this repo existing pinned `actions/checkout` rather than importing the template unpinned `@v5`.

### Verified

- checkout set compared against the canonical template: **15 repos, 0 difference** in either direction
- workflow parses as valid YAML
- additive only ΓÇö no existing step modified


---

### Why this PR also carries a second, unrelated fix

Splitting these produced a **deadlock**. Both `replay` and the other gate are required, and each fix only satisfied one:

- the replay-scope PR failed the other gate, which is broken on `main`
- the other fix branched from `main`, so it failed `replay`

Neither could ever go green alone. They are combined here so one merge satisfies both. The superseded single-purpose PR is closed.
