### PR TITLE
ci: comment the remaining action pins with their exact tags

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -81,7 +81,7 @@ jobs:
             2>&1 | tee chaos-results.json
 
       - name: Upload results
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: chaos-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload generated Swagger/OpenAPI docs
         if: github.ref_type != 'tag'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: swagger-docs
           path: |
@@ -171,7 +171,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Go coverage
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-coverage
           path: backend/coverage.out
@@ -228,7 +228,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes regenerated swagger docs to the PR head branch
 
       - name: Download generated docs
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: swagger-docs
           path: backend/docs
@@ -424,7 +424,7 @@ jobs:
 
       - name: Upload gosec results
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gosec-results
           path: backend/gosec-results.json
@@ -502,7 +502,7 @@ jobs:
           docker compose -f docker-compose.test.yml config --quiet
 
       - name: Install Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           version: "latest"
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-crash-${{ matrix.target }}
           path: |
@@ -99,7 +99,7 @@ jobs:
       issues: write
     steps:
       - name: Create issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `Fuzz failure detected — ${new Date().toISOString().slice(0, 10)}`;

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
 
       - name: Run release-please
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.token.outputs.token }}
           config-file: .release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           ls -la release/
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: release/
@@ -168,7 +168,7 @@ jobs:
           if-no-files-found: error
 
       - name: Attest build provenance (binaries)
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: "release/*"
 
@@ -247,7 +247,7 @@ jobs:
           output-file: image-sbom.spdx.json
 
       - name: Upload container SBOM
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-sbom
           path: image-sbom.spdx.json
@@ -262,7 +262,7 @@ jobs:
           STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -364,7 +364,7 @@ jobs:
           output-file: image-sbom-fips.spdx.json
 
       - name: Upload container SBOM
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: container-sbom-fips
           path: image-sbom-fips.spdx.json
@@ -379,7 +379,7 @@ jobs:
           STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Attest build provenance (container)
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -432,7 +432,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download release artifacts (binaries, checksums, sigs, deployment configs)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: release/

--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -253,7 +253,7 @@ jobs:
       # report for the run someone will actually want to read.
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signature-replay-report
           path: replay-report.json

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -105,7 +105,7 @@ jobs:
         # the job summary as warnings, and the govulncheck job covers whether
         # they are reachable.
         if: steps.osv_triage_weekly.outcome == 'failure'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -177,7 +177,7 @@ jobs:
         # Issue creation stays weekly-only to avoid opening a new issue on
         # every PR push; per-PR runs fail the job instead (next step).
         if: steps.govulncheck.outcome == 'failure' && github.event_name == 'schedule'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `govulncheck: reachable vulnerabilities found — ${new Date().toISOString().slice(0,10)}`;
@@ -270,7 +270,7 @@ jobs:
       issues: write
     steps:
       - name: Create failure issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `Scheduled build failed — ${new Date().toISOString().slice(0,10)}`;

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.create({


### PR DESCRIPTION
A bare `# v7` / `# v9` comment names a **moving** tag. It is true only until the upstream cuts a release and GitHub advances that tag past the pinned SHA — at which point zizmor's `ref-version-mismatch` fails **every PR in the repo**, with no change on our side.

That is not hypothetical. It is exactly how the `codeql-action` pins broke earlier today: `v4.37.7` shipped, the `v4` tag moved off our pinned `v4.37.6`, and green PRs went red on their own across several repos.

### What this does

Replaces each bare-major comment with the precise tag its pinned SHA **already resolves to**, so the comment cannot expire.

**No SHA changes.** No action upgrades ride along — bumping a pin stays Dependabot's job, and keeping the two separate means a lint fix never quietly ships a new action version.

### How the tags were chosen

Each pinned SHA was resolved against the upstream tag list, and the precise `vX.Y.Z` tag pointing at that exact commit was used. Any pin whose SHA could not be matched to a precise tag would have been left untouched and reported rather than guessed — there were none.

### Scope

Part of a suite-wide sweep: **53 pins across 8 repos**. `terraform-state-manager-frontend` and `pipeline-task-core` were already clean and needed no change.

Verification is zizmor itself — it runs this audit online on this PR. Note that a *local* zizmor run without a token silently skips it and reports a false clean, so the CI result here is the meaningful one.
