### PR TITLE
fix(dev): grant the dev admin a platform-admin carrier row when seeding

### DIFF
--- a/backend/scripts/create-dev-admin-user.sql
+++ b/backend/scripts/create-dev-admin-user.sql
@@ -1,10 +1,34 @@
--- Create a dev admin user, assign to default organization, and grant admin role
--- Run this inside the postgres container or via psql
+-- Create a dev admin user, assign to the default organization, and grant
+-- platform-admin through the carrier.
+--
+-- Run this inside the postgres container or via psql.
+--
+-- WHY THE CARRIER GRANT IS HERE, not implied by the role template:
+--
+-- Migration 000054 (issue #766) took the `admin` wildcard scope off every role
+-- template. Platform-admin authority now comes ONLY from a `platform_admins`
+-- row, resolved per request. The `admin` template still exists and still grants
+-- organization administration (the org_owner scope set), but it no longer
+-- confers platform-wide reach and notably no longer implies `audit:read`.
+--
+-- 000054 backfilled a carrier row for everyone who held an admin-bearing
+-- template WHEN IT RAN. A fresh stack runs migrations against an empty database
+-- and seeds afterwards, so this user postdates the backfill and gets nothing
+-- from it. Without the grant below, dev login succeeds, /admin renders, and
+-- then every platform-scoped read (audit logs first) fails -- which is exactly
+-- how this surfaced: the frontend E2E suite went red on "Audit Logs page
+-- (authenticated)" while every unauthenticated test passed.
+--
+-- The grant is made HERE, at provisioning, rather than in DevLoginHandler.
+-- Minting a carrier row at login would make DEV_MODE a way to become a platform
+-- administrator with no grant on record, which is the property the carrier
+-- exists to provide. Seeding is a deliberate provisioning act; logging in is not.
 DO $$
 DECLARE
     v_user_id uuid;
     v_org_id uuid;
     v_admin_role_template_id uuid;
+    v_granted integer;
 BEGIN
     -- Insert dev admin user
     INSERT INTO users (email, name, oidc_sub)
@@ -23,11 +47,40 @@ BEGIN
     SELECT id INTO v_admin_role_template_id FROM role_templates WHERE name = 'admin';
     RAISE NOTICE 'Admin Role Template ID: %', v_admin_role_template_id;
 
-    -- Insert org membership with admin role
+    -- Insert org membership with the admin role. Post-000054 this template is
+    -- not admin-bearing, so the membership guard accepts it.
     INSERT INTO organization_members (organization_id, user_id, role_template_id)
     VALUES (v_org_id, v_user_id, v_admin_role_template_id)
     ON CONFLICT (organization_id, user_id) DO UPDATE SET role_template_id = EXCLUDED.role_template_id;
 
+    -- Grant platform-admin via the carrier, with its audit record written in the
+    -- SAME transaction. Migration 000052 puts a DEFERRABLE INITIALLY DEFERRED
+    -- constraint trigger on platform_admins that re-checks at COMMIT for an
+    -- audit_outbox intent carrying the same pg_current_xact_id(), subject and
+    -- action -- so a bare INSERT here would abort the whole script at COMMIT.
+    -- ON CONFLICT DO NOTHING keeps this idempotent, and the intent is derived
+    -- from RETURNING so a re-run that inserts nothing also records nothing.
+    WITH granted AS (
+        INSERT INTO platform_admins (user_id, note)
+        VALUES (v_user_id, 'granted by scripts/create-dev-admin-user.sql (development seed)')
+        ON CONFLICT (user_id) DO NOTHING
+        RETURNING user_id
+    )
+    INSERT INTO audit_outbox (event_id, action, resource_type, resource_id, metadata)
+    SELECT gen_random_uuid(), 'platform_admin.granted', 'platform_admin', g.user_id::text,
+           jsonb_build_object(
+             'target_user_id', g.user_id,
+             'source', 'scripts/create-dev-admin-user.sql',
+             'origin', 'development seed')
+      FROM granted g;
+    GET DIAGNOSTICS v_granted = ROW_COUNT;
+
+    IF v_granted > 0 THEN
+        RAISE NOTICE 'Platform-admin carrier row granted to admin@dev.local.';
+    ELSE
+        RAISE NOTICE 'admin@dev.local already holds a platform-admin carrier row; nothing to grant.';
+    END IF;
+
     -- Dev login now uses JWT via POST /api/v1/dev/login (no hardcoded API key needed)
-    RAISE NOTICE 'Dev admin user and org membership with admin role assigned.';
+    RAISE NOTICE 'Dev admin user, org membership, and platform-admin carrier row are in place.';
 END $$;


### PR DESCRIPTION
Fixes the frontend E2E failure on `sethbacon/terraform-registry-frontend` `main` (run 31777467402), and a real provisioning gap behind it.

## What broke

Migration `000054` (#766) took the `admin` wildcard off every role template. Platform-admin authority now comes only from a `platform_admins` row, resolved per request.

That migration backfilled a carrier row for everyone holding an admin-bearing template **when it ran**. But a fresh stack applies migrations to an empty database and seeds *afterwards* — so `admin@dev.local` postdates the backfill and inherits nothing from it.

Reproduced against `postgres:16` with the real 54-migration chain. After the **old** seed script:

```
carrier_rows=0   admin_scope_on_template=false   audit_read_on_template=false
```

The user authenticates, `/admin` renders, and every platform-scoped read fails. **"Audit Logs page (authenticated)" failed first because the `org_owner` scope set that replaced the wildcard does not include `audit:read`** — the wildcard had implied it.

## Wider than E2E

Any path that provisions an administrator by assigning the `admin` role template *after* the migration produces a silently non-admin user. The setup wizard was updated in #874 to write the carrier; this seed script was not. Same class of gap, different door.

## Why the grant is at provisioning, not at login

`DevLoginHandler` would have been the smaller change, and it is the wrong place: minting a carrier row at login makes DEV_MODE a way to become a platform administrator **with no grant on record**, which is precisely the property the carrier exists to provide (`granted_by`, `granted_at`, `note`, and an audit entry). Seeding is a deliberate provisioning act; logging in is not.

## The trigger this had to satisfy

`000052` puts a `DEFERRABLE INITIALLY DEFERRED` constraint trigger on `platform_admins` that re-checks at COMMIT for an `audit_outbox` intent carrying the same `pg_current_xact_id()`, subject and action. A bare INSERT aborts the entire script at COMMIT — the same shape `000053` and `000054` each had to discover. The intent is written in the same transaction as a CTE off `RETURNING`, so a re-run that inserts nothing also records nothing.

## Verification

| Check | Result |
| --- | --- |
| Old seed on the real chain | reproduces the regression exactly (`carrier_rows=0`) |
| New seed, run 1 | `carrier_rows=1  outbox_intents=1`, one shared txid |
| New seed, run 2 | idempotent — "already holds a platform-admin carrier row", still 1 row / 1 intent |
| **Mutation**: drop the intent, keep the INSERT | fails with `audit outbox: platform_admin.granted on … has no audit intent in this transaction`, row **not** committed |

The mutation is the load-bearing one: it proves the trigger is what forces the intent, rather than the intent being decorative.

## Left deliberately

**Whether `audit:read` (and `scanning:read`) belong in the `org_owner` set is a separate product question**, not fixed here. An organization owner arguably should be able to read their own organization's audit log; `000054` narrowed that as a side effect of removing the wildcard. Widening it would change what every org owner can do, which is a policy decision rather than a defect fix — worth deciding on its own.