### PR TITLE
ci: pin codeql-action comment to the exact tag it resolves to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
 
@@ -572,6 +572,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:go

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -225,7 +225,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
 
@@ -234,7 +234,7 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:go
 


### PR DESCRIPTION
`Zizmor (workflow security lint)` fails every PR in this repo with exit 13:

```
action's hash pin has mismatched or missing version comment: points to commit ff2f1c621b7f
```

### Nothing in this repo changed

`# v4` is a **moving** major tag. codeql-action published `v4.37.7`, which advanced `v4` to `ff2f1c621b7f`. The pin here is `v4.37.6`:

| | SHA | tag |
| --- | --- | --- |
| our pin | `5595ccaf912e` | **v4.37.6** |
| `# v4` now resolves to | `ff2f1c621b7f` | **v4.37.7** |

The comment stopped being true the moment upstream cut a release.

### The fix

Comment the exact tag the pinned SHA resolves to. **The SHA is unchanged** — no action upgrade rides along under a lint fix; bumping the pin stays Dependabot's job.

Same fix already merged in `terraform-state-manager-frontend`, and matches the precise-version convention the rest of the pins here already use.

### Note

An audit of every SHA-pinned action in this repo found these were the only **drifted** pins. There are further pins commented with a bare major (`# v7`, `# v9`) that resolve correctly today but will drift the same way whenever their upstreams release — deliberately left alone here to keep this change to the unblock.
