### PR TITLE
fix(mirror): stop the sync from erasing stored binary checksums, and refuse to hide it when one is missing

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -140,8 +140,12 @@ func run() error {
 			verify = true
 		}
 		return runRekeySecrets(cfg, verify)
+	case "verify-mirror-sha256":
+		// verify-mirror-sha256 — list every mirrored binary the registry
+		// serves with no checksum. Read-only; exits non-zero while any remain.
+		return runVerifyMirrorSHA256(cfg)
 	default:
-		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker, bind-secrets, rekey-secrets", command)
+		return fmt.Errorf("unknown command: %s\nAvailable commands: serve, migrate, version, upgrade, scan-worker, bind-secrets, rekey-secrets, verify-mirror-sha256", command)
 	}
 }
 
@@ -1017,6 +1021,42 @@ func runBindSecrets(cfg *config.Config, verify bool) error {
 		slog.Info("bind-secrets column complete", "mode", mode, "column", name, "result", res.String())
 	}
 	return err
+}
+
+// runVerifyMirrorSHA256 lists every mirrored binary the registry serves without
+// a checksum (issue #869) and exits non-zero while any remain.
+//
+// Read-only, and no encryption key required: unlike the two sweeps above it
+// writes nothing at all. Repopulating a missing hash is the mirror sync job's
+// work, because only the sync path fetches the checksum from the UPSTREAM
+// release. Deriving it here from the SHA256SUMS blob in our own storage would
+// be easier and wrong: that blob and the binary share a storage host, and the
+// inline sha256 exists precisely so a compromise of that host is still caught.
+//
+// The intended use is the same as the verify forms of bind-secrets and
+// rekey-secrets — a runbook or CI step that gates on the exit code — plus a
+// direct answer to "which tools are affected?" that stays correct as the mirror
+// grows, rather than a list someone checked by hand once.
+func runVerifyMirrorSHA256(cfg *config.Config) error {
+	database, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer func() { _ = database.Close() }()
+
+	found, verifyErr := maintenance.VerifyMirrorSHA256(context.Background(), database)
+	for _, line := range maintenance.SummariseUnverifiable(found) {
+		slog.Warn("verify-mirror-sha256", "summary", line)
+	}
+	for _, u := range found {
+		slog.Warn("mirrored binary has no sha256 — checksum-enforcing clients cannot install it",
+			"config", u.Config, "tool", u.Tool, "version", u.Version,
+			"os", u.OS, "arch", u.Arch, "filename", u.Filename, "sums_blob_stored", u.HasSums)
+	}
+	if verifyErr == nil {
+		slog.Info("verify-mirror-sha256: every synced platform has a sha256")
+	}
+	return verifyErr
 }
 
 // runRekeySecrets re-encrypts every stored secret under the current

--- a/backend/internal/db/repositories/terraform_mirror_repository.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository.go
@@ -554,7 +554,16 @@ func (r *TerraformMirrorRepository) UpsertPlatform(ctx context.Context, p *model
 		ON CONFLICT (version_id, os, arch) DO UPDATE
 		SET upstream_url     = EXCLUDED.upstream_url,
 		    filename         = EXCLUDED.filename,
-		    sha256           = EXCLUDED.sha256,
+		    -- An incoming empty sha256 must never erase a stored one (issue
+		    -- #869). This upsert re-runs on EVERY sync tick from the upstream
+		    -- release index, and that index row carries no checksum: the hash
+		    -- is learned later, from the SHA256SUMS file. A plain
+		    -- "sha256 = EXCLUDED.sha256" therefore wiped the verified hash off
+		    -- every already-synced platform on every run, leaving the row
+		    -- sync_status='synced' with sha256='' — which the download API
+		    -- serves as an empty string while every fail-closed installer
+		    -- refuses it. Only a non-empty incoming value may overwrite.
+		    sha256           = COALESCE(NULLIF(EXCLUDED.sha256, ''), terraform_version_platforms.sha256),
 		    updated_at       = EXCLUDED.updated_at
 		RETURNING id
 	`
@@ -731,13 +740,20 @@ func (r *TerraformMirrorRepository) UpdatePlatformAttestationVerified(ctx contex
 // BackfillPlatformSHA256 populates sha256 from the supplied SUMS map for any
 // synced platform of the given version whose sha256 column is still empty.
 // No binaries are re-downloaded. sums maps filename -> hex SHA256.
-func (r *TerraformMirrorRepository) BackfillPlatformSHA256(ctx context.Context, versionID uuid.UUID, sums map[string]string) error {
-	if len(sums) == 0 {
-		return nil
-	}
+//
+// It returns how many rows it filled and, separately, every row it could not:
+// a synced platform whose filename has no entry in the SUMS map is a version
+// that can never be verified, and the caller must be able to say so. Returning
+// only an error would keep that case silent, which is how issue #869 survived
+// from ingestion until a consumer hit it.
+func (r *TerraformMirrorRepository) BackfillPlatformSHA256(
+	ctx context.Context,
+	versionID uuid.UUID,
+	sums map[string]string,
+) (filled int, unresolved []models.TerraformVersionPlatform, err error) {
 	platforms, err := r.ListPlatformsForVersion(ctx, versionID)
 	if err != nil {
-		return err
+		return 0, nil, err
 	}
 	for _, p := range platforms {
 		if p.SHA256 != "" || p.SyncStatus != "synced" {
@@ -745,13 +761,77 @@ func (r *TerraformMirrorRepository) BackfillPlatformSHA256(ctx context.Context, 
 		}
 		hash, ok := sums[p.Filename]
 		if !ok || hash == "" {
+			unresolved = append(unresolved, p)
 			continue
 		}
 		if updErr := r.UpdatePlatformSHA256(ctx, p.ID, hash); updErr != nil {
-			return updErr
+			return filled, unresolved, updErr
 		}
+		filled++
 	}
-	return nil
+	return filled, unresolved, nil
+}
+
+// ListVersionsMissingSHA256 returns every version of a config that still has at
+// least one platform in sync_status='synced' with an empty sha256 — the defect
+// state of issue #869: a binary the registry serves but cannot give a consumer
+// a checksum for.
+//
+// This deliberately does NOT filter on the version's own sync_status. The
+// invariant is a property of the platform row, and a version left 'partial' or
+// 'failed' by one unavailable platform still serves the platforms that did
+// succeed. Gating the SHA256 back-fill on version sync_status='synced' meant
+// exactly those versions were skipped forever while their rows kept being
+// served without a checksum.
+//
+// Deprecated versions are excluded: their platforms are no longer offered.
+func (r *TerraformMirrorRepository) ListVersionsMissingSHA256(ctx context.Context, configID uuid.UUID) ([]models.TerraformVersion, error) {
+	query := `
+		SELECT v.id, v.config_id, v.version, v.is_latest, v.is_deprecated, v.release_date,
+		       v.sync_status, v.sync_error, v.synced_at, v.created_at, v.updated_at,
+		       v.sums_storage_key, v.sig_storage_key, v.approval_status
+		FROM terraform_versions v
+		WHERE v.config_id = $1
+		  AND v.is_deprecated = false
+		  AND EXISTS (
+		        SELECT 1 FROM terraform_version_platforms p
+		        WHERE p.version_id = v.id
+		          AND p.sync_status = 'synced'
+		          AND p.sha256 = ''
+		      )
+		ORDER BY v.version
+	`
+
+	var versions []models.TerraformVersion
+	if err := r.db.SelectContext(ctx, &versions, query, configID); err != nil {
+		return nil, fmt.Errorf("failed to list terraform versions missing sha256: %w", err)
+	}
+	return versions, nil
+}
+
+// CountPlatformsMissingSHA256 counts the config's platform rows that are marked
+// synced but carry no checksum. Zero is the ingestion invariant of issue #869;
+// any other value is a defect state that must be reported, because the download
+// API fails open on it (it serves "") while every well-behaved consumer fails
+// closed.
+//
+// Deprecated versions are excluded so a deliberately retired version cannot
+// hold the invariant red forever.
+func (r *TerraformMirrorRepository) CountPlatformsMissingSHA256(ctx context.Context, configID uuid.UUID) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM terraform_version_platforms p
+		JOIN terraform_versions v ON v.id = p.version_id
+		WHERE v.config_id = $1
+		  AND v.is_deprecated = false
+		  AND p.sync_status = 'synced'
+		  AND p.sha256 = ''
+	`, configID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count terraform platforms missing sha256: %w", err)
+	}
+	return count, nil
 }
 
 // UpdateGPGVerifiedForVersion sets gpg_verified on all synced platforms for a version.

