### PR TITLE
ci(release): require the release environment before anything is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
   docker:
     name: Publish Docker image
     runs-on: ubuntu-latest
+    environment: release
     needs: ci
     permissions:
       contents: read
@@ -296,6 +297,7 @@ jobs:
   docker-fips:
     name: Publish FIPS Docker image
     runs-on: ubuntu-latest
+    environment: release
     needs: ci
     permissions:
       contents: read


### PR DESCRIPTION
The publishing job ran **unattended**. A tag push went straight to an external artifact — a container image or a GitHub Release — with no human in the loop.

Every repo in the estate that publishes to a third-party registry already gates this behind a reviewed environment:

| repo | environment |
| --- | --- |
| cloud-suite-ui, pipeline-task-core, terraform-drift-contract | `release` (npmjs) |
| terraform-suite-identity | `release` (Go module proxy) |
| azure-pipelines-packer, azure-pipelines-terraform | `marketplace` (ADO Marketplace) |

The container and GitHub-release publishers did not. The implicit rule was *"gate what you can't take back"* — but that inverts the actual risk. **The images gated least are the ones that actually get deployed**, and "deletable" is no help once something has pulled the tag.

### What changed

Binds the publishing job to the `release` environment, which requires a reviewer and restricts deployment to `v*` tags.

The gate is on the **first job that makes an external change**, not the final release job. In the backends, `docker` pushes images *before* `publish-release` runs — so gating only the release job would have let images reach ghcr.io unapproved. Build, test and provenance jobs still run unattended, so the approval prompt arrives with the build already green.

### Ordering was deliberate

The environment was created **before** this PR. A workflow that names a missing environment causes GitHub to auto-create it with **no protection** — it looks gated and isn't. Creating it first closes that hole.

### Note on `workflow_dispatch`

The deployment policy is tag-only (`v*`), matching the existing gated repos. A manually dispatched run executes from a branch and so will not deploy. That is arguably correct — releases should originate from tags — but it is a behaviour change worth knowing about rather than discovering.
