### PR TITLE
test(schemaguard): guard application SQL against the schema the default configuration has

### DIFF
--- a/backend/internal/schemaguard/doc.go
+++ b/backend/internal/schemaguard/doc.go
@@ -1,0 +1,11 @@
+// Package schemaguard is test-only infrastructure. It holds the guard against
+// the defect class behind issue #864: application SQL that depends on schema
+// the running configuration will not have.
+//
+// There is no production code here on purpose — nothing in the server binary
+// imports this package. Everything lives in _test.go files so the guard cannot
+// drift into being a runtime dependency of the thing it inspects.
+//
+// Start at schema_demand_guard_test.go; the reusable analyzer and its own unit
+// tests are in schema_demand_analyzer_test.go.
+package schemaguard

--- a/backend/internal/schemaguard/schema_demand_analyzer_test.go
+++ b/backend/internal/schemaguard/schema_demand_analyzer_test.go
@@ -114,8 +114,8 @@ func splitStatements(sql string) []string {
 	var cur strings.Builder
 	i := 0
 	for i < len(sql) {
-		switch {
-		case sql[i] == '\'':
+		switch sql[i] {
+		case '\'':
 			j := i + 1
 			for j < len(sql) {
 				if sql[j] == '\'' {
@@ -132,7 +132,7 @@ func splitStatements(sql string) []string {
 			}
 			cur.WriteString(sql[i : j+1])
 			i = j + 1
-		case sql[i] == '$':
+		case '$':
 			if tag, ok := dollarTag(sql, i); ok {
 				end := strings.Index(sql[i+len(tag):], tag)
 				if end < 0 {
@@ -147,7 +147,7 @@ func splitStatements(sql string) []string {
 			}
 			cur.WriteByte(sql[i])
 			i++
-		case sql[i] == ';':
+		case ';':
 			out = append(out, cur.String())
 			cur.Reset()
 			i++

--- a/backend/internal/schemaguard/schema_demand_analyzer_test.go
+++ b/backend/internal/schemaguard/schema_demand_analyzer_test.go
@@ -1,0 +1,943 @@
+package schemaguard
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file is the reusable half of the guard: a DDL replayer, a DML write
+// extractor, and the resolver that decides whether a write can land. It has no
+// opinion about this repository — schema_demand_guard_test.go supplies the
+// migration streams, the search_path and the source roots.
+//
+// Keeping the two apart is deliberate. The analyzer is exercised below against
+// hand-written fixtures whose expected answers are obvious, including the
+// empty-universe falsification; the guard proper is exercised against the real
+// tree. A single fused test would have had no way to prove the analyzer says
+// anything at all when handed nothing.
+
+// ---------------------------------------------------------------------------
+// Sentinels
+// ---------------------------------------------------------------------------
+
+var (
+	// errNoDDL means a migration stream contributed no CREATE TABLE at all.
+	// Certifying against an empty schema universe would pass every write
+	// vacuously, so this is fatal rather than "zero violations found".
+	errNoDDL = errors.New("schemaguard: migration stream produced no tables; refusing to certify against an empty schema universe")
+	// errNoWrites means the source scan found no INSERT/UPDATE/DELETE at all.
+	// Same reasoning in the other direction: a guard that inspected zero
+	// writes has proved nothing.
+	errNoWrites = errors.New("schemaguard: source scan found no SQL writes; refusing to certify with nothing to check")
+	// errNoSearchPath means the resolver was handed an empty schema list, so
+	// no unqualified name could ever resolve.
+	errNoSearchPath = errors.New("schemaguard: empty search_path; refusing to certify")
+)
+
+// ---------------------------------------------------------------------------
+// The schema model
+// ---------------------------------------------------------------------------
+
+// tableKey identifies a table by schema and name. Schema is always populated:
+// unqualified DDL is resolved against the owning stream's default schema when
+// it is replayed, not left ambiguous.
+type tableKey struct {
+	Schema string
+	Table  string
+}
+
+func (k tableKey) String() string { return k.Schema + "." + k.Table }
+
+// schemaModel is the state of the world after replaying a set of migrations.
+type schemaModel struct {
+	// columns holds the column set of every table whose shape is known.
+	columns map[tableKey]map[string]bool
+	// opaque holds relations that exist but whose column set this analyzer
+	// declines to model — views, CREATE TABLE AS SELECT. Writes to these are
+	// checked for existence only. Modelling a view's columns would mean
+	// resolving its SELECT list, which is out of scope (see the boundary
+	// section of schema_demand_guard_test.go).
+	opaque map[tableKey]bool
+}
+
+func newSchemaModel() *schemaModel {
+	return &schemaModel{
+		columns: map[tableKey]map[string]bool{},
+		opaque:  map[tableKey]bool{},
+	}
+}
+
+func (m *schemaModel) tableCount() int { return len(m.columns) + len(m.opaque) }
+
+func (m *schemaModel) has(k tableKey) bool {
+	if _, ok := m.columns[k]; ok {
+		return true
+	}
+	return m.opaque[k]
+}
+
+// ---------------------------------------------------------------------------
+// SQL lexing helpers
+// ---------------------------------------------------------------------------
+
+var (
+	lineComment  = regexp.MustCompile(`--[^\n]*`)
+	blockComment = regexp.MustCompile(`(?s)/\*.*?\*/`)
+	wsRun        = regexp.MustCompile(`\s+`)
+)
+
+// stripComments removes SQL comments. Dollar-quoted bodies are left alone by
+// splitStatements, so a `--` inside a DO $$ block is not a concern here: the
+// whole block is one statement and the DDL matchers below do not fire on it.
+func stripComments(s string) string {
+	s = blockComment.ReplaceAllString(s, " ")
+	return lineComment.ReplaceAllString(s, " ")
+}
+
+// splitStatements splits SQL on top-level semicolons, honouring single-quoted
+// strings and dollar-quoted bodies ($$ ... $$ and $tag$ ... $tag$). A naive
+// strings.Split(";") would shred every DO block in this repository's
+// migrations, and five of them contain semicolons.
+func splitStatements(sql string) []string {
+	var out []string
+	var cur strings.Builder
+	i := 0
+	for i < len(sql) {
+		switch {
+		case sql[i] == '\'':
+			j := i + 1
+			for j < len(sql) {
+				if sql[j] == '\'' {
+					if j+1 < len(sql) && sql[j+1] == '\'' { // escaped ''
+						j += 2
+						continue
+					}
+					break
+				}
+				j++
+			}
+			if j >= len(sql) {
+				j = len(sql) - 1
+			}
+			cur.WriteString(sql[i : j+1])
+			i = j + 1
+		case sql[i] == '$':
+			if tag, ok := dollarTag(sql, i); ok {
+				end := strings.Index(sql[i+len(tag):], tag)
+				if end < 0 {
+					cur.WriteString(sql[i:])
+					i = len(sql)
+					continue
+				}
+				stop := i + len(tag) + end + len(tag)
+				cur.WriteString(sql[i:stop])
+				i = stop
+				continue
+			}
+			cur.WriteByte(sql[i])
+			i++
+		case sql[i] == ';':
+			out = append(out, cur.String())
+			cur.Reset()
+			i++
+		default:
+			cur.WriteByte(sql[i])
+			i++
+		}
+	}
+	if strings.TrimSpace(cur.String()) != "" {
+		out = append(out, cur.String())
+	}
+	return out
+}
+
+// dollarTag reports the dollar-quote tag starting at i, e.g. "$$" or "$fn$".
+func dollarTag(s string, i int) (string, bool) {
+	if s[i] != '$' {
+		return "", false
+	}
+	j := i + 1
+	for j < len(s) && (s[j] == '_' || isIdentByte(s[j])) {
+		j++
+	}
+	if j < len(s) && s[j] == '$' {
+		return s[i : j+1], true
+	}
+	return "", false
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// normalize collapses whitespace so the statement matchers can be written
+// against single-spaced text.
+func normalize(s string) string { return strings.TrimSpace(wsRun.ReplaceAllString(s, " ")) }
+
+// splitTopLevel splits on commas that are not inside parentheses.
+func splitTopLevel(s string) []string {
+	var out []string
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// parenBody returns the contents of the parenthesised group that starts at the
+// first '(' in s, balanced.
+func parenBody(s string) (string, bool) {
+	open := strings.Index(s, "(")
+	if open < 0 {
+		return "", false
+	}
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[open+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// unquoteIdent lowercases a bare identifier and strips SQL double quotes.
+// Postgres folds unquoted identifiers to lower case; this repository quotes
+// exactly one column ("references" in 000032), so the two paths must agree.
+func unquoteIdent(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, ";")
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return strings.ToLower(s)
+}
+
+// parseName splits an optionally schema-qualified relation name, applying
+// defaultSchema when the name carries none.
+func parseName(raw, defaultSchema string) tableKey {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, "(")
+	parts := strings.Split(raw, ".")
+	if len(parts) >= 2 {
+		return tableKey{Schema: unquoteIdent(parts[len(parts)-2]), Table: unquoteIdent(parts[len(parts)-1])}
+	}
+	return tableKey{Schema: defaultSchema, Table: unquoteIdent(raw)}
+}
+
+// ---------------------------------------------------------------------------
+// DDL replay
+// ---------------------------------------------------------------------------
+
+var (
+	reCreateTable = regexp.MustCompile(`(?i)^CREATE\s+(?:UNLOGGED\s+|TEMP\s+|TEMPORARY\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w".]+)`)
+	// reCreateTableAnywhere is the cheap pre-filter used to pick Go string
+	// literals worth parsing as DDL.
+	reCreateTableAnywhere = regexp.MustCompile(`(?i)\bCREATE\s+(?:UNLOGGED\s+|TEMP\s+|TEMPORARY\s+)?TABLE\b`)
+	reCreateView          = regexp.MustCompile(`(?i)^CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w".]+)`)
+	reDropTable           = regexp.MustCompile(`(?i)^DROP\s+(?:MATERIALIZED\s+)?(?:TABLE|VIEW)\s+(?:IF\s+EXISTS\s+)?(.+?)(?:\s+CASCADE|\s+RESTRICT)?$`)
+	reAlterTable          = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?([\w".]+)\s+(.*)$`)
+
+	reRenameColumn = regexp.MustCompile(`(?i)^RENAME\s+COLUMN\s+([\w"]+)\s+TO\s+([\w"]+)`)
+	reRenameTable  = regexp.MustCompile(`(?i)^RENAME\s+TO\s+([\w"]+)`)
+	reAddColumn    = regexp.MustCompile(`(?i)^ADD\s+(?:COLUMN\s+)?(?:IF\s+NOT\s+EXISTS\s+)?([\w"]+)`)
+	reDropColumn   = regexp.MustCompile(`(?i)^DROP\s+(?:COLUMN\s+)?(?:IF\s+EXISTS\s+)?([\w"]+)`)
+)
+
+// tableConstraintLeaders are the words that start a table-level constraint in a
+// CREATE TABLE body or an ALTER TABLE ADD action. Anything led by one of these
+// is not a column.
+var tableConstraintLeaders = map[string]bool{
+	"constraint": true, "primary": true, "unique": true, "foreign": true,
+	"check": true, "exclude": true, "like": true, "generated": true,
+}
+
+// migrationStream is one ordered set of .up.sql files that some configuration
+// may or may not apply.
+type migrationStream struct {
+	// Name is how the stream is reported in failures.
+	Name string
+	// Dir holds the *.up.sql files.
+	Dir string
+	// DefaultSchema qualifies unqualified DDL in this stream.
+	DefaultSchema string
+}
+
+// replay applies every *.up.sql in the stream, in filename order, onto m.
+// Filename order is migration order: golang-migrate requires the zero-padded
+// numeric prefix, so a lexical sort is the applied sequence.
+func (m *schemaModel) replay(stream migrationStream) error {
+	entries, err := os.ReadDir(stream.Dir)
+	if err != nil {
+		return fmt.Errorf("schemaguard: read migration dir %s: %w", stream.Dir, err)
+	}
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".up.sql") {
+			files = append(files, e.Name())
+		}
+	}
+	if len(files) == 0 {
+		return fmt.Errorf("%w (stream %q, dir %s)", errNoDDL, stream.Name, stream.Dir)
+	}
+	sort.Strings(files)
+	for _, name := range files {
+		b, rErr := os.ReadFile(filepath.Join(stream.Dir, name)) // #nosec G304 -- test-only; path is a repo-relative migration directory
+		if rErr != nil {
+			return fmt.Errorf("schemaguard: read %s: %w", name, rErr)
+		}
+		m.applySQL(string(b), stream.DefaultSchema)
+	}
+	return nil
+}
+
+// applySQL replays the DDL in one SQL blob.
+func (m *schemaModel) applySQL(sql, defaultSchema string) {
+	for _, raw := range splitStatements(stripComments(sql)) {
+		stmt := normalize(raw)
+		if stmt == "" {
+			continue
+		}
+		switch {
+		case reCreateTable.MatchString(stmt):
+			m.applyCreateTable(stmt, defaultSchema)
+		case reCreateView.MatchString(stmt):
+			key := parseName(reCreateView.FindStringSubmatch(stmt)[1], defaultSchema)
+			delete(m.columns, key)
+			m.opaque[key] = true
+		case reDropTable.MatchString(stmt):
+			for _, n := range splitTopLevel(reDropTable.FindStringSubmatch(stmt)[1]) {
+				key := parseName(n, defaultSchema)
+				delete(m.columns, key)
+				delete(m.opaque, key)
+			}
+		case reAlterTable.MatchString(stmt):
+			mm := reAlterTable.FindStringSubmatch(stmt)
+			m.applyAlterTable(parseName(mm[1], defaultSchema), mm[2])
+		}
+	}
+}
+
+func (m *schemaModel) applyCreateTable(stmt, defaultSchema string) {
+	key := parseName(reCreateTable.FindStringSubmatch(stmt)[1], defaultSchema)
+	body, ok := parenBody(stmt)
+	if !ok {
+		// CREATE TABLE ... AS SELECT, or PARTITION OF: shape not modelled.
+		m.opaque[key] = true
+		return
+	}
+	cols := map[string]bool{}
+	for _, item := range splitTopLevel(body) {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		first := strings.ToLower(strings.Trim(strings.Fields(item)[0], `"`))
+		if tableConstraintLeaders[first] {
+			continue
+		}
+		cols[unquoteIdent(strings.Fields(item)[0])] = true
+	}
+	delete(m.opaque, key)
+	m.columns[key] = cols
+}
+
+func (m *schemaModel) applyAlterTable(key tableKey, actions string) {
+	// RENAME is never comma-listed with other actions.
+	if mm := reRenameColumn.FindStringSubmatch(actions); mm != nil {
+		if cols, ok := m.columns[key]; ok {
+			delete(cols, unquoteIdent(mm[1]))
+			cols[unquoteIdent(mm[2])] = true
+		}
+		return
+	}
+	if mm := reRenameTable.FindStringSubmatch(actions); mm != nil {
+		newKey := tableKey{Schema: key.Schema, Table: unquoteIdent(mm[1])}
+		if cols, ok := m.columns[key]; ok {
+			m.columns[newKey] = cols
+			delete(m.columns, key)
+		}
+		if m.opaque[key] {
+			m.opaque[newKey] = true
+			delete(m.opaque, key)
+		}
+		return
+	}
+	for _, action := range splitTopLevel(actions) {
+		action = strings.TrimSpace(action)
+		switch {
+		case reAddColumn.MatchString(action):
+			name := reAddColumn.FindStringSubmatch(action)[1]
+			if tableConstraintLeaders[strings.ToLower(strings.Trim(name, `"`))] {
+				continue
+			}
+			if cols, ok := m.columns[key]; ok {
+				cols[unquoteIdent(name)] = true
+			}
+		case reDropColumn.MatchString(action):
+			name := reDropColumn.FindStringSubmatch(action)[1]
+			if tableConstraintLeaders[strings.ToLower(strings.Trim(name, `"`))] {
+				continue
+			}
+			if cols, ok := m.columns[key]; ok {
+				delete(cols, unquoteIdent(name))
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Write extraction from Go source
+// ---------------------------------------------------------------------------
+
+// sqlWrite is one INSERT/UPDATE/DELETE found in a Go string literal.
+type sqlWrite struct {
+	// Table is exactly as it appeared, so "identity.audit_logs" keeps its
+	// qualifier and "audit_logs" stays unqualified for search_path resolution.
+	Table string
+	// Columns are the columns the statement names on Table. Empty for a plain
+	// DELETE, which demands only that the table exist.
+	Columns []string
+	// Pos is file:line of the literal, for the failure message.
+	Pos string
+}
+
+var (
+	reInsert       = regexp.MustCompile(`(?is)\bINSERT\s+INTO\s+([\w.]+)\s*\(([^()]*)\)`)
+	reInsertNoCols = regexp.MustCompile(`(?is)\bINSERT\s+INTO\s+([\w.]+)\s+(?:SELECT|VALUES|DEFAULT)\b`)
+	reUpdate       = regexp.MustCompile(`(?is)\bUPDATE\s+(?:ONLY\s+)?([\w.]+)\s+SET\s+(.*?)(?:\s+FROM\s+|\s+WHERE\s+|\s+RETURNING\s+|$)`)
+	reDelete       = regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+(?:ONLY\s+)?([\w.]+)`)
+	reReturning    = regexp.MustCompile(`(?is)\bRETURNING\s+(.*?)(?:\s*$)`)
+	reConflictSet  = regexp.MustCompile(`(?is)\bON\s+CONFLICT\b.*?\bDO\s+UPDATE\s+SET\s+(.*?)(?:\s+WHERE\s+|\s+RETURNING\s+|$)`)
+	reIdent        = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
+	// reRelation accepts a bare or once-qualified all-lowercase relation name.
+	// Case matters here even though SQL does not: every table in both migration
+	// streams is lower case, so a capitalised token after "DELETE FROM" is
+	// English, not SQL. Without this, `fmt.Errorf("failed to delete from S3")`
+	// is reported as a write to a missing table named S3 — three such prose
+	// matches showed up on the first run.
+	reRelation = regexp.MustCompile(`^[a-z_][a-z0-9_]*(\.[a-z_][a-z0-9_]*)?$`)
+)
+
+// nonColumnWords are tokens that appear where a column name would and are not
+// column names. EXCLUDED is the ON CONFLICT pseudo-table; the rest are
+// projections a RETURNING clause may carry.
+var nonColumnWords = map[string]bool{
+	"excluded": true, "true": true, "false": true, "null": true,
+	"default": true, "now": true, "current_timestamp": true,
+}
+
+// extractWrites pulls every DML write out of one SQL string.
+func extractWrites(sql, pos string) []sqlWrite {
+	var out []sqlWrite
+	table := ""
+	record := func(name string, cols []string) {
+		if !reRelation.MatchString(name) {
+			return
+		}
+		table = name
+		out = append(out, sqlWrite{Table: name, Columns: cols, Pos: pos})
+	}
+	for _, mm := range reInsert.FindAllStringSubmatch(sql, -1) {
+		record(mm[1], identList(mm[2]))
+	}
+	for _, mm := range reInsertNoCols.FindAllStringSubmatch(sql, -1) {
+		record(mm[1], nil)
+	}
+	for _, mm := range reUpdate.FindAllStringSubmatch(sql, -1) {
+		record(mm[1], assignedColumns(mm[2]))
+	}
+	for _, mm := range reDelete.FindAllStringSubmatch(sql, -1) {
+		record(mm[1], nil)
+	}
+	if table == "" {
+		return out
+	}
+	// RETURNING and ON CONFLICT DO UPDATE SET attach to the last write's table.
+	// Every statement in this codebase is a single write, so "last" is "the
+	// one"; a literal holding two writes with a RETURNING on the first would
+	// mis-attribute, which is a stated boundary of the guard.
+	if mm := reConflictSet.FindStringSubmatch(sql); mm != nil {
+		out = append(out, sqlWrite{Table: table, Columns: assignedColumns(mm[1]), Pos: pos})
+	}
+	if mm := reReturning.FindStringSubmatch(sql); mm != nil {
+		if cols := identList(mm[1]); len(cols) > 0 {
+			out = append(out, sqlWrite{Table: table, Columns: cols, Pos: pos})
+		}
+	}
+	return out
+}
+
+// identList turns a comma-separated projection into bare column names,
+// dropping anything that is not a plain identifier (expressions, functions,
+// `*`, literals). Dropping is a false-negative, never a false-positive.
+func identList(s string) []string {
+	var out []string
+	for _, part := range splitTopLevel(s) {
+		name := bareColumn(part)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// assignedColumns pulls the left-hand sides out of a SET clause.
+func assignedColumns(s string) []string {
+	var out []string
+	for _, part := range splitTopLevel(s) {
+		eq := strings.Index(part, "=")
+		if eq < 0 {
+			continue
+		}
+		if name := bareColumn(part[:eq]); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// bareColumn reduces "al.actor_email" to "actor_email" and rejects anything
+// that is not a simple identifier.
+func bareColumn(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `"`)
+	if s == "" || strings.ContainsAny(s, "()'* \t\n") {
+		return ""
+	}
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.ToLower(s)
+	if !reIdent.MatchString(s) || nonColumnWords[s] {
+		return ""
+	}
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning
+// ---------------------------------------------------------------------------
+
+// scanWrites walks root for non-test .go files and returns every DML write in
+// their string literals. Test files are excluded: a write that only ever runs
+// under sqlmock proves nothing about the shipped schema, and fixture SQL in
+// tests would otherwise dominate the demand set.
+func scanWrites(root string) ([]sqlWrite, error) {
+	var out []sqlWrite
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "testdata", "node_modules", ".git", "vendor":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, pErr := parser.ParseFile(fset, path, nil, 0)
+		if pErr != nil {
+			return fmt.Errorf("schemaguard: parse %s: %w", path, pErr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			text, pos, ok := stringLiteral(n, fset)
+			if !ok {
+				return true
+			}
+			out = append(out, extractWrites(text, pos)...)
+			// A folded BinaryExpr's children are literals already covered.
+			return false
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// stringLiteral folds a string literal or a `+` chain of them into one text,
+// so SQL assembled as "INSERT INTO t (" + cols + ")" still yields whatever
+// contiguous literal text there is. Non-literal operands contribute nothing,
+// which can only lose a write, never invent one.
+func stringLiteral(n ast.Node, fset *token.FileSet) (string, string, bool) {
+	switch v := n.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", "", false
+		}
+		s, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return "", "", false
+		}
+		return s, fset.Position(v.Pos()).String(), true
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", "", false
+		}
+		l, _, lok := stringLiteral(v.X, fset)
+		r, _, rok := stringLiteral(v.Y, fset)
+		if !lok && !rok {
+			return "", "", false
+		}
+		return l + " " + r, fset.Position(v.Pos()).String(), true
+	}
+	return "", "", false
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+// violation is one write the configured schema cannot accept.
+type violation struct {
+	Table  string // as written, qualified or not
+	Column string // "" when the table itself is missing
+	Pos    string
+}
+
+func (v violation) String() string {
+	if v.Column == "" {
+		return fmt.Sprintf("table %s does not exist (%s)", v.Table, v.Pos)
+	}
+	return fmt.Sprintf("%s.%s does not exist (%s)", v.Table, v.Column, v.Pos)
+}
+
+// resolveOpts controls how writes are matched against the model.
+type resolveOpts struct {
+	// SearchPath is the schema resolution order for unqualified names, exactly
+	// as Postgres would apply it.
+	SearchPath []string
+	// IgnoreSchemas are never checked (pg_catalog, information_schema).
+	IgnoreSchemas map[string]bool
+	// IgnoreTables are unqualified names owned by something other than the
+	// migration streams — golang-migrate's own bookkeeping, for instance.
+	IgnoreTables map[string]bool
+}
+
+// resolve returns every write the model cannot accept, plus the number of
+// writes actually examined.
+func resolve(m *schemaModel, writes []sqlWrite, opts resolveOpts) ([]violation, int, error) {
+	if len(opts.SearchPath) == 0 {
+		return nil, 0, errNoSearchPath
+	}
+	if m.tableCount() == 0 {
+		return nil, 0, errNoDDL
+	}
+	if len(writes) == 0 {
+		return nil, 0, errNoWrites
+	}
+
+	var out []violation
+	checked := 0
+	for _, w := range writes {
+		name := strings.ToLower(w.Table)
+		schema, bare := "", name
+		if i := strings.LastIndex(name, "."); i >= 0 {
+			schema, bare = name[:i], name[i+1:]
+		}
+		if opts.IgnoreSchemas[schema] || opts.IgnoreTables[bare] {
+			continue
+		}
+		checked++
+
+		var found *tableKey
+		if schema != "" {
+			k := tableKey{Schema: schema, Table: bare}
+			if m.has(k) {
+				found = &k
+			}
+		} else {
+			for _, s := range opts.SearchPath {
+				k := tableKey{Schema: s, Table: bare}
+				if m.has(k) {
+					found = &k
+					break
+				}
+			}
+		}
+		if found == nil {
+			out = append(out, violation{Table: w.Table, Pos: w.Pos})
+			continue
+		}
+		cols, modelled := m.columns[*found]
+		if !modelled { // opaque relation: existence only
+			continue
+		}
+		for _, c := range w.Columns {
+			if !cols[c] {
+				out = append(out, violation{Table: w.Table, Column: c, Pos: w.Pos})
+			}
+		}
+	}
+	if checked == 0 {
+		return nil, 0, errNoWrites
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out, checked, nil
+}
+
+// ===========================================================================
+// Unit tests for the analyzer itself
+// ===========================================================================
+
+func modelFromSQL(t *testing.T, schema, sql string) *schemaModel {
+	t.Helper()
+	m := newSchemaModel()
+	m.applySQL(sql, schema)
+	return m
+}
+
+func TestDDLReplayTracksColumns(t *testing.T) {
+	m := modelFromSQL(t, "public", `
+		CREATE TABLE audit_logs (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID REFERENCES users(id),
+			metadata JSONB,
+			PRIMARY KEY (id),
+			CONSTRAINT ck CHECK (id IS NOT NULL)
+		);
+		ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS actor_email VARCHAR(255);
+		ALTER TABLE audit_logs DROP COLUMN metadata;
+		ALTER TABLE audit_logs RENAME COLUMN user_id TO actor_id;
+	`)
+	cols := m.columns[tableKey{Schema: "public", Table: "audit_logs"}]
+	if cols == nil {
+		t.Fatal("public.audit_logs not modelled")
+	}
+	for _, want := range []string{"id", "actor_email", "actor_id"} {
+		if !cols[want] {
+			t.Errorf("column %q missing; got %v", want, sortedKeys(cols))
+		}
+	}
+	for _, gone := range []string{"metadata", "user_id", "primary", "constraint", "ck"} {
+		if cols[gone] {
+			t.Errorf("column %q should not be present; got %v", gone, sortedKeys(cols))
+		}
+	}
+}
+
+func TestDDLReplayHandlesDropRenameAndViews(t *testing.T) {
+	m := modelFromSQL(t, "public", `
+		CREATE TABLE old_name (a INT);
+		ALTER TABLE old_name RENAME TO new_name;
+		CREATE TABLE doomed (b INT);
+		DROP TABLE IF EXISTS doomed CASCADE;
+		CREATE OR REPLACE VIEW v_stats AS SELECT 1 AS n;
+	`)
+	if !m.has(tableKey{Schema: "public", Table: "new_name"}) {
+		t.Error("rename did not carry the table to new_name")
+	}
+	if m.has(tableKey{Schema: "public", Table: "old_name"}) {
+		t.Error("old_name survived the rename")
+	}
+	if m.has(tableKey{Schema: "public", Table: "doomed"}) {
+		t.Error("doomed survived DROP TABLE")
+	}
+	if !m.opaque[tableKey{Schema: "public", Table: "v_stats"}] {
+		t.Error("view was not recorded as an opaque relation")
+	}
+}
+
+func TestSplitStatementsSurvivesDollarQuoting(t *testing.T) {
+	stmts := splitStatements(`CREATE TABLE t (a INT); DO $$ BEGIN INSERT INTO t VALUES (1); END $$; DROP TABLE t;`)
+	if len(stmts) != 3 {
+		t.Fatalf("got %d statements, want 3: %q", len(stmts), stmts)
+	}
+	if !strings.Contains(stmts[1], "END $$") {
+		t.Errorf("DO block was split; got %q", stmts[1])
+	}
+}
+
+func TestExtractWritesFindsColumns(t *testing.T) {
+	cases := []struct {
+		name      string
+		sql       string
+		wantTable string
+		wantCols  []string
+	}{
+		{
+			name:      "insert with returning (the #864 shape)",
+			sql:       "INSERT INTO audit_logs (id, user_id, actor_email) VALUES ($1,$2,COALESCE($3,(SELECT email FROM users))) RETURNING actor_email",
+			wantTable: "audit_logs",
+			wantCols:  []string{"id", "user_id", "actor_email", "actor_email"},
+		},
+		{
+			name:      "update set",
+			sql:       "UPDATE identity.users SET name = $1, updated_at = NOW() WHERE id = $2",
+			wantTable: "identity.users",
+			wantCols:  []string{"name", "updated_at"},
+		},
+		{
+			name:      "upsert",
+			sql:       "INSERT INTO t (a) VALUES ($1) ON CONFLICT (a) DO UPDATE SET b = EXCLUDED.b",
+			wantTable: "t",
+			wantCols:  []string{"a", "b"},
+		},
+		{
+			name:      "delete demands only the table",
+			sql:       "DELETE FROM api_keys WHERE id = $1",
+			wantTable: "api_keys",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			writes := extractWrites(tc.sql, "fixture:1")
+			if len(writes) == 0 {
+				t.Fatal("no writes extracted")
+			}
+			var gotCols []string
+			for _, w := range writes {
+				if w.Table != tc.wantTable {
+					t.Errorf("table = %q, want %q", w.Table, tc.wantTable)
+				}
+				gotCols = append(gotCols, w.Columns...)
+			}
+			if strings.Join(gotCols, ",") != strings.Join(tc.wantCols, ",") {
+				t.Errorf("columns = %v, want %v", gotCols, tc.wantCols)
+			}
+		})
+	}
+}
+
+// TestResolveModelsSearchPathOrder is the mechanism behind #864 in miniature:
+// the identity schema holds actor_email, but it is not on the search_path, so
+// the unqualified write lands on public and fails.
+func TestResolveModelsSearchPathOrder(t *testing.T) {
+	m := newSchemaModel()
+	m.applySQL(`CREATE TABLE public.audit_logs (id UUID, user_id UUID);`, "public")
+	m.applySQL(`CREATE TABLE identity.audit_logs (id UUID, user_id UUID, actor_email VARCHAR(255));`, "identity")
+	writes := extractWrites("INSERT INTO audit_logs (id, actor_email) VALUES ($1,$2)", "fixture:1")
+
+	got, checked, err := resolve(m, writes, resolveOpts{SearchPath: []string{"public"}})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if checked != 1 {
+		t.Fatalf("checked = %d, want 1", checked)
+	}
+	if len(got) != 1 || got[0].Column != "actor_email" || got[0].Table != "audit_logs" {
+		t.Fatalf("violations = %v, want exactly audit_logs.actor_email", got)
+	}
+
+	got, _, err = resolve(m, writes, resolveOpts{SearchPath: []string{"identity", "public"}})
+	if err != nil {
+		t.Fatalf("resolve with identity on the path: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("violations = %v, want none once identity is on the search_path", got)
+	}
+}
+
+// TestResolveRefusesEmptyUniverse is the falsification required of this guard:
+// pointed at nothing, it must refuse to certify rather than report success.
+func TestResolveRefusesEmptyUniverse(t *testing.T) {
+	populated := newSchemaModel()
+	populated.applySQL(`CREATE TABLE public.t (a INT);`, "public")
+	someWrites := extractWrites("INSERT INTO t (a) VALUES ($1)", "fixture:1")
+
+	cases := []struct {
+		name    string
+		model   *schemaModel
+		writes  []sqlWrite
+		opts    resolveOpts
+		wantErr error
+	}{
+		{
+			name:    "no schema at all",
+			model:   newSchemaModel(),
+			writes:  someWrites,
+			opts:    resolveOpts{SearchPath: []string{"public"}},
+			wantErr: errNoDDL,
+		},
+		{
+			name:    "no writes at all",
+			model:   populated,
+			writes:  nil,
+			opts:    resolveOpts{SearchPath: []string{"public"}},
+			wantErr: errNoWrites,
+		},
+		{
+			name:    "every write filtered away leaves nothing checked",
+			model:   populated,
+			writes:  someWrites,
+			opts:    resolveOpts{SearchPath: []string{"public"}, IgnoreTables: map[string]bool{"t": true}},
+			wantErr: errNoWrites,
+		},
+		{
+			name:    "no search_path",
+			model:   populated,
+			writes:  someWrites,
+			opts:    resolveOpts{},
+			wantErr: errNoSearchPath,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, checked, err := resolve(tc.model, tc.writes, tc.opts)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+			if got != nil || checked != 0 {
+				t.Fatalf("refusal must not also report results: violations=%v checked=%d", got, checked)
+			}
+		})
+	}
+}
+
+// TestReplayRefusesEmptyStream falsifies the other empty universe: a migration
+// directory that contributes no DDL.
+func TestReplayRefusesEmptyStream(t *testing.T) {
+	dir := t.TempDir()
+	m := newSchemaModel()
+	if err := m.replay(migrationStream{Name: "empty", Dir: dir, DefaultSchema: "public"}); !errors.Is(err, errNoDDL) {
+		t.Fatalf("replay of an empty dir: err = %v, want %v", err, errNoDDL)
+	}
+	if err := m.replay(migrationStream{Name: "gone", Dir: filepath.Join(dir, "nope"), DefaultSchema: "public"}); err == nil {
+		t.Fatal("replay of a missing dir returned nil error")
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/internal/schemaguard/schema_demand_guard_test.go
+++ b/backend/internal/schemaguard/schema_demand_guard_test.go
@@ -1,0 +1,763 @@
+package schemaguard
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Issue #864 — application SQL must not depend on schema the running
+// configuration will not have.
+//
+// THE DEFECT
+//
+// The identity store writes identity.audit_logs.actor_email unconditionally.
+// That column is added by identity migration 000007, and the whole identity
+// migration stream is gated behind TFR_IDENTITY_MIGRATIONS_ENABLED, default
+// off. Separately, TFR_IDENTITY_SCHEMA_ENABLED (also default off) is what puts
+// the identity schema on the connection's search_path — with it off,
+// identityDB is the plain app pool and every unqualified identity write
+// resolves against public. public.audit_logs comes from this repository's own
+// 000001_initial_schema and has never had actor_email. So in the DEFAULT
+// configuration every audited request dies on
+//
+//	pq: column "actor_email" of relation "audit_logs" does not exist (42703)
+//
+// THE CLASS
+//
+// A gated capability became load-bearing without anything failing at build or
+// start time. PR #438's safety premise was written down explicitly — "the
+// identity schema is created but unused" — and expired silently when the audit
+// path started depending on the gated schema. Nothing in the compiler, the
+// startup sequence or the test suite could notice, because no single artefact
+// holds both halves: the SQL lives in a Go module, the schema lives in .sql
+// files, and the configuration that decides which of them apply lives in
+// environment variables read at runtime.
+//
+// This guard holds all three at once. It replays the migrations the DEFAULT
+// configuration actually applies, extracts every column application SQL
+// actually writes (this repository's and the shared identity module's alike),
+// resolves them through the search_path the default configuration actually
+// uses, and fails on anything that cannot land.
+//
+// WHY THIS SHAPE
+//
+// A dynamic test against a real postgres would reproduce #864 more literally,
+// and one is worth having, but it cannot run on every pull request here: PR CI
+// runs no migrations at all today (only chaos.yml stands up a database), which
+// is part of why this shipped. This guard is hermetic — no container, no
+// network, no database — so it runs in the `go test ./...` that already gates
+// every PR, which is the only place a guard against a silent default has any
+// chance of being seen before release.
+//
+// It is also deliberately NOT a test of the audit path. Testing the audit path
+// would have caught this instance and nothing else. The invariant here is
+// schema-wide and library-wide: 230-odd writes across both codebases are
+// checked, so the next capability to depend on gated schema fails here too.
+
+// ---------------------------------------------------------------------------
+// What this guard does NOT cover
+// ---------------------------------------------------------------------------
+//
+// Stated plainly, because a guard whose limits are undocumented gets trusted
+// past them.
+//
+//  1. READS. Only INSERT / UPDATE / DELETE are checked. A SELECT naming a
+//     missing column fails just as hard at runtime, but resolving SELECT
+//     projections means resolving aliases, joins, subqueries and CTEs. Out of
+//     scope. #864's write happened to also RETURNING the same column.
+//
+//  2. TYPES, NULLABILITY, CONSTRAINTS AND DEFAULTS. Presence of a column is
+//     all that is checked. A write of the wrong type, or omitting a NOT NULL
+//     column with no default, passes here and fails at runtime.
+//
+//  3. SQL NOT PRESENT AS A CONTIGUOUS GO STRING LITERAL. Statements assembled
+//     from fmt.Sprintf, a query builder, or a string variable contribute only
+//     whatever literal text is adjacent. This can only miss a write, never
+//     invent one. internal/db/repositories/querybuilder.go is largely invisible
+//     to this guard for that reason.
+//
+//  4. TABLES CREATED BY APPLICATION CODE RATHER THAN BY A MIGRATION. Runtime
+//     `CREATE TABLE IF NOT EXISTS` found in Go source is credited to the
+//     universe, because a configuration that runs it really will have the
+//     table. The guard does NOT verify the creating code is ever called.
+//     internal/audit/legal_hold.go is exactly this case and its EnsureTable
+//     currently has no non-test caller — the tables it credits are listed in
+//     the test log so the credit is visible rather than implicit.
+//
+//  5. NON-DEFAULT CONFIGURATIONS. Only the shipped default is checked. The
+//     cutover configurations documented in docs/identity-schema.md are not
+//     modelled, on the ground that a broken default is what ships to everyone
+//     who does not read the guide.
+//
+//  6. OTHER CONSUMERS OF THE SHARED LIBRARY. terraform-state-manager-backend
+//     runs identity.RunMigrations unconditionally while this repository gates
+//     it, and that divergence is arguably #864's root cause. Checking it needs
+//     both checkouts, which no CI job here has. See the report accompanying
+//     this guard for the cross-consumer recommendation.
+//
+//  7. WHETHER THE SERVER REFUSES TO START. This guard says the default
+//     configuration cannot execute its own SQL. It cannot say whether that is
+//     survivable, because it does not model startup preconditions. A
+//     fail-fast check in cmd/server/main.go is complementary, not redundant.
+
+// ---------------------------------------------------------------------------
+// Quarantine
+// ---------------------------------------------------------------------------
+
+// knownGap is a violation that existed when this guard landed. The list can
+// only shrink: an entry that stops matching FAILS the guard, so the fix for
+// #864 also deletes the line that excuses it. Nothing may be added here
+// without an issue number.
+type knownGap struct {
+	Table  string
+	Column string
+	Issue  string
+	Why    string
+}
+
+var knownGaps = []knownGap{
+	{
+		Table:  "audit_logs",
+		Column: "actor_email",
+		Issue:  "#864",
+		Why: "the defect this guard was written for. The shared identity store writes " +
+			"actor_email into an unqualified audit_logs; under the default configuration that " +
+			"resolves to public.audit_logs, which this repository's own migration chain never " +
+			"gave the column. Fixed by any of: adding the column to this repository's chain, " +
+			"making the identity-schema cutover the default, or making the library's write " +
+			"tolerate a pre-000007 schema. DELETE THIS ENTRY when it lands.",
+	},
+}
+
+func (g knownGap) matches(v violation) bool {
+	return strings.EqualFold(g.Table, v.Table) && strings.EqualFold(g.Column, v.Column)
+}
+
+// ---------------------------------------------------------------------------
+// Deriving the default configuration from source
+// ---------------------------------------------------------------------------
+
+const (
+	mainGoPath        = "../../cmd/server/main.go"
+	appMigrationsDir  = "../db/migrations"
+	backendSourceRoot = "../.."
+	identityModule    = "github.com/sethbacon/terraform-suite-identity"
+
+	schemaGateFunc      = "identitySchemaEnabled"
+	schemaNameFunc      = "identitySchemaName"
+	migrationsGateFunc  = "identityMigrationsEnabled"
+	identityRunMigrCall = "identity.RunMigrations"
+	appRunMigrCall      = "db.RunMigrations"
+)
+
+// envGate is a `func F() bool { return os.Getenv("E") == "true" }` style flag.
+type envGate struct {
+	Func      string
+	Env       string
+	DefaultOn bool
+}
+
+// defaultConfig is what the shipped defaults amount to.
+type defaultConfig struct {
+	SearchPath      []string
+	IdentityApplied bool
+	AppApplied      bool
+	Gates           map[string]envGate
+}
+
+// readDefaultConfig derives the default configuration from cmd/server/main.go
+// rather than restating it. That is the whole point: when #864 is fixed by
+// changing a default or removing a gate, this guard follows the change instead
+// of having to be re-taught. Anything it cannot recognise is fatal — a guard
+// that silently guesses the configuration is worse than no guard.
+func readDefaultConfig(t *testing.T) defaultConfig {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, mainGoPath, nil, 0)
+	if err != nil {
+		t.Fatalf("schemaguard: parse %s: %v", mainGoPath, err)
+	}
+
+	gates := map[string]envGate{}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if g, ok := envGateFromFunc(fn); ok {
+			gates[g.Func] = g
+		}
+	}
+	if len(gates) == 0 {
+		t.Fatalf("schemaguard: found no `os.Getenv(...) == \"true\"` feature gates in %s. "+
+			"Either the gating style changed or the file moved; refusing to certify against a "+
+			"configuration this guard cannot read.", mainGoPath)
+	}
+
+	schemaGate, ok := gates[schemaGateFunc]
+	if !ok {
+		t.Fatalf("schemaguard: %s() not found in %s. It decides whether the identity schema is on "+
+			"the connection search_path, and without it the guard cannot know which schema an "+
+			"unqualified write resolves against.", schemaGateFunc, mainGoPath)
+	}
+
+	cfg := defaultConfig{Gates: gates}
+	if schemaGate.DefaultOn {
+		cfg.SearchPath = []string{identitySchemaDefaultName(t, f), "public"}
+	} else {
+		cfg.SearchPath = []string{"public"}
+	}
+
+	calls := runMigrationsCallSites(f)
+	for _, want := range []string{identityRunMigrCall, appRunMigrCall} {
+		if _, ok := calls[want]; !ok {
+			t.Fatalf("schemaguard: no call to %s found in %s. The set of migration streams the "+
+				"binary applies is the guard's schema universe; an empty one certifies nothing.",
+				want, mainGoPath)
+		}
+	}
+	cfg.IdentityApplied = allGatesDefaultOn(t, gates, calls[identityRunMigrCall])
+	cfg.AppApplied = allGatesDefaultOn(t, gates, calls[appRunMigrCall])
+	return cfg
+}
+
+// envGateFromFunc recognises the two shapes a boolean env gate takes:
+//
+//	return os.Getenv("X") == "true"   // default off
+//	return os.Getenv("X") != "false"  // default on
+func envGateFromFunc(fn *ast.FuncDecl) (envGate, bool) {
+	if len(fn.Body.List) != 1 {
+		return envGate{}, false
+	}
+	ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(ret.Results) != 1 {
+		return envGate{}, false
+	}
+	bin, ok := ret.Results[0].(*ast.BinaryExpr)
+	if !ok || (bin.Op != token.EQL && bin.Op != token.NEQ) {
+		return envGate{}, false
+	}
+	call, ok := bin.X.(*ast.CallExpr)
+	if !ok || exprName(call.Fun) != "os.Getenv" || len(call.Args) != 1 {
+		return envGate{}, false
+	}
+	env, ok := stringLitValue(call.Args[0])
+	if !ok {
+		return envGate{}, false
+	}
+	want, ok := stringLitValue(bin.Y)
+	if !ok {
+		return envGate{}, false
+	}
+	switch {
+	case bin.Op == token.EQL && want == "true":
+		return envGate{Func: fn.Name.Name, Env: env, DefaultOn: false}, true
+	case bin.Op == token.NEQ && want == "false":
+		return envGate{Func: fn.Name.Name, Env: env, DefaultOn: true}, true
+	}
+	return envGate{}, false
+}
+
+// identitySchemaDefaultName reads the fallback literal out of
+// identitySchemaName() so a renamed default schema is followed, not assumed.
+func identitySchemaDefaultName(t *testing.T, f *ast.File) string {
+	t.Helper()
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != schemaNameFunc || fn.Body == nil {
+			continue
+		}
+		var last string
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if ret, ok := n.(*ast.ReturnStmt); ok && len(ret.Results) == 1 {
+				if s, ok := stringLitValue(ret.Results[0]); ok && s != "" {
+					last = s
+				}
+			}
+			return true
+		})
+		if last != "" {
+			return last
+		}
+	}
+	t.Fatalf("schemaguard: could not read the default schema name from %s() in %s",
+		schemaNameFunc, mainGoPath)
+	return ""
+}
+
+// runMigrationsCallSites maps "pkg.RunMigrations" to the set of gate functions
+// whose enclosing `if` must be true for that call to run. An unguarded call
+// yields an empty set, which is how "the gate was removed" is detected.
+func runMigrationsCallSites(f *ast.File) map[string][]string {
+	out := map[string][]string{}
+	var stack []string
+	var walk func(n ast.Node)
+	walk = func(n ast.Node) {
+		if n == nil {
+			return
+		}
+		switch v := n.(type) {
+		case *ast.IfStmt:
+			added := conditionGateNames(v.Cond)
+			stack = append(stack, added...)
+			walk(v.Body)
+			stack = stack[:len(stack)-len(added)]
+			// The else branch is NOT inside the condition.
+			if v.Else != nil {
+				walk(v.Else)
+			}
+			if v.Init != nil {
+				walk(v.Init)
+			}
+			return
+		case *ast.CallExpr:
+			if name := exprName(v.Fun); strings.HasSuffix(name, ".RunMigrations") {
+				if _, seen := out[name]; !seen || len(stack) < len(out[name]) {
+					out[name] = append([]string(nil), stack...)
+				}
+			}
+		}
+		for _, child := range childNodes(n) {
+			walk(child)
+		}
+	}
+	for _, decl := range f.Decls {
+		walk(decl)
+	}
+	return out
+}
+
+// conditionGateNames returns the gate functions a condition calls. Only plain
+// `f()` and `f() && g()` are understood; anything else contributes no name,
+// which makes the call look unguarded and can therefore only make the guard
+// stricter, never laxer.
+func conditionGateNames(cond ast.Expr) []string {
+	switch v := cond.(type) {
+	case *ast.CallExpr:
+		if id, ok := v.Fun.(*ast.Ident); ok && len(v.Args) == 0 {
+			return []string{id.Name}
+		}
+	case *ast.BinaryExpr:
+		if v.Op == token.LAND {
+			return append(conditionGateNames(v.X), conditionGateNames(v.Y)...)
+		}
+	case *ast.ParenExpr:
+		return conditionGateNames(v.X)
+	}
+	return nil
+}
+
+func allGatesDefaultOn(t *testing.T, gates map[string]envGate, enclosing []string) bool {
+	t.Helper()
+	for _, name := range enclosing {
+		g, ok := gates[name]
+		if !ok {
+			// An enclosing condition this guard cannot evaluate. Treat the
+			// stream as not applied: understating the universe turns unchecked
+			// writes into failures, which is the safe direction.
+			t.Logf("schemaguard: enclosing condition %q is not a recognised env gate; "+
+				"treating the guarded migration stream as NOT applied by default", name)
+			return false
+		}
+		if !g.DefaultOn {
+			return false
+		}
+	}
+	return true
+}
+
+func exprName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		if x := exprName(v.X); x != "" {
+			return x + "." + v.Sel.Name
+		}
+		return v.Sel.Name
+	}
+	return ""
+}
+
+func stringLitValue(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// childNodes returns n's children. ast.Inspect cannot be used for the walk
+// above because the enclosing-`if` stack has to be popped on the way out, and
+// Inspect's post-order callback does not say which node it is leaving.
+func childNodes(n ast.Node) []ast.Node {
+	var out []ast.Node
+	ast.Inspect(n, func(c ast.Node) bool {
+		if c == nil || c == n {
+			return c == n
+		}
+		out = append(out, c)
+		return false
+	})
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Locating the shared identity module
+// ---------------------------------------------------------------------------
+
+// identityModuleDir resolves the module's on-disk root through the go tool, so
+// a `replace` directive or a version bump is followed automatically.
+func identityModuleDir(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", identityModule).Output()
+	if err != nil {
+		t.Fatalf("schemaguard: go list -m %s: %v. The shared identity module holds both the SQL "+
+			"that broke in #864 and the migrations that would have fixed it; without it this "+
+			"guard inspects half the system and must not certify.", identityModule, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		t.Fatalf("schemaguard: go list -m %s returned no directory", identityModule)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "identity", "migrations")); err != nil {
+		t.Fatalf("schemaguard: %s has no identity/migrations directory: %v", dir, err)
+	}
+	return dir
+}
+
+// ---------------------------------------------------------------------------
+// The guard
+// ---------------------------------------------------------------------------
+
+// runtimeDDLRoots are scanned for `CREATE TABLE IF NOT EXISTS` in Go string
+// literals — tables the application creates for itself rather than through a
+// numbered migration. See boundary 4.
+var runtimeDDLRoots = []string{backendSourceRoot}
+
+// ignoredTables are unqualified names owned by neither migration stream.
+var ignoredTables = map[string]bool{
+	// golang-migrate creates and owns its own version table.
+	"schema_migrations": true,
+}
+
+var ignoredSchemas = map[string]bool{
+	"pg_catalog":         true,
+	"information_schema": true,
+	"pg_temp":            true,
+}
+
+// analysis is everything the guard derived from the tree, kept as a value so
+// the self-mutation test below can perturb it and re-resolve.
+type analysis struct {
+	Cfg    defaultConfig
+	Model  *schemaModel
+	Writes []sqlWrite
+	Opts   resolveOpts
+}
+
+// buildAnalysis derives the default configuration, replays the migration
+// streams that configuration applies, and collects every SQL write in this
+// repository and in the shared identity module.
+func buildAnalysis(t *testing.T) analysis {
+	t.Helper()
+	cfg := readDefaultConfig(t)
+	idDir := identityModuleDir(t)
+	t.Logf("default configuration: search_path=%v app_migrations_applied=%v identity_migrations_applied=%v",
+		cfg.SearchPath, cfg.AppApplied, cfg.IdentityApplied)
+
+	m := newSchemaModel()
+	if cfg.AppApplied {
+		if err := m.replay(migrationStream{Name: "app", Dir: appMigrationsDir, DefaultSchema: "public"}); err != nil {
+			t.Fatalf("schemaguard: %v", err)
+		}
+	}
+	if cfg.IdentityApplied {
+		dir := filepath.Join(idDir, "identity", "migrations")
+		if err := m.replay(migrationStream{Name: "identity", Dir: dir, DefaultSchema: "identity"}); err != nil {
+			t.Fatalf("schemaguard: %v", err)
+		}
+	}
+	migrationTables := m.tableCount()
+
+	credited := creditRuntimeDDL(t, m, runtimeDDLRoots)
+	if len(credited) > 0 {
+		t.Logf("credited to application DDL rather than to a migration (boundary 4, unverified "+
+			"that the creating code runs): %v", credited)
+	}
+	t.Logf("schema universe: %d tables (%d from migrations, %d created by application code)",
+		m.tableCount(), migrationTables, len(credited))
+
+	var writes []sqlWrite
+	for _, root := range []string{backendSourceRoot, filepath.Join(idDir, "identity")} {
+		w, err := scanWrites(root)
+		if err != nil {
+			t.Fatalf("schemaguard: scan %s: %v", root, err)
+		}
+		t.Logf("scanned %s: %d SQL writes", root, len(w))
+		writes = append(writes, w...)
+	}
+
+	return analysis{
+		Cfg:    cfg,
+		Model:  m,
+		Writes: writes,
+		Opts: resolveOpts{
+			SearchPath:    cfg.SearchPath,
+			IgnoreSchemas: ignoredSchemas,
+			IgnoreTables:  ignoredTables,
+		},
+	}
+}
+
+// TestDefaultConfigurationCanExecuteItsOwnSQL is the guard.
+func TestDefaultConfigurationCanExecuteItsOwnSQL(t *testing.T) {
+	a := buildAnalysis(t)
+	cfg := a.Cfg
+
+	// --- coherence -------------------------------------------------------
+	//
+	// A schema on the default search_path whose migration stream the default
+	// configuration does not apply is the class in its purest form: the
+	// capability is switched on while the thing it needs is switched off.
+	// Today this passes trivially (search_path is public alone); it starts
+	// biting the moment someone flips the cutover default without flipping the
+	// migrations default, which is a two-line change away.
+	streamsBySchema := map[string]bool{"public": cfg.AppApplied}
+	if len(cfg.SearchPath) > 1 {
+		streamsBySchema[cfg.SearchPath[0]] = cfg.IdentityApplied
+	}
+	for schema, applied := range streamsBySchema {
+		if !applied {
+			t.Errorf("schema %q is on the default search_path but the default configuration does "+
+				"not apply its migrations. A gated migration stream that the default "+
+				"configuration depends on is exactly the #864 defect class; either apply the "+
+				"stream unconditionally or take the schema off the default search_path.", schema)
+		}
+	}
+
+	// --- resolve ---------------------------------------------------------
+	violations, checked, err := resolve(a.Model, a.Writes, a.Opts)
+	if err != nil {
+		t.Fatalf("schemaguard: %v", err)
+	}
+	t.Logf("checked %d writes against the default schema universe", checked)
+
+	// --- verdict ---------------------------------------------------------
+	matched := make([]bool, len(knownGaps))
+	for _, v := range violations {
+		excused := false
+		for i, g := range knownGaps {
+			if g.matches(v) {
+				matched[i] = true
+				excused = true
+				break
+			}
+		}
+		if excused {
+			continue
+		}
+		t.Errorf("the DEFAULT configuration cannot execute this write: %s\n"+
+			"    search_path is %v and only the migration streams above are applied, so this "+
+			"statement fails at runtime with 42703/42P01 on every request that reaches it — "+
+			"silently, per-request, with a clean startup log. Fix the schema, the write, or the "+
+			"default configuration. If it is genuinely acceptable, add it to knownGaps with an "+
+			"issue number.", v, cfg.SearchPath)
+	}
+	for i, g := range knownGaps {
+		if !matched[i] {
+			t.Errorf("knownGaps entry %s.%s (%s) no longer matches any violation. "+
+				"The gap it excused is fixed — delete the entry. This list may only shrink; "+
+				"leaving stale entries in it is how an allow-list stops guarding anything.",
+				g.Table, g.Column, g.Issue)
+		}
+	}
+}
+
+// TestGuardFiresWhenTheDefaultSchemaLosesAColumn is the guard's own mutation
+// test, run on the real tree on every invocation.
+//
+// The failure mode this defends against is the one that has bitten this estate
+// repeatedly: a guard that is green because it is inspecting nothing. The empty
+// universe checks in the analyzer cover being handed nothing at all; this
+// covers the subtler case where the migration replay, the write extraction and
+// the resolver all run over the real tree but no longer connect — a regex that
+// stopped matching, a source root that moved, a schema name that changed. In
+// any of those states this test reports the mutation as undetected and fails.
+//
+// The column is chosen from the live data rather than named, so the test
+// cannot rot as the schema changes.
+func TestGuardFiresWhenTheDefaultSchemaLosesAColumn(t *testing.T) {
+	a := buildAnalysis(t)
+
+	baseline, checked, err := resolve(a.Model, a.Writes, a.Opts)
+	if err != nil {
+		t.Fatalf("schemaguard: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("schemaguard: baseline checked zero writes")
+	}
+
+	// Pick a (table, column) that the default schema really has and that real
+	// application SQL really writes. Sorted so the choice is deterministic.
+	victim, ok := pickWrittenColumn(a)
+	if !ok {
+		t.Fatal("schemaguard: no write in the tree names a column the default schema has. " +
+			"Either the schema replay or the write extraction has stopped working; the guard " +
+			"cannot be certifying anything in that state.")
+	}
+	t.Logf("mutating the default schema: dropping %s.%s", victim.key, victim.column)
+
+	delete(a.Model.columns[victim.key], victim.column)
+
+	mutated, _, err := resolve(a.Model, a.Writes, a.Opts)
+	if err != nil {
+		t.Fatalf("schemaguard: resolve after mutation: %v", err)
+	}
+
+	want := victim.key.Table + "." + victim.column
+	found := false
+	for _, v := range mutated {
+		if strings.EqualFold(v.Table, victim.key.Table) && strings.EqualFold(v.Column, victim.column) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("dropping %s from the default schema produced no violation naming it.\n"+
+			"    baseline violations: %d, after mutation: %d\n"+
+			"    The guard is not connecting the schema it replays to the writes it extracts, "+
+			"which means a green result from TestDefaultConfigurationCanExecuteItsOwnSQL proves "+
+			"nothing.", want, len(baseline), len(mutated))
+	}
+	if len(mutated) <= len(baseline) {
+		t.Errorf("violation count did not grow: baseline %d, mutated %d", len(baseline), len(mutated))
+	}
+}
+
+type writtenColumn struct {
+	key    tableKey
+	column string
+}
+
+// pickWrittenColumn returns a deterministic (table, column) pair that both
+// exists in the modelled default schema and is named by an extracted write.
+func pickWrittenColumn(a analysis) (writtenColumn, bool) {
+	type cand struct {
+		writtenColumn
+		sortKey string
+	}
+	var cands []cand
+	for _, w := range a.Writes {
+		name := strings.ToLower(w.Table)
+		if strings.Contains(name, ".") || ignoredTables[name] {
+			continue
+		}
+		for _, s := range a.Opts.SearchPath {
+			k := tableKey{Schema: s, Table: name}
+			cols, ok := a.Model.columns[k]
+			if !ok {
+				continue
+			}
+			for _, c := range w.Columns {
+				if cols[c] {
+					cands = append(cands, cand{writtenColumn{key: k, column: c}, k.String() + "." + c})
+				}
+			}
+			break
+		}
+	}
+	if len(cands) == 0 {
+		return writtenColumn{}, false
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].sortKey < cands[j].sortKey })
+	return cands[0].writtenColumn, true
+}
+
+// creditRuntimeDDL folds `CREATE TABLE` statements found in Go string literals
+// into the model and returns the table names it added. Only creations are
+// honoured — a DROP or RENAME in application source is not replayed, since
+// crediting a removal could only ever hide a violation.
+func creditRuntimeDDL(t *testing.T, m *schemaModel, roots []string) []string {
+	t.Helper()
+	before := map[tableKey]bool{}
+	for k := range m.columns {
+		before[k] = true
+	}
+	for k := range m.opaque {
+		before[k] = true
+	}
+	for _, root := range roots {
+		for _, sql := range scanCreateTableSQL(t, root) {
+			for _, stmt := range splitStatements(stripComments(sql)) {
+				s := normalize(stmt)
+				if reCreateTable.MatchString(s) {
+					m.applyCreateTable(s, "public")
+				}
+			}
+		}
+	}
+	var added []string
+	for k := range m.columns {
+		if !before[k] {
+			added = append(added, k.String())
+		}
+	}
+	sort.Strings(added)
+	return added
+}
+
+// scanCreateTableSQL returns every non-test Go string literal containing a
+// CREATE TABLE.
+func scanCreateTableSQL(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "testdata", "node_modules", ".git", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, pErr := parser.ParseFile(fset, path, nil, 0)
+		if pErr != nil {
+			return fmt.Errorf("parse %s: %w", path, pErr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			text, _, ok := stringLiteral(n, fset)
+			if !ok {
+				return true
+			}
+			if reCreateTableAnywhere.MatchString(text) {
+				out = append(out, text)
+			}
+			return false
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("schemaguard: scan %s for runtime DDL: %v", root, err)
+	}
+	return out
+}

--- a/backend/internal/schemaguard/schema_demand_guard_test.go
+++ b/backend/internal/schemaguard/schema_demand_guard_test.go
@@ -288,7 +288,6 @@ const (
 
 	schemaGateFunc      = "identitySchemaEnabled"
 	schemaNameFunc      = "identitySchemaName"
-	migrationsGateFunc  = "identityMigrationsEnabled"
 	identityRunMigrCall = "identity.RunMigrations"
 	appRunMigrCall      = "db.RunMigrations"
 )
@@ -616,13 +615,13 @@ func buildAnalysis(t *testing.T) analysis {
 	m := newSchemaModel()
 	if cfg.AppApplied {
 		if err := m.replay(migrationStream{Name: "app", Dir: appMigrationsDir, DefaultSchema: "public"}); err != nil {
-			t.Fatalf("schemaguard: %v", err)
+			t.Fatalf("%v", err)
 		}
 	}
 	if cfg.IdentityApplied {
 		dir := filepath.Join(idDir, "identity", "migrations")
 		if err := m.replay(migrationStream{Name: "identity", Dir: dir, DefaultSchema: "identity"}); err != nil {
-			t.Fatalf("schemaguard: %v", err)
+			t.Fatalf("%v", err)
 		}
 	}
 	migrationTables := m.tableCount()
@@ -686,7 +685,7 @@ func TestDefaultConfigurationCanExecuteItsOwnSQL(t *testing.T) {
 	// --- resolve ---------------------------------------------------------
 	violations, checked, err := resolve(a.Model, a.Writes, a.Opts)
 	if err != nil {
-		t.Fatalf("schemaguard: %v", err)
+		t.Fatalf("%v", err)
 	}
 	t.Logf("checked %d writes against the default schema universe", checked)
 
@@ -758,7 +757,7 @@ func TestGuardFiresWhenTheDefaultSchemaLosesAColumn(t *testing.T) {
 
 	baseline, checked, err := resolve(a.Model, a.Writes, a.Opts)
 	if err != nil {
-		t.Fatalf("schemaguard: %v", err)
+		t.Fatalf("%v", err)
 	}
 	if checked == 0 {
 		t.Fatal("schemaguard: baseline checked zero writes")

--- a/backend/internal/schemaguard/schema_demand_guard_test.go
+++ b/backend/internal/schemaguard/schema_demand_guard_test.go
@@ -31,6 +31,15 @@ import (
 //
 //	pq: column "actor_email" of relation "audit_logs" does not exist (42703)
 //
+// Two flags are involved, not one, and that is the part the issue's own triage
+// got wrong. Removing the TFR_IDENTITY_MIGRATIONS_ENABLED gate does not fix the
+// default topology: migration 000007 is schema-qualified (ALTER TABLE
+// identity.audit_logs), so running the identity chain adds the column to a
+// table the default configuration never writes to. Reproduced on postgres:16 in
+// #864's comments — the 42703 is identical before and after the identity chain
+// is applied. This guard models the resolution, not the flag, which is why it
+// stays red under that "fix" instead of certifying it.
+//
 // THE CLASS
 //
 // A gated capability became load-bearing without anything failing at build or
@@ -108,6 +117,14 @@ import (
 //     configuration cannot execute its own SQL. It cannot say whether that is
 //     survivable, because it does not model startup preconditions. A
 //     fail-fast check in cmd/server/main.go is complementary, not redundant.
+//
+//  8. WRITES CHOSEN AT RUNTIME. Code that probes the catalogue and picks a
+//     narrower statement when a column is missing is safe, and the guard cannot
+//     see that on its own — it reads both branches as unconditional demand. Such
+//     writes need an explicit probedWrites entry, which the guard then re-derives
+//     the justification for on every run (see below). Nothing here detects an
+//     unregistered probe, so a correct fix that is not registered shows up as a
+//     failure rather than being silently credited.
 
 // ---------------------------------------------------------------------------
 // Quarantine
@@ -129,17 +146,134 @@ var knownGaps = []knownGap{
 		Table:  "audit_logs",
 		Column: "actor_email",
 		Issue:  "#864",
-		Why: "the defect this guard was written for. The shared identity store writes " +
-			"actor_email into an unqualified audit_logs; under the default configuration that " +
-			"resolves to public.audit_logs, which this repository's own migration chain never " +
-			"gave the column. Fixed by any of: adding the column to this repository's chain, " +
-			"making the identity-schema cutover the default, or making the library's write " +
-			"tolerate a pre-000007 schema. DELETE THIS ENTRY when it lands.",
+		Why: "the defect this guard was written for, at identity/store/audit_repository.go. The " +
+			"shared identity store writes actor_email into an unqualified audit_logs; under the " +
+			"default configuration that resolves to public.audit_logs, which this repository's " +
+			"own migration chain never gave the column. Removing the migrations gate does NOT " +
+			"clear this — see the topology note at the top of the file. What clears it: a " +
+			"registry migration adding actor_email to public.audit_logs, or making the " +
+			"identity-schema cutover the default, or a probed write in the library " +
+			"(terraform-suite-identity#203), which becomes a probedWrites entry rather than a " +
+			"knownGap. DELETE THIS ENTRY when it lands.",
 	},
 }
 
 func (g knownGap) matches(v violation) bool {
 	return strings.EqualFold(g.Table, v.Table) && strings.EqualFold(g.Column, v.Column)
+}
+
+// ---------------------------------------------------------------------------
+// Probed writes
+// ---------------------------------------------------------------------------
+
+// probedWrite is a write this guard would otherwise flag, and must not,
+// because the code asks the database whether the column is there before
+// choosing the statement. That is not a gap to be excused — it is the correct
+// fix shape for this defect class, so the guard has to recognise it or it
+// punishes the behaviour it is trying to encourage.
+//
+// The entry is NOT taken on trust. Three things must hold or the guard fails:
+//
+//   - it must match a real violation (a stale entry is deleted, like knownGaps);
+//   - the file must still contain Probe, the catalogue lookup that decides;
+//   - the file must still contain a write to the same table that does NOT name
+//     the column — the narrower statement the probe falls back to. Without a
+//     fallback there is nothing to switch to and the probe is decoration.
+//
+// Delete the probe or the fallback and the suppression stops being justified
+// on the next run.
+type probedWrite struct {
+	// FileSuffix identifies the source file by path suffix.
+	FileSuffix string
+	Table      string
+	Column     string
+	// Probe is text that must appear in the file for the suppression to hold.
+	Probe string
+	Why   string
+}
+
+var probedWrites = []probedWrite{
+	{
+		FileSuffix: "internal/audit/sink.go",
+		Table:      "audit_logs",
+		Column:     "actor_email",
+		Probe:      "to_regclass",
+		Why: "PR #865's outbox sink asks to_regclass/information_schema whether the audit_logs " +
+			"this connection resolves to carries actor_email, and uses the nine-column insert " +
+			"when it does not. This is the only write to audit_logs in either codebase that " +
+			"survives a stock deployment, and it is the shape #864's direction (3) would give " +
+			"the shared library.",
+	},
+}
+
+func (p probedWrite) matches(v violation) bool {
+	return strings.EqualFold(p.Table, v.Table) &&
+		strings.EqualFold(p.Column, v.Column) &&
+		strings.Contains(filepath.ToSlash(v.Pos), p.FileSuffix)
+}
+
+// verify re-derives the two facts that make the suppression sound, from the
+// file itself, on every run.
+func (p probedWrite) verify(t *testing.T, v violation) {
+	t.Helper()
+	path := filepath.ToSlash(v.Pos)
+	if i := strings.Index(path, p.FileSuffix); i >= 0 {
+		path = path[:i] + p.FileSuffix
+	}
+	src, err := os.ReadFile(path) // #nosec G304 -- test-only; path comes from a violation this guard produced
+	if err != nil {
+		t.Errorf("probedWrite %s %s.%s: cannot read %s: %v",
+			p.FileSuffix, p.Table, p.Column, path, err)
+		return
+	}
+	if !strings.Contains(string(src), p.Probe) {
+		t.Errorf("probedWrite %s %s.%s: %q is gone from the file. The write is suppressed on the "+
+			"grounds that the code checks the destination first; without that check the "+
+			"suppression is unfounded and the write is a live #864.",
+			p.FileSuffix, p.Table, p.Column, p.Probe)
+	}
+	if !hasFallbackWrite(t, path, p.Table, p.Column) {
+		t.Errorf("probedWrite %s %s.%s: the file no longer contains a write to %s that omits %s. "+
+			"A probe with nothing to fall back to does not make the write safe.",
+			p.FileSuffix, p.Table, p.Column, p.Table, p.Column)
+	}
+}
+
+// hasFallbackWrite reports whether the file contains a write to table that
+// does not name column — the narrower statement a probe selects when the
+// column is absent.
+func hasFallbackWrite(t *testing.T, path, table, column string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Errorf("schemaguard: parse %s: %v", path, err)
+		return false
+	}
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		text, pos, ok := stringLiteral(n, fset)
+		if !ok {
+			return true
+		}
+		for _, w := range extractWrites(text, pos) {
+			if !strings.EqualFold(w.Table, table) {
+				continue
+			}
+			names := false
+			for _, c := range w.Columns {
+				if strings.EqualFold(c, column) {
+					names = true
+					break
+				}
+			}
+			if !names && len(w.Columns) > 0 {
+				found = true
+			}
+		}
+		return false
+	})
+	return found
 }
 
 // ---------------------------------------------------------------------------
@@ -558,8 +692,20 @@ func TestDefaultConfigurationCanExecuteItsOwnSQL(t *testing.T) {
 
 	// --- verdict ---------------------------------------------------------
 	matched := make([]bool, len(knownGaps))
+	probed := make([]bool, len(probedWrites))
 	for _, v := range violations {
 		excused := false
+		for i, p := range probedWrites {
+			if p.matches(v) {
+				probed[i] = true
+				p.verify(t, v)
+				excused = true
+				break
+			}
+		}
+		if excused {
+			continue
+		}
 		for i, g := range knownGaps {
 			if g.matches(v) {
 				matched[i] = true
@@ -583,6 +729,13 @@ func TestDefaultConfigurationCanExecuteItsOwnSQL(t *testing.T) {
 				"The gap it excused is fixed — delete the entry. This list may only shrink; "+
 				"leaving stale entries in it is how an allow-list stops guarding anything.",
 				g.Table, g.Column, g.Issue)
+		}
+	}
+	for i, p := range probedWrites {
+		if !probed[i] {
+			t.Errorf("probedWrites entry %s %s.%s no longer matches any violation. Either the "+
+				"write moved, or the column is now in the default schema and the suppression is "+
+				"pointless — delete the entry either way.", p.FileSuffix, p.Table, p.Column)
 		}
 	}
 }


### PR DESCRIPTION
## What this is

A guard against the defect class behind #864, not its fix. **#864 remains open** — the fix belongs to whoever owns the rollout decision.

The class: **a gated capability became load-bearing without anything failing at build or start time.** #438 added the `TFR_IDENTITY_MIGRATIONS_ENABLED` gate and was correct when written; its premise was stated out loud — *"the identity schema is created but unused"* — and expired silently when the audit path started depending on gated schema. No compiler error, no startup error, no test. The flag became required without ever being flipped, and the failure surfaced per-request, in production defaults, months later, via a Playwright timeout in another repository.

Generalised: **application SQL must not depend on schema the running configuration will not have.**

## How it works

`backend/internal/schemaguard` is a test-only package (nothing in the server binary imports it). On every `go test ./...` it:

1. **Reads the default configuration out of `cmd/server/main.go` by AST** — which env gates exist, what each defaults to, which `RunMigrations` calls are inside which gate. Derived, never restated, so changing a gate or a default moves the guard with it.
2. **Replays the migration streams that configuration actually applies** (`CREATE TABLE`, `ALTER TABLE ADD/DROP/RENAME COLUMN`, `DROP TABLE`, views, dollar-quoted `DO` blocks) into a column-level model.
3. **Extracts every `INSERT`/`UPDATE`/`DELETE` from Go string literals** in this repository *and* in the shared `terraform-suite-identity` module, resolved through the module cache so a `replace` or a version bump is followed.
4. **Resolves each write through the search_path the default configuration actually uses**, exactly as Postgres would, and fails on anything that cannot land.

Current run: search_path `[public]`, 53 tables, **235 writes checked**.

### Why this shape rather than a container test

A postgres-backed test reproduces #864 more literally, but PR CI here runs no migrations at all today — only `chaos.yml` stands up a database, which is part of why this shipped. **This guard is hermetic (no container, no network, no database) and therefore runs in the `go test ./...` that already gates every PR.** That is the only place a guard against a silent *default* gets seen before release. The dynamic proof already exists elsewhere: #864's postgres:16 reproduction and #865's `TestIntegration_SinkDeliversAgainstTheDefaultRegistryAuditLogs`.

It is also deliberately **not** a test of the audit path — that would catch this instance and nothing else.

## Two lists, both self-cleaning

- **`knownGaps`** — one entry, #864, the violation that exists today. A stale entry (one that stops matching) **fails the guard**, so the fix for #864 also deletes the line excusing it. The list can only shrink.
- **`probedWrites`** — one entry, #865's outbox sink, which asks `to_regclass` whether the `audit_logs` it resolves to carries `actor_email` and uses the narrower insert when it does not. That is the *correct* fix shape for this class, so the guard must recognise it rather than punish it. The suppression is re-derived on every run: the entry must still match a real violation, the probe must still be in the file, **and the file must still contain a write to the same table that omits the column**. Delete the probe or the fallback and the suppression stops being justified on the next run.

## Corrected topology

Recorded in the file, from #864's reproduction: **removing the migrations gate does not fix the default.** Migration `000007` is schema-qualified (`ALTER TABLE identity.audit_logs`), while the default configuration writes `public.audit_logs`. Two flags, not one. The guard models the *resolution*, not the flag — mutation M4 below demonstrates it stays red under that "fix" rather than certifying it.

## Evidence

Primary: **the guard fails on the broken tree.** With its single quarantine entry removed, on current `main`:

```
the DEFAULT configuration cannot execute this write: audit_logs.actor_email does not exist
  (terraform-suite-identity@v0.27.0/identity/store/audit_repository.go:66:11)
```

### Mutation table — every mutation compiled and was restored from a `cp` backup

| # | Mutation | Result |
|---|---|---|
| M1 | empty `knownGaps` | **FAIL** — `audit_logs.actor_email` at `identity/store/audit_repository.go:66` |
| M2 | add `actor_email` to the app chain (simulate the fix) | **FAIL** — both stale entries reported, "delete the entry" |
| M3 | flip the cutover default on, migrations still gated | **FAIL** — `search_path` becomes `[identity public]`; coherence check fires |
| M4 | remove the migrations gate (#864 direction 1) + M1 | **FAIL** — reads `identity_migrations_applied=true`, still red on `actor_email` |
| M5 | delete `to_regclass` from `internal/audit/sink.go` | **FAIL** — probe gone, suppression unfounded |
| M6 | delete the narrow fallback insert, keep the probe | **FAIL** — "a probe with nothing to fall back to does not make the write safe" |
| M7 | point the app stream at an empty directory | **FAIL** — refuses to certify against an empty schema universe |
| M8 | break the `INSERT` extractor | **FAIL** — stale-entry check catches the guard going inert |
| M8b | extractor returns nothing at all | **FAIL** — refuses to certify with nothing to check |
| M9 | rename `identitySchemaEnabled` in `main.go` | **FAIL** — refuses to certify a configuration it cannot read |

### Empty-universe falsification

Directly falsified, not assumed. `resolve` and `replay` return distinct sentinels — `errNoDDL`, `errNoWrites`, `errNoSearchPath` — asserted with `errors.Is` across four table cases plus an empty-directory replay, and additionally proven end-to-end on the real guard by M7 and M8b. A refusal never also reports results.

### Non-inertness, permanently

`TestGuardFiresWhenTheDefaultSchemaLosesAColumn` runs on the real tree on every invocation: it picks a (table, column) that the default schema really has and real SQL really writes, drops it, and requires the guard to name it. If the replay, the extraction and the resolver ever stop connecting, that test says so instead of the suite going quietly green.

## What it does NOT cover

Seven boundaries, written out in the test file: reads, types/nullability/constraints, SQL not present as a contiguous Go string literal, tables created by application code rather than a migration (`legal_hold.go`'s `EnsureTable` is credited but **has no non-test caller**), non-default configurations, other consumers of the shared library, and whether the server refuses to start. An eighth covers runtime-chosen writes and how `probedWrites` handles them.

## Scope

Test and CI infrastructure only. One new test-only package; no production code, no migration, no workflow change. `main.go`, `internal/audit/**`, `platform_admins.go`, `router.go` and `migrations/README.md` are untouched.

`go build ./... && go vet ./... && gofmt -l . && golangci-lint run` clean; `go test ./...` clean apart from the four pre-existing `internal/auth` fsnotify failures caused by this host's inotify limit (identical on pristine `main`).