--- a/backend/internal/db/repositories/terraform_mirror_repository_test.go
+++ b/backend/internal/db/repositories/terraform_mirror_repository_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1151,10 +1152,33 @@ func TestTerraformMirrorUpdatePlatformSHA256_DBError(t *testing.T) {
 
 // --- BackfillPlatformSHA256 ---
 
+// An empty SUMS map is not "nothing to do" (issue #869): every synced platform
+// with no hash is then unresolvable, and must be reported as such rather than
+// silently skipped.
 func TestTerraformMirrorBackfillPlatformSHA256_NoSums(t *testing.T) {
-	repo, _ := newTerraformMirrorRepo(t)
-	if err := repo.BackfillPlatformSHA256(context.Background(), uuid.New(), nil); err != nil {
+	repo, mock := newTerraformMirrorRepo(t)
+	versionID := uuid.New()
+
+	pNeed := testTFPlatform(versionID)
+	pNeed.SHA256 = ""
+	pNeed.SyncStatus = "synced"
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
+		WithArgs(versionID).
+		WillReturnRows(newTFPlatformRow(mock, pNeed))
+
+	filled, unresolved, err := repo.BackfillPlatformSHA256(context.Background(), versionID, nil)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if filled != 0 {
+		t.Errorf("filled = %d, want 0", filled)
+	}
+	if len(unresolved) != 1 {
+		t.Fatalf("unresolved = %d rows, want 1", len(unresolved))
+	}
+	if unresolved[0].ID != pNeed.ID {
+		t.Errorf("unresolved[0].ID = %v, want %v", unresolved[0].ID, pNeed.ID)
 	}
 }
 
@@ -1198,8 +1222,49 @@ func TestTerraformMirrorBackfillPlatformSHA256_UpdatesEmptyHashes(t *testing.T) 
 		pHas.Filename:     "darwinhash",
 		pPending.Filename: "windowshash",
 	}
-	if err := repo.BackfillPlatformSHA256(context.Background(), versionID, sums); err != nil {
+	filled, unresolved, err := repo.BackfillPlatformSHA256(context.Background(), versionID, sums)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if filled != 1 {
+		t.Errorf("filled = %d, want 1 (only the synced row with an empty sha256)", filled)
+	}
+	if len(unresolved) != 0 {
+		t.Errorf("unresolved = %d rows, want 0", len(unresolved))
+	}
+}
+
+// A synced platform whose filename is absent from the SUMS file can never be
+// verified. It is reported as unresolved rather than skipped in silence —
+// the distinction issue #869 turned on.
+func TestTerraformMirrorBackfillPlatformSHA256_FilenameAbsentFromSums(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	versionID := uuid.New()
+
+	pNeed := testTFPlatform(versionID)
+	pNeed.SHA256 = ""
+	pNeed.SyncStatus = "synced"
+	pNeed.Filename = "terraform-docs-v0.24.0-linux-amd64.tar.gz"
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
+		WithArgs(versionID).
+		WillReturnRows(newTFPlatformRow(mock, pNeed))
+
+	// SUMS parsed fine but keyed by a different name.
+	sums := map[string]string{"terraform-docs-v0.24.0-linux-arm64.tar.gz": "somehash"}
+
+	filled, unresolved, err := repo.BackfillPlatformSHA256(context.Background(), versionID, sums)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filled != 0 {
+		t.Errorf("filled = %d, want 0", filled)
+	}
+	if len(unresolved) != 1 {
+		t.Fatalf("unresolved = %d rows, want 1", len(unresolved))
+	}
+	if unresolved[0].Filename != "terraform-docs-v0.24.0-linux-amd64.tar.gz" {
+		t.Errorf("unresolved[0].Filename = %q, want the platform's stored filename", unresolved[0].Filename)
 	}
 }
 
@@ -1209,8 +1274,89 @@ func TestTerraformMirrorBackfillPlatformSHA256_ListError(t *testing.T) {
 	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
 		WillReturnError(fmt.Errorf("db error"))
 
-	if err := repo.BackfillPlatformSHA256(context.Background(), versionID, map[string]string{"x": "y"}); err == nil {
+	_, _, err := repo.BackfillPlatformSHA256(context.Background(), versionID, map[string]string{"x": "y"})
+	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list terraform platforms") {
+		t.Errorf("error = %v, want the platform-list failure to be surfaced", err)
+	}
+}
+
+// --- ListVersionsMissingSHA256 / CountPlatformsMissingSHA256 (issue #869) ---
+//
+// The semantics of these two queries (which rows they select, and that a
+// 'partial' version is included) are pinned against real PostgreSQL in
+// terraform_mirror_sha256_pg_test.go. What is checked here is the plumbing
+// that runs in every CI job: the config scoping and the error wrapping.
+
+func TestListVersionsMissingSHA256_Success(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	configID := uuid.New()
+	v := testTFVersion(configID)
+	v.Version = "0.24.0"
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_versions v\s+WHERE v.config_id`).
+		WithArgs(configID).
+		WillReturnRows(newTFVersionRow(mock, v))
+
+	versions, err := repo.ListVersionsMissingSHA256(context.Background(), configID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("got %d versions, want 1", len(versions))
+	}
+	if versions[0].Version != "0.24.0" {
+		t.Errorf("version = %q, want 0.24.0", versions[0].Version)
+	}
+}
+
+func TestListVersionsMissingSHA256_DBError(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	mock.ExpectQuery(`SELECT.*FROM terraform_versions v`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	_, err := repo.ListVersionsMissingSHA256(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list terraform versions missing sha256") {
+		t.Errorf("error = %v, want the query failure named", err)
+	}
+}
+
+func TestCountPlatformsMissingSHA256_Success(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	configID := uuid.New()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM terraform_version_platforms p`).
+		WithArgs(configID).
+		WillReturnRows(mock.NewRows([]string{"count"}).AddRow(3))
+
+	count, err := repo.CountPlatformsMissingSHA256(context.Background(), configID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestCountPlatformsMissingSHA256_DBError(t *testing.T) {
+	repo, mock := newTerraformMirrorRepo(t)
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM terraform_version_platforms p`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	count, err := repo.CountPlatformsMissingSHA256(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0 on error — a failed check must not read as clean", count)
+	}
+	if !strings.Contains(err.Error(), "failed to count terraform platforms missing sha256") {
+		t.Errorf("error = %v, want the query failure named", err)
 	}
 }
 

--- a/backend/internal/db/repositories/terraform_mirror_sha256_pg_test.go
+++ b/backend/internal/db/repositories/terraform_mirror_sha256_pg_test.go
@@ -1,0 +1,317 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// Issue #869 — the reported defect, reproduced against real PostgreSQL and the
+// real schema, because it is a property of an ON CONFLICT clause and no mock
+// can evaluate one.
+//
+// The report was that the binary mirror served sha256:"" for every
+// terraform-docs version while its SHA256SUMS blob was byte-identical to
+// upstream, and that the rows had been "bulk-touched" — updated_at moved,
+// sha256 did not. What actually happened is worse than "did not": the sync
+// job's step-4 upsert re-inserts every platform straight from the upstream
+// release index, that index row carries no checksum, and the conflict clause
+// wrote the resulting empty string over the verified hash. The row keeps
+// sync_status='synced' throughout, so the download API goes on serving the
+// binary with no checksum for it.
+//
+// Set TFR_TEST_DATABASE_URL to run these.
+
+const mirrorSHA256ScratchPrefix = "tfr_869_"
+
+func mirrorScratchDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+
+	raw := os.Getenv("TFR_TEST_DATABASE_URL")
+	if raw == "" {
+		t.Skip("TFR_TEST_DATABASE_URL not set — needs a reachable Postgres")
+	}
+	base, err := url.Parse(raw)
+	if err != nil || !strings.HasPrefix(base.Scheme, "postgres") {
+		t.Skipf("TFR_TEST_DATABASE_URL is not a postgres:// URL (%q)", raw)
+	}
+
+	admin, err := sql.Open("postgres", raw)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer admin.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := admin.PingContext(ctx); err != nil {
+		t.Skipf("Postgres not reachable at TFR_TEST_DATABASE_URL: %v", err)
+	}
+
+	name := mirrorSHA256ScratchPrefix + strings.ReplaceAll(uuid.New().String()[:8], "-", "")
+	if _, err := admin.ExecContext(ctx, `CREATE DATABASE `+name); err != nil {
+		t.Skipf("cannot create a scratch database (needs CREATEDB): %v", err)
+	}
+	t.Cleanup(func() {
+		drop, dropErr := sql.Open("postgres", raw)
+		if dropErr != nil {
+			return
+		}
+		defer drop.Close()
+		_, _ = drop.Exec(`DROP DATABASE IF EXISTS ` + name + ` WITH (FORCE)`)
+	})
+
+	scratch := *base
+	scratch.Path = "/" + name
+	dsn := scratch.String()
+
+	m, err := migrate.New("file://../migrations", dsn)
+	if err != nil {
+		t.Fatalf("migrate.New: %v", err)
+	}
+	defer func() { _, _ = m.Close() }()
+	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		t.Fatalf("applying migrations: %v", err)
+	}
+
+	db, err := sqlx.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("sqlx.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// seedMirrorVersion creates a config + version and returns the version id.
+func seedMirrorVersion(t *testing.T, db *sqlx.DB, tool, version, versionSyncStatus string) (configID, versionID uuid.UUID) {
+	t.Helper()
+	configID = uuid.New()
+	versionID = uuid.New()
+
+	if _, err := db.Exec(
+		`INSERT INTO terraform_mirror_configs (id, name, tool, upstream_url) VALUES ($1, $2, $3, $4)`,
+		configID, "mirror-"+versionID.String()[:8], tool, "https://github.com/terraform-docs/terraform-docs",
+	); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO terraform_versions (id, config_id, version, sync_status, sums_storage_key)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		versionID, configID, version, versionSyncStatus, "terraform-binaries/"+version+"/SHA256SUMS",
+	); err != nil {
+		t.Fatalf("seed version: %v", err)
+	}
+	return configID, versionID
+}
+
+func platformSHA256(t *testing.T, db *sqlx.DB, id uuid.UUID) (sha, status string, verified bool) {
+	t.Helper()
+	if err := db.QueryRow(
+		`SELECT sha256, sync_status, sha256_verified FROM terraform_version_platforms WHERE id = $1`, id,
+	).Scan(&sha, &status, &verified); err != nil {
+		t.Fatalf("read back platform: %v", err)
+	}
+	return sha, status, verified
+}
+
+// TestUpsertPlatform_ReSyncDoesNotEraseStoredSHA256 is the regression test for
+// the reported symptom. It replays the exact sequence: a first sync that stores
+// a verified hash, then the next sync's metadata upsert, which arrives with the
+// zero-valued SHA256 that performSync's step 4 always sends.
+//
+// Before the fix this left the sha256 column empty with sync_status still
+// 'synced' — the state the reporter's probe found on all three terraform-docs
+// versions.
+func TestUpsertPlatform_ReSyncDoesNotEraseStoredSHA256(t *testing.T) {
+	db := mirrorScratchDB(t)
+	repo := NewTerraformMirrorRepository(db)
+	ctx := context.Background()
+
+	_, versionID := seedMirrorVersion(t, db, "terraform-docs", "0.24.0", "synced")
+
+	const upstreamName = "terraform-docs-v0.24.0-linux-amd64.tar.gz"
+	const knownHash = "9005daf969de0b50134493a2c00078b49f5f5b39d021cda7c89bf4d4f3d776d3"
+
+	// First sync: the row is created, downloaded and its hash persisted.
+	p := &models.TerraformVersionPlatform{
+		VersionID:   versionID,
+		OS:          "linux",
+		Arch:        "amd64",
+		UpstreamURL: "https://github.com/terraform-docs/terraform-docs/releases/download/v0.24.0/" + upstreamName,
+		Filename:    upstreamName,
+		SyncStatus:  "pending",
+	}
+	if err := repo.UpsertPlatform(ctx, p); err != nil {
+		t.Fatalf("first UpsertPlatform: %v", err)
+	}
+	storageKey := "terraform-binaries/0.24.0/linux/amd64/" + upstreamName
+	backend := "azure"
+	if err := repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", &storageKey, &backend, true, false, false, nil); err != nil {
+		t.Fatalf("UpdatePlatformSyncStatus: %v", err)
+	}
+	if err := repo.UpdatePlatformSHA256(ctx, p.ID, knownHash); err != nil {
+		t.Fatalf("UpdatePlatformSHA256: %v", err)
+	}
+	if sha, _, _ := platformSHA256(t, db, p.ID); sha != knownHash {
+		t.Fatalf("precondition: sha256 = %q, want %q", sha, knownHash)
+	}
+
+	// Next sync tick: performSync step 4 re-upserts the platform from the
+	// upstream release index. That struct carries no SHA256 — same shape as
+	// the production call site.
+	reSync := &models.TerraformVersionPlatform{
+		VersionID:   versionID,
+		OS:          "linux",
+		Arch:        "amd64",
+		UpstreamURL: p.UpstreamURL,
+		Filename:    upstreamName,
+		SyncStatus:  "pending",
+	}
+	if err := repo.UpsertPlatform(ctx, reSync); err != nil {
+		t.Fatalf("re-sync UpsertPlatform: %v", err)
+	}
+
+	sha, status, _ := platformSHA256(t, db, p.ID)
+	if sha != knownHash {
+		t.Fatalf("re-sync erased the stored checksum: sha256 = %q, want %q — this is issue #869: "+
+			"the download API serves this row with sha256:\"\" and fail-closed installers refuse it", sha, knownHash)
+	}
+	if status != "synced" {
+		t.Errorf("sync_status = %q, want synced (the upsert must not disturb it)", status)
+	}
+}
+
+// A genuinely new checksum from upstream must still land — the fix preserves a
+// stored hash against an EMPTY incoming one, not against every incoming one.
+func TestUpsertPlatform_NonEmptyIncomingSHA256StillOverwrites(t *testing.T) {
+	db := mirrorScratchDB(t)
+	repo := NewTerraformMirrorRepository(db)
+	ctx := context.Background()
+
+	_, versionID := seedMirrorVersion(t, db, "terraform", "1.9.0", "synced")
+
+	p := &models.TerraformVersionPlatform{
+		VersionID: versionID, OS: "linux", Arch: "amd64",
+		UpstreamURL: "https://u", Filename: "terraform_1.9.0_linux_amd64.zip",
+		SHA256: "aaaa", SyncStatus: "pending",
+	}
+	if err := repo.UpsertPlatform(ctx, p); err != nil {
+		t.Fatalf("first UpsertPlatform: %v", err)
+	}
+	p2 := &models.TerraformVersionPlatform{
+		VersionID: versionID, OS: "linux", Arch: "amd64",
+		UpstreamURL: "https://u", Filename: "terraform_1.9.0_linux_amd64.zip",
+		SHA256: "bbbb", SyncStatus: "pending",
+	}
+	if err := repo.UpsertPlatform(ctx, p2); err != nil {
+		t.Fatalf("second UpsertPlatform: %v", err)
+	}
+
+	if sha, _, _ := platformSHA256(t, db, p.ID); sha != "bbbb" {
+		t.Fatalf("sha256 = %q, want bbbb — a non-empty upstream value must overwrite", sha)
+	}
+}
+
+// TestListVersionsMissingSHA256_IncludesPartialVersions covers the second half
+// of why the defect was permanent. The SHA256 back-fill used to walk only
+// versions whose OWN sync_status was 'synced'. A version left 'partial' by a
+// single unavailable platform still serves the platforms that succeeded, so
+// gating on the version's status skipped exactly the rows that needed repair,
+// on every run, forever.
+func TestListVersionsMissingSHA256_IncludesPartialVersions(t *testing.T) {
+	db := mirrorScratchDB(t)
+	repo := NewTerraformMirrorRepository(db)
+	ctx := context.Background()
+
+	configID, versionID := seedMirrorVersion(t, db, "terraform-docs", "0.23.0", "partial")
+
+	// One synced platform with no checksum (needs repair) and one still
+	// pending (must not, on its own, make the version a candidate).
+	if _, err := db.Exec(
+		`INSERT INTO terraform_version_platforms (version_id, os, arch, upstream_url, filename, sha256, sync_status)
+		 VALUES ($1,'linux','amd64','https://u','terraform-docs-v0.23.0-linux-amd64.tar.gz','','synced'),
+		        ($1,'freebsd','arm','https://u','terraform-docs-v0.23.0-freebsd-arm.tar.gz','','pending')`,
+		versionID,
+	); err != nil {
+		t.Fatalf("seed platforms: %v", err)
+	}
+
+	versions, err := repo.ListVersionsMissingSHA256(ctx, configID)
+	if err != nil {
+		t.Fatalf("ListVersionsMissingSHA256: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("got %d versions, want 1 — a 'partial' version with a synced, checksum-less platform must be a repair candidate", len(versions))
+	}
+	if versions[0].Version != "0.23.0" {
+		t.Errorf("version = %q, want 0.23.0", versions[0].Version)
+	}
+
+	count, err := repo.CountPlatformsMissingSHA256(ctx, configID)
+	if err != nil {
+		t.Fatalf("CountPlatformsMissingSHA256: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (only the synced row counts; a pending one is not yet being served)", count)
+	}
+}
+
+// A version with every checksum present is not a candidate, and a deprecated
+// version is not one either — its platforms are no longer offered, so it must
+// not hold the invariant red forever.
+func TestListVersionsMissingSHA256_ExcludesHealthyAndDeprecated(t *testing.T) {
+	db := mirrorScratchDB(t)
+	repo := NewTerraformMirrorRepository(db)
+	ctx := context.Background()
+
+	configID, healthyID := seedMirrorVersion(t, db, "terraform", "1.9.0", "synced")
+	if _, err := db.Exec(
+		`INSERT INTO terraform_version_platforms (version_id, os, arch, upstream_url, filename, sha256, sync_status)
+		 VALUES ($1,'linux','amd64','https://u','terraform_1.9.0_linux_amd64.zip','deadbeef','synced')`,
+		healthyID,
+	); err != nil {
+		t.Fatalf("seed healthy platform: %v", err)
+	}
+
+	deprecatedID := uuid.New()
+	if _, err := db.Exec(
+		`INSERT INTO terraform_versions (id, config_id, version, sync_status, is_deprecated)
+		 VALUES ($1, $2, '1.2.3', 'synced', true)`, deprecatedID, configID,
+	); err != nil {
+		t.Fatalf("seed deprecated version: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO terraform_version_platforms (version_id, os, arch, upstream_url, filename, sha256, sync_status)
+		 VALUES ($1,'linux','amd64','https://u','terraform_1.2.3_linux_amd64.zip','','synced')`,
+		deprecatedID,
+	); err != nil {
+		t.Fatalf("seed deprecated platform: %v", err)
+	}
+
+	versions, err := repo.ListVersionsMissingSHA256(ctx, configID)
+	if err != nil {
+		t.Fatalf("ListVersionsMissingSHA256: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("got %d candidate versions, want 0 (healthy + deprecated only): %+v", len(versions), versions)
+	}
+	count, err := repo.CountPlatformsMissingSHA256(ctx, configID)
+	if err != nil {
+		t.Fatalf("CountPlatformsMissingSHA256: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}

--- a/backend/internal/jobs/terraform_mirror_sha256_test.go
+++ b/backend/internal/jobs/terraform_mirror_sha256_test.go
@@ -1,0 +1,432 @@
+// terraform_mirror_sha256_test.go covers issue #869: the SHA256 back-fill's
+// observability and the post-sync ingestion invariant.
+//
+// The defect these guard against was not that the registry lacked a checksum —
+// it had the right one, in storage, byte-identical to upstream. It was that
+// every path which failed to put that checksum in the column returned quietly,
+// so a mirrored binary that no fail-closed installer could ever accept was
+// indistinguishable from one that needed no work. These tests assert on the
+// specific words an operator would have to see, not merely that something was
+// logged.
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/mirror"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
+)
+
+// captureJobLog redirects the standard logger for the duration of fn.
+func captureJobLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// sumsClient is a terraformReleasesClient whose FetchSHASums is scripted.
+type sumsClient struct {
+	sums map[string]string
+	err  error
+}
+
+func (s *sumsClient) ListVersions(_ context.Context) ([]mirror.TerraformVersionInfo, error) {
+	return nil, nil
+}
+func (s *sumsClient) FetchSHASums(_ context.Context, _ string) (map[string]string, []byte, error) {
+	return s.sums, nil, s.err
+}
+func (s *sumsClient) FetchSHASumsSignature(_ context.Context, _ string) ([]byte, error) {
+	return nil, nil
+}
+func (s *sumsClient) DownloadBinaryStream(_ context.Context, _ string) (io.ReadCloser, int64, error) {
+	return nil, 0, errors.New("not used")
+}
+
+var _ terraformReleasesClient = (*sumsClient)(nil)
+
+var tfMirrorVersionCols = []string{
+	"id", "config_id", "version", "is_latest", "is_deprecated", "release_date",
+	"sync_status", "sync_error", "synced_at", "created_at", "updated_at",
+	"sums_storage_key", "sig_storage_key", "approval_status",
+}
+
+var tfMirrorPlatformCols = []string{
+	"id", "version_id", "os", "arch", "upstream_url", "filename", "sha256",
+	"storage_key", "storage_backend", "sha256_verified", "gpg_verified", "attestation_verified",
+	"sync_status", "sync_error", "synced_at", "download_count", "created_at", "updated_at",
+}
+
+func newSHA256TestJob(t *testing.T) (*TerraformMirrorSyncJob, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	return NewTerraformMirrorSyncJob(repo, nil, "local"), mock
+}
+
+func testMirrorConfig() *models.TerraformMirrorConfig {
+	return &models.TerraformMirrorConfig{ID: uuid.New(), Name: "terraform-docs-mirror", Tool: "terraform-docs"}
+}
+
+// expectVersionsMissingSHA256 scripts ListVersionsMissingSHA256 to return one
+// version, and ListPlatformsForVersion to return one synced platform with no
+// checksum — the shape of every affected row in issue #869.
+func expectVersionsMissingSHA256(mock sqlmock.Sqlmock, cfg *models.TerraformMirrorConfig, versionID uuid.UUID) {
+	mock.ExpectQuery(`SELECT.*FROM terraform_versions v\s+WHERE v.config_id`).
+		WithArgs(cfg.ID).
+		WillReturnRows(mock.NewRows(tfMirrorVersionCols).AddRow(
+			versionID, cfg.ID, "0.24.0", false, false, nil,
+			"partial", nil, nil, time.Now(), time.Now(),
+			"terraform-binaries/0.24.0/SHA256SUMS", nil, "approved",
+		))
+}
+
+func expectSyncedPlatformWithoutSHA256(mock sqlmock.Sqlmock, versionID, platformID uuid.UUID, filename string) {
+	mock.ExpectQuery(`SELECT.*FROM terraform_version_platforms\s+WHERE version_id`).
+		WithArgs(versionID).
+		WillReturnRows(mock.NewRows(tfMirrorPlatformCols).AddRow(
+			platformID, versionID, "linux", "amd64", "https://u", filename, "",
+			nil, nil, false, false, false,
+			"synced", nil, nil, 0, time.Now(), time.Now(),
+		))
+}
+
+// TestBackfillSHA256_ReportsPlatformAbsentFromUpstreamSUMS is the guard for the
+// silent skip. The SUMS file was fetched and parsed successfully and simply has
+// no line for this platform's filename — nothing will ever fix that on its own,
+// and before this change the loop moved on without a word.
+func TestBackfillSHA256_ReportsPlatformAbsentFromUpstreamSUMS(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+	versionID, platformID := uuid.New(), uuid.New()
+	const filename = "terraform-docs-v0.24.0-linux-amd64.tar.gz"
+
+	expectVersionsMissingSHA256(mock, cfg, versionID)
+	expectSyncedPlatformWithoutSHA256(mock, versionID, platformID, filename)
+
+	client := &sumsClient{sums: map[string]string{"terraform-docs-v0.24.0-linux-arm64.tar.gz": "abc"}}
+
+	out := captureJobLog(t, func() {
+		if err := job.backfillSHA256(context.Background(), client, cfg); err != nil {
+			t.Fatalf("backfillSHA256: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "NO CHECKSUM") {
+		t.Fatalf("back-fill said nothing about a platform it could not resolve.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, filename) {
+		t.Errorf("log does not name the unresolvable filename %q.\nlog:\n%s", filename, out)
+	}
+	if !strings.Contains(out, "linux/amd64") {
+		t.Errorf("log does not name the platform.\nlog:\n%s", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// A SUMS fetch that fails (rate limit, 404, transport) leaves the rows
+// unverifiable until the next run. That has to be said out loud, with the
+// upstream error attached.
+func TestBackfillSHA256_ReportsSUMSFetchFailure(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+	versionID := uuid.New()
+
+	expectVersionsMissingSHA256(mock, cfg, versionID)
+
+	client := &sumsClient{err: fmt.Errorf("upstream returned 403: rate limited")}
+
+	out := captureJobLog(t, func() {
+		if err := job.backfillSHA256(context.Background(), client, cfg); err != nil {
+			t.Fatalf("backfillSHA256: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "stay unverifiable") {
+		t.Fatalf("a failed SUMS fetch was not reported as leaving rows unverifiable.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, "rate limited") {
+		t.Errorf("the upstream error was not preserved in the log.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, "0.24.0") {
+		t.Errorf("the affected version was not named.\nlog:\n%s", out)
+	}
+}
+
+// An empty-but-successful SUMS map is the third give-up branch, and used to be
+// a bare `continue`.
+func TestBackfillSHA256_ReportsEmptySUMSMap(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+	versionID := uuid.New()
+
+	expectVersionsMissingSHA256(mock, cfg, versionID)
+
+	client := &sumsClient{sums: map[string]string{}}
+
+	out := captureJobLog(t, func() {
+		if err := job.backfillSHA256(context.Background(), client, cfg); err != nil {
+			t.Fatalf("backfillSHA256: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "EMPTY SUMS map") {
+		t.Fatalf("an empty upstream SUMS map was skipped silently.\nlog:\n%s", out)
+	}
+}
+
+// The repair itself: a synced platform with no checksum whose filename IS in
+// the SUMS map gets the hash written, and the run says how many it fixed.
+func TestBackfillSHA256_PopulatesMissingHash(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+	versionID, platformID := uuid.New(), uuid.New()
+	const filename = "terraform-docs-v0.24.0-linux-amd64.tar.gz"
+	const hash = "9005daf969de0b50134493a2c00078b49f5f5b39d021cda7c89bf4d4f3d776d3"
+
+	expectVersionsMissingSHA256(mock, cfg, versionID)
+	expectSyncedPlatformWithoutSHA256(mock, versionID, platformID, filename)
+	mock.ExpectExec(`UPDATE terraform_version_platforms\s+SET sha256`).
+		WithArgs(platformID, hash).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	client := &sumsClient{sums: map[string]string{filename: hash}}
+
+	out := captureJobLog(t, func() {
+		if err := job.backfillSHA256(context.Background(), client, cfg); err != nil {
+			t.Fatalf("backfillSHA256: %v", err)
+		}
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the hash was not written back: %v", err)
+	}
+	if !strings.Contains(out, "populated 1 hash(es)") {
+		t.Errorf("log did not report the repair.\nlog:\n%s", out)
+	}
+	if strings.Contains(out, "NO CHECKSUM") {
+		t.Errorf("a resolved platform must not be reported as unresolvable.\nlog:\n%s", out)
+	}
+}
+
+// A version whose candidate query fails must surface as an error rather than a
+// clean return.
+func TestBackfillSHA256_CandidateQueryError(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+
+	mock.ExpectQuery(`SELECT.*FROM terraform_versions v`).
+		WillReturnError(errors.New("db down"))
+
+	err := job.backfillSHA256(context.Background(), &sumsClient{}, cfg)
+	if err == nil {
+		t.Fatal("expected an error when the candidate query fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list versions missing sha256") {
+		t.Errorf("err = %v, want the candidate query named", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ingestion invariant
+// ---------------------------------------------------------------------------
+
+// TestReportUnverifiablePlatforms_FiresOnSyncedRowWithEmptySHA256 is the
+// invariant's own mutation target: a platform marked synced with an empty
+// sha256 is a defect state, and the run must say so in terms an operator can
+// act on. The count also lands on the metric, since a log line alone cannot be
+// alerted on.
+func TestReportUnverifiablePlatforms_FiresOnSyncedRowWithEmptySHA256(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM terraform_version_platforms p`).
+		WithArgs(cfg.ID).
+		WillReturnRows(mock.NewRows([]string{"count"}).AddRow(3))
+
+	var count int
+	out := captureJobLog(t, func() { count = job.reportUnverifiablePlatforms(context.Background(), cfg) })
+
+	if count != 3 {
+		t.Fatalf("count = %d, want 3", count)
+	}
+	if !strings.Contains(out, "INVARIANT VIOLATION") {
+		t.Fatalf("three unverifiable platforms produced no invariant report.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, "terraform-docs-mirror") {
+		t.Errorf("the report does not name the mirror config.\nlog:\n%s", out)
+	}
+	if !strings.Contains(out, "verify-mirror-sha256") {
+		t.Errorf("the report does not tell the operator how to get the list.\nlog:\n%s", out)
+	}
+	if got := testutilGaugeValue(t, cfg); got != 3 {
+		t.Errorf("gauge = %v, want 3", got)
+	}
+}
+
+// A clean config must report zero rather than nothing: "checked, clean" and
+// "never checked" have to be distinguishable, which is precisely what was
+// missing while this sat unnoticed.
+func TestReportUnverifiablePlatforms_SetsZeroWhenClean(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+	cfg.Name = "clean-mirror"
+
+	// Seed the series with a previous run's non-zero reading. Without this the
+	// gauge would read 0 simply because it had never been set, and the
+	// assertion below would hold even if the clean path stopped publishing —
+	// which is exactly how a stale alert survives a fixed mirror.
+	telemetry.TerraformMirrorUnverifiablePlatforms.WithLabelValues(cfg.Name, cfg.Tool).Set(7)
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM terraform_version_platforms p`).
+		WithArgs(cfg.ID).
+		WillReturnRows(mock.NewRows([]string{"count"}).AddRow(0))
+
+	var count int
+	out := captureJobLog(t, func() { count = job.reportUnverifiablePlatforms(context.Background(), cfg) })
+
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
+	}
+	if strings.Contains(out, "INVARIANT VIOLATION") {
+		t.Errorf("a clean config must not report a violation.\nlog:\n%s", out)
+	}
+	if got := testutilGaugeValue(t, cfg); got != 0 {
+		t.Errorf("gauge = %v, want 0 — a clean config must publish 0, not leave the series stale", got)
+	}
+}
+
+// A failed invariant check must not read as clean.
+func TestReportUnverifiablePlatforms_QueryErrorIsReported(t *testing.T) {
+	job, mock := newSHA256TestJob(t)
+	cfg := testMirrorConfig()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\)\s+FROM terraform_version_platforms p`).
+		WillReturnError(errors.New("db down"))
+
+	out := captureJobLog(t, func() { job.reportUnverifiablePlatforms(context.Background(), cfg) })
+
+	if !strings.Contains(out, "failed to check the sha256 ingestion invariant") {
+		t.Errorf("a failed invariant check was not reported.\nlog:\n%s", out)
+	}
+}
+
+func testutilGaugeValue(t *testing.T, cfg *models.TerraformMirrorConfig) float64 {
+	t.Helper()
+	var m dto.Metric
+	g, err := telemetry.TerraformMirrorUnverifiablePlatforms.GetMetricWithLabelValues(cfg.Name, cfg.Tool)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("gauge Write: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// ---------------------------------------------------------------------------
+// syncOnePlatform — sha256_verified must reflect the row, not the blob
+// ---------------------------------------------------------------------------
+
+// existsStorage reports every key as already present, which drives
+// syncOnePlatform down its "already stored" short-circuit.
+type existsStorage struct{ fakeMirrorStorage }
+
+func (e *existsStorage) Exists(_ context.Context, _ string) (bool, error) { return true, nil }
+
+// TestSyncOnePlatform_AlreadyStoredWithoutSHA256IsNotVerified: the
+// short-circuit for a platform whose blob is already in storage used to assert
+// sha256_verified=true unconditionally. For the rows of issue #869 — synced,
+// blob present, sha256 empty — that made the admin view claim verification for
+// exactly the binaries the download API was serving with no checksum.
+func TestSyncOnePlatform_AlreadyStoredWithoutSHA256IsNotVerified(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	platformID := uuid.New()
+	key := "terraform-binaries/0.24.0/linux/amd64/terraform-docs-v0.24.0-linux-amd64.tar.gz"
+
+	// $5 is sha256_verified. false is the assertion.
+	mock.ExpectExec(`UPDATE terraform_version_platforms`).
+		WithArgs(platformID, "synced", key, "local", false, false, false, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	job := NewTerraformMirrorSyncJob(repo, &existsStorage{}, "local")
+
+	p := models.TerraformVersionPlatform{
+		ID: platformID, OS: "linux", Arch: "amd64",
+		Filename: "terraform-docs-v0.24.0-linux-amd64.tar.gz",
+		SHA256:   "", StorageKey: &key,
+	}
+	if ok := job.syncOnePlatform(context.Background(), &sumsClient{}, "0.24.0", p, nil, false, nil); !ok {
+		t.Fatal("expected the already-stored short-circuit to succeed")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sha256_verified was not written as false for a row with no checksum: %v", err)
+	}
+}
+
+// The companion: a stored blob WITH a checksum stays verified.
+func TestSyncOnePlatform_AlreadyStoredWithSHA256StaysVerified(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	platformID := uuid.New()
+	key := "terraform-binaries/1.9.0/linux/amd64/terraform_1.9.0_linux_amd64.zip"
+
+	mock.ExpectExec(`UPDATE terraform_version_platforms`).
+		WithArgs(platformID, "synced", key, "local", true, false, false, nil, sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	repo := repositories.NewTerraformMirrorRepository(sqlx.NewDb(db, "sqlmock"))
+	job := NewTerraformMirrorSyncJob(repo, &existsStorage{}, "local")
+
+	p := models.TerraformVersionPlatform{
+		ID: platformID, OS: "linux", Arch: "amd64",
+		Filename: "terraform_1.9.0_linux_amd64.zip",
+		SHA256:   "deadbeef", StorageKey: &key,
+	}
+	if ok := job.syncOnePlatform(context.Background(), &sumsClient{}, "1.9.0", p, nil, false, nil); !ok {
+		t.Fatal("expected the already-stored short-circuit to succeed")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sha256_verified was not written as true for a row with a checksum: %v", err)
+	}
+}

--- a/backend/internal/jobs/terraform_mirror_sync.go
+++ b/backend/internal/jobs/terraform_mirror_sync.go
@@ -34,6 +34,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 
 	"github.com/google/uuid"
@@ -304,6 +305,11 @@ func githubBinaryPrefix(productName string) string {
 type terraformSyncDetails struct {
 	VersionsFound int      `json:"versions_found"`
 	Errors        []string `json:"errors,omitempty"`
+	// UnverifiablePlatforms is the number of platform rows left marked synced
+	// with an empty sha256 after this run (issue #869). Recorded on every run,
+	// including zero, so the sync-history view distinguishes "checked, clean"
+	// from "never checked" — the ambiguity that let the defect sit unnoticed.
+	UnverifiablePlatforms int `json:"unverifiable_platforms"`
 }
 
 // coverage:skip:integration-only — performs live upstream HTTP + storage + DB writes for the complete sync pipeline; exercised by api-test integration suite.
@@ -452,7 +458,7 @@ func (j *TerraformMirrorSyncJob) performSync(
 	// 6b. SHA256 back-fill: for already-synced platforms with sha256='', fetch the
 	// upstream SHA256SUMS text (~5KB) and write the per-filename hashes into the
 	// sha256 column. No binaries are re-downloaded.
-	if backfillErr := j.backfillSHA256(ctx, client, cfg, allVersions); backfillErr != nil {
+	if backfillErr := j.backfillSHA256(ctx, client, cfg); backfillErr != nil {
 		log.Printf("[terraform-mirror] SHA256 back-fill error for %s: %v", cfg.Name, backfillErr)
 	}
 
@@ -472,6 +478,10 @@ func (j *TerraformMirrorSyncJob) performSync(
 	if backfillErr := j.backfillAttestation(ctx, cfg, allVersions); backfillErr != nil {
 		log.Printf("[terraform-mirror] attestation back-fill error for %s: %v", cfg.Name, backfillErr)
 	}
+
+	// 6e. Ingestion invariant: after every repair path has had its turn, no
+	// platform may still be marked synced with an empty sha256 (issue #869).
+	details.UnverifiablePlatforms = j.reportUnverifiablePlatforms(ctx, cfg)
 
 	// 7. Mark the highest fully-synced stable version as is_latest.
 	if setLatestErr := j.updateLatestVersion(ctx, cfg.ID); setLatestErr != nil {
@@ -684,7 +694,12 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 		if err == nil && exists {
 			backendName := j.storageBackendName
 			attestationVerified := verifyBinaryAttestation(ctx, attestVerifier, version, p.OS, p.Arch, p.SHA256)
-			_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", p.StorageKey, &backendName, true, sumsGPGVerified, attestationVerified, nil)
+			// sha256_verified must reflect the row, not the fact that a blob
+			// exists: a platform with no stored hash has had nothing checked
+			// against it. Asserting true here (issue #869) made the admin view
+			// claim verification for exactly the rows the download API was
+			// serving without a checksum.
+			_ = j.repo.UpdatePlatformSyncStatus(ctx, p.ID, "synced", p.StorageKey, &backendName, p.SHA256 != "", sumsGPGVerified, attestationVerified, nil)
 			return true
 		}
 	}
@@ -789,63 +804,87 @@ func (j *TerraformMirrorSyncJob) syncOnePlatform(
 }
 
 // backfillSHA256 populates the sha256 column for already-synced platforms whose
-// hash was not persisted during their original sync run. It fetches the
-// lightweight upstream SHA256SUMS text for each filtered version (~5KB each)
-// and writes per-filename hashes — no binary downloads.
-// coverage:skip:integration-only — fetches SUMS files over HTTP and writes to the database; covered by integration tests.
+// hash is not currently persisted. It fetches the lightweight upstream
+// SHA256SUMS text for each affected version (~5KB each) and writes per-filename
+// hashes — no binary downloads.
+//
+// Two properties matter here, both learned from issue #869.
+//
+// First, the candidate set is "every non-deprecated version with a synced
+// platform that has no checksum" (ListVersionsMissingSHA256), not "versions in
+// this run's filtered upstream index whose version row says 'synced'". The
+// filter governs what the mirror ACQUIRES; it must not govern what the mirror
+// can VERIFY, because a row outside the filter is still being served. Likewise
+// a version left 'partial' by one unavailable platform still serves the
+// platforms that did succeed — gating on the version's own sync_status skipped
+// exactly those, permanently.
+//
+// Second, every way this can decline to fill a row is logged. A version that
+// can never be verified must not look like a version that needed no work.
 func (j *TerraformMirrorSyncJob) backfillSHA256(
 	ctx context.Context,
 	client terraformReleasesClient,
 	cfg *models.TerraformMirrorConfig,
-	filteredVersions []mirror.TerraformVersionInfo,
 ) error {
-	wantedVersions := make(map[string]bool, len(filteredVersions))
-	for _, vi := range filteredVersions {
-		wantedVersions[vi.Version] = true
-	}
-
-	syncedVersions, err := j.repo.ListVersions(ctx, cfg.ID, true /* syncedOnly */)
+	versions, err := j.repo.ListVersionsMissingSHA256(ctx, cfg.ID)
 	if err != nil {
-		return fmt.Errorf("failed to list synced versions: %w", err)
+		return fmt.Errorf("failed to list versions missing sha256: %w", err)
 	}
 
-	for _, sv := range syncedVersions {
-		if !wantedVersions[sv.Version] {
-			continue
-		}
-
-		platforms, plErr := j.repo.ListPlatformsForVersion(ctx, sv.ID)
-		if plErr != nil {
-			log.Printf("[terraform-mirror] sha256 backfill: failed to list platforms for %s: %v", sv.Version, plErr)
-			continue
-		}
-		needsBackfill := false
-		for _, p := range platforms {
-			if p.SyncStatus == "synced" && p.SHA256 == "" {
-				needsBackfill = true
-				break
-			}
-		}
-		if !needsBackfill {
-			continue
-		}
-
+	for _, sv := range versions {
 		sums, _, sumsErr := client.FetchSHASums(ctx, sv.Version)
 		if sumsErr != nil {
-			log.Printf("[terraform-mirror] sha256 backfill: failed to fetch SUMS for %s: %v", sv.Version, sumsErr)
+			log.Printf("[terraform-mirror] sha256 backfill: %s@%s has synced platforms with no checksum and its SUMS could not be fetched — they stay unverifiable: %v",
+				cfg.Name, sv.Version, sumsErr)
 			continue
 		}
 		if len(sums) == 0 {
+			log.Printf("[terraform-mirror] sha256 backfill: %s@%s has synced platforms with no checksum and upstream returned an EMPTY SUMS map — they stay unverifiable",
+				cfg.Name, sv.Version)
 			continue
 		}
-		if bfErr := j.repo.BackfillPlatformSHA256(ctx, sv.ID, sums); bfErr != nil {
-			log.Printf("[terraform-mirror] sha256 backfill: DB update failed for %s: %v", sv.Version, bfErr)
+
+		filled, unresolved, bfErr := j.repo.BackfillPlatformSHA256(ctx, sv.ID, sums)
+		if bfErr != nil {
+			log.Printf("[terraform-mirror] sha256 backfill: DB update failed for %s@%s after filling %d: %v", cfg.Name, sv.Version, filled, bfErr)
 			continue
 		}
-		log.Printf("[terraform-mirror] sha256 backfill: populated hashes for version %s", sv.Version)
+		if filled > 0 {
+			log.Printf("[terraform-mirror] sha256 backfill: populated %d hash(es) for %s@%s", filled, cfg.Name, sv.Version)
+		}
+		for _, p := range unresolved {
+			// The SUMS file was fetched and parsed, and it has no line for
+			// this platform's filename. Nothing further will fix this on its
+			// own — it is a filename/upstream mismatch, not a transient miss.
+			log.Printf("[terraform-mirror] sha256 backfill: NO CHECKSUM for %s@%s %s/%s — filename %q absent from upstream SUMS (%d entries); the download API will serve an empty sha256 for it",
+				cfg.Name, sv.Version, p.OS, p.Arch, p.Filename, len(sums))
+		}
 	}
 
 	return nil
+}
+
+// reportUnverifiablePlatforms enforces the ingestion invariant of issue #869: a
+// platform row marked synced with an empty sha256 is a defect state, not a
+// benign gap. The registry serves that row's binary and reports sha256:"" for
+// it — the API fails OPEN where every well-behaved consumer fails CLOSED, so
+// nothing downstream can raise the alarm and it has to be raised here.
+//
+// It reports rather than repairs: repair is backfillSHA256's job and has
+// already run by this point. Reaching a non-zero count means repair could not
+// complete, which is precisely what an operator needs told.
+func (j *TerraformMirrorSyncJob) reportUnverifiablePlatforms(ctx context.Context, cfg *models.TerraformMirrorConfig) int {
+	count, err := j.repo.CountPlatformsMissingSHA256(ctx, cfg.ID)
+	if err != nil {
+		log.Printf("[terraform-mirror] failed to check the sha256 ingestion invariant for %s: %v", cfg.Name, err)
+		return 0
+	}
+	telemetry.TerraformMirrorUnverifiablePlatforms.WithLabelValues(cfg.Name, cfg.Tool).Set(float64(count))
+	if count > 0 {
+		log.Printf("[terraform-mirror] INVARIANT VIOLATION for %s (%s): %d platform(s) are marked synced with an empty sha256. The download API returns sha256:\"\" for these and checksum-enforcing clients cannot install them. Run 'terraform-registry verify-mirror-sha256' for the list.",
+			cfg.Name, cfg.Tool, count)
+	}
+	return count
 }
 
 // backfillGPGVerification re-verifies the SHA256SUMS GPG signature for any synced

--- a/backend/internal/maintenance/mirrorsha256.go
+++ b/backend/internal/maintenance/mirrorsha256.go
@@ -1,0 +1,152 @@
+package maintenance
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Issue #869. The binary mirror served terraform-docs with sha256:"" for six
+// weeks: every fail-closed installer refused it, and nothing in the registry
+// said a word. The hash had been ingested correctly and was then erased on each
+// subsequent sync by an upsert that carried an empty value (see
+// TerraformMirrorRepository.UpsertPlatform).
+//
+// That defect is fixed at the write, and the sync job now re-derives any
+// missing hash from upstream on its next run. What was still absent is a way to
+// ASK — a single, re-runnable question an operator or a CI step can put to a
+// live registry: is there any binary here that we serve but cannot give a
+// consumer a checksum for?
+//
+// This is that question. It is read-only by construction. It deliberately does
+// not repair, and in particular it never reads the SHA256SUMS blob out of our
+// own storage to populate the column: the mirror's SHA256SUMS file and the
+// binary it describes sit on the same storage host, while the API's inline
+// sha256 comes from the application. Sourcing one from the other would collapse
+// two authorities into one and quietly retire the control that makes a
+// storage-account compromise detectable. Repopulation belongs to the sync path,
+// which fetches from the upstream release, and only there.
+
+// UnverifiablePlatform is one mirrored binary that the registry serves without
+// a checksum: a terraform_version_platforms row in sync_status='synced' whose
+// sha256 column is empty.
+type UnverifiablePlatform struct {
+	Config   string
+	Tool     string
+	Version  string
+	OS       string
+	Arch     string
+	Filename string
+	// HasSums records whether the version has a stored SHA256SUMS blob. It
+	// separates the two shapes this defect takes: with a SUMS file the mirror
+	// holds the answer and merely failed to put it in the column (the
+	// terraform-docs case), without one the version predates checksum
+	// persistence entirely (the legacy terraform 1.13.x case). Both are
+	// unusable to a checksum-enforcing client; they differ in what fixes them.
+	HasSums bool
+}
+
+func (u UnverifiablePlatform) String() string {
+	sums := "no-sums-blob"
+	if u.HasSums {
+		sums = "sums-blob-stored"
+	}
+	return fmt.Sprintf("%s (%s) %s %s/%s %s [%s]", u.Config, u.Tool, u.Version, u.OS, u.Arch, u.Filename, sums)
+}
+
+// ErrUnverifiableBinariesRemain is returned by VerifyMirrorSHA256 when the
+// registry is still serving at least one binary with no checksum.
+//
+// It exists so the check is scriptable, for the same reason ErrUnboundRemain
+// does. The asymmetry that makes this worth a non-zero exit: the download API
+// fails OPEN on this state — it returns sha256:"" and a 200 — while every
+// client that verifies fails CLOSED. Nobody downstream can raise the alarm, so
+// the gate has to be here.
+var ErrUnverifiableBinariesRemain = errors.New("maintenance: mirrored binaries remain without a checksum")
+
+// verifyMirrorSHA256Query is the whole audit. Deprecated versions are excluded
+// because their platforms are no longer offered for download; everything else
+// the mirror will serve is in scope, including versions outside a config's
+// current version filter — the filter governs what the mirror acquires, not
+// what it is already publishing.
+const verifyMirrorSHA256Query = `
+	SELECT c.name, c.tool, v.version, p.os, p.arch, p.filename,
+	       (v.sums_storage_key IS NOT NULL AND v.sums_storage_key <> '') AS has_sums
+	FROM terraform_version_platforms p
+	JOIN terraform_versions v        ON v.id = p.version_id
+	JOIN terraform_mirror_configs c  ON c.id = v.config_id
+	WHERE p.sync_status = 'synced'
+	  AND p.sha256 = ''
+	  AND v.is_deprecated = false
+	ORDER BY c.name, v.version, p.os, p.arch
+`
+
+// VerifyMirrorSHA256 lists every mirrored binary the registry serves without a
+// checksum, newest configs first, and returns ErrUnverifiableBinariesRemain if
+// there is at least one.
+//
+// Callers get the rows even alongside the error: the point of the command is
+// the list, and a caller that only learned "some" would have to re-query to say
+// which.
+func VerifyMirrorSHA256(ctx context.Context, db *sql.DB) ([]UnverifiablePlatform, error) {
+	if db == nil {
+		return nil, errors.New("maintenance: no database handle")
+	}
+
+	rows, err := db.QueryContext(ctx, verifyMirrorSHA256Query)
+	if err != nil {
+		return nil, fmt.Errorf("maintenance: failed to query mirrored platforms: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var found []UnverifiablePlatform
+	for rows.Next() {
+		var u UnverifiablePlatform
+		if scanErr := rows.Scan(&u.Config, &u.Tool, &u.Version, &u.OS, &u.Arch, &u.Filename, &u.HasSums); scanErr != nil {
+			return nil, fmt.Errorf("maintenance: failed to scan mirrored platform: %w", scanErr)
+		}
+		found = append(found, u)
+	}
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("maintenance: failed to read mirrored platforms: %w", rows.Err())
+	}
+
+	if len(found) > 0 {
+		return found, ErrUnverifiableBinariesRemain
+	}
+	return found, nil
+}
+
+// SummariseUnverifiable groups the findings by config and tool for a one-line
+// summary per mirror, so an operator sees the shape of the problem before the
+// per-row list. Sorted for a stable, diffable output.
+func SummariseUnverifiable(found []UnverifiablePlatform) []string {
+	counts := make(map[string]int, len(found))
+	for _, u := range found {
+		counts[u.Config+" ("+u.Tool+")"]++
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, fmt.Sprintf("%s: %d platform(s) with no sha256", k, counts[k]))
+	}
+	return out
+}
+
+// FormatUnverifiable renders the full finding list, one row per line.
+func FormatUnverifiable(found []UnverifiablePlatform) string {
+	var b strings.Builder
+	for _, u := range found {
+		b.WriteString(u.String())
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/backend/internal/maintenance/mirrorsha256_test.go
+++ b/backend/internal/maintenance/mirrorsha256_test.go
@@ -1,0 +1,166 @@
+package maintenance
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+// Issue #869. What an operator relies on from this command: it names every
+// affected binary, it distinguishes "there is a SUMS blob we failed to read a
+// column out of" from "this version predates checksum persistence", and it
+// exits non-zero while any remain so a runbook or CI step can gate on it.
+
+func TestVerifyMirrorSHA256_ReportsEveryAffectedBinary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`FROM terraform_version_platforms p`).
+		WillReturnRows(mock.NewRows([]string{"name", "tool", "version", "os", "arch", "filename", "has_sums"}).
+			// The reported case: SUMS blob present, column empty.
+			AddRow("tools", "terraform-docs", "0.24.0", "linux", "amd64", "terraform-docs-v0.24.0-linux-amd64.tar.gz", true).
+			AddRow("tools", "terraform-docs", "0.23.0", "linux", "amd64", "terraform-docs-v0.23.0-linux-amd64.tar.gz", true).
+			// The legacy shape: no SUMS blob either.
+			AddRow("hashicorp", "terraform", "1.13.4", "linux", "amd64", "terraform_1.13.4_linux_amd64.zip", false))
+
+	found, verifyErr := VerifyMirrorSHA256(context.Background(), db)
+
+	if !errors.Is(verifyErr, ErrUnverifiableBinariesRemain) {
+		t.Fatalf("err = %v, want ErrUnverifiableBinariesRemain — the command must exit non-zero while any remain", verifyErr)
+	}
+	if len(found) != 3 {
+		t.Fatalf("found %d rows, want 3", len(found))
+	}
+	if found[0].Version != "0.24.0" || found[0].Filename != "terraform-docs-v0.24.0-linux-amd64.tar.gz" {
+		t.Errorf("found[0] = %+v, want the terraform-docs 0.24.0 linux/amd64 row", found[0])
+	}
+	if !found[0].HasSums {
+		t.Error("found[0].HasSums = false, want true — this version has a stored SUMS blob")
+	}
+	if found[2].HasSums {
+		t.Error("found[2].HasSums = true, want false — the legacy row has no SUMS blob")
+	}
+
+	line := found[0].String()
+	for _, want := range []string{"tools", "terraform-docs", "0.24.0", "linux/amd64", "sums-blob-stored"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("String() = %q, want it to contain %q", line, want)
+		}
+	}
+	if !strings.Contains(found[2].String(), "no-sums-blob") {
+		t.Errorf("String() = %q, want no-sums-blob for a version with no stored SUMS", found[2].String())
+	}
+}
+
+func TestVerifyMirrorSHA256_CleanMirrorReturnsNoError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`FROM terraform_version_platforms p`).
+		WillReturnRows(mock.NewRows([]string{"name", "tool", "version", "os", "arch", "filename", "has_sums"}))
+
+	found, verifyErr := VerifyMirrorSHA256(context.Background(), db)
+	if verifyErr != nil {
+		t.Fatalf("err = %v, want nil for a clean mirror", verifyErr)
+	}
+	if len(found) != 0 {
+		t.Errorf("found %d rows, want 0", len(found))
+	}
+}
+
+// A query failure must not be reported as a clean mirror: that would turn the
+// gate green on a database it never managed to ask.
+func TestVerifyMirrorSHA256_QueryErrorIsNotCleanliness(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`FROM terraform_version_platforms p`).
+		WillReturnError(errors.New("connection refused"))
+
+	found, verifyErr := VerifyMirrorSHA256(context.Background(), db)
+	if verifyErr == nil {
+		t.Fatal("expected an error when the query fails, got nil")
+	}
+	if errors.Is(verifyErr, ErrUnverifiableBinariesRemain) {
+		t.Error("a query failure must not be reported as findings")
+	}
+	if !strings.Contains(verifyErr.Error(), "failed to query mirrored platforms") {
+		t.Errorf("err = %v, want the query failure named", verifyErr)
+	}
+	if found != nil {
+		t.Errorf("found = %+v, want nil", found)
+	}
+}
+
+func TestVerifyMirrorSHA256_NilDatabase(t *testing.T) {
+	found, err := VerifyMirrorSHA256(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an error for a nil database handle, got nil")
+	}
+	if found != nil {
+		t.Errorf("found = %+v, want nil", found)
+	}
+}
+
+// The query is only useful if it cannot silently narrow. These are the three
+// clauses that decide what the audit covers.
+func TestVerifyMirrorSHA256_QueryScope(t *testing.T) {
+	for _, want := range []string{
+		"p.sync_status = 'synced'", // only rows the registry actually serves
+		"p.sha256 = ''",            // the defect state itself
+		"v.is_deprecated = false",  // a retired version must not hold the gate red
+	} {
+		if !strings.Contains(verifyMirrorSHA256Query, want) {
+			t.Errorf("audit query is missing %q — it no longer asks the question the command claims to answer", want)
+		}
+	}
+	// Reading the answer out of our own storage would collapse the two
+	// authorities the inline sha256 exists to keep apart.
+	if strings.Contains(verifyMirrorSHA256Query, "UPDATE") || strings.Contains(verifyMirrorSHA256Query, "INSERT") {
+		t.Error("the audit query must be read-only")
+	}
+}
+
+func TestSummariseUnverifiable_GroupsByConfigAndTool(t *testing.T) {
+	found := []UnverifiablePlatform{
+		{Config: "tools", Tool: "terraform-docs", Version: "0.24.0"},
+		{Config: "tools", Tool: "terraform-docs", Version: "0.23.0"},
+		{Config: "hashicorp", Tool: "terraform", Version: "1.13.4"},
+	}
+	got := SummariseUnverifiable(found)
+	if len(got) != 2 {
+		t.Fatalf("got %d summary lines, want 2: %v", len(got), got)
+	}
+	// Sorted, so hashicorp precedes tools.
+	if !strings.Contains(got[0], "hashicorp (terraform): 1 platform(s)") {
+		t.Errorf("got[0] = %q", got[0])
+	}
+	if !strings.Contains(got[1], "tools (terraform-docs): 2 platform(s)") {
+		t.Errorf("got[1] = %q", got[1])
+	}
+}
+
+func TestFormatUnverifiable_OneRowPerLine(t *testing.T) {
+	out := FormatUnverifiable([]UnverifiablePlatform{
+		{Config: "tools", Tool: "terraform-docs", Version: "0.24.0", OS: "linux", Arch: "amd64", Filename: "a.tar.gz", HasSums: true},
+		{Config: "tools", Tool: "terraform-docs", Version: "0.23.0", OS: "linux", Arch: "amd64", Filename: "b.tar.gz", HasSums: true},
+	})
+	if lines := strings.Count(out, "\n"); lines != 2 {
+		t.Errorf("got %d lines, want 2:\n%s", lines, out)
+	}
+	if !strings.Contains(out, "a.tar.gz") || !strings.Contains(out, "b.tar.gz") {
+		t.Errorf("output does not name both binaries:\n%s", out)
+	}
+}

--- a/backend/internal/mirror/github_releases.go
+++ b/backend/internal/mirror/github_releases.go
@@ -24,6 +24,7 @@ package mirror
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -364,7 +365,11 @@ func (c *GitHubReleasesClient) parseRelease(rel gitHubRelease) (TerraformVersion
 // individual .sha256 sidecar files for each binary asset.
 func (c *GitHubReleasesClient) FetchSHASums(ctx context.Context, version string) (map[string]string, []byte, error) {
 	sumsURL, err := c.findSHA256SumsURL(ctx, version)
-	if err != nil {
+	// ErrNoMatchingAsset is expected for tools that ship per-file .sha256
+	// sidecars instead of a combined file (OPA) — fall through to those. Any
+	// other error means the release itself could not be read, and must not be
+	// laundered into "this release has no checksums".
+	if err != nil && !errors.Is(err, ErrNoMatchingAsset) {
 		return nil, nil, err
 	}
 
@@ -429,10 +434,18 @@ func (c *GitHubReleasesClient) fetchPerFileSHASums(ctx context.Context, version 
 func (c *GitHubReleasesClient) FetchSHASumsSignature(ctx context.Context, version string) ([]byte, error) {
 	sigURL, err := c.findSHA256SumsSigURL(ctx, version)
 	if err != nil {
+		// Both misses are errors now (see findAssetURL). Keep the original
+		// wording for the "release exists, no .sig asset" case — callers log
+		// it as an expected outcome for unsigned-upstream tools — but let the
+		// sentinel travel with it so it stays machine-distinguishable from an
+		// unreachable upstream.
+		if errors.Is(err, ErrNoMatchingAsset) {
+			return nil, fmt.Errorf("no SHA256SUMS signature asset found for version %s in %s/%s: %w", version, c.Owner, c.Repo, err)
+		}
 		return nil, err
 	}
 	if sigURL == "" {
-		return nil, fmt.Errorf("no SHA256SUMS signature asset found for version %s in %s/%s", version, c.Owner, c.Repo)
+		return nil, fmt.Errorf("no SHA256SUMS signature asset found for version %s in %s/%s: %w", version, c.Owner, c.Repo, ErrNoMatchingAsset)
 	}
 	return c.fetchURL(ctx, sigURL, 65536) // 64 KB cap
 }
@@ -469,15 +482,41 @@ func (c *GitHubReleasesClient) findSHA256SumsSigURL(ctx context.Context, version
 	return c.findAssetURL(ctx, version, sha256sumsSigRE)
 }
 
+// ErrNoMatchingAsset reports that the upstream release for a version was
+// fetched successfully but carries no asset matching the requested pattern
+// (or whose product prefix does not match c.ProductName).
+//
+// This is a legitimate outcome for some tools — OPA publishes no combined
+// SHA256SUMS file and terraform-docs publishes no detached signature — so
+// callers that have a fallback check for it with errors.Is. It is returned as
+// an error rather than an empty string because the alternative ("", nil) is
+// indistinguishable from a rate-limited or unreachable upstream, which is what
+// let a permanently unverifiable mirrored version go unnoticed (issue #869).
+var ErrNoMatchingAsset = errors.New("no matching release asset")
+
+// ErrReleaseNotFound reports that no upstream release could be fetched for a
+// version under either tag spelling — a 404, a rate-limit response, or a
+// transport failure. Unlike ErrNoMatchingAsset this is never an expected
+// outcome for a version the mirror has already ingested: it means the checksum
+// source is temporarily or permanently unreachable, and any caller that would
+// otherwise treat "no checksum" as "nothing to do" must surface it.
+var ErrReleaseNotFound = errors.New("upstream release not found")
+
 // findAssetURL fetches the specific release by tag (tries with and without
 // leading "v") and returns the browser_download_url of the first asset whose
 // name matches any of the supplied regexes and whose product prefix (capture
 // group 1) matches c.ProductName.
+//
+// It never returns ("", nil): a miss is always ErrNoMatchingAsset (release
+// reachable, nothing matched) or ErrReleaseNotFound (release unreachable), so
+// callers can tell "this tool has no such asset" from "we could not look".
 func (c *GitHubReleasesClient) findAssetURL(ctx context.Context, version string, res ...*regexp.Regexp) (string, error) {
 	// GitHub tags may use "v1.9.0" or "1.9.0" — try both.
+	var lastErr error
 	for _, tag := range []string{"v" + version, version} {
 		rel, err := c.fetchReleaseByTag(ctx, tag)
 		if err != nil {
+			lastErr = err
 			continue
 		}
 		for _, asset := range rel.Assets {
@@ -490,9 +529,11 @@ func (c *GitHubReleasesClient) findAssetURL(ctx context.Context, version string,
 			}
 		}
 		// Found the release but not the asset — no point checking the other tag.
-		return "", nil
+		return "", fmt.Errorf("%w: %s/%s release %q has %d assets, none matching product %q",
+			ErrNoMatchingAsset, c.Owner, c.Repo, tag, len(rel.Assets), c.ProductName)
 	}
-	return "", nil
+	return "", fmt.Errorf("%w: %s/%s version %s (tried tags %q and %q): %w",
+		ErrReleaseNotFound, c.Owner, c.Repo, version, "v"+version, version, lastErr)
 }
 
 func (c *GitHubReleasesClient) fetchReleaseByTag(ctx context.Context, tag string) (gitHubRelease, error) {

--- a/backend/internal/mirror/github_releases_test.go
+++ b/backend/internal/mirror/github_releases_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -987,5 +988,134 @@ func TestGitHubFetchSHASums_PerFileFallback(t *testing.T) {
 	}
 	if len(raw) == 0 {
 		t.Error("raw bytes should not be empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findAssetURL sentinels (issue #869)
+// ---------------------------------------------------------------------------
+
+// TestFindAssetURL_ReleaseFetchedButNoMatchingAsset: the release exists and was
+// read, and simply has no asset of the requested shape. That is an expected
+// outcome for some tools, and it must be reported as ErrNoMatchingAsset rather
+// than ("", nil) — the ambiguity of the old return is what made a version that
+// could never be verified indistinguishable from one that needed no work.
+func TestFindAssetURL_ReleaseFetchedButNoMatchingAsset(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := gitHubRelease{TagName: "v0.24.0", Assets: []gitHubAsset{
+			{Name: "terraform-docs-v0.24.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/a"},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	}))
+	defer ts.Close()
+
+	c := newTestGitHubClient(ts, "terraform-docs", "terraform-docs", "terraform-docs")
+	url, err := c.findAssetURL(context.Background(), "0.24.0", sha256sumsSigRE)
+	if url != "" {
+		t.Errorf("url = %q, want empty", url)
+	}
+	if !errors.Is(err, ErrNoMatchingAsset) {
+		t.Fatalf("err = %v, want ErrNoMatchingAsset", err)
+	}
+	if errors.Is(err, ErrReleaseNotFound) {
+		t.Error("a reachable release must not be reported as ErrReleaseNotFound")
+	}
+	if !strings.Contains(err.Error(), "terraform-docs") {
+		t.Errorf("err = %v, want the product name in the message so a log line identifies the tool", err)
+	}
+}
+
+// TestFindAssetURL_ReleaseUnreachable: every tag lookup failed (404, rate
+// limit, transport). Nothing can be concluded about the assets, and returning
+// ("", nil) here let a rate-limited sync look like a tool with no checksums.
+func TestFindAssetURL_ReleaseUnreachable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // e.g. secondary rate limit
+	}))
+	defer ts.Close()
+
+	c := newTestGitHubClient(ts, "terraform-docs", "terraform-docs", "terraform-docs")
+	url, err := c.findAssetURL(context.Background(), "0.24.0", tfDocsSumsRE)
+	if url != "" {
+		t.Errorf("url = %q, want empty", url)
+	}
+	if !errors.Is(err, ErrReleaseNotFound) {
+		t.Fatalf("err = %v, want ErrReleaseNotFound", err)
+	}
+	if errors.Is(err, ErrNoMatchingAsset) {
+		t.Error("an unreachable release must not be reported as ErrNoMatchingAsset — that is the confusion being removed")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("err = %v, want the upstream status preserved for diagnosis", err)
+	}
+}
+
+// A rate-limited upstream must surface as an error from FetchSHASums, not as an
+// empty checksum map that a caller reads as "nothing to back-fill".
+func TestGitHubFetchSHASums_UnreachableReleaseIsAnError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	c := newTestGitHubClient(ts, "terraform-docs", "terraform-docs", "terraform-docs")
+	sums, _, err := c.FetchSHASums(context.Background(), "0.24.0")
+	if err == nil {
+		t.Fatal("expected an error when the release cannot be fetched, got nil")
+	}
+	if !errors.Is(err, ErrReleaseNotFound) {
+		t.Errorf("err = %v, want ErrReleaseNotFound", err)
+	}
+	if len(sums) != 0 {
+		t.Errorf("sums = %v, want empty", sums)
+	}
+}
+
+// TestGitHubFetchSHASums_TerraformDocsCombinedFile pins the half of issue #869
+// that turned out NOT to be the defect, so it stays that way: for the
+// terraform-docs layout, FetchSHASums finds the combined .sha256sum asset and
+// returns a map keyed by exactly the asset filenames stored in
+// terraform_version_platforms.filename. The body is the real upstream
+// v0.20.0 checksum file.
+func TestGitHubFetchSHASums_TerraformDocsCombinedFile(t *testing.T) {
+	const sumsBody = "" +
+		"8c7ea42429d7f5e3dae3de32f3873fde0419332932549147f40916d3f613b8f7  terraform-docs-v0.20.0-darwin-amd64.tar.gz\n" +
+		"34ae01772412bb11474e6718ea62113e38ff5964ee570a98c69fafe3a6dff286  terraform-docs-v0.20.0-linux-amd64.tar.gz\n" +
+		"fb372a26f934dc0e163ca914a5aa99fe13d094b1f64f937efe9dc79bdddf05a0  terraform-docs-v0.20.0-windows-amd64.zip\n"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha256sum") {
+			_, _ = w.Write([]byte(sumsBody))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/releases/tags/v0.20.0") {
+			rel := gitHubRelease{TagName: "v0.20.0", Assets: []gitHubAsset{
+				{Name: "terraform-docs-v0.20.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/terraform-docs-v0.20.0-linux-amd64.tar.gz"},
+				{Name: "terraform-docs-v0.20.0-windows-amd64.zip", BrowserDownloadURL: "https://example.com/terraform-docs-v0.20.0-windows-amd64.zip"},
+				{Name: "terraform-docs-v0.20.0.sha256sum", BrowserDownloadURL: "https://example.com/terraform-docs-v0.20.0.sha256sum"},
+			}}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(rel)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	c := newTestGitHubClient(ts, "terraform-docs", "terraform-docs", "terraform-docs")
+	sums, raw, err := c.FetchSHASums(context.Background(), "0.20.0")
+	if err != nil {
+		t.Fatalf("FetchSHASums error: %v", err)
+	}
+	if string(raw) != sumsBody {
+		t.Errorf("raw bytes differ from the served checksum file")
+	}
+	const wantKey = "terraform-docs-v0.20.0-linux-amd64.tar.gz"
+	if got := sums[wantKey]; got != "34ae01772412bb11474e6718ea62113e38ff5964ee570a98c69fafe3a6dff286" {
+		t.Errorf("sums[%q] = %q, want the upstream linux/amd64 hash — the map must be keyed by the stored platform filename", wantKey, got)
+	}
+	if len(sums) != 3 {
+		t.Errorf("len(sums) = %d, want 3", len(sums))
 	}
 }

--- a/backend/internal/telemetry/metrics.go
+++ b/backend/internal/telemetry/metrics.go
@@ -266,6 +266,28 @@ var AppInfo = promauto.NewGaugeVec(
 	[]string{"version", "go_version", "build_date"},
 )
 
+// TerraformMirrorUnverifiablePlatforms is the ingestion invariant of issue
+// #869 as a metric: per mirror config, the number of platform rows marked
+// synced that carry no sha256. Set by the mirror sync job at the end of every
+// run, including to 0, so a clean config is distinguishable from one that has
+// not been checked.
+//
+// It deserves an alert at > 0. The binary-download API fails OPEN on this state
+// (it returns sha256:"") while checksum-enforcing installers fail CLOSED, so
+// the mirror looks healthy from the outside while being unusable to exactly the
+// clients that verify.
+//
+// Example PromQL queries:
+//   - Any unverifiable binary:  max(terraform_mirror_unverifiable_platforms) > 0
+//   - By tool:                  sum by (tool) (terraform_mirror_unverifiable_platforms)
+var TerraformMirrorUnverifiablePlatforms = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "terraform_mirror_unverifiable_platforms",
+		Help: "Platform rows marked synced with an empty sha256, by mirror config (0 is the healthy value)",
+	},
+	[]string{"config", "tool"},
+)
+
 // ModuleScanQueueDepth tracks how many modules are awaiting a security scan.
 // Updated by the scanning subsystem whenever a module is enqueued or dequeued.
 var ModuleScanQueueDepth = promauto.NewGauge(

--- a/backend/internal/telemetry/metrics_test.go
+++ b/backend/internal/telemetry/metrics_test.go
@@ -19,6 +19,7 @@ func TestMetricRegistration(t *testing.T) {
 		{"ModuleDownloadsTotal", ModuleDownloadsTotal},
 		{"ProviderDownloadsTotal", ProviderDownloadsTotal},
 		{"TerraformBinaryDownloadsTotal", TerraformBinaryDownloadsTotal},
+		{"TerraformMirrorUnverifiablePlatforms", TerraformMirrorUnverifiablePlatforms},
 		{"MirrorSyncDuration", MirrorSyncDuration},
 		{"MirrorSyncErrorsTotal", MirrorSyncErrorsTotal},
 		{"APIKeyExpiryNotificationsSentTotal", APIKeyExpiryNotificationsSentTotal},
@@ -62,6 +63,10 @@ func TestProviderDownloadsTotalLabels(t *testing.T) {
 
 func TestTerraformBinaryDownloadsTotalLabels(t *testing.T) {
 	TerraformBinaryDownloadsTotal.WithLabelValues("1.9.0", "linux", "amd64").Inc()
+}
+
+func TestTerraformMirrorUnverifiablePlatformsLabels(t *testing.T) {
+	TerraformMirrorUnverifiablePlatforms.WithLabelValues("tools", "terraform-docs").Set(0)
 }
 
 func TestMirrorSyncDurationLabels(t *testing.T) {

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -245,6 +245,52 @@ sum by (os) (rate(terraform_binary_downloads_total[5m]))
 sum by (version) (increase(terraform_binary_downloads_total[24h]))
 ```
 
+#### `terraform_mirror_unverifiable_platforms`
+
+| Property | Value                                                                        |
+| -------- | ---------------------------------------------------------------------------- |
+| Type     | Gauge (GaugeVec)                                                             |
+| Labels   | `config` (mirror config name), `tool` (e.g. `terraform`, `terraform-docs`)   |
+| Source   | `internal/jobs/terraform_mirror_sync.go` — `reportUnverifiablePlatforms`     |
+| Updated  | At the end of every sync run for the config, including when the value is `0` |
+
+Counts platform rows marked `synced` that carry no `sha256`. **The healthy value is `0`, and
+any other value should page someone.**
+
+This measures a failure the mirror cannot report any other way. The binary-download API
+fails *open* on a missing checksum — it returns `200` with `"sha256": ""` — while every
+well-behaved installer fails *closed* and refuses to install an unverified binary. From the
+outside the mirror looks healthy; to exactly the clients that verify, it is unusable. Nobody
+downstream is in a position to raise the alarm, so it is raised here.
+
+The gauge is published on every run even when clean, so a value of `0` means "checked, clean"
+rather than "never checked". Run `terraform-registry verify-mirror-sha256` for the list of
+affected binaries (see [troubleshooting.md](troubleshooting.md)).
+
+```promql
+# Any mirrored binary that cannot be verified
+max(terraform_mirror_unverifiable_platforms) > 0
+
+# Which tool is affected
+sum by (tool) (terraform_mirror_unverifiable_platforms)
+```
+
+Suggested alert:
+
+```yaml
+- alert: MirrorBinaryWithoutChecksum
+  expr: max(terraform_mirror_unverifiable_platforms) > 0
+  for: 15m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Mirrored binaries are being served without a checksum"
+    description: >
+      The binary mirror is serving at least one platform with an empty sha256.
+      Checksum-enforcing clients cannot install it. Run
+      `terraform-registry verify-mirror-sha256` for the affected list.
+```
+
 ---
 
 ### API Key Notification Metrics

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -585,6 +585,54 @@ If a mirror has `auto_approve_rules` configured but versions still land in
 - Invalid `auto_approve_rules` JSON is treated as "no rules" and the version is
   held for manual review.
 
+### Binary Mirror Returns an Empty `sha256`
+
+A checksum-enforcing installer refuses to install a mirrored binary:
+
+```text
+Checksum verification is required but the registry did not provide a sha256 for
+https://registry.example.com/terraform/binaries/terraform-docs/versions/0.24.0/linux/amd64
+```
+
+The installer is behaving correctly. The download endpoint returns `200` with
+`"sha256": ""` — it fails **open** where the client fails **closed** — so the mirror
+looks healthy from the outside while being unusable to any client that verifies.
+
+**Diagnose:**
+
+- List every affected binary across all mirror configs. Read-only, safe to run against
+  a live registry, and exits non-zero while any remain, so it works as a runbook or CI
+  gate:
+
+  ```bash
+  terraform-registry verify-mirror-sha256
+  ```
+
+  Each row names the config, tool, version, platform, filename, and whether the version
+  has a stored `SHA256SUMS` blob.
+
+- The same count is exported per config as
+  `terraform_mirror_unverifiable_platforms` (see [observability.md](observability.md)),
+  and is written into each sync run's `sync_details` as `unverifiable_platforms`.
+
+**Fix:**
+
+- **Trigger a sync for the affected config** (Admin → Terraform Mirrors → **Sync now**,
+  or `POST /api/v1/admin/terraform-mirror/configs/{id}/sync`; the scheduler will also
+  pick it up on its next tick). The sync job's SHA256 back-fill re-fetches the upstream
+  `SHA256SUMS` and repopulates the column — no binaries are re-downloaded, only a few KB
+  of checksum text per version.
+- Re-run `verify-mirror-sha256` to confirm it now exits zero.
+- If a version stays listed after a sync, the run's logs name the reason per platform —
+  a `SHA256SUMS` that could not be fetched (rate limit, network) resolves itself on a
+  later run, while `NO CHECKSUM for …` means the platform's filename is absent from the
+  upstream checksum file and needs looking at.
+
+> Do **not** work around this by having clients fall back to the mirror's own
+> `shasums_url`. That file and the binary it describes are served from the same storage
+> host, while the inline `sha256` comes from the API — keeping them separate is what
+> makes a storage-account compromise detectable. Collapsing them removes the control.
+
 ---
 
 ## Frontend Issues


### PR DESCRIPTION
Closes #869

## Root cause — neither hypothesis in the issue

Both were tested before anything was changed, and both are refuted:

| Hypothesis | Verdict | Evidence |
| --- | --- | --- |
| 1. `FetchSHASums` returns an empty map because `findAssetURL` gates on `EqualFold(m[1], c.ProductName)` | **False** | `productNameForTool("terraform-docs")` → `"terraform-docs"`, passed through `githubBinaryPrefix` unchanged. `tfDocsSumsRE` captures exactly `terraform-docs` from `terraform-docs-v0.24.0.sha256sum`. Driven end to end against a fake GitHub API serving the real upstream release layout and the real 1082-byte `v0.20.0` checksum body: a correctly-keyed map comes back. Pinned by `TestGitHubFetchSHASums_TerraformDocsCombinedFile`. |
| 2. The stored `filename` is not the upstream asset name | **False** | `parseRelease` sets `Filename = asset.Name` verbatim, and the issue's own probe reports `filename: "terraform-docs-v0.24.0-linux-amd64.tar.gz"` — byte-identical to the SUMS key. |

**The actual cause is a third one: `UpsertPlatform` erases the checksum on every sync.**

`performSync` step 4 re-upserts every platform row straight from the upstream release index on every tick. That index row carries no checksum — the hash is learned later, from `SHA256SUMS` — so `p.SHA256` is always `""` at that call site. The conflict clause wrote it through:

```sql
ON CONFLICT (version_id, os, arch) DO UPDATE
SET ... sha256 = EXCLUDED.sha256, updated_at = EXCLUDED.updated_at
```

`sync_status` is *not* in the conflict clause, so the row stays `synced` throughout. That is exactly the reported state, and it explains the reporter's forensic detail precisely: the rows were bulk-touched, `updated_at` moved — and `sha256` did not *stay* empty, it was **deleted**.

Reproduced against real PostgreSQL with the real schema (`TestUpsertPlatform_ReSyncDoesNotEraseStoredSHA256`), because no mock can evaluate an `ON CONFLICT` clause. Reverting the fix reproduces `sha256 = ""` with `sync_status = synced`.

### Why it never self-healed

`backfillSHA256` exists to re-derive a missing hash from upstream, and would have repaired this within ten minutes. It did not, because it only walked versions whose **own** `sync_status` was `synced`, and only those present in the current run's filtered upstream index. A version left `partial` by a single unavailable platform still serves the platforms that succeeded — so those rows were skipped on every run, permanently, while the upsert kept wiping them.

The candidate set is now *"every non-deprecated version with a synced platform that has no checksum"*. The version filter governs what the mirror **acquires**; it must not govern what the mirror can **verify**, because a row outside the filter is still being served.

## What changed

**1. Populate `sha256` — the corrected sync path.** The clobber is fixed at the write (`COALESCE(NULLIF(EXCLUDED.sha256, ''), …)`), and the widened back-fill repopulates every affected version from **upstream** on the next sync run.

*How an operator runs it:* trigger a sync for the affected config (Admin → Terraform Mirrors → **Sync now**, or `POST /api/v1/admin/terraform-mirror/configs/{id}/sync`; the scheduler also picks it up on its next tick), then confirm with `terraform-registry verify-mirror-sha256`. No binaries are re-downloaded — only a few KB of checksum text per version.

*Why not a maintenance command that repairs, or a migration:* a SQL migration cannot read blob storage, and a command that populated the column from the `SHA256SUMS` blob in our own storage would collapse the two authorities the issue explicitly asks to keep apart — that blob and the binary sit on the same storage host, while the inline `sha256` comes from the API. Only the sync path fetches from the upstream release, so only the sync path may populate. The new command is therefore **read-only**.

**2. The no-match path is observable.** `findAssetURL` returned `("", nil)` both when the release was read and had no matching asset *and* when no release could be fetched at all — a rate-limited upstream was indistinguishable from a tool that publishes no such file. It now returns `ErrNoMatchingAsset` or `ErrReleaseNotFound`; `FetchSHASums` still falls through to per-file `.sha256` sidecars (OPA) on the former only. `backfillSHA256`'s three silent give-up branches — failed SUMS fetch, empty SUMS map, filename absent from the SUMS — each now name the config, version, platform and filename.

**3. Ingestion invariant.** A platform marked `synced` with an empty `sha256` is a defect state. Every sync run counts them, logs the violation, records `unverifiable_platforms` in `sync_details`, and publishes `terraform_mirror_unverifiable_platforms{config,tool}` — **on every run, including 0**, so "checked, clean" is distinguishable from "never checked". The API fails **open** here (returns `""` with a 200) while every well-behaved consumer fails **closed**, so nothing downstream can raise the alarm.

`syncOnePlatform`'s already-stored short-circuit also asserted `sha256_verified = true` unconditionally, which made the admin view claim verification for exactly the rows being served with no checksum. It now reflects the row.

**4. `verify-mirror-sha256`** — the re-runnable answer to "which tools are affected?", read-only, exits non-zero while any remain, so a runbook or CI step can gate on it. Each row names config, tool, version, platform, filename, and whether a `SHA256SUMS` blob is stored (which separates the terraform-docs shape from the legacy shape).

## Legacy terraform 1.13.4–1.14.3 — in scope

They are a different generation (no `sums_storage_key`, so no `shasums_url`), but they are the **same defect state**: rows the registry serves and cannot give a consumer a checksum for. Ignoring them would leave the invariant permanently red and the new gate permanently non-zero, which retires the gate.

They are repaired by the same mechanism rather than a separate one, and only because the back-fill no longer honours the version filter: HashiCorp still publishes `terraform_1.13.4_SHA256SUMS`, so the next sync fills them in. A version genuinely withdrawn upstream will stay listed by `verify-mirror-sha256` with a logged reason per run — visible, which is the point. Deprecated versions are excluded throughout: their platforms are no longer offered, so they must not hold the gate red forever.

## Other affected tools

Every tool is affected by the clobber — it is in a shared code path, not a terraform-docs one. terraform/opa/sentinel/packer looked healthy only because the back-fill happened to repair them in the same run; terraform-docs and the legacy terraform rows are the ones where the repair was permanently gated out.

Rather than a hand-checked list, `verify-mirror-sha256` is the re-runnable query, and `terraform_mirror_unverifiable_platforms` the continuous one.

## Mutation table

Every guard was broken and watched to fail. **Every mutation compiles** — a build failure is not a test result.

| # | Mutation | Test that fired | Result |
| --- | --- | --- | --- |
| 1 | `UpsertPlatform` back to `sha256 = EXCLUDED.sha256` | `TestUpsertPlatform_ReSyncDoesNotEraseStoredSHA256` | FAIL — `sha256 = ""`, want the stored hash |
| 2 | `findAssetURL` no-match returns `("", nil)` | `TestFindAssetURL_ReleaseFetchedButNoMatchingAsset` | FAIL |
| 3 | `findAssetURL` unreachable returns `("", nil)` (`_ = lastErr` to compile) | `TestFindAssetURL_ReleaseUnreachable`, `TestGitHubFetchSHASums_UnreachableReleaseIsAnError` | FAIL ×2 |
| 4 | Drop the per-platform "NO CHECKSUM" log | `TestBackfillSHA256_ReportsPlatformAbsentFromUpstreamSUMS` | FAIL |
| 5 | Restore the bare `continue` on a failed SUMS fetch | `TestBackfillSHA256_ReportsSUMSFetchFailure` | FAIL |
| 6 | Restore the bare `continue` on `len(sums) == 0` | `TestBackfillSHA256_ReportsEmptySUMSMap` | FAIL |
| 7 | Silence the invariant (`if false`) | `TestReportUnverifiablePlatforms_FiresOnSyncedRowWithEmptySHA256` | FAIL |
| 8 | Publish the gauge only when `count > 0` | `TestReportUnverifiablePlatforms_SetsZeroWhenClean` | **PASSED first — the test was inert.** The gauge read 0 only because the series had never been set. Test corrected to seed a previous non-zero reading; mutation then FAILs `gauge = 7, want 0` |
| 9 | Restore blind `sha256_verified = true` in the already-stored branch | `TestSyncOnePlatform_AlreadyStoredWithoutSHA256IsNotVerified` | FAIL |
| 10 | Re-gate repair candidates on version `sync_status = 'synced'` | `TestListVersionsMissingSHA256_IncludesPartialVersions` | FAIL — `got 0 versions, want 1` |
| 11 | Count `pending` rows in the invariant too | `TestListVersionsMissingSHA256_IncludesPartialVersions` | FAIL — `count = 2, want 1` |
| 12 | Drop the unresolved-row report from `BackfillPlatformSHA256` | `…_FilenameAbsentFromSums`, `…_NoSums` | FAIL ×2 |
| 13 | `VerifyMirrorSHA256` returns nil while findings remain | `TestVerifyMirrorSHA256_ReportsEveryAffectedBinary` | FAIL |
| 14 | Audit query drops the `sync_status = 'synced'` filter | `TestVerifyMirrorSHA256_QueryScope` | FAIL |
| 15 | Swallow the audit query error and report clean | `TestVerifyMirrorSHA256_QueryErrorIsNotCleanliness` | FAIL |

Assertions are on sentinels (`errors.Is(err, ErrNoMatchingAsset)` / `ErrReleaseNotFound` / `ErrUnverifiableBinariesRemain`), exact values (`count`, `filled`, gauge readings, `sha256_verified` as a positional sqlmock arg), and the specific words an operator would have to see — never a bare `err != nil`.

## Verification

- `go build ./... && go vet ./... && gofmt -l . && go test ./...` clean. The four `internal/auth` fsnotify tests fail on the dev host from an exhausted inotify limit, identically on pristine `main`.
- The `ON CONFLICT` and query-scope tests run against a throwaway PostgreSQL 16 with all migrations applied, gated on `TFR_TEST_DATABASE_URL` (the existing pattern from `audit_outbox_migration_test.go`); they skip in CI, and every property they cover has a CI-runnable sqlmock companion.
- Package coverage: `db/repositories` 88.9% (gate 85), `mirror` 89.1% (gate 83), `jobs` 35.6% → 37.4%.
- No migration was needed, so no `migrations/README.md` row.
