### PR TITLE
feat(identity)!: resolve registry's authorization from registry's own tables

### DIFF
--- a/backend/cmd/role-drift/main.go
+++ b/backend/cmd/role-drift/main.go
@@ -1,0 +1,141 @@
+// Command role-drift reports every way registry's own authorization tables
+// disagree with the identity tables they were derived from, and exits non-zero
+// while any row is unreconciled.
+//
+// IT IS THE GATE ON THE READ CUTOVER (sethbacon/terraform-suite-identity#206).
+// The rule is the one `bind-secrets verify` established in this estate: a clean
+// exit is what permits the next step, and nothing else does.
+//
+//	role-drift            # compare, print, exit 0 only if the two copies agree
+//	role-drift -v         # also print what was compared when there is no drift
+//
+// Exit codes, so a pipeline can tell the three outcomes apart:
+//
+//	0  the two copies agree
+//	1  they disagree; every disagreement is printed
+//	2  the comparison could not be made (unreachable table, bad config, ...)
+//
+// 2 is separate from 1 DELIBERATELY. "Could not check" must never be spelled
+// the same way as "checked and found nothing", or a misconfigured run gates the
+// cutover open.
+//
+// It reads configuration exactly as cmd/server does -- the same config file and
+// the same TFR_IDENTITY_* environment -- because which schema and which
+// database hold the live identity rows is chosen at process start, and a check
+// that decided that for itself would be comparing something other than what the
+// server compares.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// exit codes, named so the switch below reads as the contract above.
+const (
+	exitClean       = 0
+	exitDrift       = 1
+	exitIndetermina = 2
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	configPath := flag.String("config", "", "path to the registry config file (same file cmd/server reads)")
+	verbose := flag.Bool("v", false, "print what was compared even when there is no drift")
+	timeout := flag.Duration("timeout", 5*time.Minute, "maximum time to spend comparing")
+	flag.Parse()
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "role-drift: could not load configuration: %v\n", err)
+		return exitIndetermina
+	}
+
+	registryDB, err := db.Connect(cfg.Database.GetDSN(), cfg.Database.MaxConnections, cfg.Database.MinIdleConnections)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "role-drift: could not connect to the registry database: %v\n", err)
+		return exitIndetermina
+	}
+	defer func() { _ = registryDB.Close() }()
+
+	identityDB, closeIdentity, err := connectIdentity(cfg, registryDB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "role-drift: could not connect to the identity database: %v\n", err)
+		return exitIndetermina
+	}
+	defer closeIdentity()
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	report, err := repositories.CheckMemberRoleDrift(ctx, identityDB, registryDB)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "role-drift: could not compare the two copies: %v\n", err)
+		return exitIndetermina
+	}
+
+	if report.Clean() {
+		if *verbose {
+			printScope(report)
+		}
+		fmt.Printf("role-drift: no drift (%d membership(s), %d role template(s) compared)\n",
+			report.SourceMemberships, report.SourceRoleTemplates)
+		return exitClean
+	}
+
+	fmt.Fprintf(os.Stderr, "role-drift: %d disagreement(s) between registry's own authorization tables "+
+		"and the identity tables they mirror\n\n", len(report.Rows))
+	for _, row := range report.Rows {
+		fmt.Fprintln(os.Stderr, "  "+row.String())
+	}
+	fmt.Fprintln(os.Stderr)
+	printScope(report)
+	fmt.Fprintln(os.Stderr, "\nRestarting the backend re-derives registry's tables from the identity source and "+
+		"repairs anything a transient write failure left behind; re-run this afterwards. Rows that persist are "+
+		"described in docs/identity-schema.md, which also says which ones an operator must decide rather than repair.")
+	return exitDrift
+}
+
+// printScope states what was compared. A gate that reports "no drift" without
+// saying how many rows it looked at cannot be told apart from a gate that
+// looked at nothing, and this estate has certified an empty universe before.
+func printScope(report repositories.DriftReport) {
+	fmt.Fprintf(os.Stderr, "compared: %d source membership(s) vs %d mirrored, %d source role template(s) vs %d mirrored\n",
+		report.SourceMemberships, report.MirroredMemberships,
+		report.SourceRoleTemplates, report.MirroredRoleTemplates)
+}
+
+// connectIdentity opens the connection the application resolves identity reads
+// through, applying the same TFR_IDENTITY_SCHEMA_* rules cmd/server does.
+//
+// When the cutover is off, identity IS the registry connection; the returned
+// closer is then a no-op so the deferred close in run() does not close a handle
+// it already owns.
+func connectIdentity(cfg *config.Config, registryDB *sql.DB) (*sql.DB, func(), error) {
+	if os.Getenv("TFR_IDENTITY_SCHEMA_ENABLED") != "true" {
+		return registryDB, func() {}, nil
+	}
+	name := os.Getenv("TFR_IDENTITY_SCHEMA_NAME")
+	if name == "" {
+		name = "identity"
+	}
+	idb, err := db.Connect(
+		cfg.IdentityDatabase.GetDSNWithSearchPath(name+",public"),
+		cfg.IdentityDatabase.MaxConnections, cfg.IdentityDatabase.MinIdleConnections,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return idb, func() { _ = idb.Close() }, nil
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -536,13 +536,22 @@ func serve(cfg *config.Config) error {
 		// Under a shared identity database, exactly one app must own role-template
 		// seeding (suite.role_seed_owner) or the apps overwrite each other's role
 		// scopes on restart. Default "self" preserves standalone behavior.
+		//
+		// REGISTRY NO LONGER READS THIS TABLE (terraform-suite-identity#206,
+		// phase 3b): authorization comes from registry's own
+		// `registry_role_templates`, seeded in internal/api/router.go after the
+		// reconcile. This call stays because the STATE MANAGER still reads the
+		// shared table, and because it is the surface a rollback to the previous
+		// image reads -- both of which need it current. It is the one call
+		// suite.role_seed_owner still gates.
 		if cfg.Suite.ShouldSeedRoles("registry") {
-			if err := repositories.SeedSystemRoleTemplates(
+			if err := repositories.SeedSharedIdentityRoleTemplates(
 				context.Background(), identityDB, models.PredefinedRoleTemplates(),
 			); err != nil {
 				return fmt.Errorf("failed to seed system role templates: %w", err)
 			}
-			slog.Info("system role templates seeded into identity schema")
+			slog.Info("system role templates seeded into the shared identity schema " +
+				"(read by the state manager and by a rollback, not by this process)")
 		} else {
 			slog.Info("skipping system role template seeding; another app owns it",
 				"role_seed_owner", cfg.Suite.RoleSeedOwner)

--- a/backend/internal/adminfloor/adminfloor.go
+++ b/backend/internal/adminfloor/adminfloor.go
@@ -476,12 +476,27 @@ func withoutUser(users []string, id string) []string {
 
 // organizationState returns the organization's members and, of those, the ones
 // who can administer it. Both lists name only users that still resolve.
+// The membership and the user come from the identity tables -- who belongs
+// where, and whether the grant resolves to somebody who can exercise it, are
+// still identity's facts. The SCOPES come from registry's own tables
+// (terraform-suite-identity#206, phase 3b): invariant B asks who can administer
+// this organization IN REGISTRY, and since the read cutover that is decided by
+// `organization_member_roles` joined to `registry_role_templates`. Reading the
+// shared tables here would let the floor certify an administrator the request
+// path does not recognise -- refusing a safe demotion, or permitting the one
+// that empties the organization.
+//
+// Both LEFT JOINs, so a member with no mirrored role is still COUNTED AS A
+// MEMBER and not as an administrator. That is the fail-closed direction for
+// invariant B: it can only make the guard refuse more, never less.
 func (g *Guard) organizationState(ctx context.Context, orgID string) (members, admins []string, err error) {
 	rows, err := g.identity.QueryContext(ctx, `
-		SELECT om.user_id, rt.scopes
+		SELECT om.user_id, rrt.scopes
 		  FROM organization_members om
 		  JOIN users u ON u.id = om.user_id
-		  LEFT JOIN role_templates rt ON rt.id = om.role_template_id
+		  LEFT JOIN organization_member_roles omr
+		         ON omr.organization_id = om.organization_id AND omr.user_id = om.user_id
+		  LEFT JOIN registry_role_templates rrt ON rrt.id = omr.role_template_id
 		 WHERE om.organization_id = $1`, orgID)
 	if err != nil {
 		return nil, nil, err
@@ -526,10 +541,15 @@ func (g *Guard) organizationsOf(ctx context.Context, userID string) ([]string, e
 // exist carries nothing, which is the fail-closed reading: the caller uses
 // this to decide whether the principal KEEPS authority, so "unknown" must not
 // answer yes.
+//
+// Registry's own table since phase 3b, matching organizationState above and the
+// request path: the caller passes Change.KeepsRoleTemplateID, the id a
+// membership write is ABOUT to store, and what that id will confer after the
+// write is decided by `registry_role_templates`.
 func (g *Guard) roleTemplateScopes(ctx context.Context, roleTemplateID string) ([]string, error) {
 	var raw []byte
 	err := g.identity.QueryRowContext(ctx,
-		`SELECT scopes FROM role_templates WHERE id = $1`, roleTemplateID).Scan(&raw)
+		`SELECT scopes FROM registry_role_templates WHERE id = $1`, roleTemplateID).Scan(&raw)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/backend/internal/adminfloor/adminfloor_postgres_test.go
+++ b/backend/internal/adminfloor/adminfloor_postgres_test.go
@@ -102,10 +102,19 @@ func postgresPool(t *testing.T) *sql.DB {
 		_, _ = cleanup.Exec(`DROP SCHEMA IF EXISTS ` + testSchema + ` CASCADE`)
 	})
 
-	// The columns the floor actually reads, with the types migration 000001
-	// and 000051 give them. scopes is JSONB here, the registry's own encoding;
-	// the TEXT[] form the shared identity schema uses is covered by
+	// The columns the floor actually reads, with the types migration 000001,
+	// 000051 and 000055 give them. scopes is JSONB here, the registry's own
+	// encoding; the TEXT[] form the shared identity schema uses is covered by
 	// TestParseRoleScopes, which does not need a database.
+	//
+	// `role_templates` and `organization_members` are still here even though
+	// the floor no longer reads a role from them: the membership FACT is still
+	// identity's, and the shared table is still what a rollback reads. Since
+	// terraform-suite-identity#206 phase 3b the floor resolves SCOPES from
+	// registry's own pair below, which is why they have to exist for these
+	// tests to run at all -- a schema missing them made every query error, and
+	// the floor correctly refused with ErrIndeterminate rather than counting
+	// administrators it could not see.
 	schema := []string{
 		`CREATE TABLE users (id UUID PRIMARY KEY, email VARCHAR(255) NOT NULL)`,
 		`CREATE TABLE organizations (id UUID PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
@@ -114,6 +123,12 @@ func postgresPool(t *testing.T) *sql.DB {
 			organization_id UUID REFERENCES organizations(id) ON DELETE CASCADE,
 			user_id UUID REFERENCES users(id) ON DELETE CASCADE,
 			role_template_id UUID REFERENCES role_templates(id) ON DELETE SET NULL,
+			PRIMARY KEY (organization_id, user_id))`,
+		`CREATE TABLE registry_role_templates (id UUID PRIMARY KEY, name TEXT NOT NULL UNIQUE, scopes JSONB NOT NULL DEFAULT '[]')`,
+		`CREATE TABLE organization_member_roles (
+			organization_id UUID NOT NULL,
+			user_id UUID NOT NULL,
+			role_template_id UUID REFERENCES registry_role_templates(id) ON DELETE SET NULL,
 			PRIMARY KEY (organization_id, user_id))`,
 		`CREATE TABLE platform_admins (user_id UUID PRIMARY KEY, granted_by UUID, granted_at TIMESTAMPTZ NOT NULL DEFAULT now(), note TEXT)`,
 	}
@@ -178,6 +193,15 @@ func seedTwoAdministrators(t *testing.T, pool *sql.DB) {
 		`INSERT INTO organization_members VALUES ('` + orgMain + `', '` + userAdminA + `', '` + tmplAdmin + `')`,
 		`INSERT INTO organization_members VALUES ('` + orgMain + `', '` + userAdminB + `', '` + tmplAdmin + `')`,
 		`INSERT INTO organization_members VALUES ('` + orgMain + `', '` + userViewerC + `', '` + tmplViewer + `')`,
+		// Registry's own copy, reconciled (terraform-suite-identity#206 phase
+		// 3b). The floor reads the SCOPES from here; seeding it with anything
+		// other than the identity rows above would test a divergence rather
+		// than the invariant.
+		`INSERT INTO registry_role_templates (id, name, scopes) VALUES ('` + tmplAdmin + `', 'admin', '["admin"]'::jsonb)`,
+		`INSERT INTO registry_role_templates (id, name, scopes) VALUES ('` + tmplViewer + `', 'viewer', '["modules:read"]'::jsonb)`,
+		`INSERT INTO organization_member_roles VALUES ('` + orgMain + `', '` + userAdminA + `', '` + tmplAdmin + `')`,
+		`INSERT INTO organization_member_roles VALUES ('` + orgMain + `', '` + userAdminB + `', '` + tmplAdmin + `')`,
+		`INSERT INTO organization_member_roles VALUES ('` + orgMain + `', '` + userViewerC + `', '` + tmplViewer + `')`,
 		`INSERT INTO platform_admins (user_id) VALUES ('` + userAdminA + `')`,
 	}
 	for _, s := range stmts {

--- a/backend/internal/adminfloor/adminfloor_test.go
+++ b/backend/internal/adminfloor/adminfloor_test.go
@@ -519,7 +519,7 @@ func TestProtect_RefusesDemotingAnOrganizationsLastAdministrator(t *testing.T) {
 	expectLock(registry)
 
 	keeps := viewerTemplate
-	identity.ExpectQuery("SELECT scopes FROM role_templates").
+	identity.ExpectQuery("SELECT scopes FROM registry_role_templates").
 		WithArgs(keeps).
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(viewerScopes)))
 	identity.ExpectQuery("WHERE om.organization_id").

--- a/backend/internal/api/admin/admin_floor_idp_test.go
+++ b/backend/internal/api/admin/admin_floor_idp_test.go
@@ -75,6 +75,8 @@ func expectManagedOrgLookup(identity sqlmock.Sqlmock) {
 	identity.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
 			AddRow("org-1", "user-1", &roleID, time.Now()))
+	// The membership FACT is still identity's; the role it holds is registry's.
+	expectRegistryRoleFor(identity, registryRole{id: roleID})
 }
 
 // TestIdPReconcile_SkipsADeprovisionThatWouldStrandTheOrganization.

--- a/backend/internal/api/admin/admin_floor_test.go
+++ b/backend/internal/api/admin/admin_floor_test.go
@@ -168,16 +168,19 @@ func TestUpdateMemberHandler_RefusesDemotingTheLastOrganizationAdmin(t *testing.
 
 	// checkRoleAssignment runs first; the caller is a platform administrator so
 	// the ceiling permits anything and no per-org lookup happens.
-	identity.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	identity.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(floorViewerScopes)))
-	// Then the existing-member read.
+	// Then the existing-member read, whose ROLE now comes from registry's own
+	// tables -- the same role the identity row above carries.
 	identity.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows([]string{"organization_id", "user_id", "role_template_id", "created_at"}).
 			AddRow("org-1", "owner-1", "role-owner", time.Now()))
+	expectRegistryRoleFor(identity, registryRole{id: "role-owner"})
 
 	floorExpectLock(registry)
-	// The floor's own read of the replacement template, then invariant A, then B.
-	identity.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	// The floor's own read of the replacement template -- registry's table since
+	// phase 3b -- then invariant A, then B.
+	identity.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(floorViewerScopes)))
 	expectOrganizationState(identity,
 		[2]string{"owner-1", floorOwnerScopes},
@@ -211,6 +214,7 @@ func TestUpdateMemberHandler_RefusesClearingTheLastOrganizationAdminsRole(t *tes
 	identity.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows([]string{"organization_id", "user_id", "role_template_id", "created_at"}).
 			AddRow("org-1", "owner-1", "role-owner", time.Now()))
+	expectRegistryRoleFor(identity, registryRole{id: "role-owner"})
 
 	floorExpectLock(registry)
 	expectOrganizationState(identity,
@@ -237,14 +241,15 @@ func TestUpdateMemberHandler_RefusesClearingTheLastOrganizationAdminsRole(t *tes
 func TestUpdateMemberHandler_AllowsReRolingOntoAnotherAdministrativeTemplate(t *testing.T) {
 	registry, identity, r := newFlooredOrgRouter(t)
 
-	identity.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	identity.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(floorOwnerScopes)))
 	identity.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows([]string{"organization_id", "user_id", "role_template_id", "created_at"}).
 			AddRow("org-1", "owner-1", "role-owner", time.Now()))
+	expectRegistryRoleFor(identity, registryRole{id: "role-owner"})
 
 	floorExpectLock(registry)
-	identity.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	identity.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(floorOwnerScopes)))
 	expectOrganizationState(identity,
 		[2]string{"owner-1", floorOwnerScopes},
@@ -259,6 +264,10 @@ func TestUpdateMemberHandler_AllowsReRolingOntoAnotherAdministrativeTemplate(t *
 			"Owner One", "owner@example.com", "org_owner", "Organization Owner",
 			[]byte(floorOwnerScopes),
 		))
+	expectRegistryRoleFor(identity, registryRole{
+		id: "role-owner-2", name: "org_owner", displayName: "Organization Owner",
+		scopes: floorOwnerScopes,
+	})
 
 	body := `{"role_template_id":"77777777-7777-7777-7777-777777777777"}`
 	w := httptest.NewRecorder()

--- a/backend/internal/api/admin/apikeys_test.go
+++ b/backend/internal/api/admin/apikeys_test.go
@@ -64,6 +64,16 @@ func sampleMemberRoleRow() *sqlmock.Rows {
 		)
 }
 
+// expectSampleMemberRegistryRoleAK queues the read of registry's own role tables
+// that now follows every sampleMemberRoleRow, answering with the SAME role
+// template id and the SAME scopes so the caller's derived authority is unchanged.
+func expectSampleMemberRegistryRoleAK(mock sqlmock.Sqlmock) {
+	expectRegistryRoleFor(mock, registryRole{
+		id: "role-1", name: "admin-role", displayName: "Admin Role",
+		scopes: string(testAdminRoleScopes),
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Router helper
 // ---------------------------------------------------------------------------
@@ -174,6 +184,9 @@ func TestListAPIKeys_OrgFilter_WithManageScope(t *testing.T) {
 			&roleName, &roleDisplay,
 			[]byte(`["api_keys:manage"]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{
+		id: roleID, name: roleName, displayName: roleDisplay, scopes: `["api_keys:manage"]`,
+	})
 	// Manager sees all keys in the org.
 	mock.ExpectQuery("WHERE ak.organization_id").
 		WillReturnRows(sampleAKListRow())
@@ -317,6 +330,7 @@ func TestCreateAPIKey_Success(t *testing.T) {
 	// GetMemberWithRole
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 	// CreateAPIKey INSERT
 	mock.ExpectExec("INSERT INTO api_keys").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -361,6 +375,7 @@ func TestCreateAPIKey_InvalidExpiry(t *testing.T) {
 	mock, r := newAPIKeyRouter(t, "user-1", nil)
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 
 	badExpiry := "not-a-date"
 	w := httptest.NewRecorder()
@@ -454,6 +469,7 @@ func TestCreateAPIKey_NoRoleTemplate(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE").
 		WillReturnRows(sqlmock.NewRows(memberRoleCols).
 			AddRow("org-1", "user-1", nil, time.Now(), "Alice", "alice@example.com", nil, nil, testKeyScopes))
+	expectRegistryRoleFor(mock, registryRole{scopes: string(testKeyScopes)})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/apikeys",
@@ -479,6 +495,9 @@ func TestCreateAPIKey_ScopeExceedsRole(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(memberRoleCols).
 			AddRow("org-1", "user-1", &roleTemplateID, time.Now(), "Alice", "alice@example.com",
 				&roleName, &roleDisplay, limitedScopes))
+	expectRegistryRoleFor(mock, registryRole{
+		id: roleTemplateID, name: roleName, displayName: roleDisplay, scopes: string(limitedScopes),
+	})
 
 	w := httptest.NewRecorder()
 	// Request providers:write which user doesn't have
@@ -498,6 +517,7 @@ func TestCreateAPIKey_CreateDBError(t *testing.T) {
 	mock, r := newAPIKeyRouter(t, "user-1", nil)
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 	mock.ExpectExec("INSERT INTO api_keys").
 		WillReturnError(errDB)
 
@@ -731,6 +751,7 @@ func TestRotateAPIKey_ImmediateRevoke(t *testing.T) {
 	// key's stored scopes (issue #733).
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 	mock.ExpectExec("INSERT INTO api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("DELETE FROM api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -754,6 +775,7 @@ func TestRotateAPIKey_WithGracePeriod(t *testing.T) {
 	// key's stored scopes (issue #733).
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 	mock.ExpectExec("INSERT INTO api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE api_keys.*SET name").WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -816,6 +838,9 @@ func TestUpdateAPIKey_ScopeExceedsUserRole(t *testing.T) {
 			&roleName, &roleDisplay,
 			[]byte(`["modules:read"]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{
+		id: roleID, name: roleName, displayName: roleDisplay, scopes: `["modules:read"]`,
+	})
 
 	// User tries to give "admin" scope (exceeds their role)
 	body := `{"scopes":["modules:read","admin"]}`
@@ -850,6 +875,7 @@ func TestUpdateAPIKey_WithValidScopes_AdminRole(t *testing.T) {
 	// Admin role - any scope is allowed
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberRoleRow())
+	expectSampleMemberRegistryRoleAK(mock)
 	mock.ExpectExec("UPDATE api_keys").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	body := `{"scopes":["modules:read","modules:write"]}`
@@ -931,6 +957,7 @@ func TestUpdateAPIKey_ScopeChange_NullRole_FailsClosed(t *testing.T) {
 			"Alice", "alice@example.com",
 			nil, nil, []byte(`[]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{})
 
 	body := `{"scopes":["modules:read"]}`
 	w := httptest.NewRecorder()

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -750,6 +750,10 @@ func TestMeHandler_SuccessWithMemberships(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members").
 		WillReturnRows(sqlmock.NewRows(meOrgMembershipCols).
 			AddRow("org-1", "acme", "role-1", time.Now(), "admin", "Administrator", `["admin","write","read"]`))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: "org-1", id: "role-1", name: "admin", displayName: "Administrator",
+		scopes: `["admin","write","read"]`,
+	})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/me", nil))
@@ -904,7 +908,7 @@ var authMemberCols = []string{"organization_id", "user_id", "role_template_id", 
 // scopes is marshaled to the JSON array the real `scopes` column holds.
 func expectRoleScopesLookup(mock sqlmock.Sqlmock, roleName string, scopes []string) {
 	scopesJSON, _ := json.Marshal(scopes)
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE name").
 		WithArgs(roleName).
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow(scopesJSON))
 }
@@ -978,6 +982,7 @@ func TestApplyGroupMappings_MatchingGroup_UpdateMember(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
 			AddRow("org-1", "user-1", &roleID, time.Now()))
+	expectRegistryRoleFor(mock, registryRole{id: roleID})
 
 	// guardProvisionableRole → scopes lookup (non-admin, so the write proceeds)
 	expectRoleScopesLookup(mock, "editor", []string{"modules:read", "modules:write"})
@@ -1269,6 +1274,7 @@ func TestApplyGroupMappings_DefaultRole_ExistingMemberNotOverwritten(t *testing.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
 			AddRow("org-default", "user-1", "rt-manual", time.Now()))
+	expectRegistryRoleFor(mock, registryRole{id: "rt-manual"})
 
 	// No role-template lookup and no UPDATE/INSERT must follow.
 
@@ -1697,6 +1703,8 @@ func expectIsMember(mock sqlmock.Sqlmock, orgID, userID, roleID string) {
 	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 		WillReturnRows(sqlmock.NewRows(authMemberCols).
 			AddRow(orgID, userID, roleID, time.Now()))
+	// The membership FACT is still identity's; the ROLE it holds is registry's.
+	expectRegistryRoleFor(mock, registryRole{id: roleID})
 }
 
 // expectNotMember queues a CheckMembership lookup that reports no membership.
@@ -2137,7 +2145,7 @@ func TestReconcile_GuardProvisionableRole_UnknownRoleTemplate_DefersToRealLookup
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
 	// guardProvisionableRole's own scopes lookup finds no such role template.
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE name").
 		WithArgs("ghost-role").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}))
 	// AddMemberWithParams's lookup is reached and fails with its own clear error.
@@ -2678,6 +2686,10 @@ func TestMeHandler_AllowedScopesUnionsThePlatformAdminCarrier(t *testing.T) {
 			mock.ExpectQuery("SELECT.*FROM organization_members").
 				WillReturnRows(sqlmock.NewRows(meOrgMembershipCols).
 					AddRow("org-1", "acme", "role-1", time.Now(), "reader", "Reader", tt.membershipScopes))
+			expectRegistryRolesForUser(mock, registryRole{
+				orgID: "org-1", id: "role-1", name: "reader", displayName: "Reader",
+				scopes: tt.membershipScopes,
+			})
 
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/auth/me", nil))

--- a/backend/internal/api/admin/credential_binding_class_test.go
+++ b/backend/internal/api/admin/credential_binding_class_test.go
@@ -140,6 +140,16 @@ func ownerMemberRow() *sqlmock.Rows {
 	)
 }
 
+// expectOwnerRegistryRole queues the read of registry's own role tables that now
+// follows every ownerMemberRow, answering with the SAME role template id and the
+// SAME scopes so the owner-derived ceiling is unchanged.
+func expectOwnerRegistryRole(mock sqlmock.Sqlmock) {
+	expectRegistryRoleFor(mock, registryRole{
+		id: "role-owner", name: "owner", displayName: "Owner",
+		scopes: string(ownerRoleScopes),
+	})
+}
+
 // storedKeyRow is an existing api_keys row owned by user-1 in org-1 carrying
 // scopes -- the subject of update and rotate.
 func storedKeyRow(scopes string) *sqlmock.Rows {
@@ -180,6 +190,7 @@ func TestCredentialBindingClass_KeyMinting(t *testing.T) {
 				case "create":
 					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 						WillReturnRows(ownerMemberRow())
+					expectOwnerRegistryRole(mock)
 					if allowed {
 						mock.ExpectExec("INSERT INTO api_keys").
 							WillReturnResult(sqlmock.NewResult(1, 1))
@@ -196,6 +207,7 @@ func TestCredentialBindingClass_KeyMinting(t *testing.T) {
 						WillReturnRows(storedKeyRow(`["modules:read"]`))
 					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 						WillReturnRows(ownerMemberRow())
+					expectOwnerRegistryRole(mock)
 					if allowed {
 						mock.ExpectExec("UPDATE api_keys.*SET name").
 							WillReturnResult(sqlmock.NewResult(1, 1))
@@ -212,6 +224,7 @@ func TestCredentialBindingClass_KeyMinting(t *testing.T) {
 						WillReturnRows(storedKeyRow(`["` + tc.requested + `"]`))
 					mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 						WillReturnRows(ownerMemberRow())
+					expectOwnerRegistryRole(mock)
 					if allowed {
 						mock.ExpectExec("INSERT INTO api_keys").
 							WillReturnResult(sqlmock.NewResult(1, 1))
@@ -302,7 +315,7 @@ func TestCredentialBindingClass_RoleAssignment(t *testing.T) {
 			defer db.Close()
 			h := &OrganizationHandlers{db: db, orgRepo: repositories.NewOrganizationRepository(db)}
 
-			mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+			mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 				WillReturnRows(sqlmock.NewRows([]string{"scopes"}).
 					AddRow([]byte(`["` + tt.roleScope + `"]`)))
 			// The caller's role in the target org grants both scopes, so the
@@ -314,6 +327,10 @@ func TestCredentialBindingClass_RoleAssignment(t *testing.T) {
 					"Alice", "alice@example.com", "owner", "Owner",
 					[]byte(`["organizations:write","modules:read"]`),
 				))
+			expectRegistryRoleFor(mock, registryRole{
+				id: "role-owner", name: "owner", displayName: "Owner",
+				scopes: `["organizations:write","modules:read"]`,
+			})
 
 			c, _ := gin.CreateTestContext(httptest.NewRecorder())
 			c.Request = httptest.NewRequest(http.MethodPut, "/organizations/org-1/members/u", nil)

--- a/backend/internal/api/admin/credential_lifecycle_class_test.go
+++ b/backend/internal/api/admin/credential_lifecycle_class_test.go
@@ -302,6 +302,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 
 				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 					WillReturnRows(sampleMemberWithRoleRow())
+				expectSampleMemberRegistryRole(mock)
 				mock.ExpectExec("DELETE FROM organization_members").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -325,10 +326,11 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				r := gin.New()
 				r.PUT("/organizations/:id/members/:user_id", h.UpdateMemberHandler())
 
-				mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+				mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 					WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
 				mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 					WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+				expectRegistryRoleFor(mock, registryRole{id: oldRoleTemplateUUID})
 				mock.ExpectExec("UPDATE organization_members").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				// The scopes the member RETAINS under the new role template
@@ -336,6 +338,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				// modules:read, so a key with providers:write is deleted.
 				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 					WillReturnRows(sampleMemberWithRoleRow())
+				expectSampleMemberRegistryRole(mock)
 				mock.ExpectExec("INSERT INTO user_token_revocations").
 					WithArgs("user-1").
 					WillReturnResult(sqlmock.NewResult(1, 1))
@@ -343,6 +346,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 					[]byte(`["providers:write"]`))
 				mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 					WillReturnRows(sampleMemberWithRoleRow())
+				expectSampleMemberRegistryRole(mock)
 
 				w := httptest.NewRecorder()
 				r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1/members/user-1",
@@ -363,11 +367,11 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				r.Use(func(c *gin.Context) { c.Set("user_id", knownUserUUID) })
 				r.PUT("/role-templates/:id", h.UpdateRoleTemplate)
 
-				mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+				mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 					WillReturnRows(sampleRTRow())
 				mock.ExpectExec("UPDATE role_templates.*SET display_name").
 					WillReturnResult(sqlmock.NewResult(1, 1))
-				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles").
 					WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 						AddRow("member-1", "org-1"))
 				mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -401,9 +405,9 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				r.Use(func(c *gin.Context) { c.Set("user_id", knownUserUUID) })
 				r.DELETE("/role-templates/:id", h.DeleteRoleTemplate)
 
-				mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+				mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 					WillReturnRows(sampleRTRow())
-				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+				mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles").
 					WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 						AddRow("member-1", "org-1"))
 				mock.ExpectExec("DELETE FROM role_templates WHERE id").
@@ -446,6 +450,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 					WillReturnRows(sqlmock.NewRows(authMemberCols).
 						AddRow("org-1", "user-1", &roleID, time.Now()))
+				expectRegistryRoleFor(mock, registryRole{id: roleID})
 				mock.ExpectExec("DELETE FROM organization_members").
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				expectOrgKeySweep(mock, "user-1", "org-1", "key-idp-deprovision")
@@ -488,6 +493,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 					WillReturnRows(sqlmock.NewRows(authMemberCols).
 						AddRow("org-1", "user-1", &oldRole, time.Now()))
+				expectRegistryRoleFor(mock, registryRole{id: oldRole})
 				// The guard's lookup doubles as the retention filter: "viewer"
 				// grants read only, so it is what the member retains.
 				expectRoleScopesLookup(mock, "viewer", []string{"modules:read"})
@@ -545,6 +551,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
 					WillReturnRows(sqlmock.NewRows(authMemberCols).
 						AddRow("org-1", "user-1", &oldRole, time.Now()))
+				expectRegistryRoleFor(mock, registryRole{id: oldRole})
 				expectRoleScopesLookup(mock, "publisher", []string{"modules:read", "modules:write"})
 				mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 					WithArgs("publisher").
@@ -672,6 +679,7 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 				mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 					WillReturnRows(sqlmock.NewRows(authMemberCols).
 						AddRow("org-1", "user-1", nil, time.Now()))
+				expectRegistryRolesForOrg(mock, registryRole{userID: "user-1"})
 				mock.ExpectExec("DELETE FROM organizations").
 					WillReturnResult(sqlmock.NewResult(0, 1))
 				mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -786,6 +794,9 @@ func TestCredentialLifecycleClass_AuthorityReductionInvalidatesAllCredentialFami
 						"org-1", "user-1", "rt-viewer", time.Now(),
 						"Alice", "alice@example.com", "viewer", "Viewer",
 						[]byte(`["modules:read"]`)))
+				expectRegistryRoleFor(mock, registryRole{
+					id: "rt-viewer", name: "viewer", displayName: "Viewer", scopes: `["modules:read"]`,
+				})
 
 				owner := "user-1"
 				r := gin.New()

--- a/backend/internal/api/admin/cross_org_authz_test.go
+++ b/backend/internal/api/admin/cross_org_authz_test.go
@@ -68,6 +68,9 @@ func TestEvaluatePolicy_ForeignOrg_Denied(t *testing.T) {
 			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
 			[]byte(`["mirrors:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "rt-viewer", name: "viewer", displayName: "Viewer", scopes: `["mirrors:read"]`,
+	})
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPost, "/evaluate?organization_id="+orgBeta, strings.NewReader(evaluateBody))
@@ -97,6 +100,9 @@ func TestEvaluatePolicy_OwnOrg_Allowed(t *testing.T) {
 			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
 			[]byte(`["mirrors:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "rt-viewer", name: "viewer", displayName: "Viewer", scopes: `["mirrors:read"]`,
+	})
 	mock.ExpectQuery("(?s)FROM mirror_policies").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "organization_id", "name", "description", "policy_type",
@@ -157,6 +163,9 @@ func TestScanningStats_NonAdmin_EveryQueryCarriesTheTenantPredicate(t *testing.T
 			orgAlpha, "Alpha", "rt-devops", time.Now(), "devops", "DevOps",
 			[]byte(`["scanning:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "rt-devops", name: "devops", displayName: "DevOps", scopes: `["scanning:read"]`,
+	})
 
 	// Each of the three queries must join through to modules AND constrain
 	// m.organization_id. `= ANY` is what OrgScope.SQL emits for a bounded set;
@@ -212,6 +221,9 @@ func TestModuleScanByVersion_CallerOutsideDefaultOrg_NotFound(t *testing.T) {
 			orgAlpha, "Alpha", "rt-devops", time.Now(), "devops", "DevOps",
 			[]byte(`["scanning:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "rt-devops", name: "devops", displayName: "DevOps", scopes: `["scanning:read"]`,
+	})
 	mock.ExpectQuery("(?s)FROM organizations").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}).
 			AddRow(orgBeta, "default", "Beta", nil, nil, time.Now(), time.Now()))
@@ -292,6 +304,9 @@ func TestDashboardStats_MirrorQueriesCarryTheTenantPredicate(t *testing.T) {
 			orgAlpha, "Alpha", "rt-viewer", time.Now(), "viewer", "Viewer",
 			[]byte(`["mirrors:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "rt-viewer", name: "viewer", displayName: "Viewer", scopes: `["mirrors:read"]`,
+	})
 
 	opts := defaultStatsOpts()
 	opts.mirrorHealthQuery = "(?s)FROM mirror_configurations.*organization_id = ANY"

--- a/backend/internal/api/admin/dev_test.go
+++ b/backend/internal/api/admin/dev_test.go
@@ -375,6 +375,10 @@ func TestListDevUsers_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members").
 		WillReturnRows(sqlmock.NewRows(membershipSQLCols).
 			AddRow("org-1", "default", "rt-1", now, "admin", "Administrator", `["admin"]`))
+	// 3. the role that membership holds, from registry's own tables
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: "org-1", id: "rt-1", name: "admin", displayName: "Administrator", scopes: `["admin"]`,
+	})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/dev/users", nil))

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -46,9 +46,15 @@ import (
 // — a transient DB error here should not silently let an unverified role's
 // scopes through.
 func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) ([]string, error) {
+	// REGISTRY's own table (terraform-suite-identity#206, phase 3b), for the same
+	// reason as role_ceiling.go: the returned scopes are what the member WILL
+	// hold once the write commits, and since the read cutover that is decided by
+	// `registry_role_templates`. They are also the retention filter for the
+	// credential sweep, so reading the shared table would retain credentials
+	// against an authority the product no longer confers.
 	var scopesJSON []byte
 	err := h.db.QueryRowContext(ctx,
-		`SELECT scopes FROM role_templates WHERE name = $1`, roleTemplateName).Scan(&scopesJSON)
+		`SELECT scopes FROM registry_role_templates WHERE name = $1`, roleTemplateName).Scan(&scopesJSON)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/backend/internal/api/admin/main_test.go
+++ b/backend/internal/api/admin/main_test.go
@@ -3,10 +3,111 @@ package admin
 import (
 	"os"
 	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestMain(m *testing.M) {
 	// Set JWT secret for tests that exercise GenerateJWT (e.g., RefreshHandler success path)
 	os.Setenv("TFR_JWT_SECRET", "test-admin-jwt-secret-that-is-32chars!!")
 	os.Exit(m.Run())
+}
+
+// ---------------------------------------------------------------------------
+// registry's own role tables (sethbacon/terraform-suite-identity#206, phase 3b)
+// ---------------------------------------------------------------------------
+//
+// Why these helpers exist: the role-bearing reads on repositories'
+// OrganizationRepository and UserRepository no longer answer from the identity
+// tables alone. Each one still asks the shared identity store first -- that is
+// what supplies the membership FACT and the user/organization columns, and it
+// is the query these fixtures already seed -- and then issues ONE ADDITIONAL
+// query, on the SAME connection and IMMEDIATELY AFTER, against registry's own
+// `organization_member_roles` joined to `registry_role_templates`. The role and
+// the scopes it returns are what the accessor reports.
+//
+// So every fixture that drives one of those accessors needs one of the three
+// expectations below queued directly after the identity row it already seeds.
+//
+// A FOURTH shape exists in the production code and has no helper here: the bulk
+// per-page read (MemberRoleReader.RolesForUsers, `WHERE omr.user_id = ANY($1)`)
+// that UserRepository's ListUsersWithMemberships and SearchWithMemberships
+// issue. Every user-list fixture in this package returns users with NO
+// memberships, and the overlay skips the read entirely in that case, so nothing
+// here drives it. A fixture that gives a listed user a membership will need it.
+//
+// The row must repeat the SAME role template id and the SAME scopes as that
+// identity row, because the production code compares the two: when they differ
+// it logs an ERROR and increments registry_role_read_divergence_total. A
+// fixture that let them drift would still pass, while quietly exercising the
+// disagreement path instead of the behaviour the test was written for.
+
+// registryRole is one membership's row in registry's own tables.
+//
+// A membership that holds NO role template is `registryRole{}` (or one with a
+// nil id): a row that exists and confers nothing. That is different from
+// queueing no row at all, which is the missing-mirror divergence.
+type registryRole struct {
+	// orgID and userID identify the membership. Each read below projects only
+	// the one(s) it keys its result by, so a fixture need only set the field(s)
+	// that read looks at.
+	orgID  string
+	userID string
+
+	// id is the role template held: a string, or nil for none. Repeat whatever
+	// the identity fixture seeded into organization_members.role_template_id.
+	id any
+
+	// name, displayName and scopes are the template's. The display shapes carry
+	// all three, so repeat whatever the identity fixture seeded there too;
+	// scopes is a JSON array literal and defaults to the empty set.
+	name        string
+	displayName string
+	scopes      string
+}
+
+// scopesJSON is the scopes column as the reader parses it, defaulting to the
+// empty array so that the zero registryRole is the "holds no role" row rather
+// than a JSON parse error.
+func (r registryRole) scopesJSON() []byte {
+	if r.scopes == "" {
+		return []byte(`[]`)
+	}
+	return []byte(r.scopes)
+}
+
+// registryRoleCols are the four columns every one of these reads projects after
+// its leading key column(s).
+var registryRoleCols = []string{"role_template_id", "name", "display_name", "scopes"}
+
+// expectRegistryRoleFor queues the single-membership read (MemberRoleReader
+// .RoleFor), issued by GetMember, CheckMembership, GetMemberWithRole and
+// GetUserScopesForOrg.
+func expectRegistryRoleFor(mock sqlmock.Sqlmock, role registryRole) {
+	mock.ExpectQuery(`SELECT omr\.role_template_id,`).
+		WillReturnRows(sqlmock.NewRows(registryRoleCols).
+			AddRow(role.id, role.name, role.displayName, role.scopesJSON()))
+}
+
+// expectRegistryRolesForOrg queues the per-organization read (RolesForOrg),
+// keyed by user id, issued by ListMembers and ListMembersWithUsers. Both skip
+// it entirely when the store returned no members.
+func expectRegistryRolesForOrg(mock sqlmock.Sqlmock, roles ...registryRole) {
+	rows := sqlmock.NewRows(append([]string{"user_id"}, registryRoleCols...))
+	for _, role := range roles {
+		rows.AddRow(role.userID, role.id, role.name, role.displayName, role.scopesJSON())
+	}
+	mock.ExpectQuery(`SELECT omr\.user_id, omr\.role_template_id`).WillReturnRows(rows)
+}
+
+// expectRegistryRolesForUser queues the per-user read (RolesForUser), keyed by
+// organization id, issued by GetUserMemberships -- and so also by
+// GetUserCombinedScopes, OrgScopeForUser and GetUserWithOrgRoles, which are
+// built on it. All of them skip it when the store returned no memberships.
+func expectRegistryRolesForUser(mock sqlmock.Sqlmock, roles ...registryRole) {
+	rows := sqlmock.NewRows(append([]string{"organization_id"}, registryRoleCols...))
+	for _, role := range roles {
+		rows.AddRow(role.orgID, role.id, role.name, role.displayName, role.scopesJSON())
+	}
+	mock.ExpectQuery(`SELECT omr\.organization_id, omr\.role_template_id`).WillReturnRows(rows)
 }

--- a/backend/internal/api/admin/namespace_create_org_test.go
+++ b/backend/internal/api/admin/namespace_create_org_test.go
@@ -82,15 +82,28 @@ func createAxisAdmin() gin.HandlerFunc {
 	}
 }
 
+// createAxisMembershipFixture is a GetUserMemberships result together with the
+// read of registry's own role tables that now follows it. They are built from
+// the same scopes in one place so the membership and the role it confers cannot
+// drift apart -- if they did, the resolver would see different authority than
+// the row below describes and the case would silently stop testing what it says.
+type createAxisMembershipFixture struct {
+	rows  *sqlmock.Rows
+	roles []registryRole
+}
+
 // createAxisMemberships builds a GetUserMemberships result granting `scopes` in
 // each named organization.
-func createAxisMemberships(scopes string, orgIDs ...string) *sqlmock.Rows {
-	rows := sqlmock.NewRows(membershipCols)
+func createAxisMemberships(scopes string, orgIDs ...string) *createAxisMembershipFixture {
+	f := &createAxisMembershipFixture{rows: sqlmock.NewRows(membershipCols)}
 	for i, id := range orgIDs {
-		rows.AddRow(id, fmt.Sprintf("org-%d", i), "role-1", time.Now(),
+		f.rows.AddRow(id, fmt.Sprintf("org-%d", i), "role-1", time.Now(),
 			"devops", "DevOps", []byte(scopes))
+		f.roles = append(f.roles, registryRole{
+			orgID: id, id: "role-1", name: "devops", displayName: "DevOps", scopes: scopes,
+		})
 	}
-	return rows
+	return f
 }
 
 // createAxisWant is the outcome required of ONE create path.
@@ -119,7 +132,7 @@ type createAxisCase struct {
 	// memberships is primed only when the fallback resolver is expected to
 	// reach GetUserMemberships; a nil value asserts by omission that it does
 	// not (an unexpected statement fails the row).
-	memberships *sqlmock.Rows
+	memberships *createAxisMembershipFixture
 	// membershipsErr makes the membership lookup fail.
 	membershipsErr error
 	// wantDefaultOrgLookup primes GetDefaultOrganization, which only the
@@ -298,7 +311,10 @@ func primeResolution(mock sqlmock.Sqlmock, tc createAxisCase) {
 	case tc.membershipsErr != nil:
 		mock.ExpectQuery("(?s)FROM organization_members").WillReturnError(tc.membershipsErr)
 	case tc.memberships != nil:
-		mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(tc.memberships)
+		mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(tc.memberships.rows)
+		if len(tc.memberships.roles) > 0 {
+			expectRegistryRolesForUser(mock, tc.memberships.roles...)
+		}
 	}
 	if tc.wantDefaultOrgLookup {
 		mock.ExpectQuery("SELECT.*FROM organizations").

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -765,6 +765,7 @@ func TestAddMember_AlreadyMember(t *testing.T) {
 	// GetMember finds existing
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRow())
+	expectRegistryRoleFor(mock, registryRole{})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/organizations/org-1/members",
@@ -825,6 +826,7 @@ func TestRemoveMember_RevokesUserTokens(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 	mock.ExpectExec("DELETE FROM organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -851,6 +853,7 @@ func TestRemoveMember_RevocationErrorDoesNotFailRequest(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 	mock.ExpectExec("DELETE FROM organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -934,6 +937,7 @@ func TestRemoveMember_APIKeyRevocationFails_FlagsIncomplete(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 	mock.ExpectExec("DELETE FROM organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	// The JWT half succeeds ...
@@ -1076,6 +1080,14 @@ func sampleMemberWithRoleRow() *sqlmock.Rows {
 	)
 }
 
+// expectSampleMemberRegistryRole queues the read of registry's own role tables
+// that now follows every sampleMemberWithRoleRow, answering with the SAME
+// (absent) role template id and the SAME scopes, so the membership still confers
+// exactly what the row above described.
+func expectSampleMemberRegistryRole(mock sqlmock.Sqlmock) {
+	expectRegistryRoleFor(mock, registryRole{scopes: `["modules:read"]`})
+}
+
 func TestUpdateMember_InvalidJSON(t *testing.T) {
 	_, r := newOrgRouter(t)
 	w := httptest.NewRecorder()
@@ -1123,6 +1135,7 @@ func TestUpdateMember_UpdateDBError(t *testing.T) {
 	mock, r := newOrgRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRow())
+	expectRegistryRoleFor(mock, registryRole{})
 	// UpdateMember → UpdateMemberRoleTemplate → ExecContext
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnError(errDB)
@@ -1141,11 +1154,13 @@ func TestUpdateMember_Success(t *testing.T) {
 	mock, r := newOrgRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRow())
+	expectRegistryRoleFor(mock, registryRole{})
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	// GetMemberWithRole returns member with role info
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 
 	body := `{"role_template_id": null}`
 	w := httptest.NewRecorder()
@@ -1168,12 +1183,13 @@ const (
 func TestUpdateMember_RoleTemplateChanged_RevokesUserTokens(t *testing.T) {
 	mock, r := newOrgRouterWithRevocation(t, true)
 	// checkRoleAssignment looks up the target role template's scopes first.
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
 	// Member currently holds oldRoleTemplateUUID; the request reassigns to
 	// newRoleTemplateUUID — a real change that must trigger revocation.
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+	expectRegistryRoleFor(mock, registryRole{id: oldRoleTemplateUUID})
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -1182,6 +1198,7 @@ func TestUpdateMember_RoleTemplateChanged_RevokesUserTokens(t *testing.T) {
 	expectOrgKeySweep(mock, "user-1", "org-1", "key-1")
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 
 	body := `{"role_template_id": "` + newRoleTemplateUUID + `"}`
 	w := httptest.NewRecorder()
@@ -1202,14 +1219,16 @@ func TestUpdateMember_RoleTemplateChanged_RevokesUserTokens(t *testing.T) {
 // tries to run an unexpected exec.
 func TestUpdateMember_RoleTemplateUnchanged_SkipsRevocation(t *testing.T) {
 	mock, r := newOrgRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+	expectRegistryRoleFor(mock, registryRole{id: oldRoleTemplateUUID})
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 
 	body := `{"role_template_id": "` + oldRoleTemplateUUID + `"}`
 	w := httptest.NewRecorder()
@@ -1438,6 +1457,7 @@ func TestAddMember_SuccessWithRole(t *testing.T) {
 	// GetMemberWithRole succeeds
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("POST", "/organizations/org-1/members",
@@ -1561,6 +1581,7 @@ func TestUpdateMember_GetMemberWithRoleDBError(t *testing.T) {
 	mock, r := newOrgRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRow())
+	expectRegistryRoleFor(mock, registryRole{})
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	// GetMemberWithRole fails - handler should return basic member info (200)
@@ -1637,14 +1658,16 @@ func TestUpdateMemberHandler_SweepFails_ReportsRevocationIncomplete(t *testing.T
 	r := gin.New()
 	r.PUT("/organizations/:id/members/:user_id", h.UpdateMemberHandler())
 
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`[]`)))
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRowWithRole(oldRoleTemplateUUID))
+	expectRegistryRoleFor(mock, registryRole{id: oldRoleTemplateUUID})
 	mock.ExpectExec("UPDATE organization_members").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 	// The JWT half of the sweep fails after the reassignment committed.
 	mock.ExpectExec("INSERT INTO user_token_revocations").
 		WillReturnError(errDB)
@@ -1652,6 +1675,7 @@ func TestUpdateMemberHandler_SweepFails_ReportsRevocationIncomplete(t *testing.T
 		[]byte(`["providers:write"]`))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(sampleMemberWithRoleRow())
+	expectSampleMemberRegistryRole(mock)
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1/members/user-1",

--- a/backend/internal/api/admin/platform_admin_grant_class_test.go
+++ b/backend/internal/api/admin/platform_admin_grant_class_test.go
@@ -100,7 +100,7 @@ func newMemberRouterAs(t *testing.T, userID string, scopes []string) (sqlmock.Sq
 // ordered mode makes an unconsumed expectation a failure, so queueing it would
 // assert the opposite of the property.
 func expectRoleTemplateLookup(mock sqlmock.Sqlmock, roleScopesJSON string) {
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(roleScopesJSON)))
 }
 
@@ -117,6 +117,10 @@ func expectOrgOwnerCeilingLookups(mock sqlmock.Sqlmock, roleScopesJSON string) {
 			// organization needs, and no wildcard.
 			[]byte(`["organizations:write","users:read","api_keys:manage","modules:read","modules:write","providers:read","providers:write","mirrors:read","mirrors:manage","scm:read","scm:manage"]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{
+		id: "role-owner", name: "org_owner", displayName: "Organization Owner",
+		scopes: `["organizations:write","users:read","api_keys:manage","modules:read","modules:write","providers:read","providers:write","mirrors:read","mirrors:manage","scm:read","scm:manage"]`,
+	})
 }
 
 const adminBearingRoleUUID = "44444444-4444-4444-4444-444444444444"
@@ -212,6 +216,9 @@ func TestPlatformAdminGrantClass_OrgScopedCallerCanStillGrantWithinItsAuthority(
 			"Target One", "target@example.com", "publisher", "Publisher",
 			[]byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{
+		id: "role-pub", name: "publisher", displayName: "Publisher", scopes: `["modules:write"]`,
+	})
 
 	body := `{"user_id":"target-1","role_template_id":"55555555-5555-5555-5555-555555555555"}`
 	w := httptest.NewRecorder()

--- a/backend/internal/api/admin/rbac_test.go
+++ b/backend/internal/api/admin/rbac_test.go
@@ -190,7 +190,7 @@ func newRBACRouterWithRevocation(t *testing.T, withRevocation bool) (sqlmock.Sql
 
 func TestRBACListRoleTemplates_Success(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates.*ORDER BY").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates.*ORDER BY").
 		WillReturnRows(sampleRTRow())
 
 	w := httptest.NewRecorder()
@@ -203,7 +203,7 @@ func TestRBACListRoleTemplates_Success(t *testing.T) {
 
 func TestRBACListRoleTemplates_DBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates").WillReturnError(errDB)
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates").WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/role-templates", nil))
@@ -229,7 +229,7 @@ func TestRBACGetRoleTemplate_InvalidID(t *testing.T) {
 
 func TestRBACGetRoleTemplate_NotFound(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(emptyRTRows())
 
 	w := httptest.NewRecorder()
@@ -242,7 +242,7 @@ func TestRBACGetRoleTemplate_NotFound(t *testing.T) {
 
 func TestRBACGetRoleTemplate_Found(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 
 	w := httptest.NewRecorder()
@@ -271,7 +271,7 @@ func TestRBACCreateRoleTemplate_MissingFields(t *testing.T) {
 func TestRBACCreateRoleTemplate_Conflict(t *testing.T) {
 	mock, r := newRBACRouter(t)
 	// GetRoleTemplateByName finds existing
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE name").
 		WillReturnRows(sampleRTRow())
 
 	w := httptest.NewRecorder()
@@ -289,7 +289,7 @@ func TestRBACCreateRoleTemplate_Conflict(t *testing.T) {
 
 func TestRBACCreateRoleTemplate_Success(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE name").
 		WillReturnRows(emptyRTRows())
 	mock.ExpectExec("INSERT INTO role_templates").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -334,7 +334,7 @@ func TestRBACRoleTemplates_RefuseTheAdminScope(t *testing.T) {
 			if tt.method == http.MethodPut {
 				// Update reads the existing row and refuses system templates
 				// before it binds the body, so this one lookup is legitimate.
-				mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+				mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 					WillReturnRows(sampleRTRow())
 			}
 
@@ -366,7 +366,7 @@ func TestRBACRoleTemplates_RefuseTheAdminScope(t *testing.T) {
 // refusal that rejected every scope list would satisfy the test above.
 func TestRBACRoleTemplates_StillAcceptOrdinaryScopes(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE name").
 		WillReturnRows(emptyRTRows())
 	mock.ExpectExec("INSERT INTO role_templates").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -390,7 +390,7 @@ func TestRBACRoleTemplates_StillAcceptOrdinaryScopes(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_NotFound(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(emptyRTRows())
 
 	w := httptest.NewRecorder()
@@ -408,7 +408,7 @@ func TestRBACUpdateRoleTemplate_NotFound(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_SystemTemplate(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTSystemRow())
 
 	w := httptest.NewRecorder()
@@ -426,7 +426,7 @@ func TestRBACUpdateRoleTemplate_SystemTemplate(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_Success(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -453,11 +453,11 @@ func TestRBACUpdateRoleTemplate_Success(t *testing.T) {
 func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	logs := captureSlogOutput(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 			AddRow("member-1", "org-1").
 			AddRow("member-2", "org-2"))
@@ -511,7 +511,7 @@ func TestRBACUpdateRoleTemplate_ScopesChanged_RevokesMemberTokens(t *testing.T) 
 func TestRBACUpdateRoleTemplate_ScopesWidened_SkipsRevocation(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	logs := captureSlogOutput(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -557,7 +557,7 @@ func assertNoSweepAttempted(t *testing.T, mock sqlmock.Sqlmock, logs *bytes.Buff
 func TestRBACUpdateRoleTemplate_ScopesReordered_SkipsRevocation(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
 	logs := captureSlogOutput(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -582,7 +582,7 @@ func TestRBACUpdateRoleTemplate_ScopesReordered_SkipsRevocation(t *testing.T) {
 // unexpected query or exec.
 func TestRBACUpdateRoleTemplate_ScopesUnchanged_SkipsRevocation(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = testRTScopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -609,7 +609,7 @@ func TestRBACUpdateRoleTemplate_ScopesUnchanged_SkipsRevocation(t *testing.T) {
 
 func TestRBACDeleteRoleTemplate_NotFound(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(emptyRTRows())
 
 	w := httptest.NewRecorder()
@@ -622,7 +622,7 @@ func TestRBACDeleteRoleTemplate_NotFound(t *testing.T) {
 
 func TestRBACDeleteRoleTemplate_SystemTemplate(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTSystemRow())
 
 	w := httptest.NewRecorder()
@@ -635,7 +635,7 @@ func TestRBACDeleteRoleTemplate_SystemTemplate(t *testing.T) {
 
 func TestRBACDeleteRoleTemplate_Success(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -654,9 +654,9 @@ func TestRBACDeleteRoleTemplate_Success(t *testing.T) {
 // revoked (issue #559 finding [9]).
 func TestRBACDeleteRoleTemplate_RevokesMemberTokens(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 			AddRow("member-1", "org-1").
 			AddRow("member-2", "org-2"))
@@ -688,9 +688,9 @@ func TestRBACDeleteRoleTemplate_RevokesMemberTokens(t *testing.T) {
 // over-privileged or compromised role template.
 func TestRBACDeleteRoleTemplate_MemberLookupDBError_StillDeletes(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WillReturnError(errDB)
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -1200,7 +1200,7 @@ func TestRBACListMirrorPolicies_DBError(t *testing.T) {
 
 func TestRBACDeleteRoleTemplate_GetDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -1213,7 +1213,7 @@ func TestRBACDeleteRoleTemplate_GetDBError(t *testing.T) {
 
 func TestRBACDeleteRoleTemplate_DeleteDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").
 		WillReturnError(errDB)
@@ -1354,7 +1354,7 @@ func newRBACRouterWithOrg(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
 
 func TestRBACGetRoleTemplate_DBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -1371,7 +1371,7 @@ func TestRBACGetRoleTemplate_DBError(t *testing.T) {
 
 func TestRBACCreateRoleTemplate_GetByNameDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE name").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -1389,7 +1389,7 @@ func TestRBACCreateRoleTemplate_GetByNameDBError(t *testing.T) {
 
 func TestRBACCreateRoleTemplate_CreateDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE name").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE name").
 		WillReturnRows(emptyRTRows())
 	mock.ExpectExec("INSERT INTO role_templates").
 		WillReturnError(errDB)
@@ -1424,7 +1424,7 @@ func TestRBACUpdateRoleTemplate_InvalidID(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_GetDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -1438,7 +1438,7 @@ func TestRBACUpdateRoleTemplate_GetDBError(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_BindJSONError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 
 	w := httptest.NewRecorder()
@@ -1452,7 +1452,7 @@ func TestRBACUpdateRoleTemplate_BindJSONError(t *testing.T) {
 
 func TestRBACUpdateRoleTemplate_UpdateDBError(t *testing.T) {
 	mock, r := newRBACRouter(t)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnError(errDB)
@@ -1569,6 +1569,10 @@ func TestRBACCreateApproval_OrgComesFromConfigNotContext(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
 			knownUUID, "Owner", "role-1", time.Now(),
 			"devops", "DevOps", []byte(`["mirrors:manage"]`)))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: knownUUID, id: "role-1", name: "devops", displayName: "DevOps",
+		scopes: `["mirrors:manage"]`,
+	})
 	mock.ExpectExec("INSERT INTO mirror_approval_requests").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -2057,12 +2061,12 @@ func TestRBACEvaluatePolicy_RequiresApproval(t *testing.T) {
 // go away, and the admin had no way to know.
 func TestRBACUpdateRoleTemplate_SweepFails_ReportsRevocationIncomplete(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow()) // scopes = ["modules:read","providers:write"]
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	// The member lookup that drives the sweep fails after the edit committed.
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles").
 		WillReturnError(errDB)
 
 	w := httptest.NewRecorder()
@@ -2095,11 +2099,11 @@ func TestRBACUpdateRoleTemplate_SweepFails_ReportsRevocationIncomplete(t *testin
 // The happy path must NOT carry the flag, or it means nothing.
 func TestRBACUpdateRoleTemplate_SweepSucceeds_NoRevocationIncomplete(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
 	mock.ExpectExec("UPDATE role_templates.*SET display_name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles").
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 			AddRow("member-1", "org-1"))
 	mock.ExpectExec("INSERT INTO user_token_revocations").
@@ -2133,9 +2137,9 @@ func TestRBACUpdateRoleTemplate_SweepSucceeds_NoRevocationIncomplete(t *testing.
 // and must report the same way.
 func TestRBACDeleteRoleTemplate_SweepFails_ReportsRevocationIncomplete(t *testing.T) {
 	mock, r := newRBACRouterWithRevocation(t, true)
-	mock.ExpectQuery("SELECT.*FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRTRow())
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles").
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 			AddRow("member-1", "org-1"))
 	mock.ExpectExec("DELETE FROM role_templates WHERE id").

--- a/backend/internal/api/admin/role_ceiling.go
+++ b/backend/internal/api/admin/role_ceiling.go
@@ -38,9 +38,16 @@ func (h *OrganizationHandlers) checkRoleAssignment(c *gin.Context, roleTemplateI
 		return roleAssignmentCheck{allowed: false, status: http.StatusBadRequest}
 	}
 
+	// REGISTRY's own table (terraform-suite-identity#206, phase 3b). This asks
+	// "what will this template confer once it is assigned", and since the read
+	// cutover the answer is `registry_role_templates`. Reading the shared table
+	// would compute the ceiling — and the platform-admin refusal below — from a
+	// scope set the product does not actually enforce, so a template registry
+	// treats as admin-bearing could be waved through on the strength of what
+	// identity says it carries.
 	var scopesJSON []byte
 	err = h.db.QueryRowContext(c.Request.Context(),
-		`SELECT scopes FROM role_templates WHERE id = $1`, id).Scan(&scopesJSON)
+		`SELECT scopes FROM registry_role_templates WHERE id = $1`, id).Scan(&scopesJSON)
 	if err == sql.ErrNoRows {
 		return roleAssignmentCheck{allowed: false, status: http.StatusBadRequest}
 	}

--- a/backend/internal/api/admin/role_ceiling_test.go
+++ b/backend/internal/api/admin/role_ceiling_test.go
@@ -48,7 +48,7 @@ func TestCheckRoleAssignment_CrossOrgCallerCannotEscalate(t *testing.T) {
 	h := newRoleCeilingHandlers(db)
 
 	roleID := "11111111-1111-1111-1111-111111111111"
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`["organizations:write"]`)))
 	// Caller has no membership row at all in the target org.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
@@ -77,7 +77,7 @@ func TestCheckRoleAssignment_SameOrgSufficientScopeAllowed(t *testing.T) {
 	h := newRoleCeilingHandlers(db)
 
 	roleID := "22222222-2222-2222-2222-222222222222"
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`["modules:read"]`)))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(sqlmock.NewRows(orgMembersWithUserCols).AddRow(
@@ -85,6 +85,10 @@ func TestCheckRoleAssignment_SameOrgSufficientScopeAllowed(t *testing.T) {
 			"Caller Two", "caller2@example.com", "org_owner", "Organization Owner",
 			[]byte(`["organizations:write","modules:read","modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, registryRole{
+		id: "role-1", name: "org_owner", displayName: "Organization Owner",
+		scopes: `["organizations:write","modules:read","modules:write"]`,
+	})
 
 	c := newRoleCeilingContext("org-a", "caller-2", nil)
 	chk := h.checkRoleAssignment(c, &roleID)
@@ -114,7 +118,7 @@ func TestCheckRoleAssignment_GlobalAdminBypassesPerOrgLookup(t *testing.T) {
 	h := newRoleCeilingHandlers(db)
 
 	roleID := "33333333-3333-3333-3333-333333333333"
-	mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`["users:write","organizations:write"]`)))
 
 	c := newRoleCeilingContext("org-c", "caller-3", []string{"admin"})
@@ -157,7 +161,7 @@ func TestCheckRoleAssignment_NobodyMayAssignAnAdminBearingTemplate(t *testing.T)
 			roleID := "44444444-4444-4444-4444-444444444444"
 			// Only the template read is queued. The per-org ceiling lookup must
 			// not happen: the answer does not depend on the caller.
-			mock.ExpectQuery("SELECT scopes FROM role_templates WHERE id").
+			mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE id").
 				WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow([]byte(`["admin"]`)))
 
 			c := newRoleCeilingContext("org-c", "caller-4", caller.scopes)

--- a/backend/internal/api/admin/scans_tenant_scope_test.go
+++ b/backend/internal/api/admin/scans_tenant_scope_test.go
@@ -62,10 +62,20 @@ func membershipRowsForScanScope(orgID string, scopes string) *sqlmock.Rows {
 		AddRow(orgID, "org-alpha", "role-1", time.Now(), "devops", "DevOps", []byte(scopes))
 }
 
+// expectScanScopeRegistryRole queues the read of registry's own role tables that
+// now follows the membership lookup above, repeating the same role and the same
+// scopes so the caller's resolved scope is unchanged.
+func expectScanScopeRegistryRole(mock sqlmock.Sqlmock, orgID, scopes string) {
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgID, id: "role-1", name: "devops", displayName: "DevOps", scopes: scopes,
+	})
+}
+
 func TestGetScanByID_ScopedCallerGetsTheScopedQuery(t *testing.T) {
 	mock, r := scopedScanRouter(t)
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["scanning:read"]`))
+	expectScanScopeRegistryRole(mock, scanOrgAlpha, `["scanning:read"]`)
 	// The scoped form joins through module_versions -> modules and binds
 	// m.organization_id. A platform-wide scope emits the literal TRUE and would
 	// not match this expectation, which is what makes the test meaningful.
@@ -84,6 +94,7 @@ func TestGetScanByID_OutOfScopeIs404NotForbidden(t *testing.T) {
 	mock, r := scopedScanRouter(t)
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["scanning:read"]`))
+	expectScanScopeRegistryRole(mock, scanOrgAlpha, `["scanning:read"]`)
 	// A scan owned by another organization matches no row under this scope.
 	mock.ExpectQuery("(?s)JOIN modules.*m.organization_id").
 		WillReturnRows(sqlmock.NewRows(scanAdminCols))
@@ -112,6 +123,7 @@ func TestGetScanByID_MembershipWithoutScanningReadReachesNothing(t *testing.T) {
 	// scanning:read. Membership is not authority (#719).
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRowsForScanScope(scanOrgAlpha, `["modules:read"]`))
+	expectScanScopeRegistryRole(mock, scanOrgAlpha, `["modules:read"]`)
 	// The empty scope emits the literal FALSE rather than binding a column, so
 	// the predicate is unsatisfiable before the database considers a single row.
 	// Matching on FALSE here is the assertion: if this ever became a bound

--- a/backend/internal/api/admin/tenant_scope_class_test.go
+++ b/backend/internal/api/admin/tenant_scope_class_test.go
@@ -163,6 +163,26 @@ func classMembershipRowsWithScopes(orgID string, scopes string) *sqlmock.Rows {
 		orgID, "Org", "role-1", time.Now(), "custom", "Custom", []byte(scopes))
 }
 
+// expectClassRegistryRoles queues the read of registry's own role tables that
+// now follows every classMembershipRows lookup, answering with the SAME role and
+// the SAME scopes so each site's resolved tenant scope is unchanged.
+func expectClassRegistryRoles(mock sqlmock.Sqlmock, member bool) {
+	orgID := classOrgAlpha
+	if member {
+		orgID = classOrgBeta
+	}
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgID, id: "role-1", name: "devops", displayName: "DevOps", scopes: classRoleScopes,
+	})
+}
+
+// expectClassRegistryRolesWithScopes is the same for classMembershipRowsWithScopes.
+func expectClassRegistryRolesWithScopes(mock sqlmock.Sqlmock, orgID, scopes string) {
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgID, id: "role-1", name: "custom", displayName: "Custom", scopes: scopes,
+	})
+}
+
 func tenantScopeSites() []tenantScopeSite {
 	return []tenantScopeSite{
 		{
@@ -172,6 +192,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				// The tenant constraint is a QUERY PREDICATE, so the expectation
 				// requires it in the statement: strip the guard and the emitted
 				// SQL no longer matches, the read errors, and this row goes red.
@@ -208,6 +229,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				// As with the by-id axis: the predicate is in the statement, so
 				// the stream never receives the foreign tenant's rows. The
 				// earlier revision of this batch filtered them out in Go after
@@ -239,6 +261,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM mirror_configurations").WillReturnRows(
 					sqlmock.NewRows(mirrorCfgCols).AddRow(
 						classResource, "beta-mirror", nil, "https://registry.terraform.io", classOrgBeta,
@@ -266,6 +289,7 @@ func tenantScopeSites() []tenantScopeSite {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM mirror_configurations").WillReturnRows(sqlmock.NewRows(mirrorCfgCols))
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)INSERT INTO mirror_configurations").WillReturnRows(
 					sqlmock.NewRows([]string{"id", "created_at", "updated_at"}).
 						AddRow(classResource, time.Now(), time.Now()))
@@ -299,6 +323,7 @@ func tenantScopeSites() []tenantScopeSite {
 						nil, nil, nil, nil, true, 24, nil, nil, nil,
 						time.Now(), time.Now(), nil))
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectExec("(?s)UPDATE mirror_configurations").WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewMirrorHandler(repositories.NewMirrorRepository(sqlxDB),
 					repositories.NewOrganizationRepository(sqlxDB.DB),
@@ -328,6 +353,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM mirror_policies").WillReturnRows(
 					sqlmock.NewRows(mpListCols).AddRow(
 						classResource, classOrgBeta, "beta-policy", nil, "allow",
@@ -356,6 +382,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM mirror_policies").WillReturnRows(
 					sqlmock.NewRows(mpListCols).AddRow(
 						classResource, nil, "global-policy", nil, "deny",
@@ -381,6 +408,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM mirror_approval_requests").WillReturnRows(
 					sqlmock.NewRows(approvalListCols).AddRow(
 						classResource, classResource, classOrgBeta, nil,
@@ -413,6 +441,7 @@ func tenantScopeSites() []tenantScopeSite {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM mirror_configurations").WillReturnRows(sqlmock.NewRows(mirrorCfgCols))
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectExec("(?s)INSERT INTO mirror_configurations").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewMirrorHandler(repositories.NewMirrorRepository(sqlxDB),
@@ -454,6 +483,7 @@ func tenantScopeSites() []tenantScopeSite {
 						nil, nil, nil, nil, true, 24, nil, nil, nil,
 						time.Now(), time.Now(), nil))
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectExec("(?s)UPDATE mirror_configurations").WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewMirrorHandler(repositories.NewMirrorRepository(sqlxDB),
 					repositories.NewOrganizationRepository(sqlxDB.DB),
@@ -543,6 +573,7 @@ func tenantScopeSites() []tenantScopeSite {
 				}
 				mock.ExpectQuery("(?s)FROM organization_members").
 					WillReturnRows(classMembershipRowsWithScopes(classOrgBeta, scopes))
+				expectClassRegistryRolesWithScopes(mock, classOrgBeta, scopes)
 				mock.ExpectQuery("(?s)FROM mirror_configurations").WillReturnRows(
 					sqlmock.NewRows(mirrorCfgCols).AddRow(
 						classResource, "beta-mirror", nil, "https://registry.terraform.io", classOrgBeta,
@@ -573,6 +604,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectExec("(?s)INSERT INTO mirror_policies").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewRBACHandlers(repositories.NewRBACRepository(sqlxDB), nil, nil).
@@ -609,6 +641,7 @@ func tenantScopeSites() []tenantScopeSite {
 						nil, nil, nil, nil, true, 24, nil, nil, nil,
 						time.Now(), time.Now(), nil))
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectExec("(?s)INSERT INTO mirror_approval_requests").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewRBACHandlers(repositories.NewRBACRepository(sqlxDB), nil, nil).
@@ -635,6 +668,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				// The predicate must be in the statement. Strip the guard and
 				// the emitted SQL stops matching, so the row goes red.
 				mock.ExpectQuery(`(?s)SELECT COUNT.*organization_id = ANY`).
@@ -659,6 +693,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery(`(?s)SELECT va\.organization_id FROM`).
 					WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow(classOrgBeta))
 				mock.ExpectQuery("(?s)FROM version_approval_events").WillReturnRows(
@@ -690,6 +725,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM namespace_claims").WillReturnRows(
 					sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}).
 						AddRow("beta-ns", classOrgBeta, nil, time.Now()))
@@ -714,6 +750,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM namespace_claims").WillReturnRows(
 					sqlmock.NewRows([]string{"namespace", "organization_id", "claimed_by", "created_at"}).
 						AddRow("beta-ns", classOrgBeta, nil, time.Now()))
@@ -743,6 +780,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				// The tenant constraint is a QUERY PREDICATE since identity
 				// v0.25.0, on BOTH statements this handler issues: the page and
 				// its total. Previously the handler fetched each in-scope id one
@@ -781,6 +819,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				name, display := "alpha", "Alpha"
 				orgID := classOrgAlpha
 				if member {
@@ -813,6 +852,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM scm_providers").WillReturnRows(sqlmock.NewRows(scmProvCols))
 				mock.ExpectExec("(?s)INSERT INTO scm_providers").WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewSCMProviderHandlers(&config.Config{},
@@ -843,6 +883,7 @@ func tenantScopeSites() []tenantScopeSite {
 			mount: func(t *testing.T, member bool) (*gin.Engine, sqlmock.Sqlmock) {
 				mock, sqlxDB, r := classSQLMock(t)
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(classMembershipRows(member))
+				expectClassRegistryRoles(mock, member)
 				mock.ExpectQuery("(?s)FROM scm_providers").WillReturnRows(sqlmock.NewRows(scmProvCols))
 				mock.ExpectExec("(?s)INSERT INTO scm_providers").WillReturnResult(sqlmock.NewResult(1, 1))
 				h := NewSCMProviderHandlers(&config.Config{},

--- a/backend/internal/api/admin/tenant_scoping_test.go
+++ b/backend/internal/api/admin/tenant_scoping_test.go
@@ -86,6 +86,9 @@ func TestSCMList_NonAdmin_OwnOrgFilter_Allowed(t *testing.T) {
 			orgAlpha, "Alpha", "role-viewer", time.Now(),
 			"viewer", "Viewer", []byte(`["scm:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "role-viewer", name: "viewer", displayName: "Viewer", scopes: `["scm:read"]`,
+	})
 	mock.ExpectQuery("(?s)FROM scm_providers").WillReturnRows(sqlmock.NewRows(scmProvCols))
 
 	w := httptest.NewRecorder()
@@ -104,6 +107,9 @@ func TestSCMList_NonAdmin_Unfiltered_ScopedToOwnOrgs(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
 			orgAlpha, "Alpha", "role-viewer", time.Now(), "viewer", "Viewer", []byte(`["scm:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "role-viewer", name: "viewer", displayName: "Viewer", scopes: `["scm:read"]`,
+	})
 	mock.ExpectQuery("(?s)FROM scm_providers WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows(scmProvCols))
 
@@ -162,6 +168,9 @@ func TestListAuditLogs_NonAdmin_ForeignOrgFilter_Denied(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(membershipCols).AddRow(
 			orgAlpha, "Alpha", "role-auditor", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`),
 		))
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgAlpha, id: "role-auditor", name: "auditor", displayName: "Auditor", scopes: `["audit:read"]`,
+	})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/audit-logs?organization_id="+orgBeta, nil))
@@ -190,6 +199,10 @@ func TestListAuditLogs_NonAdmin_MultiOrg_ScopesToAllOwnOrgs(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(membershipCols).
 			AddRow(orgAlpha, "Alpha", "r1", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`)).
 			AddRow(orgBeta, "Beta", "r2", time.Now(), "auditor", "Auditor", []byte(`["audit:read"]`)))
+	expectRegistryRolesForUser(mock,
+		registryRole{orgID: orgAlpha, id: "r1", name: "auditor", displayName: "Auditor", scopes: `["audit:read"]`},
+		registryRole{orgID: orgBeta, id: "r2", name: "auditor", displayName: "Auditor", scopes: `["audit:read"]`},
+	)
 	mock.ExpectQuery(`SELECT COUNT.*FROM audit_logs.*organization_id = ANY`).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery(`SELECT al\.id.*FROM audit_logs.*organization_id = ANY`).

--- a/backend/internal/api/admin/users_tenant_scope_test.go
+++ b/backend/internal/api/admin/users_tenant_scope_test.go
@@ -66,6 +66,17 @@ func membershipRow(orgID string, scopes []string) *sqlmock.Rows {
 		AddRow(orgID, "org-"+orgID[:4], "role-1", time.Now(), "user_manager", "User Manager", raw)
 }
 
+// expectMembershipRowRegistryRole queues the read of registry's own role tables
+// that now follows a membershipRow, answering with the SAME role and the SAME
+// scopes so the resolved tenant scope is exactly what the row above granted.
+func expectMembershipRowRegistryRole(mock sqlmock.Sqlmock, orgID string, scopes []string) {
+	raw, _ := json.Marshal(scopes)
+	expectRegistryRolesForUser(mock, registryRole{
+		orgID: orgID, id: "role-1", name: "user_manager", displayName: "User Manager",
+		scopes: string(raw),
+	})
+}
+
 func TestUserAxisScope_ByPrincipal(t *testing.T) {
 	tests := []struct {
 		name string
@@ -74,6 +85,10 @@ func TestUserAxisScope_ByPrincipal(t *testing.T) {
 		userID string
 		// membership rows OrgScopeForUser will read (nil = no query expected)
 		rows *sqlmock.Rows
+		// the scopes those rows carry. Registry's own role tables are read
+		// straight after and must answer with the same set, or the resolved
+		// scope stops being the one the row above describes.
+		roleScopes []string
 		// expectations
 		wantAll          bool
 		wantPermitsAlpha bool
@@ -94,6 +109,7 @@ func TestUserAxisScope_ByPrincipal(t *testing.T) {
 			scopes:           []string{string(auth.ScopeUsersRead)},
 			userID:           scopeUserID,
 			rows:             membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}),
+			roleScopes:       []string{string(auth.ScopeUsersRead)},
 			wantPermitsAlpha: true,
 			wantPermitsBeta:  false,
 			wantUnowned:      true,
@@ -105,6 +121,7 @@ func TestUserAxisScope_ByPrincipal(t *testing.T) {
 			// A member of alpha, but the role template there does not carry
 			// users:read. Membership is not authority (#719).
 			rows:             membershipRow(orgAlpha, []string{string(auth.ScopeModulesRead)}),
+			roleScopes:       []string{string(auth.ScopeModulesRead)},
 			wantPermitsAlpha: false,
 			wantPermitsBeta:  false,
 			wantUnowned:      true,
@@ -122,6 +139,7 @@ func TestUserAxisScope_ByPrincipal(t *testing.T) {
 			c, mock, db := userScopeCtx(t, tt.scopes, tt.userID)
 			if tt.rows != nil {
 				mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(tt.rows)
+				expectMembershipRowRegistryRole(mock, orgAlpha, tt.roleScopes)
 			}
 			h := NewUserHandlers(&config.Config{}, db)
 
@@ -156,6 +174,7 @@ func TestUserAxisScope_ScopedCallerIsNotPlatformWide(t *testing.T) {
 	c, mock, db := userScopeCtx(t, []string{string(auth.ScopeUsersRead)}, scopeUserID)
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	expectMembershipRowRegistryRole(mock, orgAlpha, []string{string(auth.ScopeUsersRead)})
 	h := NewUserHandlers(&config.Config{}, db)
 
 	scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
@@ -202,6 +221,7 @@ func TestGetUser_OutOfScopeTarget_Is404(t *testing.T) {
 	// OrgScopeForUser: caller holds users:read in alpha.
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	expectMembershipRowRegistryRole(mock, orgAlpha, []string{string(auth.ScopeUsersRead)})
 	// Match the SCOPED form of the query specifically. sqlmock does not
 	// evaluate predicates, so an expectation that merely said "FROM" would be
 	// satisfied by the unscoped query too and this test would pass with the
@@ -232,6 +252,7 @@ func TestGetUserMemberships_FiltersOutOfScopeOrganizations(t *testing.T) {
 	mock, r := scopedUserRouter(t)
 	mock.ExpectQuery("(?s)FROM organization_members").
 		WillReturnRows(membershipRow(orgAlpha, []string{string(auth.ScopeUsersRead)}))
+	expectMembershipRowRegistryRole(mock, orgAlpha, []string{string(auth.ScopeUsersRead)})
 	// Scoped form, for the same reason as above.
 	mock.ExpectQuery("(?s)osm.organization_id = ANY").WillReturnRows(sampleUserRow())
 	// The target belongs to BOTH organizations; only alpha may be disclosed.
@@ -239,6 +260,10 @@ func TestGetUserMemberships_FiltersOutOfScopeOrganizations(t *testing.T) {
 		AddRow(orgAlpha, "org-alpha", "role-1", time.Now(), "viewer", "Viewer", []byte(`[]`)).
 		AddRow(orgBeta, "org-beta", "role-2", time.Now(), "viewer", "Viewer", []byte(`[]`))
 	mock.ExpectQuery("(?s)FROM organization_members").WillReturnRows(both)
+	expectRegistryRolesForUser(mock,
+		registryRole{orgID: orgAlpha, id: "role-1", name: "viewer", displayName: "Viewer", scopes: `[]`},
+		registryRole{orgID: orgBeta, id: "role-2", name: "viewer", displayName: "Viewer", scopes: `[]`},
+	)
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/users/target/memberships", nil))

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -46,6 +46,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/credlifecycle"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/jobs"
@@ -208,48 +209,78 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	orgRepo := repositories.NewOrganizationRepository(identityDB)
 	tokenRepo := repositories.NewTokenRepository(identityDB)
 	// Registry's own per-app authorization tables
-	// (sethbacon/terraform-suite-identity#206, migration 000055). NOTHING READS
-	// THEM YET; the repositories above dual-write them so the read cutover has
-	// a populated copy to switch onto.
+	// (sethbacon/terraform-suite-identity#206, migration 000055). SINCE PHASE 3b
+	// EVERY ROLE AND EVERY SCOPE SET READ BY THIS PROCESS COMES FROM THEM. The
+	// repositories above still dual-write the identity tables, which is what
+	// keeps the rollback (deploy the previous image) real.
 	//
-	// Two INDEPENDENT startup steps, for the same reason the carrier is verified
-	// above -- reported, not assumed. Independent because they concern different
-	// connections, and the topology that breaks one leaves the other working.
+	// Three startup steps, in this order, and the order is load-bearing.
 	//
-	// 1. Probe the tables on the IDENTITY connection, which is where the LIVE
-	//    dual-write lands: the membership half has to share a connection with
-	//    the organization_members write it shadows. In the default topology that
-	//    connection is the registry connection; under TFR_IDENTITY_SCHEMA_ENABLED
-	//    it resolves them through the trailing `,public` of its search_path. In
-	//    the one topology where it cannot -- identity in a SEPARATE DATABASE --
-	//    this is where that is said out loud, rather than left to be discovered
-	//    as missing rows at the cutover.
+	// 1. VERIFY, and now FATALLY. The probe asks whether the connection the
+	//    repositories resolve `organization_members` through also resolves
+	//    registry's two tables. In the default topology it is one connection; under
+	//    TFR_IDENTITY_SCHEMA_ENABLED the identity pool's `search_path` resolves
+	//    them through its trailing `,public`. The one topology where it cannot is
+	//    identity in a SEPARATE DATABASE.
 	//
-	// 2. Reconcile, which is the backfill. It reads through the identity
-	//    connection and writes through the REGISTRY one, so it is correct in
-	//    every topology INCLUDING the one step 1 rejects -- which is why it is
-	//    not conditional on that probe. In a separate-database deployment this
-	//    is the only thing keeping the two copies together, so skipping it there
-	//    would be exactly backwards.
+	//    Before the cutover that was logged and survivable: nothing read these
+	//    tables, so an unreachable mirror cost only diagnosis. It is not
+	//    survivable now. Every authorization decision would be served from a table
+	//    this connection cannot see -- which is not "degraded", it is every
+	//    principal resolving to no role, i.e. a total outage that presents as a
+	//    permissions problem. Refusing to boot is the smaller failure and the one
+	//    an operator can act on.
 	//
-	//    It runs on every boot rather than once: 000055 deliberately ships no
-	//    SQL backfill (a migration cannot see which schema or database is live),
-	//    a re-derivation is a no-op when nothing changed, and it repairs
-	//    whatever a transient mirror failure left behind.
+	// 2. RECONCILE, which re-derives registry's tables from the identity source.
+	//    It runs on every boot: 000055 ships no SQL backfill (a migration cannot
+	//    see which schema or database is live), a re-derivation is a no-op when
+	//    nothing changed, and it repairs whatever a transient mirror failure left
+	//    behind.
 	//
-	// Both are logged, never fatal. A deployment whose mirror is broken must
-	// still boot -- reads do not come from these tables, so a failure here
-	// costs nothing at request time and everything at diagnosis time.
+	//    IT IS STILL CORRECT TO RUN IT AFTER THE READ CUTOVER, which is worth
+	//    stating because phase 3a's comment predicted the opposite. It would be
+	//    wrong if registry's tables were the only record of registry's decisions,
+	//    because re-deriving would then overwrite them. They are not: every write
+	//    path still writes the identity tables FIRST and mirrors only on success,
+	//    so identity is by construction at least as current as the mirror, and
+	//    "make the mirror equal identity" can only repair. When phase 4 drops the
+	//    dual-write, this call goes with it.
+	//
+	// 3. SEED registry's own role templates -- AFTER the reconcile, never before.
+	//    Step 2 rewrites each template from the identity copy, so a seed that ran
+	//    first would be undone on the same boot.
 	if vErr := repositories.NewMemberRoleMirror(identityDB).Verify(context.Background()); vErr != nil {
-		slog.Error("registry's own role tables are not reachable from the identity connection; "+
-			"role assignments will not be mirrored as they happen, only re-derived at each restart. "+
-			"This does not affect authorization today, and MUST be resolved before the read cutover",
-			"error", vErr)
+		log.Fatalf("registry's own role tables (migration 000055) are not reachable from the connection "+
+			"this process resolves identity reads through, and since terraform-suite-identity#206 phase 3b "+
+			"they are where every role and scope set comes from. Booting would serve every principal no role "+
+			"at all. This is the separate-identity-database topology (TFR_IDENTITY_DATABASE_*): create "+
+			"registry_role_templates and organization_member_roles where that connection can resolve them, "+
+			"or run identity in the registry database. Cause: %v", vErr)
 	}
 	if report, rErr := repositories.ReconcileMemberRoles(context.Background(), identityDB, db); rErr != nil {
-		slog.Error("could not reconcile registry's own role tables from the identity source", "error", rErr)
+		slog.Error("could not reconcile registry's own role tables from the identity source; "+
+			"authorization is served from whatever they already hold, and role changes made while the "+
+			"live mirror was failing are NOT repaired. Run `role-drift`", "error", rErr)
 	} else {
 		slog.Info("registry role tables reconciled", "report", report)
+	}
+	// Registry's role→scope policy, into registry's own table.
+	//
+	// Gated on the same suite.role_seed_owner as the shared-table seed in
+	// cmd/server, deliberately, even though registry's own table has no
+	// cross-application contention for the flag to arbitrate. While the
+	// reconcile above still derives this table from the shared one, seeding one
+	// without the other would make the two disagree by construction and leave
+	// `role-drift` -- the gate on this whole phase -- permanently non-zero on a
+	// deployment that is in fact healthy. The flag retires in phase 4, together
+	// with the reconcile that creates the coupling.
+	if cfg.Suite.ShouldSeedRoles("registry") {
+		if sErr := repositories.SeedSystemRoleTemplates(
+			context.Background(), db, models.PredefinedRoleTemplates(),
+		); sErr != nil {
+			slog.Error("could not seed registry's own role templates; roles resolve to whatever "+
+				"the reconcile derived from the identity tables", "error", sErr)
+		}
 	}
 	// userTokenRevocationRepo lives on the registry's own domain connection
 	// (not identityDB) since it has no FK dependency on the identity schema and

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -266,15 +266,37 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	}
 	// Registry's role→scope policy, into registry's own table.
 	//
-	// Gated on the same suite.role_seed_owner as the shared-table seed in
-	// cmd/server, deliberately, even though registry's own table has no
-	// cross-application contention for the flag to arbitrate. While the
+	// Gated on EXACTLY the same two conditions as the shared-table seed in
+	// cmd/server, and both matter.
+	//
+	// suite.role_seed_owner, even though registry's own table has no
+	// cross-application contention for the flag to arbitrate: while the
 	// reconcile above still derives this table from the shared one, seeding one
 	// without the other would make the two disagree by construction and leave
 	// `role-drift` -- the gate on this whole phase -- permanently non-zero on a
-	// deployment that is in fact healthy. The flag retires in phase 4, together
-	// with the reconcile that creates the coupling.
-	if cfg.Suite.ShouldSeedRoles("registry") {
+	// deployment that is in fact healthy.
+	//
+	// The identity-schema CUTOVER, because that is the only topology this seed
+	// was ever for. It exists because the shared identity module seeds role
+	// templates with identity-core scopes only, so registry layers its own
+	// domain scopes on top. In the DEFAULT topology the templates are seeded by
+	// registry's own migrations and have been amended by them since -- migration
+	// 000018 added `scanning:read` to `devops` and `auditor`, which
+	// models.PredefinedRoleTemplates() does not carry -- so running the seed
+	// there would strip that scope from both roles on every boot. The migrations
+	// are the more current statement of registry's policy in that topology, and
+	// the reconcile above has already copied them.
+	//
+	// (That mismatch is a PRE-EXISTING defect in the cutover topology, where
+	// this list has always been what gets seeded. It is not made better or worse
+	// here, and it is not this change's to fix: correcting the list changes what
+	// two role templates confer, which a read cutover gated on equivalence must
+	// not do quietly.)
+	//
+	// identityDB != db is the cutover test. NewRouter is handed the same handle
+	// twice when identity data lives in the app's own schema, and a distinct one
+	// exactly when cmd/server opened a dedicated identity pool.
+	if identityDB != db && cfg.Suite.ShouldSeedRoles("registry") {
 		if sErr := repositories.SeedSystemRoleTemplates(
 			context.Background(), db, models.PredefinedRoleTemplates(),
 		); sErr != nil {

--- a/backend/internal/api/scim/identity_notfound_idempotence_test.go
+++ b/backend/internal/api/scim/identity_notfound_idempotence_test.go
@@ -51,6 +51,9 @@ func TestSCIMDeprovision_PartiallyRemovedMembershipsStillSucceed(t *testing.T) {
 				"provisioner", "Provisioner", []byte(`["scim:provision"]`)).
 			AddRow(scimOrgBeta, "Beta", "role-2", time.Now(),
 				"provisioner", "Provisioner", []byte(`["scim:provision"]`)))
+	// The same two memberships, with the roles registry's own tables hold for
+	// them (terraform-suite-identity#206, phase 3b).
+	expectCallerRegistryRoles(mock, scimOrgAlpha, scimOrgBeta)
 
 	// Alpha's membership was already gone; only Beta's row is removed, so only
 	// Beta comes back.
@@ -85,6 +88,7 @@ func TestSCIMDeprovision_AllMembershipsAlreadyRemovedSucceeds(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows(scimMembershipCols).AddRow(
 			scimOrgAlpha, "Alpha", "role-1", time.Now(),
 			"provisioner", "Provisioner", []byte(`["scim:provision"]`)))
+	expectCallerRegistryRoles(mock, scimOrgAlpha)
 
 	mock.ExpectQuery("(?s)DELETE FROM organization_members").
 		WithArgs(scimTargetID, boundScope{want: []string{scimOrgAlpha}}).

--- a/backend/internal/api/scim/tenant_scope_class_test.go
+++ b/backend/internal/api/scim/tenant_scope_class_test.go
@@ -51,6 +51,35 @@ var scimUserCols = []string{
 	"id", "email", "name", "oidc_sub", "created_at", "updated_at",
 }
 
+// scimRegistryRoleCols is the projection MemberRoleReader.RolesForUser selects
+// (terraform-suite-identity#206, phase 3b).
+var scimRegistryRoleCols = []string{
+	"organization_id", "role_template_id", "role_template_name",
+	"role_template_display_name", "role_template_scopes",
+}
+
+// expectCallerRegistryRoles primes the SECOND read every membership accessor
+// now issues: the shared identity store still answers "which organizations is
+// this caller a member of", and registry's own organization_member_roles
+// answers "with what role, here".
+//
+// The rows given must carry the SAME role ids and scopes as the identity rows
+// queued just before, so these fixtures keep testing the tenant predicate they
+// were written for rather than accidentally testing a divergence. A mismatch is
+// not silent -- the read path logs it and increments
+// registry_role_read_divergence_total -- but it would change what the
+// surrounding assertion means, which is worse than loud.
+func expectCallerRegistryRoles(mock sqlmock.Sqlmock, orgIDs ...string) {
+	rows := sqlmock.NewRows(scimRegistryRoleCols)
+	for i, orgID := range orgIDs {
+		rows.AddRow(orgID, fmt.Sprintf("role-%d", i+1),
+			"provisioner", "Provisioner", []byte(`["scim:provision"]`))
+	}
+	mock.ExpectQuery(`(?s)FROM organization_member_roles omr.*WHERE omr\.user_id`).
+		WithArgs(scimCallerID).
+		WillReturnRows(rows)
+}
+
 // scimDeprovisionPath is one enumerated deactivation path over
 // organization_members.
 type scimDeprovisionPath struct {
@@ -196,6 +225,10 @@ func TestSCIMDeprovisionClass_OnlyRemovesInScopeMemberships(t *testing.T) {
 				WillReturnRows(sqlmock.NewRows(scimMembershipCols).AddRow(
 					scimOrgAlpha, "Alpha", "role-1", time.Now(),
 					"provisioner", "Provisioner", []byte(`["scim:provision"]`)))
+			// ...and the role each of those memberships carries IN REGISTRY,
+			// which is where the scope that resolves the tenant predicate now
+			// comes from (terraform-suite-identity#206, phase 3b).
+			expectCallerRegistryRoles(mock, scimOrgAlpha)
 
 			// GUARD scim-deprovision-tenant-scope. One statement, scoped to
 			// Alpha, RETURNING the organizations it actually removed — the value

--- a/backend/internal/db/repositories/member_role_divergence.go
+++ b/backend/internal/db/repositories/member_role_divergence.go
@@ -1,0 +1,126 @@
+// member_role_divergence.go is the answer to "how would we know the read
+// cutover was wrong" (sethbacon/terraform-suite-identity#206, phase 3b).
+//
+// # The hazard this exists for
+//
+// A gap in the dual-write does not surface as an error. It surfaces as a
+// principal holding the WRONG ROLE -- denied something they should have, or
+// allowed something they should not -- and every layer above reports success.
+// The drift check (member_role_drift.go) gates the cutover on that being zero
+// BEFORE reads flip. This file is what keeps it from going silent AFTER.
+//
+// # The mechanism, and why it costs nothing
+//
+// Every accessor in organization_repository.go already holds BOTH answers. It
+// asks the shared identity store for the membership -- which still carries
+// `organization_members.role_template_id` and the joined `role_templates`
+// columns, because phase 4 has not dropped them -- and then overlays the role
+// from registry's own tables. So the comparison is between two values already
+// in hand: no extra query, no shadow read, no sampling.
+//
+// That is only true while the old columns still exist. When phase 4 drops
+// them the store's answer becomes empty and this comparison stops meaning
+// anything; it must be removed in the same change, not left reporting
+// "identity says no role" for every request.
+//
+// # What it catches, stated as limits rather than claims
+//
+//   - A membership registry has no row for, or holds a different template for,
+//     ON THE REQUESTS THAT ACTUALLY READ IT. A dormant principal nobody
+//     authenticates as is invisible here; the periodic drift check is what
+//     covers them.
+//   - It does NOT catch a mirrored row with no membership. Every accessor asks
+//     the store first, so a mirror row for a non-member is never reached --
+//     which is also why it confers nothing today. It becomes reachable only
+//     when phase 4 moves the membership fact itself, and the drift check
+//     reports it now.
+//   - It does NOT catch two templates that agree by id but differ in SCOPES.
+//     The id is what is compared here because it is what both sides carry per
+//     membership; scope equality is a property of the template tables and is
+//     the drift check's second half.
+package repositories
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Divergence kinds. Values, not free strings, so the metric's label set is
+// closed and a dashboard cannot be broken by a typo at a new call site.
+const (
+	// DivergenceMissingMirror: identity has the membership, registry's own
+	// tables have no row for it. The principal LOSES whatever the role
+	// conferred, because a missing row fails closed.
+	DivergenceMissingMirror = "missing_mirror"
+	// DivergenceRoleDiffers: both sides have a row and they name different
+	// role templates (including one naming none). The direction is not
+	// knowable from the kind alone -- it may grant or withhold -- so the log
+	// carries both ids.
+	DivergenceRoleDiffers = "role_differs"
+)
+
+// RoleReadDivergenceTotal counts reads where registry's own authorization
+// tables disagreed with the identity tables they were derived from.
+//
+// STEADY STATE IS ZERO, and that is the point: this is not a rate to watch
+// trend, it is a counter that should never leave zero. Alert on
+// `increase(...) > 0`, not on a threshold.
+//
+// Labelled by accessor so the report names which read path saw it -- the
+// accessors have different blast radii, and "GetUserCombinedScopes disagreed"
+// (a token being minted) is a different page from "ListMembers disagreed" (an
+// admin screen).
+var RoleReadDivergenceTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "registry_role_read_divergence_total",
+		Help: "Reads where registry's own role tables disagreed with the identity tables they mirror (terraform-suite-identity#206). Steady state is zero; alert on any increase.",
+	},
+	[]string{"accessor", "kind"},
+)
+
+// compareRole reports a disagreement between the identity role the store
+// returned and the role registry's own tables hold for the same membership.
+//
+// It NEVER changes the answer. The caller has already decided that registry's
+// tables are authoritative; making this function able to override that would
+// give the product two answers to one question and put the choice between them
+// inside a diagnostic.
+//
+// identityRoleID is the value the shared store read from
+// `organization_members.role_template_id`. registryRole is what
+// MemberRoleReader found, nil when there is no mirrored row.
+func compareRole(ctx context.Context, accessor, orgID, userID string, identityRoleID *string, registryRole *MirroredRole) {
+	if registryRole == nil {
+		RoleReadDivergenceTotal.WithLabelValues(accessor, DivergenceMissingMirror).Inc()
+		slog.ErrorContext(ctx, "registry has no mirrored role for a membership that exists in identity; "+
+			"the principal is being served NO role here",
+			"accessor", accessor, "organization_id", orgID, "user_id", userID,
+			"identity_role_template_id", derefRole(identityRoleID),
+			"remedy", "run `role-drift` (cmd/role-drift); restarting the backend re-derives the mirror")
+		return
+	}
+	if sameRole(identityRoleID, registryRole.RoleTemplateID) {
+		return
+	}
+	RoleReadDivergenceTotal.WithLabelValues(accessor, DivergenceRoleDiffers).Inc()
+	slog.ErrorContext(ctx, "registry's own role assignment disagrees with the identity tables it mirrors; "+
+		"registry's answer is the one being served",
+		"accessor", accessor, "organization_id", orgID, "user_id", userID,
+		"identity_role_template_id", derefRole(identityRoleID),
+		"registry_role_template_id", derefRole(registryRole.RoleTemplateID),
+		"remedy", "run `role-drift` (cmd/role-drift); restarting the backend re-derives the mirror")
+}
+
+// derefRole renders an optional role template id for a log field. "none" rather
+// than an empty string, because an empty string in a structured log is
+// indistinguishable from a field the writer forgot to populate -- and here the
+// difference between "no role" and "not recorded" is the whole subject.
+func derefRole(id *string) string {
+	if id == nil {
+		return "none"
+	}
+	return *id
+}

--- a/backend/internal/db/repositories/member_role_drift.go
+++ b/backend/internal/db/repositories/member_role_drift.go
@@ -1,0 +1,375 @@
+// member_role_drift.go compares registry's own authorization tables against the
+// identity tables they were derived from, and reports every way they disagree.
+//
+// THIS IS THE GATE ON THE READ CUTOVER (sethbacon/terraform-suite-identity#206,
+// phase 3b). The estate's precedent is `bind-secrets verify`: it exits non-zero
+// while any row is unreconciled, and zero is what permits the next step. The
+// runnable verb is cmd/role-drift; this file is the comparison, kept in the
+// library so the same code answers the pre-flip gate, the post-flip check, and
+// the tests.
+//
+// # Why it is Go and not the SQL query phase 3a shipped
+//
+// docs/identity-schema.md carried a FULL OUTER JOIN that compared the two
+// copies in one statement. It is correct as far as it reaches, and it cannot
+// reach far enough for a gate:
+//
+//   - It requires both copies on ONE connection. Under TFR_IDENTITY_DATABASE_*
+//     they are in different databases and no statement can join them. That is
+//     exactly the topology whose dual-write phase 3a could not perform, i.e.
+//     the one most likely to have drifted.
+//   - It compares role template SCOPES but not NAMES. Registry resolves
+//     templates by name (GetRoleTemplateByName, and the group-mapping
+//     reconciliation), so two rows that agree on id and scopes but disagree on
+//     name resolve to different templates for the same request.
+//   - It cannot see a membership whose role_template_id names a template that
+//     does not exist at the SOURCE. The reconcile mirrors those with no role by
+//     design, so the pair renders as an ordinary "roles disagree" with no
+//     indication that the identity data is what is malformed.
+//   - It cannot see a row whose organization_id or user_id is not a UUID. Those
+//     are skipped by the reconcile and can never be mirrored, so they are
+//     permanently unreconciled and a gate that does not count them can return
+//     zero forever while a membership stays invisible.
+//
+// Each of those is a case where a principal ends up with the wrong role and
+// nothing says so, which is the failure this phase is engineered against.
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// Drift kinds. Ordered here by blast radius, worst first, which is also the
+// order DriftReport sorts them into: an operator reading a long report should
+// meet the rows that grant authority before the rows that withhold it.
+const (
+	// DriftMirrorWithoutMembership: registry holds a role for a principal who
+	// is not a member. Inert while the membership fact still comes from
+	// identity -- every accessor asks the store first -- and it GRANTS
+	// authority the product never issued the moment phase 4 moves that fact.
+	DriftMirrorWithoutMembership = "mirror_without_membership"
+	// DriftRoleDiffers: both copies have the membership and name different
+	// role templates. May grant or withhold; the report carries both ids.
+	DriftRoleDiffers = "role_differs"
+	// DriftMembershipNotMirrored: identity has the membership, registry has no
+	// row. The principal is served no role at all after the cutover.
+	DriftMembershipNotMirrored = "membership_not_mirrored"
+	// DriftTemplateScopesDiffer: same template id on both sides, different
+	// scope sets. Every holder's effective authority differs.
+	DriftTemplateScopesDiffer = "template_scopes_differ"
+	// DriftTemplateNameDiffers: same id, different name. Registry resolves
+	// templates by name in the group-mapping reconciliation and the admin API,
+	// so the two copies answer a name lookup with different rows.
+	DriftTemplateNameDiffers = "template_name_differs"
+	// DriftTemplateNotMirrored: a source template with no registry copy. Any
+	// membership naming it resolves to no role.
+	DriftTemplateNotMirrored = "template_not_mirrored"
+	// DriftMirroredTemplateOrphaned: a registry template the source no longer
+	// has. Left behind by a delete whose mirror write failed.
+	DriftMirroredTemplateOrphaned = "mirrored_template_orphaned"
+	// DriftMembershipRoleMissingTemplate: an identity membership naming a
+	// template that does not exist in identity's own role_templates. The
+	// inconsistency is in the SOURCE; the reconcile mirrors it with no role
+	// rather than inventing an assignment, so it can never reconcile to zero
+	// until an operator decides what the role should be.
+	DriftMembershipRoleMissingTemplate = "membership_role_missing_template"
+	// DriftUnparseableRow: a source row whose organization_id or user_id is not
+	// a UUID. It can never be mirrored, so it is permanently unreconciled.
+	DriftUnparseableRow = "unparseable_row"
+)
+
+// driftKindOrder ranks the kinds for the report's ordering. A kind missing from
+// this map sorts last rather than panicking -- a report that omitted a row
+// because its kind was new would be the worst possible failure of a gate.
+var driftKindOrder = map[string]int{
+	DriftMirrorWithoutMembership:       0,
+	DriftRoleDiffers:                   1,
+	DriftMembershipNotMirrored:         2,
+	DriftTemplateScopesDiffer:          3,
+	DriftTemplateNameDiffers:           4,
+	DriftTemplateNotMirrored:           5,
+	DriftMirroredTemplateOrphaned:      6,
+	DriftMembershipRoleMissingTemplate: 7,
+	DriftUnparseableRow:                8,
+}
+
+// DriftRow is one disagreement.
+type DriftRow struct {
+	Kind string
+	// OrganizationID / UserID identify the membership, empty for a
+	// template-level row.
+	OrganizationID string
+	UserID         string
+	// RoleTemplateID identifies the template, empty for a membership-level row
+	// that is not about one particular template.
+	RoleTemplateID string
+	// Identity / Registry are the two disagreeing values, rendered for a human.
+	// "none" means the side had no value; "absent" means it had no row at all.
+	Identity string
+	Registry string
+}
+
+// String renders one row for the verb's output.
+func (d DriftRow) String() string {
+	var where string
+	switch {
+	case d.OrganizationID != "" || d.UserID != "":
+		where = fmt.Sprintf("organization=%s user=%s", d.OrganizationID, d.UserID)
+	default:
+		where = fmt.Sprintf("role_template=%s", d.RoleTemplateID)
+	}
+	return fmt.Sprintf("%-33s %s  identity=%s  registry=%s", d.Kind, where, d.Identity, d.Registry)
+}
+
+// DriftReport is the whole comparison.
+type DriftReport struct {
+	// Rows is every disagreement found, worst first.
+	Rows []DriftRow
+	// SourceMemberships / SourceRoleTemplates / MirroredMemberships /
+	// MirroredRoleTemplates are what was actually compared.
+	//
+	// They are reported because a gate that passes MUST be able to prove it
+	// looked at something. Two empty databases agree perfectly, and a check
+	// that answers "no drift" without saying it compared zero rows to zero rows
+	// is how a cutover gets certified against nothing at all.
+	SourceMemberships     int
+	SourceRoleTemplates   int
+	MirroredMemberships   int
+	MirroredRoleTemplates int
+}
+
+// Clean reports whether the two copies agree.
+func (r DriftReport) Clean() bool { return len(r.Rows) == 0 }
+
+// CheckMemberRoleDrift compares registry's own authorization tables against the
+// identity tables, through the two connections the application itself uses.
+//
+// identityDB MUST be the connection the application resolves identity reads
+// through and registryDB the one migration 000055 created the tables on --
+// the same pair ReconcileMemberRoles takes, and for the same reason: which
+// schema and which database hold the live rows is a decision made at process
+// start, and this function inherits it rather than inferring it.
+//
+// It returns an error for STRUCTURAL failures only. A disagreement is data, not
+// an error: the caller decides what a non-empty report means, and cmd/role-drift
+// turns it into an exit code.
+func CheckMemberRoleDrift(ctx context.Context, identityDB, registryDB *sql.DB) (DriftReport, error) {
+	var report DriftReport
+
+	// Refuse against a source or a destination that is not there. An
+	// unreachable table and an empty one are indistinguishable from a row
+	// count, and a gate that cannot tell them apart reports "no drift" for the
+	// deployment whose tables it never found.
+	if err := verifyIdentitySource(ctx, identityDB); err != nil {
+		return report, err
+	}
+	if err := NewMemberRoleMirror(registryDB).Verify(ctx); err != nil {
+		return report, fmt.Errorf("registry role tables unusable: %w", err)
+	}
+
+	sourceTemplates, err := identitystore.NewRoleTemplateRepository(identityDB).ListRoleTemplates(ctx)
+	if err != nil {
+		return report, fmt.Errorf("read effective role templates: %w", err)
+	}
+	mirroredTemplates, err := NewMemberRoleReader(registryDB).ListRoleTemplates(ctx)
+	if err != nil {
+		return report, fmt.Errorf("read mirrored role templates: %w", err)
+	}
+	report.SourceRoleTemplates = len(sourceTemplates)
+	report.MirroredRoleTemplates = len(mirroredTemplates)
+
+	sourceMembers, unparseable, err := readEffectiveMemberships(ctx, identityDB)
+	if err != nil {
+		return report, err
+	}
+	mirroredMembers, err := readMirroredMemberships(ctx, registryDB)
+	if err != nil {
+		return report, err
+	}
+	report.SourceMemberships = len(sourceMembers)
+	report.MirroredMemberships = len(mirroredMembers)
+
+	rows := driftInTemplates(sourceTemplates, mirroredTemplates)
+	rows = append(rows, driftInMemberships(sourceMembers, mirroredMembers, sourceTemplates)...)
+	if unparseable > 0 {
+		// No identifiers: they are precisely the rows whose identifiers could
+		// not be represented. readEffectiveMemberships logs each one with its
+		// raw value as it skips it.
+		rows = append(rows, DriftRow{
+			Kind:     DriftUnparseableRow,
+			Identity: fmt.Sprintf("%d row(s) with a non-UUID organization_id or user_id", unparseable),
+			Registry: "absent",
+		})
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Kind != rows[j].Kind {
+			return driftKindOrder[rows[i].Kind] < driftKindOrder[rows[j].Kind]
+		}
+		if rows[i].OrganizationID != rows[j].OrganizationID {
+			return rows[i].OrganizationID < rows[j].OrganizationID
+		}
+		if rows[i].UserID != rows[j].UserID {
+			return rows[i].UserID < rows[j].UserID
+		}
+		return rows[i].RoleTemplateID < rows[j].RoleTemplateID
+	})
+	report.Rows = rows
+	return report, nil
+}
+
+// driftInTemplates compares the two role-template sets by id.
+//
+// By id, not by name, because the id is what a membership stores: two rows that
+// share a name and differ in id are two DIFFERENT templates as far as every
+// assignment is concerned. The name is then compared as a property of the
+// matched pair, which is how DriftTemplateNameDiffers can exist at all.
+func driftInTemplates(source, mirrored []*models.RoleTemplate) []DriftRow {
+	byID := make(map[uuid.UUID]*models.RoleTemplate, len(mirrored))
+	for _, t := range mirrored {
+		byID[t.ID] = t
+	}
+
+	var rows []DriftRow
+	seen := make(map[uuid.UUID]bool, len(source))
+	for _, want := range source {
+		seen[want.ID] = true
+		got, ok := byID[want.ID]
+		if !ok {
+			rows = append(rows, DriftRow{
+				Kind:           DriftTemplateNotMirrored,
+				RoleTemplateID: want.ID.String(),
+				Identity:       want.Name,
+				Registry:       "absent",
+			})
+			continue
+		}
+		if want.Name != got.Name {
+			rows = append(rows, DriftRow{
+				Kind:           DriftTemplateNameDiffers,
+				RoleTemplateID: want.ID.String(),
+				Identity:       want.Name,
+				Registry:       got.Name,
+			})
+		}
+		if !sameScopes(want.Scopes, got.Scopes) {
+			rows = append(rows, DriftRow{
+				Kind:           DriftTemplateScopesDiffer,
+				RoleTemplateID: want.ID.String(),
+				Identity:       renderScopes(want.Scopes),
+				Registry:       renderScopes(got.Scopes),
+			})
+		}
+	}
+	for _, got := range mirrored {
+		if seen[got.ID] {
+			continue
+		}
+		rows = append(rows, DriftRow{
+			Kind:           DriftMirroredTemplateOrphaned,
+			RoleTemplateID: got.ID.String(),
+			Identity:       "absent",
+			Registry:       got.Name,
+		})
+	}
+	return rows
+}
+
+// driftInMemberships compares the two assignment sets both ways.
+func driftInMemberships(source, mirrored map[memberKey]*string, sourceTemplates []*models.RoleTemplate) []DriftRow {
+	live := make(map[string]bool, len(sourceTemplates))
+	for _, t := range sourceTemplates {
+		live[t.ID.String()] = true
+	}
+
+	var rows []DriftRow
+	for key, sourceRole := range source {
+		// A membership naming a template the source itself does not have is
+		// reported on its own terms. The reconcile mirrors it with NO role, so
+		// without this it would surface as an ordinary role_differs and an
+		// operator would go looking for a broken dual-write instead of the
+		// broken identity row that actually caused it.
+		if sourceRole != nil && !live[*sourceRole] {
+			rows = append(rows, DriftRow{
+				Kind:           DriftMembershipRoleMissingTemplate,
+				OrganizationID: key.orgID,
+				UserID:         key.userID,
+				RoleTemplateID: *sourceRole,
+				Identity:       *sourceRole,
+				Registry:       "none (mirrored with no role, deliberately)",
+			})
+			continue
+		}
+		mirroredRole, ok := mirrored[key]
+		if !ok {
+			rows = append(rows, DriftRow{
+				Kind:           DriftMembershipNotMirrored,
+				OrganizationID: key.orgID,
+				UserID:         key.userID,
+				Identity:       derefRole(sourceRole),
+				Registry:       "absent",
+			})
+			continue
+		}
+		if !sameRole(sourceRole, mirroredRole) {
+			rows = append(rows, DriftRow{
+				Kind:           DriftRoleDiffers,
+				OrganizationID: key.orgID,
+				UserID:         key.userID,
+				Identity:       derefRole(sourceRole),
+				Registry:       derefRole(mirroredRole),
+			})
+		}
+	}
+	for key, mirroredRole := range mirrored {
+		if _, ok := source[key]; ok {
+			continue
+		}
+		rows = append(rows, DriftRow{
+			Kind:           DriftMirrorWithoutMembership,
+			OrganizationID: key.orgID,
+			UserID:         key.userID,
+			Identity:       "absent",
+			Registry:       derefRole(mirroredRole),
+		})
+	}
+	return rows
+}
+
+// sameScopes compares two scope sets as SETS: order and duplicates do not
+// change what a template confers, and reporting a reordering as drift would
+// make the gate un-passable for a deployment that is in fact correct.
+func sameScopes(a, b []string) bool {
+	seen := make(map[string]bool, len(a))
+	for _, s := range a {
+		seen[s] = true
+	}
+	for _, s := range b {
+		if !seen[s] {
+			return false
+		}
+		delete(seen, s)
+	}
+	return len(seen) == 0
+}
+
+// renderScopes formats a scope set for the report, sorted so two renderings of
+// the same set read the same.
+func renderScopes(scopes []string) string {
+	if len(scopes) == 0 {
+		return "[]"
+	}
+	out := append([]string(nil), scopes...)
+	sort.Strings(out)
+	return "[" + strings.Join(out, " ") + "]"
+}

--- a/backend/internal/db/repositories/member_role_equivalence_pg_test.go
+++ b/backend/internal/db/repositories/member_role_equivalence_pg_test.go
@@ -1,0 +1,628 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+
+	identityauth "github.com/sethbacon/terraform-suite-identity/identity/auth"
+	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	registryauth "github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+// THE EQUIVALENCE PROOF for the read cutover
+// (sethbacon/terraform-suite-identity#206, phase 3b).
+//
+// Everything else in this change argues that the flip is safe. This file is the
+// only thing that DEMONSTRATES it: for a representative set of principals it
+// resolves effective scopes BOTH WAYS -- once with the SQL the pre-cutover code
+// issued against `organization_members` joined to `role_templates`, and once
+// through the accessors as they are now -- and asserts the two agree, scope for
+// scope, principal by principal, organization by organization.
+//
+// The final test is the other half of the proof, and it is the one that makes
+// the rest of the file mean anything: it corrupts ONE mirrored row and asserts
+// the comparison FAILS. A test that only ever sees agreement cannot distinguish
+// "the two copies agree" from "the comparison is not looking at anything", and
+// this repository has shipped guards that could not tell those apart.
+//
+// CI DOES NOT RUN THIS. No workflow sets TFR_TEST_DATABASE_URL (issue #886), so
+// everything below skips on a PR. It is evidence produced locally against
+// postgres:16 and named as such in the pull request.
+
+// principal is one (organization, user) pair and the role it should hold.
+type principal struct {
+	name   string
+	orgID  string
+	userID string
+	// roleID is empty for a membership that carries no role at all.
+	roleID string
+	scopes []string
+}
+
+// seedEquivalenceEstate builds a deployment with the shapes that actually
+// distinguish a correct cutover from a plausible one.
+//
+// Not one happy-path member: the cases below are the ones where "resolve the
+// role from a different table" can go wrong in a way a single-member fixture
+// would never show -- a user in TWO organizations with DIFFERENT roles (the
+// cross-organization union is the token mint, and collapsing it is a privilege
+// escalation), a membership with NO role (nil and "" are different rows, and a
+// missing mirror row looks like this one if the overlay is sloppy), a role with
+// an EMPTY scope list, and two members sharing one template (so a per-member
+// overlay cannot accidentally pass by being per-template).
+func seedEquivalenceEstate(t *testing.T, db *sql.DB) []principal {
+	t.Helper()
+
+	orgAlpha, orgBeta := uuid.NewString(), uuid.NewString()
+	mustExec(t, db, `INSERT INTO organizations (id, name, display_name) VALUES ($1,'alpha','Alpha'),($2,'beta','Beta')`,
+		orgAlpha, orgBeta)
+
+	admin, publisher, viewer, empty := uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString()
+	mustExec(t, db, `INSERT INTO role_templates (id, name, display_name, scopes, is_system) VALUES
+		($1,'eq-admin','EQ Admin','["organizations:write","modules:write","modules:read"]'::jsonb,false),
+		($2,'eq-publisher','EQ Publisher','["modules:write","modules:read","providers:read"]'::jsonb,false),
+		($3,'eq-viewer','EQ Viewer','["modules:read"]'::jsonb,false),
+		($4,'eq-empty','EQ Empty','[]'::jsonb,false)`,
+		admin, publisher, viewer, empty)
+
+	// dual belongs to both organizations with DIFFERENT roles. This is the one
+	// that catches a resolver which unions across organizations.
+	dual := uuid.NewString()
+	// solo shares eq-viewer with dual's beta membership, so a template-keyed
+	// overlay cannot pass by accident.
+	solo := uuid.NewString()
+	// roleless is a member with role_template_id NULL -- present, entitled to
+	// nothing. Indistinguishable from "not mirrored" unless the overlay keeps
+	// the distinction migration 000055 built into the schema.
+	roleless := uuid.NewString()
+	// emptyScoped holds a template that exists and confers nothing.
+	emptyScoped := uuid.NewString()
+
+	for _, id := range []string{dual, solo, roleless, emptyScoped} {
+		mustExec(t, db, `INSERT INTO users (id, email, name) VALUES ($1,$2,'Test User')`, id, id+"@example.com")
+	}
+
+	mustExec(t, db, `INSERT INTO organization_members (organization_id, user_id, role_template_id) VALUES
+		($1,$2,$3), ($4,$2,$5),
+		($1,$6,$7),
+		($1,$8,NULL),
+		($4,$9,$10)`,
+		orgAlpha, dual, admin,
+		orgBeta, viewer,
+		solo, publisher,
+		roleless,
+		emptyScoped, empty)
+
+	return []principal{
+		{"dual in alpha (admin)", orgAlpha, dual, admin, []string{"organizations:write", "modules:write", "modules:read"}},
+		{"dual in beta (viewer)", orgBeta, dual, viewer, []string{"modules:read"}},
+		{"solo in alpha (publisher)", orgAlpha, solo, publisher, []string{"modules:write", "modules:read", "providers:read"}},
+		{"roleless in alpha (no role)", orgAlpha, roleless, "", nil},
+		{"emptyScoped in beta (empty template)", orgBeta, emptyScoped, empty, nil},
+	}
+}
+
+// scopesTheOldWay resolves a principal's effective scopes in ONE organization
+// with the query the pre-cutover code issued.
+//
+// It is written out here rather than called through the shared store, on
+// purpose: the store is what the cutover changed the CALLERS of, so asking it
+// again would be asking the new code whether it agrees with itself. This is the
+// old SQL, against the old tables, and it is the independent side of the
+// comparison.
+func scopesTheOldWay(t *testing.T, db *sql.DB, orgID, userID string) []string {
+	t.Helper()
+	var raw []byte
+	err := db.QueryRow(`
+		SELECT COALESCE(rt.scopes, '[]'::jsonb)
+		  FROM organization_members om
+		  LEFT JOIN role_templates rt ON rt.id = om.role_template_id
+		 WHERE om.organization_id = $1 AND om.user_id = $2`, orgID, userID).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("resolve scopes the old way for (%s, %s): %v", orgID, userID, err)
+	}
+	var scopes []string
+	if err := json.Unmarshal(raw, &scopes); err != nil {
+		t.Fatalf("parse old-way scopes: %v", err)
+	}
+	return scopes
+}
+
+// roleTheOldWay reads the role template id the pre-cutover code would have
+// resolved for a membership.
+func roleTheOldWay(t *testing.T, db *sql.DB, orgID, userID string) string {
+	t.Helper()
+	var id sql.NullString
+	err := db.QueryRow(
+		`SELECT role_template_id FROM organization_members WHERE organization_id = $1 AND user_id = $2`,
+		orgID, userID).Scan(&id)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("resolve role the old way: %v", err)
+	}
+	if !id.Valid {
+		return ""
+	}
+	return id.String
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	x, y := sortedCopy(a), sortedCopy(b)
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// equivalenceFixture builds the estate, reconciles registry's tables from it,
+// and returns the repository the cutover put in front of every caller.
+func equivalenceFixture(t *testing.T) (*sql.DB, *OrganizationRepository, []principal) {
+	t.Helper()
+	db, _ := reconcileScratchDB(t, 55)
+	principals := seedEquivalenceEstate(t, db)
+
+	report, err := ReconcileMemberRoles(context.Background(), db, db)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if report.SourceMemberships != len(principals) {
+		t.Fatalf("reconcile read %d source membership(s), want %d — the fixture and the "+
+			"reconcile disagree about what was seeded", report.SourceMemberships, len(principals))
+	}
+	return db, NewOrganizationRepository(db), principals
+}
+
+// TestEquivalence_EffectiveScopesMatchBothWays is the proof.
+//
+// For every principal, every accessor that answers "what may this person do
+// here" is asked, and its answer is compared to what the pre-cutover SQL
+// resolves from the identity tables. Not "no error": the exact scope set, the
+// exact role template id.
+func TestEquivalence_EffectiveScopesMatchBothWays(t *testing.T) {
+	db, repo, principals := equivalenceFixture(t)
+	ctx := context.Background()
+
+	for _, p := range principals {
+		t.Run(p.name, func(t *testing.T) {
+			wantScopes := scopesTheOldWay(t, db, p.orgID, p.userID)
+			wantRole := roleTheOldWay(t, db, p.orgID, p.userID)
+
+			// The fixture's own expectation, checked against the old way as
+			// well: if these disagree the seed is wrong and every comparison
+			// below would be comparing two copies of the same mistake.
+			if !sameStringSet(wantScopes, p.scopes) {
+				t.Fatalf("fixture disagrees with the identity tables: seeded %v, identity resolves %v",
+					sortedCopy(p.scopes), sortedCopy(wantScopes))
+			}
+
+			// 1. The per-organization authorization check -- the accessor every
+			//    org-scoped route is decided by.
+			got, err := repo.GetUserScopesForOrg(ctx, p.userID, p.orgID)
+			if err != nil {
+				t.Fatalf("GetUserScopesForOrg: %v", err)
+			}
+			if !sameStringSet(got, wantScopes) {
+				t.Errorf("GetUserScopesForOrg = %v, identity tables resolve %v",
+					sortedCopy(got), sortedCopy(wantScopes))
+			}
+
+			// 2. The membership accessor the per-resource guards are built on.
+			member, err := repo.GetMemberWithRole(ctx, p.orgID, p.userID, identitystore.OrgScopeAllOrganizations())
+			if err != nil {
+				t.Fatalf("GetMemberWithRole: %v", err)
+			}
+			if !sameStringSet(member.RoleTemplateScopes, wantScopes) {
+				t.Errorf("GetMemberWithRole scopes = %v, identity tables resolve %v",
+					sortedCopy(member.RoleTemplateScopes), sortedCopy(wantScopes))
+			}
+			if gotRole := derefOrEmpty(member.RoleTemplateID); gotRole != wantRole {
+				t.Errorf("GetMemberWithRole role_template_id = %q, identity tables hold %q", gotRole, wantRole)
+			}
+
+			// 3. The bare membership read.
+			bare, err := repo.GetMember(ctx, p.orgID, p.userID, identitystore.OrgScopeAllOrganizations())
+			if err != nil {
+				t.Fatalf("GetMember: %v", err)
+			}
+			if gotRole := derefOrEmpty(bare.RoleTemplateID); gotRole != wantRole {
+				t.Errorf("GetMember role_template_id = %q, identity tables hold %q", gotRole, wantRole)
+			}
+
+			// 4. CheckMembership's second return value, which several route
+			//    guards read INSTEAD of calling GetMember.
+			isMember, checkRole, err := repo.CheckMembership(ctx, p.orgID, p.userID, identitystore.OrgScopeAllOrganizations())
+			if err != nil {
+				t.Fatalf("CheckMembership: %v", err)
+			}
+			if !isMember {
+				t.Errorf("CheckMembership says not a member, but the identity tables have the row")
+			}
+			if gotRole := derefOrEmpty(checkRole); gotRole != wantRole {
+				t.Errorf("CheckMembership role_template_id = %q, identity tables hold %q", gotRole, wantRole)
+			}
+		})
+	}
+}
+
+// TestEquivalence_CrossOrganizationUnionMatches covers the accessors keyed by
+// USER rather than by membership -- the token mint and the tenant predicate.
+//
+// Separate from the per-membership proof because they are the ones that can be
+// wrong in the direction that ESCALATES: a resolver that attached the wrong
+// organization's role to a membership, or that unioned two organizations into
+// one, produces a token carrying authority the principal holds nowhere.
+func TestEquivalence_CrossOrganizationUnionMatches(t *testing.T) {
+	db, repo, principals := equivalenceFixture(t)
+	ctx := context.Background()
+
+	// Every distinct user in the fixture.
+	users := map[string]bool{}
+	for _, p := range principals {
+		users[p.userID] = true
+	}
+
+	for userID := range users {
+		t.Run(userID[:8], func(t *testing.T) {
+			// The old way: union the scopes of every membership this user has.
+			want := map[string]bool{}
+			perOrg := map[string][]string{}
+			rows, err := db.Query(
+				`SELECT organization_id FROM organization_members WHERE user_id = $1`, userID)
+			if err != nil {
+				t.Fatalf("list organizations: %v", err)
+			}
+			var orgIDs []string
+			for rows.Next() {
+				var orgID string
+				if err := rows.Scan(&orgID); err != nil {
+					t.Fatalf("scan: %v", err)
+				}
+				orgIDs = append(orgIDs, orgID)
+			}
+			_ = rows.Close()
+			for _, orgID := range orgIDs {
+				scopes := scopesTheOldWay(t, db, orgID, userID)
+				perOrg[orgID] = scopes
+				for _, s := range scopes {
+					want[s] = true
+				}
+			}
+			wantUnion := make([]string, 0, len(want))
+			for s := range want {
+				wantUnion = append(wantUnion, s)
+			}
+
+			got, err := repo.GetUserCombinedScopes(ctx, userID) //nolint:staticcheck // SA1019: the cross-org union is exactly what is under test here
+			if err != nil {
+				t.Fatalf("GetUserCombinedScopes: %v", err)
+			}
+			if !sameStringSet(got, wantUnion) {
+				t.Errorf("GetUserCombinedScopes = %v, identity tables union to %v",
+					sortedCopy(got), sortedCopy(wantUnion))
+			}
+
+			// GetUserMemberships must keep the roles attached to the RIGHT
+			// organizations, which the union above cannot show.
+			memberships, err := repo.GetUserMemberships(ctx, userID)
+			if err != nil {
+				t.Fatalf("GetUserMemberships: %v", err)
+			}
+			if len(memberships) != len(orgIDs) {
+				t.Fatalf("GetUserMemberships returned %d membership(s), identity has %d",
+					len(memberships), len(orgIDs))
+			}
+			for _, m := range memberships {
+				if !sameStringSet(m.RoleTemplateScopes, perOrg[m.OrganizationID]) {
+					t.Errorf("organization %s: scopes = %v, identity tables resolve %v",
+						m.OrganizationID, sortedCopy(m.RoleTemplateScopes), sortedCopy(perOrg[m.OrganizationID]))
+				}
+			}
+
+			// OrgScopeForUser is the tenant predicate. Ask it for a scope only
+			// SOME of this user's organizations grant, so a resolver that
+			// unioned would return an organization it must not.
+			scope, err := repo.OrgScopeForUser(ctx, userID, "modules:write", registryauth.ReadWritePairs())
+			if err != nil {
+				t.Fatalf("OrgScopeForUser: %v", err)
+			}
+			var wantOrgs []string
+			for orgID, scopes := range perOrg {
+				if identityauth.HasScope(scopes, "modules:write", registryauth.ReadWritePairs()) {
+					wantOrgs = append(wantOrgs, orgID)
+				}
+			}
+			if !sameStringSet(scope.OrganizationIDs(), wantOrgs) {
+				t.Errorf("OrgScopeForUser(modules:write) = %v, identity tables grant it in %v",
+					sortedCopy(scope.OrganizationIDs()), sortedCopy(wantOrgs))
+			}
+		})
+	}
+}
+
+// TestEquivalence_DriftCheckIsZeroOnAReconciledEstate is the gate itself, run
+// against the estate the proof above uses. It must be clean, and it must say it
+// compared something.
+func TestEquivalence_DriftCheckIsZeroOnAReconciledEstate(t *testing.T) {
+	db, _, principals := equivalenceFixture(t)
+
+	report, err := CheckMemberRoleDrift(context.Background(), db, db)
+	if err != nil {
+		t.Fatalf("CheckMemberRoleDrift: %v", err)
+	}
+	if !report.Clean() {
+		for _, row := range report.Rows {
+			t.Errorf("unexpected drift: %s", row)
+		}
+		t.Fatal("a freshly reconciled estate must produce zero drift; the gate is unusable otherwise")
+	}
+	if report.SourceMemberships != len(principals) {
+		t.Errorf("drift check compared %d membership(s), fixture seeded %d — a gate that "+
+			"reports clean without looking at the rows is the failure it exists to prevent",
+			report.SourceMemberships, len(principals))
+	}
+	if report.SourceRoleTemplates == 0 || report.MirroredRoleTemplates == 0 {
+		t.Errorf("drift check compared %d source and %d mirrored role template(s); zero on either "+
+			"side means it certified an empty universe",
+			report.SourceRoleTemplates, report.MirroredRoleTemplates)
+	}
+}
+
+// TestEquivalence_ACorruptedMirrorRowBreaksTheProof is the falsification, and
+// it is what makes every assertion above worth reading.
+//
+// Each case corrupts registry's copy in ONE way a dual-write gap actually
+// produces, and requires that BOTH the equivalence comparison and the drift
+// check notice. A case where the equivalence held would mean the accessors are
+// not reading registry's tables at all; a case where the drift check stayed
+// clean would mean the gate cannot see the very defect it gates on.
+func TestEquivalence_ACorruptedMirrorRowBreaksTheProof(t *testing.T) {
+	cases := []struct {
+		name string
+		// corrupt mutates registry's copy and returns the principal it damaged.
+		corrupt  func(t *testing.T, db *sql.DB, p principal)
+		wantKind string
+	}{
+		{
+			name: "the mirrored row is deleted (a membership that never mirrored)",
+			corrupt: func(t *testing.T, db *sql.DB, p principal) {
+				mustExec(t, db, `DELETE FROM organization_member_roles WHERE organization_id=$1 AND user_id=$2`,
+					p.orgID, p.userID)
+			},
+			wantKind: DriftMembershipNotMirrored,
+		},
+		{
+			name: "the mirrored row names a different template (a stale dual-write)",
+			corrupt: func(t *testing.T, db *sql.DB, p principal) {
+				var other string
+				if err := db.QueryRow(
+					`SELECT id FROM registry_role_templates WHERE id <> $1 LIMIT 1`, p.roleID).Scan(&other); err != nil {
+					t.Fatalf("find another template: %v", err)
+				}
+				mustExec(t, db, `UPDATE organization_member_roles SET role_template_id=$3
+				                 WHERE organization_id=$1 AND user_id=$2`, p.orgID, p.userID, other)
+			},
+			wantKind: DriftRoleDiffers,
+		},
+		{
+			name: "the mirrored row's role is cleared (a lost re-role)",
+			corrupt: func(t *testing.T, db *sql.DB, p principal) {
+				mustExec(t, db, `UPDATE organization_member_roles SET role_template_id=NULL
+				                 WHERE organization_id=$1 AND user_id=$2`, p.orgID, p.userID)
+			},
+			wantKind: DriftRoleDiffers,
+		},
+		{
+			name: "the mirrored template's scopes were not updated",
+			corrupt: func(t *testing.T, db *sql.DB, p principal) {
+				mustExec(t, db, `UPDATE registry_role_templates SET scopes='["modules:read"]'::jsonb WHERE id=$1`,
+					p.roleID)
+			},
+			wantKind: DriftTemplateScopesDiffer,
+		},
+		{
+			name: "the mirrored template was renamed",
+			corrupt: func(t *testing.T, db *sql.DB, p principal) {
+				mustExec(t, db, `UPDATE registry_role_templates SET name='eq-renamed' WHERE id=$1`, p.roleID)
+			},
+			wantKind: DriftTemplateNameDiffers,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, repo, principals := equivalenceFixture(t)
+			ctx := context.Background()
+
+			// The admin in alpha: a principal whose role actually confers
+			// something, so a corruption is observable as a scope change.
+			var victim principal
+			for _, p := range principals {
+				if p.roleID != "" && len(p.scopes) > 1 {
+					victim = p
+					break
+				}
+			}
+			if victim.roleID == "" {
+				t.Fatal("no scoped principal in the fixture — nothing to corrupt")
+			}
+
+			before, err := repo.GetUserScopesForOrg(ctx, victim.userID, victim.orgID)
+			if err != nil {
+				t.Fatalf("GetUserScopesForOrg before: %v", err)
+			}
+			if !sameStringSet(before, victim.scopes) {
+				t.Fatalf("the estate was already wrong before the corruption: %v vs %v",
+					sortedCopy(before), sortedCopy(victim.scopes))
+			}
+
+			tc.corrupt(t, db, victim)
+
+			// 1. The equivalence proof must now FAIL for this principal.
+			//    A rename does not change what the template confers, so it is
+			//    the one corruption the scope comparison legitimately cannot
+			//    see -- which is exactly why the drift check compares names.
+			if tc.wantKind != DriftTemplateNameDiffers {
+				after, err := repo.GetUserScopesForOrg(ctx, victim.userID, victim.orgID)
+				if err != nil {
+					t.Fatalf("GetUserScopesForOrg after: %v", err)
+				}
+				identity := scopesTheOldWay(t, db, victim.orgID, victim.userID)
+				if sameStringSet(after, identity) {
+					t.Errorf("after corrupting registry's copy, GetUserScopesForOrg still returns %v, "+
+						"which equals what the identity tables resolve. The accessor is NOT reading "+
+						"registry's tables, so every equivalence assertion in this file is vacuous",
+						sortedCopy(after))
+				}
+			}
+
+			// 2. The gate must report it, with the right kind and naming the
+			//    right row.
+			report, err := CheckMemberRoleDrift(ctx, db, db)
+			if err != nil {
+				t.Fatalf("CheckMemberRoleDrift: %v", err)
+			}
+			if report.Clean() {
+				t.Fatalf("the drift check reports no drift after %s — the gate cannot see the "+
+					"defect it gates on", tc.name)
+			}
+			var found *DriftRow
+			for i := range report.Rows {
+				if report.Rows[i].Kind == tc.wantKind {
+					found = &report.Rows[i]
+					break
+				}
+			}
+			if found == nil {
+				var kinds []string
+				for _, r := range report.Rows {
+					kinds = append(kinds, r.Kind)
+				}
+				t.Fatalf("drift reported %v, want a %q row", kinds, tc.wantKind)
+			}
+			switch tc.wantKind {
+			case DriftMembershipNotMirrored, DriftRoleDiffers:
+				if found.OrganizationID != victim.orgID || found.UserID != victim.userID {
+					t.Errorf("drift row names (%s, %s), corruption was to (%s, %s)",
+						found.OrganizationID, found.UserID, victim.orgID, victim.userID)
+				}
+			default:
+				if found.RoleTemplateID != victim.roleID {
+					t.Errorf("drift row names template %s, corruption was to %s",
+						found.RoleTemplateID, victim.roleID)
+				}
+			}
+
+			// 3. And the repair must work: re-deriving from the source clears
+			//    it. This is the operator's first remedy, and an unverified
+			//    remedy in a runbook is a guess.
+			if _, err := ReconcileMemberRoles(ctx, db, db); err != nil {
+				t.Fatalf("reconcile after corruption: %v", err)
+			}
+			repaired, err := CheckMemberRoleDrift(ctx, db, db)
+			if err != nil {
+				t.Fatalf("CheckMemberRoleDrift after repair: %v", err)
+			}
+			if !repaired.Clean() {
+				for _, row := range repaired.Rows {
+					t.Errorf("drift survived the reconcile: %s", row)
+				}
+			}
+			restored, err := repo.GetUserScopesForOrg(ctx, victim.userID, victim.orgID)
+			if err != nil {
+				t.Fatalf("GetUserScopesForOrg after repair: %v", err)
+			}
+			if !sameStringSet(restored, victim.scopes) {
+				t.Errorf("after the repair the principal resolves %v, want %v",
+					sortedCopy(restored), sortedCopy(victim.scopes))
+			}
+		})
+	}
+}
+
+// TestEquivalence_MirrorRowWithoutMembershipConfersNothing pins the one drift
+// direction that GRANTS rather than withholds.
+//
+// A row in `organization_member_roles` for somebody who is not a member is
+// inert TODAY, because every accessor asks the shared store for the membership
+// first. That is a property of the ordering in organization_repository.go, not
+// a coincidence, and it stops holding the moment phase 4 moves the membership
+// fact -- so it is pinned here, and the drift check reports the row meanwhile.
+func TestEquivalence_MirrorRowWithoutMembershipConfersNothing(t *testing.T) {
+	db, repo, principals := equivalenceFixture(t)
+	ctx := context.Background()
+
+	orgID := principals[0].orgID
+	stranger := uuid.NewString()
+	var adminTemplate string
+	if err := db.QueryRow(`SELECT id FROM registry_role_templates WHERE name = 'eq-admin'`).Scan(&adminTemplate); err != nil {
+		t.Fatalf("find eq-admin: %v", err)
+	}
+	// A user row, but NO membership: the grant exists only in registry's mirror.
+	mustExec(t, db, `INSERT INTO users (id, email, name) VALUES ($1,$2,'Stranger')`, stranger, stranger+"@example.com")
+	mustExec(t, db, `INSERT INTO organization_member_roles (organization_id, user_id, role_template_id)
+	                 VALUES ($1,$2,$3)`, orgID, stranger, adminTemplate)
+
+	scopes, err := repo.GetUserScopesForOrg(ctx, stranger, orgID)
+	if err != nil {
+		t.Fatalf("GetUserScopesForOrg: %v", err)
+	}
+	if len(scopes) != 0 {
+		t.Errorf("a mirrored role with no membership conferred %v — the accessor is resolving "+
+			"authority from registry's tables WITHOUT confirming membership first, which turns "+
+			"every stale mirror row into a live grant", sortedCopy(scopes))
+	}
+	isMember, _, err := repo.CheckMembership(ctx, orgID, stranger, identitystore.OrgScopeAllOrganizations())
+	if err != nil {
+		t.Fatalf("CheckMembership: %v", err)
+	}
+	if isMember {
+		t.Error("CheckMembership says a principal with only a mirrored role row is a member")
+	}
+
+	// And the gate reports it, because phase 4 is when it stops being inert.
+	report, err := CheckMemberRoleDrift(ctx, db, db)
+	if err != nil {
+		t.Fatalf("CheckMemberRoleDrift: %v", err)
+	}
+	var found bool
+	for _, row := range report.Rows {
+		if row.Kind == DriftMirrorWithoutMembership && row.UserID == stranger {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the drift check did not report the mirrored row with no membership; rows were %v",
+			report.Rows)
+	}
+}
+
+// derefOrEmpty renders an optional role template id as a comparable string.
+func derefOrEmpty(id *string) string {
+	if id == nil {
+		return ""
+	}
+	return *id
+}

--- a/backend/internal/db/repositories/member_role_equivalence_pg_test.go
+++ b/backend/internal/db/repositories/member_role_equivalence_pg_test.go
@@ -14,6 +14,7 @@ import (
 	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
 
 	registryauth "github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
 // THE EQUIVALENCE PROOF for the read cutover
@@ -625,4 +626,119 @@ func derefOrEmpty(id *string) string {
 		return ""
 	}
 	return *id
+}
+
+// TestEquivalence_TheBootSequenceLeavesTheGateAtZero exercises the ACTUAL order
+// internal/api/router.go runs on every start and requires `role-drift` to be
+// clean afterwards, in BOTH topologies.
+//
+// This is the property most easily reasoned into existence and hardest to notice
+// the loss of, and reasoning got it wrong once already: seeding registry's table
+// unconditionally left permanent `template_scopes_differ` drift on a completely
+// healthy default deployment, because migration 000018 added `scanning:read` to
+// `devops` and `auditor` and models.PredefinedRoleTemplates() does not carry it.
+// A gate that can never return zero is not a gate -- it gets ignored, and the
+// real divergence it exists to catch is ignored with it.
+//
+// It also pins the ORDER. Seeding first and reconciling second leaves the
+// reconcile's copy of identity's templates as the final state, which is the same
+// failure with the two halves swapped.
+func TestEquivalence_TheBootSequenceLeavesTheGateAtZero(t *testing.T) {
+	// boot runs the startup sequence router.go performs, once.
+	boot := func(t *testing.T, db *sql.DB, cutover bool) {
+		t.Helper()
+		ctx := context.Background()
+		if cutover {
+			// cmd/server, before NewRouter: the shared table gets registry's
+			// scopes layered onto the identity module's core-only seed.
+			if err := SeedSharedIdentityRoleTemplates(ctx, db, models.PredefinedRoleTemplates()); err != nil {
+				t.Fatalf("seed the shared identity role templates: %v", err)
+			}
+		}
+		if _, err := ReconcileMemberRoles(ctx, db, db); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if cutover {
+			if err := SeedSystemRoleTemplates(ctx, db, models.PredefinedRoleTemplates()); err != nil {
+				t.Fatalf("seed registry's own role templates: %v", err)
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		// cutover is TFR_IDENTITY_SCHEMA_ENABLED: the only topology either seed
+		// runs in. Both are modelled on one database because what is under test
+		// is the DRIFT the sequence leaves, not which schema each statement
+		// resolves to -- that is
+		// TestReconcile_UsesTheEffectiveSourceUnderTheSchemaCutover's subject.
+		cutover bool
+	}{
+		{"default topology (migrations are the policy; neither seed runs)", false},
+		{"identity-schema cutover (both seeds run)", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, _ := reconcileScratchDB(t, 55)
+			seedEquivalenceEstate(t, db)
+			ctx := context.Background()
+
+			boot(t, db, tc.cutover)
+
+			report, err := CheckMemberRoleDrift(ctx, db, db)
+			if err != nil {
+				t.Fatalf("CheckMemberRoleDrift: %v", err)
+			}
+			if !report.Clean() {
+				for _, row := range report.Rows {
+					t.Errorf("boot left drift behind: %s", row)
+				}
+				t.Fatal("the startup sequence leaves `role-drift` non-zero on a healthy " +
+					"deployment, which makes the gate on this whole phase un-passable")
+			}
+
+			// A second boot must be identical: both seeds are idempotent and
+			// the reconcile must not undo either.
+			boot(t, db, tc.cutover)
+			report, err = CheckMemberRoleDrift(ctx, db, db)
+			if err != nil {
+				t.Fatalf("CheckMemberRoleDrift after a second boot: %v", err)
+			}
+			for _, row := range report.Rows {
+				t.Errorf("the second boot introduced drift: %s", row)
+			}
+
+			// Whatever the topology, registry must resolve every system role
+			// template by NAME, under the id its memberships name. A seed that
+			// inserted a second row under a fresh uuid instead of updating the
+			// reconciled one would strip every holder of their role.
+			reader := NewMemberRoleReader(db)
+			for _, want := range models.PredefinedRoleTemplates() {
+				got, tErr := reader.GetRoleTemplateByName(ctx, want.Name)
+				if tErr != nil {
+					t.Errorf("registry cannot resolve role template %q: %v", want.Name, tErr)
+					continue
+				}
+				identityScopes := templateScopesTheOldWay(t, db, want.Name)
+				if !sameStringSet(got.Scopes, identityScopes) {
+					t.Errorf("role template %q: registry resolves %v, the identity tables hold %v",
+						want.Name, sortedCopy(got.Scopes), sortedCopy(identityScopes))
+				}
+			}
+		})
+	}
+}
+
+// templateScopesTheOldWay reads a system template's scopes from the shared table,
+// the way the pre-cutover code did.
+func templateScopesTheOldWay(t *testing.T, db *sql.DB, name string) []string {
+	t.Helper()
+	var raw []byte
+	if err := db.QueryRow(`SELECT scopes FROM role_templates WHERE name = $1`, name).Scan(&raw); err != nil {
+		t.Fatalf("read %q the old way: %v", name, err)
+	}
+	var scopes []string
+	if err := json.Unmarshal(raw, &scopes); err != nil {
+		t.Fatalf("parse %q scopes: %v", name, err)
+	}
+	return scopes
 }

--- a/backend/internal/db/repositories/member_role_read_class_test.go
+++ b/backend/internal/db/repositories/member_role_read_class_test.go
@@ -1,0 +1,679 @@
+package repositories
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Class guard for the role-read cutover
+// (sethbacon/terraform-suite-identity#206, phase 3b).
+//
+// The property: EVERY accessor that returns a member's role, or what that role
+// confers, resolves it from registry's own tables. Not most of them. All.
+//
+// A partial cutover is worse than none. Two accessors reading two copies give
+// the product two answers to one question, and they differ ONLY on the rows
+// that are wrong -- which is to say, only where it matters, and never in a way
+// a passing test would show. The failure mode is a principal who is allowed
+// through one route and denied through another, with no error anywhere.
+//
+// The defect is an ABSENT OVERRIDE, and an absent override cannot be caught by
+// testing the overrides that are present:
+//
+//  1. The shared store grows a role-bearing reader that this package does not
+//     override. Go promotes it, every caller compiles, and it serves identity's
+//     answer forever. No diff in this repository at all -- it arrives with a
+//     dependency bump.
+//  2. An override is added that delegates correctly and never consults
+//     registry's tables. It passes every behavioural test, because the shared
+//     store's answer is still correct on every row that has not drifted.
+//
+// There is a test below for each, on BOTH wrapper types, and every one of them
+// fails on an empty universe. A guard that inspects zero read paths and reports
+// green is how three earlier guards in this repository certified nothing.
+
+// selectorPath renders a call's function expression as a DOTTED PATH --
+// "r.roles.RoleFor", "r.GetMemberWithRole", "r.OrganizationRepository.GetMember",
+// "compareRole".
+//
+// The receiver is the whole point, and the first version of this guard did not
+// have it. Matching on the bare method NAME cannot tell
+// `r.OrganizationRepository.GetMemberWithRole` -- the DELEGATION every override
+// starts with -- from `r.GetMemberWithRole`, the sibling call by which a derived
+// accessor legitimately reaches the reader. With names alone, an override gutted
+// down to nothing but its delegation still "reached a reader call", and both
+// guards below certified it. That was verified by mutation, not reasoned about:
+// deleting the body of GetMemberWithRole left them green.
+//
+// This is the same failure this estate has recorded before -- an AST scanner
+// that returned an empty receiver for nested selectors and passed.
+func selectorPath(expr ast.Expr) string {
+	switch f := expr.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		base := selectorPath(f.X)
+		if base == "" {
+			return f.Sel.Name
+		}
+		return base + "." + f.Sel.Name
+	}
+	return ""
+}
+
+// calledPaths returns every dotted call path in fn.
+func calledPaths(fn *ast.FuncDecl) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok {
+			if p := selectorPath(call.Fun); p != "" {
+				out[p] = true
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// siblingCall reports the method name when path is a call on THIS type
+// (`r.Foo`), and "" for anything else -- including `r.Embedded.Foo`, which is
+// delegation to the shared store and reaches nothing of registry's.
+func siblingCall(path string) string {
+	parts := strings.Split(path, ".")
+	if len(parts) != 2 || parts[0] != "r" {
+		return ""
+	}
+	return parts[1]
+}
+
+// overlayHelpers are the two package-local helpers that perform the overlay and
+// the comparison on behalf of a caller. They are named rather than derived
+// because one is a plain function and one is a method, so neither is reachable
+// by the per-type fixpoint below -- and both are themselves verified by
+// TestMemberRoleReadClass_TheOverlayHelpersReachBoth.
+var overlayHelpers = map[string]bool{
+	"overlayMemberships": true,
+	"r.overlayUsers":     true,
+}
+
+// coveredOverrides returns the overrides that reach `direct` -- either by
+// calling one of those functions themselves, or transitively through a SIBLING
+// override that does.
+//
+// The fixpoint is what lets GetUserScopesForOrg, GetUserCombinedScopes and
+// OrgScopeForUser be correct implementations rather than exemptions: each is
+// nothing but a call to a sibling override plus a reduction, which is exactly
+// how they should be written, and the guard follows them there.
+func coveredOverrides(overrides map[string]*ast.FuncDecl, direct func(path string) bool) map[string]bool {
+	covered := map[string]bool{}
+	for name, fn := range overrides {
+		for path := range calledPaths(fn) {
+			if direct(path) || overlayHelpers[path] {
+				covered[name] = true
+				break
+			}
+		}
+	}
+	for changed := true; changed; {
+		changed = false
+		for name, fn := range overrides {
+			if covered[name] {
+				continue
+			}
+			for path := range calledPaths(fn) {
+				if sib := siblingCall(path); sib != "" && covered[sib] {
+					covered[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return covered
+}
+
+// readsRegistryTables reports whether a call path reaches the reader directly.
+func readsRegistryTables(path string) bool { return strings.HasPrefix(path, "r.roles.") }
+
+// reportsDivergence reports whether a call path is the comparison itself.
+func reportsDivergence(path string) bool { return path == "compareRole" }
+
+// roleReadSQL matches a projection that carries a MEMBERSHIP's role template.
+//
+// It is anchored on SELECT deliberately, so the membership WRITERS are not
+// swept in: `INSERT INTO organization_members (..., role_template_id, ...)` and
+// `UPDATE organization_members SET role_template_id = $3` both name the column
+// and neither returns it. Those are the write guard's universe
+// (member_role_mirror_class_test.go), and a method that appeared in both
+// universes would have to satisfy two contradictory requirements.
+//
+// The bounded gap tolerates the column lists these queries actually have
+// without letting a SELECT hundreds of lines earlier match an unrelated
+// mention.
+var roleReadSQL = regexp.MustCompile(`(?is)SELECT[^;]{0,800}?\brole_template_id\b`)
+
+// storeSQLConstants returns every package-level string constant declared in the
+// shared store, so a method that references its query by NAME can be expanded.
+//
+// Without this the guard would see `GetMemberWithRole` as having no SQL at all:
+// the identity module hoisted its membership projections into named constants
+// in membership.go, and five of the store's role-bearing reads are now nothing
+// but a constant reference plus a scan. A guard that matched only inline
+// literals would derive a universe missing exactly the accessors that matter
+// most, and report green.
+func storeSQLConstants(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, file := range parseDir(t, dir) {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					if s, ok := constStringValue(vs.Values[i], out); ok {
+						out[name.Name] = s
+					}
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("found no string constants in the shared identity store — the module layout " +
+			"changed and the SQL expansion below would silently see empty query bodies")
+	}
+	return out
+}
+
+// constStringValue renders a constant's value, following `A + B` concatenation
+// and already-known constant references. The membership constants are built
+// exactly that way (`"SELECT " + userMembershipColumns + userMembershipFrom`).
+func constStringValue(expr ast.Expr, known map[string]string) (string, bool) {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		s, err := strconv.Unquote(v.Value)
+		if err != nil {
+			return v.Value, true
+		}
+		return s, true
+	case *ast.Ident:
+		s, ok := known[v.Name]
+		return s, ok
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", false
+		}
+		l, lok := constStringValue(v.X, known)
+		r, rok := constStringValue(v.Y, known)
+		if !lok && !rok {
+			return "", false
+		}
+		return l + r, true
+	}
+	return "", false
+}
+
+// parseDir parses every non-test .go file under dir.
+func parseDir(t *testing.T, dir string) []*ast.File {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	var out []*ast.File
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		out = append(out, file)
+	}
+	return out
+}
+
+// expandedBody renders a method's SQL: its own string literals, plus the value
+// of every package-level string constant it names.
+func expandedBody(t *testing.T, fn *ast.FuncDecl, consts map[string]string) string {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString(bodyText(t, fn))
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok {
+			if s, found := consts[ident.Name]; found {
+				sb.WriteString(s)
+				sb.WriteString("\n")
+			}
+		}
+		return true
+	})
+	return sb.String()
+}
+
+// storeRoleReaders derives, from the pinned module's own source, every method on
+// the named store type that returns a membership's role -- directly in its own
+// SQL, or by calling one that does.
+//
+// The transitive step is not decoration. GetUserCombinedScopes,
+// GetUserScopesForOrg and OrgScopeForUser contain no SQL whatsoever: they
+// delegate and then reduce. Those three are the token mint, the per-organization
+// authorization check, and the tenant predicate -- i.e. the three most
+// consequential role reads in the product -- and a guard matching only SQL would
+// miss all three.
+func storeRoleReaders(t *testing.T, typeName string) map[string]bool {
+	t.Helper()
+	dir := identityStoreDir(t)
+	consts := storeSQLConstants(t, dir)
+	methods := methodsOn(t, dir, typeName)
+	if len(methods) == 0 {
+		t.Fatalf("found no methods on the shared store's %s — the module layout changed "+
+			"and this guard has no universe", typeName)
+	}
+
+	readers := map[string]bool{}
+	for name, fn := range methods {
+		if roleReadSQL.MatchString(expandedBody(t, fn, consts)) {
+			readers[name] = true
+		}
+	}
+	if len(readers) == 0 {
+		t.Fatalf("found no role-bearing SELECT in the shared store's %s — either the SQL moved "+
+			"or roleReadSQL is stale. Refusing to certify the read cutover against an empty universe", typeName)
+	}
+
+	for changed := true; changed; {
+		changed = false
+		for name, fn := range methods {
+			if readers[name] {
+				continue
+			}
+			for called := range calledMethodNames(fn) {
+				if readers[called] {
+					readers[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return readers
+}
+
+// storeRoleReadersNotNeedingOverride records EXPORTED methods the closure pulls
+// in that do not, in fact, return a role, with the reason.
+//
+// Checked in BOTH directions: an entry naming a method the pinned module no
+// longer derives as a reader fails the test, so the list cannot rot into a
+// permanent exemption for something that changed shape. It is empty today, and
+// that is the correct state -- it exists so that a future exemption has to be
+// written down and justified rather than smuggled into the regex.
+var storeRoleReadersNotNeedingOverride = map[string]map[string]string{
+	"OrganizationRepository": {},
+	"UserRepository":         {},
+}
+
+// unexportedReaderCoverage asserts the ONE structural exemption this guard
+// grants: an UNEXPORTED store method cannot be overridden from this package,
+// and does not need to be, PROVIDED every exported method that reaches it is.
+//
+// UserRepository.loadMembershipsForUsers is exactly that case -- it is the bulk
+// membership fetch behind ListUsersWithMemberships and SearchWithMemberships,
+// and both of those are overridden. The exemption is therefore not "trust us":
+// the closure in storeRoleReaders marks any caller of a reader as a reader, so
+// the exported callers are already in the universe the test above requires an
+// override for. What this function adds is the other half -- that such an
+// exported caller EXISTS. An unexported reader nobody calls would otherwise be
+// exempted by a rule with nothing behind it, and a future refactor that made it
+// the only path would be exempted too.
+func unexportedReaderCoverage(t *testing.T, typeName string, readers map[string]bool) {
+	t.Helper()
+	dir := identityStoreDir(t)
+	methods := methodsOn(t, dir, typeName)
+
+	for name := range readers {
+		if ast.IsExported(name) {
+			continue
+		}
+		var callers []string
+		for caller, fn := range methods {
+			if !ast.IsExported(caller) || !readers[caller] {
+				continue
+			}
+			if calledMethodNames(fn)[name] {
+				callers = append(callers, caller)
+			}
+		}
+		if len(callers) == 0 {
+			t.Errorf("the shared identity store's %s.%s returns a member's role and is UNEXPORTED, "+
+				"so repositories.%s cannot override it — and no exported reader on the same type "+
+				"calls it, so nothing overridable covers it either. Every route through it resolves "+
+				"roles from the identity tables with no way to intercept. This needs a change in the "+
+				"identity module, not an exemption here.", typeName, name, typeName)
+			continue
+		}
+		sort.Strings(callers)
+		t.Logf("%s.%s is unexported (not overridable); covered through %v, which are overridden",
+			typeName, name, callers)
+	}
+}
+
+// wrapperTypes are the two types in this package that wrap a store repository
+// with role-bearing reads.
+var wrapperTypes = []string{"OrganizationRepository", "UserRepository"}
+
+// TestMemberRoleReadClass_EveryStoreRoleReaderIsOverridden is bypass 1.
+func TestMemberRoleReadClass_EveryStoreRoleReaderIsOverridden(t *testing.T) {
+	for _, typeName := range wrapperTypes {
+		t.Run(typeName, func(t *testing.T) {
+			readers := storeRoleReaders(t, typeName)
+			overrides := methodsOn(t, ".", typeName)
+			if len(overrides) == 0 {
+				t.Fatalf("repositories.%s declares no methods — it is a type alias again, or it was "+
+					"renamed. Either way every role read is promoted straight from the shared store "+
+					"and resolves from the identity tables", typeName)
+			}
+
+			exempt := storeRoleReadersNotNeedingOverride[typeName]
+			unexportedReaderCoverage(t, typeName, readers)
+
+			var missing []string
+			seen := map[string]bool{}
+			for name := range readers {
+				if !ast.IsExported(name) {
+					// Not reachable from this package; unexportedReaderCoverage
+					// has already proved an overridden exported caller exists.
+					continue
+				}
+				if exempt[name] != "" {
+					seen[name] = true
+					continue
+				}
+				if overrides[name] == nil {
+					missing = append(missing, name)
+				}
+			}
+			sort.Strings(missing)
+			for _, name := range missing {
+				t.Errorf("the shared identity store's %s.%s returns a member's role template, but "+
+					"repositories.%s does not override it. Go promotes the embedded method, so every "+
+					"caller keeps compiling and this one accessor keeps resolving roles from "+
+					"`organization_members.role_template_id` while every other resolves them from "+
+					"registry's own tables (terraform-suite-identity#206 phase 3b). Add an override "+
+					"that delegates and then overlays, or — if it returns no role — record it in "+
+					"storeRoleReadersNotNeedingOverride with the reason.", typeName, name, typeName)
+			}
+
+			for name := range exempt {
+				if !seen[name] {
+					t.Errorf("storeRoleReadersNotNeedingOverride[%q] names %q, which the pinned module "+
+						"no longer derives as a role reader — drop the entry", typeName, name)
+				}
+			}
+			t.Logf("%s: checked %d store role reader(s) against %d override(s)",
+				typeName, len(readers), len(overrides))
+		})
+	}
+}
+
+// TestMemberRoleReadClass_EveryOverrideReadsRegistrysTables is bypass 2: an
+// override that delegates correctly and then returns identity's role unchanged.
+// It compiles, it passes every behavioural test, and it cuts nothing over.
+func TestMemberRoleReadClass_EveryOverrideReadsRegistrysTables(t *testing.T) {
+	for _, typeName := range wrapperTypes {
+		t.Run(typeName, func(t *testing.T) {
+			readers := storeRoleReaders(t, typeName)
+			overrides := methodsOn(t, ".", typeName)
+			exempt := storeRoleReadersNotNeedingOverride[typeName]
+			covered := coveredOverrides(overrides, readsRegistryTables)
+
+			var checked int
+			for name := range overrides {
+				if !readers[name] || exempt[name] != "" {
+					continue
+				}
+				checked++
+				if !covered[name] {
+					t.Errorf("repositories.%s.%s overrides a store role reader but never reaches "+
+						"r.roles -- not directly, and not through a sibling override. The override "+
+						"exists precisely so the role comes from registry's own tables; without that "+
+						"call it is a pass-through that returns identity's answer and looks like a "+
+						"cutover. Note that delegating to r.%s.%s does NOT count: that is the shared "+
+						"store, which is what the cutover moved away from.",
+						typeName, name, typeName, name)
+				}
+			}
+			if checked == 0 {
+				t.Fatalf("%s: no override matched a store role reader — the two derivations have "+
+					"drifted apart and this guard is vacuous", typeName)
+			}
+			t.Logf("%s: checked %d override(s) for a registry-table read", typeName, checked)
+		})
+	}
+}
+
+// TestMemberRoleReadClass_TheOverlayHelpersReachBoth verifies the two named
+// helpers in overlayHelpers, which the fixpoint above trusts.
+//
+// Without this the allowlist would be the guard's one unchecked assumption:
+// naming a helper that had stopped calling the reader, or stopped comparing,
+// would silently exempt every override that goes through it -- which is most of
+// them on UserRepository.
+func TestMemberRoleReadClass_TheOverlayHelpersReachBoth(t *testing.T) {
+	local := parseDir(t, ".")
+	bodies := map[string]map[string]bool{}
+	for _, file := range local {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			name := fn.Name.Name
+			if fn.Recv != nil {
+				name = "r." + name
+			}
+			bodies[name] = calledPaths(fn)
+		}
+	}
+
+	for helper := range overlayHelpers {
+		calls, found := bodies[helper]
+		if !found {
+			t.Errorf("overlayHelpers names %q, which does not exist in this package — the fixpoint "+
+				"is exempting overrides through a helper that is gone", helper)
+			continue
+		}
+		var reads, compares bool
+		for path := range calls {
+			if readsRegistryTables(path) {
+				reads = true
+			}
+			if reportsDivergence(path) {
+				compares = true
+			}
+			// A helper may reach either through the other helper.
+			if overlayHelpers[path] {
+				reads, compares = true, true
+			}
+		}
+		if !reads && !compares {
+			t.Errorf("%s neither reads registry's tables nor reports divergence, yet the fixpoint "+
+				"treats a call to it as satisfying both", helper)
+		}
+	}
+}
+
+// TestMemberRoleReadClass_EveryOverrideReportsDivergence is the third property,
+// and it is the one that keeps the cutover from going silent.
+//
+// Every override holds BOTH answers -- the store's, from the identity tables it
+// still queries, and registry's. Comparing them is free, and it is the only
+// per-principal signal that a dual-write gap exists at all: the drift check runs
+// when somebody runs it, while this fires on the request that is actually being
+// served the wrong role.
+//
+// An override that overlays without comparing loses that for nothing, and loses
+// it invisibly.
+func TestMemberRoleReadClass_EveryOverrideReportsDivergence(t *testing.T) {
+	for _, typeName := range wrapperTypes {
+		t.Run(typeName, func(t *testing.T) {
+			readers := storeRoleReaders(t, typeName)
+			overrides := methodsOn(t, ".", typeName)
+			exempt := storeRoleReadersNotNeedingOverride[typeName]
+			covered := coveredOverrides(overrides, reportsDivergence)
+
+			var checked int
+			for name := range overrides {
+				if !readers[name] || exempt[name] != "" {
+					continue
+				}
+				checked++
+				if !covered[name] {
+					t.Errorf("repositories.%s.%s serves registry's role without ever reaching "+
+						"compareRole -- not directly, and not through a sibling override. That "+
+						"comparison is free (both answers are already in hand) and it is the only "+
+						"signal that a dual-write gap has left this principal with the wrong role; "+
+						"without it the divergence is silent until somebody runs the drift check.",
+						typeName, name)
+				}
+			}
+			if checked == 0 {
+				t.Fatalf("%s: no override matched a store role reader — this guard is vacuous", typeName)
+			}
+			t.Logf("%s: checked %d override(s) for a divergence report", typeName, checked)
+		})
+	}
+}
+
+// sharedRoleTemplateRead matches a hand-written SELECT/JOIN against the SHARED
+// role_templates table.
+//
+// The optional schema qualifier is there because the same read appears
+// unqualified, as `public.role_templates`, and as `identity.role_templates`
+// depending on the topology the author had in mind. The `\s+` after FROM/JOIN is
+// what keeps `registry_role_templates` -- registry's OWN table, which every one
+// of these should now name -- from matching.
+var sharedRoleTemplateRead = regexp.MustCompile(`(?i)\b(?:FROM|JOIN)\s+(?:public\.|identity\.)?role_templates\b`)
+
+// sharedRoleTemplateReadExemptions are files permitted to READ the shared table,
+// keyed by module-relative path, with the reason.
+//
+// Checked in both directions: an entry whose file no longer contains such a read
+// fails the test, so a stale exemption cannot quietly cover a new one.
+var sharedRoleTemplateReadExemptions = map[string]string{}
+
+// TestMemberRoleReadClass_NoHandWrittenSharedRoleTemplateRead is bypass 3, and
+// it is the one the first version of this change did not have.
+//
+// The two tests above reason about the WRAPPER TYPES. They are blind to a
+// handler that issues its own SQL, and two did: role_ceiling.go's
+// checkRoleAssignment -- which decides whether a role may be assigned at all,
+// and refuses the platform-admin template -- and group_mapping_guard.go's
+// guardProvisionableRole, which decides what an IdP group claim may confer and
+// supplies the retention filter for the credential sweep. Both read
+// `SELECT scopes FROM role_templates`, both are authorization decisions, and
+// both would have kept computing them from the copy registry no longer enforces.
+//
+// Neither was found by the wrapper guards. Neither would have been found by any
+// behavioural test, because the two copies agree until they do not. It took
+// reading the diff, which is exactly the review step a class guard exists to
+// replace.
+func TestMemberRoleReadClass_NoHandWrittenSharedRoleTemplateRead(t *testing.T) {
+	// Self-check FIRST: a regex that matches nothing would make every assertion
+	// below vacuous, and this file's whole subject is guards that certify
+	// nothing.
+	for _, positive := range []string{
+		"SELECT scopes FROM role_templates WHERE id = $1",
+		"LEFT JOIN role_templates rt ON rt.id = om.role_template_id",
+		"FROM identity.role_templates",
+	} {
+		if !sharedRoleTemplateRead.MatchString(positive) {
+			t.Fatalf("sharedRoleTemplateRead does not match %q — the scan below would certify nothing", positive)
+		}
+	}
+	for _, negative := range []string{
+		"SELECT scopes FROM registry_role_templates WHERE id = $1",
+		"LEFT JOIN registry_role_templates rrt ON rrt.id = omr.role_template_id",
+	} {
+		if sharedRoleTemplateRead.MatchString(negative) {
+			t.Fatalf("sharedRoleTemplateRead matches %q — it cannot tell registry's own table "+
+				"from the shared one, so every correct read would be reported", negative)
+		}
+	}
+
+	root := moduleRoot(t)
+	var scanned int
+	offenders := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == "vendor" || name == "testdata" || name == "migrations" || strings.HasPrefix(name, ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		scanned++
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+
+		src, readErr := os.ReadFile(path) //nolint:gosec // G304: path comes from WalkDir over the module root
+		if readErr != nil {
+			return readErr
+		}
+		if m := sharedRoleTemplateRead.FindString(string(src)); m != "" {
+			offenders[rel] = m
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no Go files — this guard has no universe and would certify nothing")
+	}
+
+	for rel, match := range offenders {
+		if reason := sharedRoleTemplateReadExemptions[rel]; reason != "" {
+			continue
+		}
+		t.Errorf("%s reads the SHARED role_templates by hand (%q). Since the read cutover "+
+			"(terraform-suite-identity#206 phase 3b) registry's authorization is decided by "+
+			"registry_role_templates, so this computes an answer the product does not enforce — "+
+			"and the two copies agree until the moment they matter. Read registry's own table, "+
+			"or record the file in sharedRoleTemplateReadExemptions with the reason.", rel, match)
+	}
+	for rel := range sharedRoleTemplateReadExemptions {
+		if _, still := offenders[rel]; !still {
+			t.Errorf("sharedRoleTemplateReadExemptions names %q, which no longer reads the shared "+
+				"role_templates — drop the entry", rel)
+		}
+	}
+	t.Logf("scanned %d Go file(s) for a hand-written shared role_templates read", scanned)
+}

--- a/backend/internal/db/repositories/member_role_reader.go
+++ b/backend/internal/db/repositories/member_role_reader.go
@@ -1,0 +1,378 @@
+// member_role_reader.go READS registry's own per-app authorization tables --
+// `registry_role_templates` and `organization_member_roles`, migration 000055.
+//
+// Design: sethbacon/terraform-suite-identity#206. Phase 3a created these tables
+// and dual-wrote them while every authorization decision still came from
+// `organization_members.role_template_id` joined to `role_templates`. THIS FILE
+// IS THE OTHER HALF: from here on, "which role does this member hold in
+// registry, and what does it confer" is answered by registry's own tables.
+//
+// It is the mirror image of member_role_mirror.go, which exposes no reads for
+// exactly the reason this type exists separately: a read method on the writer
+// would have been the first step of the cutover, and the cutover had to be its
+// own reviewable change. Keeping the two types apart also keeps the guard in
+// member_role_read_class_test.go able to say which methods read the mirror.
+//
+// # What still does NOT come from here
+//
+// The membership FACT. `organization_members` remains the answer to "is this
+// principal a member of this organization at all", and it stays there until
+// phase 4. Every accessor in organization_repository.go therefore asks the
+// shared identity store first -- which also supplies the user and organization
+// columns the display shapes carry -- and overlays only the ROLE from here. A
+// mirrored row whose membership no longer exists confers nothing, because
+// nothing asks this file about a principal the store did not already return.
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// roleRowScanner is the one method *sql.Row and *sql.Rows share, so the scan
+// helpers below serve both the single-row and the multi-row reads.
+type roleRowScanner interface {
+	Scan(dest ...any) error
+}
+
+// MirroredRole is what registry's own tables say about one membership: the role
+// template it holds, and what that template confers.
+//
+// A membership with a row but no role is represented by a non-nil MirroredRole
+// whose RoleTemplateID is nil -- NOT by a nil MirroredRole. The distinction is
+// the same one migration 000055 preserved in the schema: "this member holds no
+// role here" and "this member has no row here" are different facts, and only
+// the second one is drift.
+type MirroredRole struct {
+	// RoleTemplateID is the template the membership holds, or nil for none.
+	RoleTemplateID *string
+	// Name / DisplayName are the template's, empty when RoleTemplateID is nil.
+	Name        string
+	DisplayName string
+	// Scopes is what the template confers. Always non-nil; empty for no role,
+	// which is the fail-closed value -- an empty scope set denies everything.
+	Scopes []string
+}
+
+// namePtr returns Name as the *string the shared models carry, nil when there
+// is no role. The models use a pointer because the source columns are
+// nullable; this keeps a role-less membership serialising as `null` exactly as
+// it did when the value came from a LEFT JOIN that matched nothing.
+func (r *MirroredRole) namePtr() *string {
+	if r == nil || r.RoleTemplateID == nil {
+		return nil
+	}
+	n := r.Name
+	return &n
+}
+
+// displayNamePtr is namePtr for the display name.
+func (r *MirroredRole) displayNamePtr() *string {
+	if r == nil || r.RoleTemplateID == nil {
+		return nil
+	}
+	d := r.DisplayName
+	return &d
+}
+
+// id returns the role template id, or nil for a nil receiver.
+func (r *MirroredRole) id() *string {
+	if r == nil {
+		return nil
+	}
+	return r.RoleTemplateID
+}
+
+// scopes returns the conferred scopes, or an empty set for a nil receiver.
+//
+// A nil receiver means "registry has no row for this membership", and the
+// fail-closed reading of that is no authority at all. Returning nil scopes
+// rather than erroring is safe HERE only because the callers that matter treat
+// an empty scope set as a denial; the error path is in the accessors, which do
+// not construct a nil MirroredRole from a failed query -- they return the
+// error. See organization_repository.go.
+func (r *MirroredRole) scopes() []string {
+	if r == nil || r.Scopes == nil {
+		return []string{}
+	}
+	return r.Scopes
+}
+
+// noRole is the value every accessor uses for "registry has no row here". It is
+// a package-level function rather than a nil literal so the fail-closed choice
+// has one name and one place to read about it.
+func noRole() *MirroredRole { return nil }
+
+// MemberRoleReader reads registry's own authorization tables.
+//
+// It is built on the connection the caller resolves `organization_members`
+// through. In the default topology that is registry's only connection; under
+// TFR_IDENTITY_SCHEMA_ENABLED it is the identity pool, whose
+// `search_path=<identity>,public` resolves these two tables through the
+// trailing `,public`. The one topology where that is false -- identity in a
+// SEPARATE DATABASE -- is refused at boot rather than served from a table the
+// connection cannot see (internal/api/router.go).
+type MemberRoleReader struct {
+	db *sql.DB
+}
+
+// NewMemberRoleReader builds a reader over the given connection.
+func NewMemberRoleReader(db *sql.DB) *MemberRoleReader {
+	return &MemberRoleReader{db: db}
+}
+
+// mirroredRoleColumns is the one projection every membership read below
+// selects, so a schema change edits one literal rather than three.
+//
+// LEFT JOIN, and COALESCE on the template columns: a mirrored row with a NULL
+// role_template_id is a legitimate "no role here", and it must come back as a
+// row rather than vanish -- otherwise it is indistinguishable from "no mirrored
+// row", which is the one difference the drift check exists to see.
+const mirroredRoleColumns = `omr.role_template_id,
+		       COALESCE(rrt.name, ''), COALESCE(rrt.display_name, ''),
+		       COALESCE(rrt.scopes, '[]'::jsonb)`
+
+// mirroredRoleFrom is the canonical FROM/JOIN chain for a membership read.
+const mirroredRoleFrom = `
+		FROM organization_member_roles omr
+		LEFT JOIN registry_role_templates rrt ON rrt.id = omr.role_template_id`
+
+// scanMirroredRole scans one mirroredRoleColumns row.
+func scanMirroredRole(row roleRowScanner, leading ...any) (*MirroredRole, error) {
+	var role MirroredRole
+	var scopesJSON []byte
+	dest := make([]any, 0, len(leading)+4)
+	dest = append(dest, leading...)
+	dest = append(dest, &role.RoleTemplateID, &role.Name, &role.DisplayName, &scopesJSON)
+	if err := row.Scan(dest...); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(scopesJSON, &role.Scopes); err != nil {
+		return nil, fmt.Errorf("parse mirrored role scopes: %w", err)
+	}
+	if role.Scopes == nil {
+		role.Scopes = []string{}
+	}
+	return &role, nil
+}
+
+// RoleFor returns the role registry's own tables record for one membership, or
+// nil when there is no mirrored row for it.
+//
+// nil is NOT an error. It is the drift the divergence signal reports and the
+// drift check gates on, and it fails closed at every call site: a nil role
+// yields no scopes.
+func (r *MemberRoleReader) RoleFor(ctx context.Context, orgID, userID string) (*MirroredRole, error) {
+	role, err := scanMirroredRole(r.db.QueryRowContext(ctx,
+		`SELECT `+mirroredRoleColumns+mirroredRoleFrom+`
+		 WHERE omr.organization_id = $1 AND omr.user_id = $2`, orgID, userID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return noRole(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read registry role for (%s, %s): %w", orgID, userID, err)
+	}
+	return role, nil
+}
+
+// RolesForUser returns every organization in which registry records a role for
+// this user, keyed by organization id.
+//
+// One query for the whole set rather than RoleFor per membership: the
+// user-axis accessors resolve a principal's authority across every
+// organization they belong to and run on the login path, where an N+1 would be
+// a per-organization round trip on every token mint.
+func (r *MemberRoleReader) RolesForUser(ctx context.Context, userID string) (map[string]*MirroredRole, error) {
+	return r.rolesKeyedBy(ctx,
+		`SELECT omr.organization_id, `+mirroredRoleColumns+mirroredRoleFrom+`
+		 WHERE omr.user_id = $1`, userID)
+}
+
+// RolesForOrg returns every user for whom registry records a role in this
+// organization, keyed by user id.
+func (r *MemberRoleReader) RolesForOrg(ctx context.Context, orgID string) (map[string]*MirroredRole, error) {
+	return r.rolesKeyedBy(ctx,
+		`SELECT omr.user_id, `+mirroredRoleColumns+mirroredRoleFrom+`
+		 WHERE omr.organization_id = $1`, orgID)
+}
+
+// RolesForUsers is the bulk form of RolesForUser: user id -> organization id ->
+// role.
+//
+// It exists because the shared store's user-list accessors deliberately load
+// memberships for a whole page in ONE query rather than N, and an overlay that
+// then issued one read per user would reintroduce exactly the N+1 they avoid --
+// on the admin user list, the page with the most rows.
+//
+// An empty userIDs returns an empty map without a round trip: `= ANY('{}')`
+// matches nothing, and asking the database to confirm that on every empty page
+// is a query whose answer is already known.
+func (r *MemberRoleReader) RolesForUsers(ctx context.Context, userIDs []string) (map[string]map[string]*MirroredRole, error) {
+	out := map[string]map[string]*MirroredRole{}
+	if len(userIDs) == 0 {
+		return out, nil
+	}
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT omr.user_id, omr.organization_id, `+mirroredRoleColumns+mirroredRoleFrom+`
+		 WHERE omr.user_id = ANY($1)`, pq.Array(userIDs))
+	if err != nil {
+		return nil, fmt.Errorf("read registry roles for %d user(s): %w", len(userIDs), err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var userID, orgID string
+		role, scanErr := scanMirroredRole(rows, &userID, &orgID)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan registry role: %w", scanErr)
+		}
+		if out[userID] == nil {
+			out[userID] = map[string]*MirroredRole{}
+		}
+		out[userID][orgID] = role
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read registry roles for %d user(s): %w", len(userIDs), err)
+	}
+	return out, nil
+}
+
+// rolesKeyedBy runs a membership read whose first column is the map key.
+func (r *MemberRoleReader) rolesKeyedBy(ctx context.Context, query, arg string) (map[string]*MirroredRole, error) {
+	rows, err := r.db.QueryContext(ctx, query, arg)
+	if err != nil {
+		return nil, fmt.Errorf("read registry roles: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]*MirroredRole{}
+	for rows.Next() {
+		var key string
+		role, scanErr := scanMirroredRole(rows, &key)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan registry role: %w", scanErr)
+		}
+		out[key] = role
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read registry roles: %w", err)
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Role templates
+// ---------------------------------------------------------------------------
+
+// registryRoleTemplateColumns is the projection for a whole template row.
+const registryRoleTemplateColumns = `id, name, display_name, description, scopes, is_system, created_at, updated_at`
+
+// scanRegistryRoleTemplate scans one registryRoleTemplateColumns row.
+func scanRegistryRoleTemplate(row roleRowScanner) (*models.RoleTemplate, error) {
+	var t models.RoleTemplate
+	var scopesJSON []byte
+	if err := row.Scan(&t.ID, &t.Name, &t.DisplayName, &t.Description,
+		&scopesJSON, &t.IsSystem, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(scopesJSON, &t.Scopes); err != nil {
+		return nil, fmt.Errorf("parse role template scopes: %w", err)
+	}
+	if t.Scopes == nil {
+		t.Scopes = []string{}
+	}
+	return &t, nil
+}
+
+// ListRoleTemplates returns registry's own role templates.
+func (r *MemberRoleReader) ListRoleTemplates(ctx context.Context) ([]*models.RoleTemplate, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+registryRoleTemplateColumns+` FROM registry_role_templates ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("list registry role templates: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]*models.RoleTemplate, 0)
+	for rows.Next() {
+		t, scanErr := scanRegistryRoleTemplate(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan registry role template: %w", scanErr)
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list registry role templates: %w", err)
+	}
+	return out, nil
+}
+
+// GetRoleTemplate returns one of registry's own role templates by id.
+//
+// It returns identitystore's ErrNotFound sentinel for a missing row, matching
+// what the shared store's RoleTemplateRepository returned from this call
+// before the cutover: the handlers map that sentinel onto 404, and answering a
+// different error here would turn "no such template" into a 500.
+func (r *MemberRoleReader) GetRoleTemplate(ctx context.Context, id uuid.UUID) (*models.RoleTemplate, error) {
+	return r.roleTemplateWhere(ctx, `id = $1`, id, "role template")
+}
+
+// GetRoleTemplateByName returns one of registry's own role templates by name.
+func (r *MemberRoleReader) GetRoleTemplateByName(ctx context.Context, name string) (*models.RoleTemplate, error) {
+	return r.roleTemplateWhere(ctx, `name = $1`, name, "role template by name")
+}
+
+// roleTemplateWhere is the shared single-template read.
+func (r *MemberRoleReader) roleTemplateWhere(ctx context.Context, predicate string, arg any, what string) (*models.RoleTemplate, error) {
+	t, err := scanRegistryRoleTemplate(r.db.QueryRowContext(ctx,
+		`SELECT `+registryRoleTemplateColumns+` FROM registry_role_templates WHERE `+predicate, arg))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("%s not found: %w", what, identitystore.ErrNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get registry %s: %w", what, err)
+	}
+	return t, nil
+}
+
+// MembershipsWithTemplate returns the (user, organization) pairs that hold the
+// given template in REGISTRY.
+//
+// This is the credential-invalidation sweep's input: when a template's scopes
+// change or it is deleted, these are the principals whose JWTs and API keys
+// snapshotted the old authority. It reads registry's own assignment table
+// because that is now what conferred the authority being withdrawn -- sweeping
+// the identity table's holders would revoke the wrong set the moment the two
+// disagree, which is precisely the state the drift check exists to detect.
+func (r *MemberRoleReader) MembershipsWithTemplate(ctx context.Context, roleTemplateID uuid.UUID) ([]RoleTemplateMembership, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id = $1`,
+		roleTemplateID)
+	if err != nil {
+		return nil, fmt.Errorf("list registry memberships holding %s: %w", roleTemplateID, err)
+	}
+	defer rows.Close()
+
+	var out []RoleTemplateMembership
+	for rows.Next() {
+		var m RoleTemplateMembership
+		if err := rows.Scan(&m.UserID, &m.OrganizationID); err != nil {
+			return nil, fmt.Errorf("scan registry membership: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list registry memberships holding %s: %w", roleTemplateID, err)
+	}
+	return out, nil
+}

--- a/backend/internal/db/repositories/member_role_reader_test.go
+++ b/backend/internal/db/repositories/member_role_reader_test.go
@@ -1,0 +1,494 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+// Unit tests for the READ half of the cutover
+// (sethbacon/terraform-suite-identity#206, phase 3b).
+//
+// The Postgres file (member_role_equivalence_pg_test.go) proves the two copies
+// resolve the same authority. These pin the DECISIONS the read path makes that a
+// real database would answer identically either way -- what a missing row means,
+// what a failed query means, and which connection the write path reads back
+// through -- and they run in CI, which the Postgres file does not.
+//
+// Every assertion is on an exact value. "No error" would pass for a reader that
+// returned nothing at all, which is the failure mode with the largest blast
+// radius here: an empty scope set denies, silently and plausibly.
+
+func newReader(t *testing.T) (*MemberRoleReader, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewMemberRoleReader(db), mock
+}
+
+// TestReader_RoleFor_NoRowIsNotAnError pins the distinction migration 000055
+// built into the schema and the read path depends on: a membership with no
+// mirrored row yields (nil, nil), not an error and not an empty role.
+//
+// It matters because the two are handled differently one layer up: nil is
+// reported as divergence and fails closed, while an error is returned to the
+// caller and denies with a 500. Collapsing them would either hide a real
+// dual-write gap or turn one into an outage.
+func TestReader_RoleFor_NoRowIsNotAnError(t *testing.T) {
+	reader, mock := newReader(t)
+	mock.ExpectQuery("FROM organization_member_roles").
+		WithArgs(testOrgID, testUserID).
+		WillReturnRows(sqlmock.NewRows(registryRoleCols))
+
+	role, err := reader.RoleFor(context.Background(), testOrgID, testUserID)
+	if err != nil {
+		t.Fatalf("RoleFor: %v", err)
+	}
+	if role != nil {
+		t.Fatalf("RoleFor = %+v, want nil for a membership with no mirrored row", role)
+	}
+	// And the nil receiver must fail CLOSED rather than panic: every accessor
+	// calls these three on whatever RoleFor returned.
+	if got := role.id(); got != nil {
+		t.Errorf("nil role id() = %v, want nil", got)
+	}
+	if got := role.scopes(); len(got) != 0 {
+		t.Errorf("nil role scopes() = %v, want empty", got)
+	}
+	if got := role.namePtr(); got != nil {
+		t.Errorf("nil role namePtr() = %v, want nil", got)
+	}
+}
+
+// TestReader_RoleFor_MirroredRowWithNoRole is the OTHER side of that
+// distinction: a row exists and carries no role. It must come back as a non-nil
+// MirroredRole with a nil id, because that is "no role here" rather than "not
+// mirrored", and only the second is drift.
+func TestReader_RoleFor_MirroredRowWithNoRole(t *testing.T) {
+	reader, mock := newReader(t)
+	mock.ExpectQuery("FROM organization_member_roles").
+		WillReturnRows(sqlmock.NewRows(registryRoleCols).AddRow(nil, "", "", []byte(`[]`)))
+
+	role, err := reader.RoleFor(context.Background(), testOrgID, testUserID)
+	if err != nil {
+		t.Fatalf("RoleFor: %v", err)
+	}
+	if role == nil {
+		t.Fatal("a mirrored row carrying no role came back as nil, which is how " +
+			"'this member is entitled to nothing' becomes indistinguishable from " +
+			"'the dual-write missed this member'")
+	}
+	if role.RoleTemplateID != nil {
+		t.Errorf("RoleTemplateID = %v, want nil", *role.RoleTemplateID)
+	}
+	if len(role.Scopes) != 0 {
+		t.Errorf("Scopes = %v, want empty", role.Scopes)
+	}
+}
+
+// TestReader_RoleFor_QueryFailureIsReturned: a failed lookup must NOT be
+// absorbed into "no role". An empty scope set denies and looks exactly like an
+// unprivileged member, so absorbing it would turn a database fault into a
+// plausible-looking authorization answer nobody investigates.
+func TestReader_RoleFor_QueryFailureIsReturned(t *testing.T) {
+	reader, mock := newReader(t)
+	sentinel := errors.New("connection reset")
+	mock.ExpectQuery("FROM organization_member_roles").WillReturnError(sentinel)
+
+	role, err := reader.RoleFor(context.Background(), testOrgID, testUserID)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want it to wrap %v — a bare non-nil check would also pass for "+
+			"a reader that mapped every failure onto 'no role'", err, sentinel)
+	}
+	if role != nil {
+		t.Errorf("role = %+v, want nil alongside the error", role)
+	}
+}
+
+// TestReader_RolesForUser_KeysByOrganization is the property that keeps the
+// cross-organization accessors honest: a user with two memberships must get two
+// DISTINCT roles, attached to the right organizations. Keying them wrongly is
+// the privilege-escalation shape -- one organization's admin role applied in
+// another.
+func TestReader_RolesForUser_KeysByOrganization(t *testing.T) {
+	reader, mock := newReader(t)
+	mock.ExpectQuery(`SELECT omr\.organization_id,.*WHERE omr\.user_id`).
+		WithArgs(testUserID).
+		WillReturnRows(sqlmock.NewRows(append([]string{"organization_id"}, registryRoleCols...)).
+			AddRow(testOrgID, testRoleID, "admin", "Admin", []byte(`["organizations:write"]`)).
+			AddRow(testOtherOrg, nil, "", "", []byte(`[]`)))
+
+	roles, err := reader.RolesForUser(context.Background(), testUserID)
+	if err != nil {
+		t.Fatalf("RolesForUser: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Fatalf("len = %d, want 2", len(roles))
+	}
+	first := roles[testOrgID]
+	if first == nil || first.RoleTemplateID == nil || *first.RoleTemplateID != testRoleID {
+		t.Fatalf("roles[%s] = %+v, want role %s", testOrgID, first, testRoleID)
+	}
+	if len(first.Scopes) != 1 || first.Scopes[0] != "organizations:write" {
+		t.Errorf("roles[%s].Scopes = %v, want [organizations:write]", testOrgID, first.Scopes)
+	}
+	second := roles[testOtherOrg]
+	if second == nil {
+		t.Fatalf("roles[%s] missing", testOtherOrg)
+	}
+	if second.RoleTemplateID != nil {
+		t.Errorf("roles[%s].RoleTemplateID = %v, want nil", testOtherOrg, *second.RoleTemplateID)
+	}
+	if len(second.Scopes) != 0 {
+		t.Errorf("roles[%s].Scopes = %v, want empty — the second organization's role must not "+
+			"inherit the first's", testOtherOrg, second.Scopes)
+	}
+}
+
+// TestReader_RolesForUsers_EmptyInputIssuesNoQuery: the bulk read is called once
+// per admin user page, including pages where nobody has a membership. Asking the
+// database to confirm that `= ANY('{}')` matches nothing is a round trip whose
+// answer is already known.
+func TestReader_RolesForUsers_EmptyInputIssuesNoQuery(t *testing.T) {
+	reader, mock := newReader(t)
+
+	roles, err := reader.RolesForUsers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RolesForUsers: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Errorf("len = %d, want 0", len(roles))
+	}
+	// No expectation was queued, so any statement at all is unexpected.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestReader_GetRoleTemplate_MissReportsTheStoreSentinel: the handlers map
+// store.ErrNotFound onto 404. Answering a different error would turn "no such
+// role template" into a 500 on every admin screen that looks one up.
+func TestReader_GetRoleTemplate_MissReportsTheStoreSentinel(t *testing.T) {
+	reader, mock := newReader(t)
+	mock.ExpectQuery("FROM registry_role_templates WHERE id").
+		WillReturnRows(sqlmock.NewRows(roleTemplateCols))
+
+	tpl, err := reader.GetRoleTemplate(context.Background(), uuid.New())
+	if !errors.Is(err, identitystore.ErrNotFound) {
+		t.Fatalf("err = %v, want store.ErrNotFound", err)
+	}
+	if tpl != nil {
+		t.Errorf("tpl = %+v, want nil", tpl)
+	}
+}
+
+// TestOrganizationRepository_MirrorsTheSourceNotTheMirror is a REGRESSION guard
+// for the defect phase 3b creates and phase 3a could not have.
+//
+// The write path re-reads the membership it just wrote and mirrors what it
+// finds. Phase 3a read it back through `r.GetMember`, which was then the store's
+// promoted method. Phase 3b overrides GetMember to REPLACE the role with
+// whatever registry's tables already hold -- so the same expression now reads
+// the mirror, and mirroring that writes the mirror's current value back into
+// itself. The dual-write becomes a no-op on every role CHANGE: the source moves,
+// the mirror does not, and since reads come from the mirror the change never
+// takes effect anywhere. No error, no failing behavioural test.
+//
+// The fixture is the distinguishing one: the source read-back returns a role
+// that is DIFFERENT from what registry holds. A correct implementation mirrors
+// the source's; the broken one issues a registry read here and then writes the
+// old value.
+func TestOrganizationRepository_MirrorsTheSourceNotTheMirror(t *testing.T) {
+	repo, mock := newOrgRepo(t)
+
+	const landed = "55555555-5555-5555-5555-555555555555"
+	expectSourceMemberInsert(mock)
+	expectReadBack(mock, landed)
+	// NOTHING between the read-back and the mirror write. If the read-back went
+	// through this type's override it would query organization_member_roles
+	// here, which no expectation matches.
+	expectMirrorAssign(mock, landed)
+
+	asked := testRoleID
+	if err := repo.AddMemberWithRoleTemplate(context.Background(), testOrgID, testUserID, &asked,
+		identitystore.OrgScopeAllOrganizations()); err != nil {
+		t.Fatalf("AddMemberWithRoleTemplate: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("the write path did not mirror the role the SOURCE now holds (%s). "+
+			"mirrorMemberFromSource must call r.OrganizationRepository.GetMember, not r.GetMember: "+
+			"the override replaces the role with registry's current value, so mirroring it writes "+
+			"the mirror back into itself and every role change is silently lost: %v", landed, err)
+	}
+}
+
+// TestCompareRole_ReportsEachDivergenceKind pins the signal that keeps the
+// cutover from going silent between drift-check runs.
+//
+// Asserted on the METRIC, by value, because the log is not machine-checkable and
+// a comparison that quietly did nothing would otherwise look identical to one
+// that found agreement.
+func TestCompareRole_ReportsEachDivergenceKind(t *testing.T) {
+	role := func(id string) *MirroredRole {
+		if id == "" {
+			return &MirroredRole{Scopes: []string{}}
+		}
+		return &MirroredRole{RoleTemplateID: &id, Scopes: []string{}}
+	}
+	ptr := func(s string) *string { return &s }
+
+	cases := []struct {
+		name     string
+		identity *string
+		registry *MirroredRole
+		wantKind string // empty means "must not report anything"
+	}{
+		{"agreeing roles", ptr(testRoleID), role(testRoleID), ""},
+		{"both carry no role", nil, role(""), ""},
+		{"no mirrored row at all", ptr(testRoleID), nil, DivergenceMissingMirror},
+		{"different templates", ptr(testRoleID), role("99999999-9999-9999-9999-999999999999"), DivergenceRoleDiffers},
+		{"registry cleared the role", ptr(testRoleID), role(""), DivergenceRoleDiffers},
+		{"registry invented a role", nil, role(testRoleID), DivergenceRoleDiffers},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			accessor := "test-" + tc.name
+			before := map[string]float64{
+				DivergenceMissingMirror: divergenceCount(t, accessor, DivergenceMissingMirror),
+				DivergenceRoleDiffers:   divergenceCount(t, accessor, DivergenceRoleDiffers),
+			}
+
+			compareRole(context.Background(), accessor, testOrgID, testUserID, tc.identity, tc.registry)
+
+			for _, kind := range []string{DivergenceMissingMirror, DivergenceRoleDiffers} {
+				got := divergenceCount(t, accessor, kind) - before[kind]
+				want := 0.0
+				if kind == tc.wantKind {
+					want = 1.0
+				}
+				if got != want {
+					t.Errorf("%s counter moved by %v, want %v", kind, got, want)
+				}
+			}
+		})
+	}
+}
+
+// divergenceCount reads one counter's current value, by label pair.
+func divergenceCount(t *testing.T, accessor, kind string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(RoleReadDivergenceTotal.WithLabelValues(accessor, kind))
+}
+
+// TestDriftInMemberships_ClassifiesEveryDirection pins the classification the
+// gate reports, without a database.
+//
+// The kinds are not interchangeable: an operator reads them to decide whether to
+// restart (a mirror that fell behind), to repair identity data (a membership
+// naming a template that does not exist), or to investigate a grant the product
+// never issued (a mirrored row with no membership). A comparison that found the
+// right ROWS under the wrong KINDS would send them to the wrong remedy.
+func TestDriftInMemberships_ClassifiesEveryDirection(t *testing.T) {
+	tpl := uuid.New()
+	other := uuid.New()
+	templates := []*models.RoleTemplate{{ID: tpl}, {ID: other}}
+
+	id := func(u uuid.UUID) *string { s := u.String(); return &s }
+	missing := uuid.New()
+
+	source := map[memberKey]*string{
+		{orgID: "org-agree", userID: "u"}:   id(tpl),
+		{orgID: "org-differs", userID: "u"}: id(tpl),
+		{orgID: "org-absent", userID: "u"}:  id(tpl),
+		{orgID: "org-orphan", userID: "u"}:  id(missing),
+	}
+	mirrored := map[memberKey]*string{
+		{orgID: "org-agree", userID: "u"}:     id(tpl),
+		{orgID: "org-differs", userID: "u"}:   id(other),
+		{orgID: "org-orphan", userID: "u"}:    nil,
+		{orgID: "org-nomembers", userID: "u"}: id(tpl),
+	}
+
+	rows := driftInMemberships(source, mirrored, templates)
+	got := map[string]string{}
+	for _, r := range rows {
+		if prev, dup := got[r.OrganizationID]; dup {
+			t.Fatalf("organization %s reported twice (%s and %s)", r.OrganizationID, prev, r.Kind)
+		}
+		got[r.OrganizationID] = r.Kind
+	}
+
+	want := map[string]string{
+		"org-differs":   DriftRoleDiffers,
+		"org-absent":    DriftMembershipNotMirrored,
+		"org-orphan":    DriftMembershipRoleMissingTemplate,
+		"org-nomembers": DriftMirrorWithoutMembership,
+	}
+	for org, kind := range want {
+		if got[org] != kind {
+			t.Errorf("organization %s classified %q, want %q", org, got[org], kind)
+		}
+	}
+	if kind, reported := got["org-agree"]; reported {
+		t.Errorf("an agreeing membership was reported as %q — a gate that reports drift on "+
+			"correct rows can never be satisfied, so it stops being a gate", kind)
+	}
+	if len(rows) != len(want) {
+		t.Errorf("reported %d row(s), want %d: %v", len(rows), len(want), rows)
+	}
+}
+
+// TestDriftInTemplates_SeesNameAndScopeDifferences covers the half the SQL
+// divergence query phase 3a shipped could not: a template that agrees on id and
+// scopes but disagrees on NAME still resolves to a different row for every
+// name-keyed lookup.
+func TestDriftInTemplates_SeesNameAndScopeDifferences(t *testing.T) {
+	same := uuid.New()
+	renamed := uuid.New()
+	rescoped := uuid.New()
+	onlySource := uuid.New()
+	onlyMirror := uuid.New()
+
+	source := []*models.RoleTemplate{
+		{ID: same, Name: "viewer", Scopes: []string{"modules:read"}},
+		{ID: renamed, Name: "publisher", Scopes: []string{"modules:write"}},
+		{ID: rescoped, Name: "auditor", Scopes: []string{"audit:read", "modules:read"}},
+		{ID: onlySource, Name: "new", Scopes: []string{"modules:read"}},
+	}
+	mirrored := []*models.RoleTemplate{
+		// Reordered scopes: a set, not a list. Reporting this would make the
+		// gate un-passable on a correct deployment.
+		{ID: same, Name: "viewer", Scopes: []string{"modules:read"}},
+		{ID: renamed, Name: "publisher-renamed", Scopes: []string{"modules:write"}},
+		{ID: rescoped, Name: "auditor", Scopes: []string{"modules:read"}},
+		{ID: onlyMirror, Name: "stale", Scopes: []string{}},
+	}
+
+	rows := driftInTemplates(source, mirrored)
+	got := map[string]string{}
+	for _, r := range rows {
+		got[r.RoleTemplateID] = r.Kind
+	}
+	want := map[uuid.UUID]string{
+		renamed:    DriftTemplateNameDiffers,
+		rescoped:   DriftTemplateScopesDiffer,
+		onlySource: DriftTemplateNotMirrored,
+		onlyMirror: DriftMirroredTemplateOrphaned,
+	}
+	for id, kind := range want {
+		if got[id.String()] != kind {
+			t.Errorf("template %s classified %q, want %q", id, got[id.String()], kind)
+		}
+	}
+	if kind, reported := got[same.String()]; reported {
+		t.Errorf("an identical template was reported as %q", kind)
+	}
+}
+
+// TestSameScopes_IsSetEquality pins that scope comparison ignores order and
+// tolerates nothing else. Order is not meaning; a missing scope is.
+func TestSameScopes_IsSetEquality(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"identical", []string{"a", "b"}, []string{"a", "b"}, true},
+		{"reordered", []string{"b", "a"}, []string{"a", "b"}, true},
+		{"both empty", nil, []string{}, true},
+		{"one missing", []string{"a", "b"}, []string{"a"}, false},
+		{"one extra", []string{"a"}, []string{"a", "b"}, false},
+		{"same length, different member", []string{"a", "b"}, []string{"a", "c"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameScopes(tc.a, tc.b); got != tc.want {
+				t.Errorf("sameScopes(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckMemberRoleDrift_RefusesAnUnreachableSource is the "could not check"
+// path. It must be an ERROR and never a clean report: a gate that answers "no
+// drift" for a database it could not read gates nothing open.
+//
+// The assertion is on WHICH refusal, not on "an error happened". The first
+// version of this test checked `err != nil` and was inert under mutation:
+// deleting the source probe entirely still produced an error, because the very
+// next statement had no sqlmock expectation and failed for an unrelated reason.
+// It reported green for a gate that had stopped checking the thing it names.
+func TestCheckMemberRoleDrift_RefusesAnUnreachableSource(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// to_regclass returns NULL: the table does not resolve on this connection.
+	mock.ExpectQuery("to_regclass").WithArgs("organization_members").
+		WillReturnRows(sqlmock.NewRows([]string{"to_regclass"}).AddRow(nil))
+
+	report, err := CheckMemberRoleDrift(context.Background(), db, db)
+	if err == nil {
+		t.Fatal("CheckMemberRoleDrift returned no error for a source that does not resolve")
+	}
+	const want = "effective organization_members does not resolve on the identity connection"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %q, want it to name the unresolved SOURCE table (%q). Any other error "+
+			"means the source probe did not run and something downstream failed instead", err, want)
+	}
+	if !report.Clean() {
+		t.Errorf("report carried %d row(s) alongside the error; the caller must not be able to "+
+			"read a partial comparison as a result", len(report.Rows))
+	}
+	if report.SourceMemberships != 0 {
+		t.Errorf("SourceMemberships = %d, want 0", report.SourceMemberships)
+	}
+}
+
+// TestCheckMemberRoleDrift_RefusesUnreachableRegistryTables is the same refusal
+// on the other connection. Separate, and asserting a DIFFERENT message, because
+// the two failures send an operator to different places: an unresolved source
+// means the identity connection is wrong, an unresolved mirror means migration
+// 000055 has not run where this connection can see it.
+func TestCheckMemberRoleDrift_RefusesUnreachableRegistryTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// The source resolves...
+	for _, table := range identitySourceTables {
+		mock.ExpectQuery("to_regclass").WithArgs(table).
+			WillReturnRows(sqlmock.NewRows([]string{"to_regclass"}).AddRow("public." + table))
+	}
+	// ...and registry's own tables do not.
+	mock.ExpectQuery("to_regclass").WithArgs("registry_role_templates").
+		WillReturnRows(sqlmock.NewRows([]string{"to_regclass"}).AddRow(nil))
+
+	report, err := CheckMemberRoleDrift(context.Background(), db, db)
+	if err == nil {
+		t.Fatal("CheckMemberRoleDrift returned no error for mirror tables that do not resolve")
+	}
+	if !errors.Is(err, ErrMirrorUnreachable) {
+		t.Fatalf("err = %v, want it to wrap ErrMirrorUnreachable", err)
+	}
+	if !report.Clean() {
+		t.Errorf("report carried %d row(s) alongside the error", len(report.Rows))
+	}
+}

--- a/backend/internal/db/repositories/organization_repository.go
+++ b/backend/internal/db/repositories/organization_repository.go
@@ -10,9 +10,13 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
+	identityauth "github.com/sethbacon/terraform-suite-identity/identity/auth"
 	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 )
 
 // OrganizationRepository handles organization database operations.
@@ -48,6 +52,13 @@ type OrganizationRepository struct {
 	// in a SEPARATE DATABASE -- is caught at boot by VerifyMemberRoleMirror
 	// rather than discovered as missing rows later.
 	mirror *MemberRoleMirror
+
+	// roles READS those tables. Since phase 3b it is where every role and every
+	// scope set this type returns comes from; the embedded repository still
+	// supplies the membership FACT and the user/organization columns, because
+	// `organization_members` remains the record of who belongs where until
+	// phase 4.
+	roles *MemberRoleReader
 }
 
 // NewOrganizationRepository constructs an OrganizationRepository over the given connection.
@@ -55,7 +66,271 @@ func NewOrganizationRepository(db *sql.DB) *OrganizationRepository {
 	return &OrganizationRepository{
 		OrganizationRepository: identitystore.NewOrganizationRepository(db),
 		mirror:                 NewMemberRoleMirror(db),
+		roles:                  NewMemberRoleReader(db),
 	}
+}
+
+// ===========================================================================
+// Role READS -- registry's own tables (terraform-suite-identity#206, phase 3b)
+// ===========================================================================
+//
+// Each override below has the same three steps, and the order is the argument
+// for its correctness:
+//
+//  1. Ask the embedded store. That answers "is this principal a member", and
+//     supplies the organization/user columns the display shapes carry. Those
+//     facts are still identity's and are not moving in this phase.
+//  2. Ask registry's own tables what role that membership holds HERE.
+//  3. Report any disagreement (compareRole) and return REGISTRY's answer.
+//
+// Step 1 first is what makes a stray mirrored row inert: a row in
+// `organization_member_roles` whose membership no longer exists is never
+// reached, because nothing below asks about a principal the store did not
+// already return. That is the one drift direction that GRANTS authority, and
+// this ordering is why it cannot.
+//
+// A FAILED read of registry's tables is returned as an error, never absorbed
+// into "no role". The distinction matters: an empty scope set denies and looks
+// exactly like a successful lookup of an unprivileged member, so absorbing the
+// error would turn a database fault into a silent, plausible-looking
+// authorization answer. Both accessors that deliberately absorb ErrNotFound in
+// the shared store (CheckMembership, GetUserScopesForOrg) keep absorbing only
+// THAT sentinel, for the reasons their doc comments give.
+//
+// EVERY ROLE-BEARING READ ON THE STORE IS OVERRIDDEN, and that is enforced
+// rather than intended: Go promotes any method this type does not re-declare,
+// so a missed one would keep compiling and keep serving identity's answer
+// while its siblings serve registry's -- two answers to one question, differing
+// only on the rows that are wrong. member_role_read_class_test.go derives the
+// store's role-bearing readers from the pinned module's source and fails when
+// one has no override here.
+
+// GetMember retrieves a membership, with the role registry's own tables hold.
+func (r *OrganizationRepository) GetMember(ctx context.Context, orgID, userID string, scope identitystore.OrgScope) (*models.OrganizationMember, error) {
+	member, err := r.OrganizationRepository.GetMember(ctx, orgID, userID, scope)
+	if err != nil {
+		return nil, err
+	}
+	role, err := r.roles.RoleFor(ctx, member.OrganizationID, member.UserID)
+	if err != nil {
+		return nil, err
+	}
+	compareRole(ctx, "GetMember", member.OrganizationID, member.UserID, member.RoleTemplateID, role)
+	member.RoleTemplateID = role.id()
+	return member, nil
+}
+
+// ListMembers lists an organization's members with registry's own roles.
+func (r *OrganizationRepository) ListMembers(ctx context.Context, orgID string, scope identitystore.OrgScope) ([]*models.OrganizationMember, error) {
+	members, err := r.OrganizationRepository.ListMembers(ctx, orgID, scope)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return members, nil
+	}
+	// One read for the organization rather than one per member: this is the
+	// list shape, and an N+1 here is a round trip per row on a page that
+	// renders every member.
+	roles, err := r.roles.RolesForOrg(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	for _, member := range members {
+		role := roles[member.UserID]
+		compareRole(ctx, "ListMembers", member.OrganizationID, member.UserID, member.RoleTemplateID, role)
+		member.RoleTemplateID = role.id()
+	}
+	return members, nil
+}
+
+// CheckMembership answers "is this user a member, and with what role", the
+// role coming from registry's own tables.
+//
+// Overridden even though the shared store implements it in terms of GetMember:
+// Go has no virtual dispatch, so the store's call reaches the store's GetMember
+// and never this type's. Exactly the same trap the write overrides document for
+// AddMemberWithParams, and it is silent in the same way.
+func (r *OrganizationRepository) CheckMembership(ctx context.Context, orgID, userID string, scope identitystore.OrgScope) (bool, *string, error) {
+	member, err := r.GetMember(ctx, orgID, userID, scope)
+	if errors.Is(err, identitystore.ErrNotFound) {
+		return false, nil, nil
+	}
+	if err != nil {
+		return false, nil, err
+	}
+	return true, member.RoleTemplateID, nil
+}
+
+// GetMemberWithRole retrieves a membership with the role template registry's
+// own tables record for it -- id, name, display name, and the SCOPES.
+//
+// This is the accessor the per-resource route guards and the API-key auth path
+// are built on, so it is the single most authorization-critical read in the
+// product.
+func (r *OrganizationRepository) GetMemberWithRole(ctx context.Context, orgID, userID string, scope identitystore.OrgScope) (*models.OrganizationMemberWithUser, error) {
+	member, err := r.OrganizationRepository.GetMemberWithRole(ctx, orgID, userID, scope)
+	if err != nil {
+		return nil, err
+	}
+	role, err := r.roles.RoleFor(ctx, member.OrganizationID, member.UserID)
+	if err != nil {
+		return nil, err
+	}
+	compareRole(ctx, "GetMemberWithRole", member.OrganizationID, member.UserID, member.RoleTemplateID, role)
+	applyMirroredRole(role, &member.RoleTemplateID, &member.RoleTemplateName,
+		&member.RoleTemplateDisplayName, &member.RoleTemplateScopes)
+	return member, nil
+}
+
+// ListMembersWithUsers lists an organization's members and their users, with
+// registry's own roles.
+func (r *OrganizationRepository) ListMembersWithUsers(ctx context.Context, orgID string, scope identitystore.OrgScope) ([]*models.OrganizationMemberWithUser, error) {
+	members, err := r.OrganizationRepository.ListMembersWithUsers(ctx, orgID, scope)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return members, nil
+	}
+	roles, err := r.roles.RolesForOrg(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	for _, member := range members {
+		role := roles[member.UserID]
+		compareRole(ctx, "ListMembersWithUsers", member.OrganizationID, member.UserID, member.RoleTemplateID, role)
+		applyMirroredRole(role, &member.RoleTemplateID, &member.RoleTemplateName,
+			&member.RoleTemplateDisplayName, &member.RoleTemplateScopes)
+	}
+	return members, nil
+}
+
+// GetUserMemberships returns every organization the user belongs to, each
+// carrying the role registry's own tables hold for it.
+//
+// This is the base of three derived accessors (GetUserCombinedScopes,
+// OrgScopeForUser, and the shared UserRepository's GetUserWithOrgRoles), which
+// is why it is keyed per organization: a user with the right role in one
+// organization and none in another must not have the two merged here.
+func (r *OrganizationRepository) GetUserMemberships(ctx context.Context, userID string) ([]*models.UserMembership, error) {
+	memberships, err := r.OrganizationRepository.GetUserMemberships(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(memberships) == 0 {
+		return memberships, nil
+	}
+	roles, err := r.roles.RolesForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range memberships {
+		role := roles[m.OrganizationID]
+		compareRole(ctx, "GetUserMemberships", m.OrganizationID, userID, m.RoleTemplateID, role)
+		applyMirroredRole(role, &m.RoleTemplateID, &m.RoleTemplateName,
+			&m.RoleTemplateDisplayName, &m.RoleTemplateScopes)
+	}
+	return memberships, nil
+}
+
+// GetUserCombinedScopes returns the flat, cross-organization union of the
+// scopes registry's own role templates confer on this user.
+//
+// Overridden, and the derivation re-stated rather than delegated, for the
+// no-virtual-dispatch reason: the store's implementation calls the store's
+// GetUserMemberships, so delegating would union IDENTITY's scopes into a token
+// while every per-request check used registry's.
+//
+// Deprecated: this union carries no per-organization qualifier and must not
+// stand in for a per-org authorization check; use GetUserScopesForOrg. The
+// marker is preserved from the shared store's method so the existing
+// //nolint:staticcheck dispositions at the deliberate call sites keep applying.
+func (r *OrganizationRepository) GetUserCombinedScopes(ctx context.Context, userID string) (identityauth.GlobalScopes, error) {
+	memberships, err := r.GetUserMemberships(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	scopes := make(identityauth.GlobalScopes, 0)
+	for _, m := range memberships {
+		for _, scope := range m.RoleTemplateScopes {
+			if seen[scope] {
+				continue
+			}
+			seen[scope] = true
+			scopes = append(scopes, scope)
+		}
+	}
+	return scopes, nil
+}
+
+// GetUserScopesForOrg returns what registry's own role template confers on
+// this user in ONE organization.
+//
+// Overridden for the no-virtual-dispatch reason; the store's version calls the
+// store's GetMemberWithRole. It keeps absorbing ErrNotFound into the empty
+// scope set, which denies, exactly as the shared store documents.
+func (r *OrganizationRepository) GetUserScopesForOrg(ctx context.Context, userID, orgID string) (identityauth.OrgScopes, error) {
+	// UNSCOPED BY DESIGN, as in the shared store: this derives what the
+	// principal may do in orgID, so it cannot be gated on the authority it is
+	// deriving.
+	member, err := r.GetMemberWithRole(ctx, orgID, userID, identitystore.OrgScopeAllOrganizations())
+	if errors.Is(err, identitystore.ErrNotFound) {
+		return identityauth.OrgScopes{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	scopes := make(identityauth.OrgScopes, 0, len(member.RoleTemplateScopes))
+	for _, scope := range member.RoleTemplateScopes {
+		if seen[scope] {
+			continue
+		}
+		seen[scope] = true
+		scopes = append(scopes, scope)
+	}
+	return scopes, nil
+}
+
+// OrgScopeForUser returns the organizations in which registry's own role
+// template grants the user the required scope.
+//
+// Overridden for the no-virtual-dispatch reason; the store's version calls the
+// store's GetUserMemberships. This is the tenant predicate every list and
+// per-resource route is narrowed by, so serving it from identity while the
+// per-resource check served registry would let the two disagree about which
+// organizations a caller may even see.
+func (r *OrganizationRepository) OrgScopeForUser(ctx context.Context, userID, required string, rwPairs identityauth.ReadWritePairs) (identitystore.OrgScope, error) {
+	if userID == "" {
+		return identitystore.OrgScope{}, nil
+	}
+	memberships, err := r.GetUserMemberships(ctx, userID)
+	if err != nil {
+		return identitystore.OrgScope{}, err
+	}
+	orgIDs := make([]string, 0, len(memberships))
+	for _, m := range memberships {
+		if identityauth.HasScope(m.RoleTemplateScopes, required, rwPairs) {
+			orgIDs = append(orgIDs, m.OrganizationID)
+		}
+	}
+	return identitystore.OrgScopeOrganizations(orgIDs...), nil
+}
+
+// applyMirroredRole overwrites a membership's four role fields with what
+// registry's own tables hold.
+//
+// One helper for all three display shapes: the fields are the same four in
+// every one of them, and a per-accessor copy is how one of them ends up
+// updating the id but not the scopes -- which would leave a member rendered
+// with the new role's name and the old role's authority.
+func applyMirroredRole(role *MirroredRole, id, name, displayName **string, scopes *[]string) {
+	*id = role.id()
+	*name = role.namePtr()
+	*displayName = role.displayNamePtr()
+	*scopes = role.scopes()
 }
 
 // mirrorMemberFromSource re-reads the membership that was just written and
@@ -67,8 +342,22 @@ func NewOrganizationRepository(db *sql.DB) *OrganizationRepository {
 // mirror nothing. Reading the row back through the same scope collapses all of
 // that into one answer that is true by observation. Role writes are rare
 // administrative actions, so the extra SELECT costs nothing that matters.
+//
+// THE EMBEDDED SELECTOR IS LOAD-BEARING, and it became so in phase 3b. This
+// method must read what the SOURCE now says; `r.GetMember` is this type's
+// override, which reads the membership from the store and then REPLACES its role
+// with whatever registry's tables already hold. Mirroring that would write the
+// mirror's own current value back into itself -- a dual-write that is a no-op on
+// every role CHANGE, silently, while every test that only checks "a mirror write
+// happened" keeps passing. Since reads now come from those tables, the change
+// would never take effect anywhere.
+//
+// Phase 3a removed this selector to satisfy staticcheck's QF1008, correctly at
+// the time: GetMember was not then overridden. It is now.
+// TestOrganizationRepository_MirrorsTheSourceNotTheMirror fails if it is dropped
+// again.
 func (r *OrganizationRepository) mirrorMemberFromSource(ctx context.Context, orgID, userID string, scope identitystore.OrgScope) {
-	member, err := r.GetMember(ctx, orgID, userID, scope)
+	member, err := r.OrganizationRepository.GetMember(ctx, orgID, userID, scope) //nolint:staticcheck // QF1008: the embedded selector is REQUIRED — see above; r.GetMember would mirror the mirror
 	if err != nil {
 		mirrorFailed(ctx, "read back membership", err, "organization_id", orgID, "user_id", userID)
 		return

--- a/backend/internal/db/repositories/organization_repository_test.go
+++ b/backend/internal/db/repositories/organization_repository_test.go
@@ -46,6 +46,64 @@ func emptyOrgMemberRow() *sqlmock.Rows {
 	return sqlmock.NewRows(orgMemberCols)
 }
 
+// ---------------------------------------------------------------------------
+// Registry's own role tables (terraform-suite-identity#206, phase 3b)
+// ---------------------------------------------------------------------------
+//
+// Every role-bearing accessor now issues a SECOND query, against registry's own
+// organization_member_roles, immediately after the shared store's. The helpers
+// below queue it.
+//
+// The role and scopes they carry MUST match the identity row queued just before,
+// or the fixture stops testing the accessor and starts testing a divergence:
+// the read path notices the disagreement, logs it at ERROR and increments
+// registry_role_read_divergence_total, and the assertion above it silently
+// changes meaning. Divergence has its own tests, in
+// member_role_divergence_test.go, where it is the subject rather than an
+// accident.
+
+// registryRoleCols is MemberRoleReader.mirroredRoleColumns.
+var registryRoleCols = []string{
+	"role_template_id", "role_template_name", "role_template_display_name", "role_template_scopes",
+}
+
+// expectRegistryRoleFor queues the single-membership read (RoleFor). A nil
+// scopes argument queues NO ROW, which is how "registry has no mirror for this
+// membership" is expressed.
+func expectRegistryRoleFor(mock sqlmock.Sqlmock, roleID string, scopes []byte) {
+	rows := sqlmock.NewRows(registryRoleCols)
+	if scopes != nil {
+		rows.AddRow(nullableRole(roleID), "viewer", "Viewer", scopes)
+	}
+	mock.ExpectQuery(`(?s)FROM organization_member_roles omr.*WHERE omr\.organization_id = \$1 AND omr\.user_id = \$2`).
+		WillReturnRows(rows)
+}
+
+// expectRegistryRolesForOrg queues the per-organization read (RolesForOrg),
+// keyed by user id.
+func expectRegistryRolesForOrg(mock sqlmock.Sqlmock, userID, roleID string, scopes []byte) {
+	mock.ExpectQuery(`(?s)SELECT omr\.user_id,.*FROM organization_member_roles omr.*WHERE omr\.organization_id = \$1`).
+		WillReturnRows(sqlmock.NewRows(append([]string{"user_id"}, registryRoleCols...)).
+			AddRow(userID, nullableRole(roleID), "viewer", "Viewer", scopes))
+}
+
+// expectRegistryRolesForUser queues the per-user read (RolesForUser), keyed by
+// organization id.
+func expectRegistryRolesForUser(mock sqlmock.Sqlmock, orgID, roleID string, scopes []byte) {
+	mock.ExpectQuery(`(?s)SELECT omr\.organization_id,.*FROM organization_member_roles omr.*WHERE omr\.user_id = \$1`).
+		WillReturnRows(sqlmock.NewRows(append([]string{"organization_id"}, registryRoleCols...)).
+			AddRow(orgID, nullableRole(roleID), "viewer", "Viewer", scopes))
+}
+
+// nullableRole renders an empty role id as SQL NULL, so a fixture can express a
+// mirrored membership that carries no role.
+func nullableRole(roleID string) interface{} {
+	if roleID == "" {
+		return nil
+	}
+	return roleID
+}
+
 func newOrgRepo(t *testing.T) (*OrganizationRepository, sqlmock.Sqlmock) {
 	t.Helper()
 	db, mock, err := sqlmock.New()
@@ -397,6 +455,7 @@ func TestGetMember_Found(t *testing.T) {
 	repo, mock := newOrgRepo(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sampleOrgMemberRow())
+	expectRegistryRoleFor(mock, "", []byte(`[]`))
 
 	m, err := repo.GetMember(context.Background(), "org-1", "user-1", OrgScopeAllOrganizations())
 	if err != nil {
@@ -461,6 +520,7 @@ func TestListMembersWithUsers_WithMember(t *testing.T) {
 		AddRow("org-1", "user-1", nil, time.Now(), "Alice", "alice@example.com", nil, nil, scopesJSON)
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN users").
 		WillReturnRows(rows)
+	expectRegistryRolesForOrg(mock, "user-1", "", scopesJSON)
 
 	members, err := repo.ListMembersWithUsers(context.Background(), "org-1", OrgScopeAllOrganizations())
 	if err != nil {
@@ -572,6 +632,7 @@ func TestGetMemberWithRole_Found(t *testing.T) {
 	repo, mock := newOrgRepo(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members").
 		WillReturnRows(sampleMemberWithRoleRepoRow())
+	expectRegistryRoleFor(mock, "", []byte(`["modules:read"]`))
 
 	m, err := repo.GetMemberWithRole(context.Background(), "org-1", "user-1", OrgScopeAllOrganizations())
 	if err != nil {
@@ -596,6 +657,7 @@ func TestListMembers_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows(orgMemberRepoCols).
 			AddRow("org-1", "user-1", nil, time.Now()))
+	expectRegistryRolesForOrg(mock, "user-1", "", []byte(`[]`))
 
 	members, err := repo.ListMembers(context.Background(), "org-1", OrgScopeAllOrganizations())
 	if err != nil {
@@ -732,6 +794,7 @@ func TestCheckMembership_IsMember(t *testing.T) {
 	repo, mock := newOrgRepo(t)
 	mock.ExpectQuery("SELECT.*FROM organization_members WHERE organization_id").
 		WillReturnRows(sqlmock.NewRows(orgMemberRepoCols).AddRow("org-1", "user-1", nil, time.Now()))
+	expectRegistryRoleFor(mock, "", []byte(`[]`))
 
 	isMember, _, err := repo.CheckMembership(context.Background(), "org-1", "user-1", OrgScopeAllOrganizations())
 	if err != nil {
@@ -776,6 +839,7 @@ func TestGetUserMemberships_Success(t *testing.T) {
 			"org-1", "default", nil, time.Now(),
 			"viewer", "Viewer", []byte(`["modules:read"]`),
 		))
+	expectRegistryRolesForUser(mock, "org-1", "", []byte(`["modules:read"]`))
 
 	memberships, err := repo.GetUserMemberships(context.Background(), "user-1")
 	if err != nil {
@@ -811,6 +875,7 @@ func TestGetUserCombinedScopes_Success(t *testing.T) {
 			"org-1", "default", nil, time.Now(),
 			"viewer", "Viewer", []byte(`["modules:read","modules:write"]`),
 		))
+	expectRegistryRolesForUser(mock, "org-1", "", []byte(`["modules:read","modules:write"]`))
 
 	scopes, err := repo.GetUserCombinedScopes(context.Background(), "user-1") //nolint:staticcheck // SA1019: unit test for the deprecated-but-retained method itself
 	if err != nil {

--- a/backend/internal/db/repositories/rbac_repository.go
+++ b/backend/internal/db/repositories/rbac_repository.go
@@ -20,7 +20,6 @@ import (
 // is delegated to the shared identity store so it follows the identity schema.
 type RBACRepository struct {
 	db            *sqlx.DB
-	identityDB    *sqlx.DB
 	roleTemplates *identitystore.RoleTemplateRepository
 	// mirror writes registry's own registry_role_templates
 	// (sethbacon/terraform-suite-identity#206, migration 000055).
@@ -32,6 +31,17 @@ type RBACRepository struct {
 	// migration 000055 actually created the table. That is correct in every
 	// identity topology, including a separate identity database.
 	mirror *MemberRoleMirror
+
+	// roles READS registry's own tables. Since phase 3b every role template
+	// this repository RETURNS comes from `registry_role_templates`, and the
+	// membership sweep that follows a template change reads
+	// `organization_member_roles`. Writes still go to both locations -- the
+	// shared table is what the state manager and the rollback path read, and
+	// phase 4 is what removes it.
+	//
+	// Built on `db` for the same reason the mirror is: that is the connection
+	// migration 000055 created the tables on.
+	roles *MemberRoleReader
 }
 
 // NewRBACRepository creates a new RBAC repository whose role-template access uses
@@ -47,9 +57,9 @@ func NewRBACRepository(db *sqlx.DB) *RBACRepository {
 func NewRBACRepositoryWithIdentity(db, identityDB *sqlx.DB) *RBACRepository {
 	return &RBACRepository{
 		db:            db,
-		identityDB:    identityDB,
 		roleTemplates: identitystore.NewRoleTemplateRepository(identityDB.DB),
 		mirror:        NewMemberRoleMirror(db.DB),
+		roles:         NewMemberRoleReader(db.DB),
 	}
 }
 
@@ -71,42 +81,41 @@ type RoleTemplateMembership struct {
 // where they actually held this template must be revoked (issue #732). Without
 // the organization this query cannot express the second sweep without either
 // over-revoking (every key the member holds anywhere) or not revoking at all.
+//
+// It reads REGISTRY's own `organization_member_roles` since phase 3b
+// (terraform-suite-identity#206). The sweep withdraws credentials that
+// snapshotted the authority a template conferred, and since the cutover that
+// authority came from registry's tables -- so sweeping the identity table's
+// holders would revoke exactly the wrong set on any row where the two disagree,
+// which is the state this phase's drift check and divergence metric exist to
+// surface.
 func (r *RBACRepository) ListRoleTemplateMemberships(ctx context.Context, roleTemplateID uuid.UUID) ([]RoleTemplateMembership, error) {
-	query := `SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id = $1`
-	rows, err := r.identityDB.QueryContext(ctx, query, roleTemplateID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var out []RoleTemplateMembership
-	for rows.Next() {
-		var m RoleTemplateMembership
-		if err := rows.Scan(&m.UserID, &m.OrganizationID); err != nil {
-			return nil, err
-		}
-		out = append(out, m)
-	}
-	return out, rows.Err()
+	return r.roles.MembershipsWithTemplate(ctx, roleTemplateID)
 }
 
 // ============================================================================
-// Role Templates (delegated to the shared identity store)
+// Role Templates
 // ============================================================================
+//
+// READS come from registry's own `registry_role_templates` (phase 3b); WRITES
+// still go to the shared identity store as well as registry's table. The
+// asymmetry is deliberate and is what makes the rollback in
+// docs/identity-schema.md real: deploying the previous image returns every read
+// to a shared table that has been kept current all along.
 
-// ListRoleTemplates returns all role templates.
+// ListRoleTemplates returns registry's own role templates.
 func (r *RBACRepository) ListRoleTemplates(ctx context.Context) ([]*models.RoleTemplate, error) {
-	return r.roleTemplates.ListRoleTemplates(ctx)
+	return r.roles.ListRoleTemplates(ctx)
 }
 
-// GetRoleTemplate retrieves a role template by ID.
+// GetRoleTemplate retrieves one of registry's own role templates by ID.
 func (r *RBACRepository) GetRoleTemplate(ctx context.Context, id uuid.UUID) (*models.RoleTemplate, error) {
-	return r.roleTemplates.GetRoleTemplate(ctx, id)
+	return r.roles.GetRoleTemplate(ctx, id)
 }
 
-// GetRoleTemplateByName retrieves a role template by name.
+// GetRoleTemplateByName retrieves one of registry's own role templates by name.
 func (r *RBACRepository) GetRoleTemplateByName(ctx context.Context, name string) (*models.RoleTemplate, error) {
-	return r.roleTemplates.GetRoleTemplateByName(ctx, name)
+	return r.roles.GetRoleTemplateByName(ctx, name)
 }
 
 // CreateRoleTemplate creates a new role template, and mirrors it into

--- a/backend/internal/db/repositories/rbac_repository_test.go
+++ b/backend/internal/db/repositories/rbac_repository_test.go
@@ -111,7 +111,7 @@ func samplePolicyListRow() *sqlmock.Rows {
 
 func TestListRoleTemplates_Success(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates ORDER BY name").
 		WillReturnRows(sampleRoleTemplateRow())
 
 	templates, err := repo.ListRoleTemplates(context.Background())
@@ -125,7 +125,7 @@ func TestListRoleTemplates_Success(t *testing.T) {
 
 func TestListRoleTemplates_Empty(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates ORDER BY name").
 		WillReturnRows(sqlmock.NewRows(roleTemplateCols))
 
 	templates, err := repo.ListRoleTemplates(context.Background())
@@ -139,7 +139,7 @@ func TestListRoleTemplates_Empty(t *testing.T) {
 
 func TestListRoleTemplates_Error(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates ORDER BY name").
 		WillReturnError(errDB)
 
 	_, err := repo.ListRoleTemplates(context.Background())
@@ -155,7 +155,7 @@ func TestListRoleTemplates_Error(t *testing.T) {
 func TestGetRoleTemplate_Found(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	mock.ExpectQuery("SELECT id.*FROM role_templates.*WHERE id").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sampleRoleTemplateRow())
 
 	tpl, err := repo.GetRoleTemplate(context.Background(), id)
@@ -169,7 +169,7 @@ func TestGetRoleTemplate_Found(t *testing.T) {
 
 func TestGetRoleTemplate_NotFound(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates.*WHERE id").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates WHERE id").
 		WillReturnRows(sqlmock.NewRows(roleTemplateCols))
 
 	tpl, err := repo.GetRoleTemplate(context.Background(), uuid.New())
@@ -187,7 +187,7 @@ func TestGetRoleTemplate_NotFound(t *testing.T) {
 
 func TestGetRoleTemplate_Error(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates.*WHERE id").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates WHERE id").
 		WillReturnError(errDB)
 
 	_, err := repo.GetRoleTemplate(context.Background(), uuid.New())
@@ -202,7 +202,7 @@ func TestGetRoleTemplate_Error(t *testing.T) {
 
 func TestGetRoleTemplateByName_Found(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates.*WHERE name").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates WHERE name").
 		WillReturnRows(sampleRoleTemplateRow())
 
 	tpl, err := repo.GetRoleTemplateByName(context.Background(), "admin")
@@ -216,7 +216,7 @@ func TestGetRoleTemplateByName_Found(t *testing.T) {
 
 func TestGetRoleTemplateByName_NotFound(t *testing.T) {
 	repo, mock := newRBACRepo(t)
-	mock.ExpectQuery("SELECT id.*FROM role_templates.*WHERE name").
+	mock.ExpectQuery("SELECT id.*FROM registry_role_templates WHERE name").
 		WillReturnRows(sqlmock.NewRows(roleTemplateCols))
 
 	tpl, err := repo.GetRoleTemplateByName(context.Background(), "unknown")
@@ -692,7 +692,7 @@ func TestListRoleTemplateMemberships_Success(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WithArgs(id).
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}).
 			AddRow("user-1", "org-1").
@@ -717,7 +717,7 @@ func TestListRoleTemplateMemberships_Empty(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WillReturnRows(sqlmock.NewRows([]string{"user_id", "organization_id"}))
 
 	memberships, err := repo.ListRoleTemplateMemberships(context.Background(), id)
@@ -733,7 +733,7 @@ func TestListRoleTemplateMemberships_DBError(t *testing.T) {
 	repo, mock := newRBACRepo(t)
 	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 
-	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_members WHERE role_template_id").
+	mock.ExpectQuery("SELECT DISTINCT user_id, organization_id FROM organization_member_roles WHERE role_template_id").
 		WillReturnError(errDB)
 
 	_, err := repo.ListRoleTemplateMemberships(context.Background(), id)

--- a/backend/internal/db/repositories/role_template_seed.go
+++ b/backend/internal/db/repositories/role_template_seed.go
@@ -15,16 +15,30 @@ type systemRoleTemplateExecer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-// upsertSystemRoleTemplateQuery idempotently inserts or updates a system role
-// template by its (unique) name. The conflict update only fires when something
-// actually changed, so steady-state restarts perform no writes.
+// upsertSystemRoleTemplateSQL builds the idempotent "insert or update by name"
+// statement for a role-template table. The conflict update only fires when
+// something actually changed, so steady-state restarts perform no writes.
 //
-// This deliberately bypasses the identity module's RoleTemplateRepository.Update,
+// Parameterised by table because there are now TWO of them and their bodies
+// must not drift apart: registry's own `registry_role_templates`, which is what
+// registry READS since the cutover, and the shared `role_templates`, which the
+// state manager and the rollback path still read. A table name cannot be a bind
+// parameter, so it is interpolated -- from the two constants below and nothing
+// else, never from input.
+//
+// Both deliberately bypass the identity module's RoleTemplateRepository.Update,
 // which refuses to modify is_system rows (`WHERE is_system = false`). Seeding the
 // system role→scope mapping is a privileged bootstrap write owned by the app, not
 // a user-facing edit, so it must reach the protected system rows directly.
-const upsertSystemRoleTemplateQuery = `
-INSERT INTO role_templates (id, name, display_name, description, scopes, is_system, created_at, updated_at)
+//
+// ON CONFLICT (name), not (id), and that is what makes the ordering in
+// internal/api/router.go work: the reconcile has already inserted each template
+// under the id the IDENTITY copy carries, and conflicting on the name updates
+// that row in place rather than creating a second one under a fresh uuid. The
+// id is therefore still the one every mirrored membership names.
+func upsertSystemRoleTemplateSQL(table string) string {
+	return `
+INSERT INTO ` + table + ` (id, name, display_name, description, scopes, is_system, created_at, updated_at)
 VALUES (gen_random_uuid(), $1, $2, $3, $4, true, NOW(), NOW())
 ON CONFLICT (name) DO UPDATE SET
     display_name = EXCLUDED.display_name,
@@ -32,33 +46,73 @@ ON CONFLICT (name) DO UPDATE SET
     scopes       = EXCLUDED.scopes,
     is_system    = true,
     updated_at   = NOW()
-WHERE role_templates.scopes       IS DISTINCT FROM EXCLUDED.scopes
-   OR role_templates.display_name IS DISTINCT FROM EXCLUDED.display_name
-   OR role_templates.description  IS DISTINCT FROM EXCLUDED.description
-   OR role_templates.is_system    IS DISTINCT FROM true`
+WHERE ` + table + `.scopes       IS DISTINCT FROM EXCLUDED.scopes
+   OR ` + table + `.display_name IS DISTINCT FROM EXCLUDED.display_name
+   OR ` + table + `.description  IS DISTINCT FROM EXCLUDED.description
+   OR ` + table + `.is_system    IS DISTINCT FROM true`
 
-// SeedSystemRoleTemplates idempotently upserts the given system role templates by
-// name against the supplied connection.
+}
+
+// The two tables, spelled once each.
+const (
+	registryRoleTemplateTable = "registry_role_templates"
+	sharedRoleTemplateTable   = "role_templates"
+)
+
+// SeedSystemRoleTemplates idempotently upserts the given system role templates,
+// by name, into REGISTRY'S OWN `registry_role_templates`
+// (sethbacon/terraform-suite-identity#206, phase 3b).
 //
-// It is used under the identity-schema cutover (TFR_IDENTITY_SCHEMA_ENABLED): the
-// shared identity module seeds these roles with identity-core scopes only, so the
-// registry layers its own domain scopes onto them here ("identity-core +
-// app-extended"). In the default public-schema configuration the role templates
-// are already seeded with the full app scopes by migration 000001, so this is not
-// invoked.
+// That table is what every authorization decision now reads, so registry's
+// role→scope mapping has to be written there by registry. Before the read
+// cutover this function targeted the shared `role_templates`, which is the table
+// two applications collide on and which `TFR_SUITE_ROLE_SEED_OWNER` exists to
+// arbitrate; registry's own table has no such contention, because no other
+// application writes it.
 //
-// The connection's search_path determines which schema is written: under cutover
-// it resolves the unqualified role_templates to the shared identity schema.
+// IT MUST RUN AFTER ReconcileMemberRoles, not before. The reconcile derives
+// registry's table from the identity source, including the template scopes; a
+// seed that ran first would be overwritten by it on the same boot. router.go
+// orders the two and says so.
+//
+// The connection's search_path determines which schema is written, exactly as
+// before.
 func SeedSystemRoleTemplates(ctx context.Context, db systemRoleTemplateExecer, templates []models.RoleTemplate) error {
+	return seedRoleTemplates(ctx, db, registryRoleTemplateTable, templates)
+}
+
+// SeedSharedIdentityRoleTemplates idempotently upserts the same templates into
+// the SHARED `role_templates`.
+//
+// Registry no longer reads that table, and it keeps writing it for two reasons
+// that both outlive this phase:
+//
+//   - The state manager still reads it. It has not done its own phase 3, so
+//     removing registry's seed here would change another application's roles
+//     from a registry-side change.
+//   - It is the rollback surface. The rollback for a bad read cutover is to
+//     deploy the previous image, and that image reads this table; it has to
+//     still be current when it does.
+//
+// This is the call `TFR_SUITE_ROLE_SEED_OWNER` gates, and the only one -- see
+// the note on the flag in docs/configuration.md for why it cannot retire until
+// phase 4.
+func SeedSharedIdentityRoleTemplates(ctx context.Context, db systemRoleTemplateExecer, templates []models.RoleTemplate) error {
+	return seedRoleTemplates(ctx, db, sharedRoleTemplateTable, templates)
+}
+
+// seedRoleTemplates is the shared body of the two seeds above.
+func seedRoleTemplates(ctx context.Context, db systemRoleTemplateExecer, table string, templates []models.RoleTemplate) error {
+	query := upsertSystemRoleTemplateSQL(table)
 	for i := range templates {
 		t := templates[i]
 		scopesJSON, err := json.Marshal(t.Scopes)
 		if err != nil {
 			return fmt.Errorf("marshal scopes for role template %q: %w", t.Name, err)
 		}
-		if _, err := db.ExecContext(ctx, upsertSystemRoleTemplateQuery,
+		if _, err := db.ExecContext(ctx, query,
 			t.Name, t.DisplayName, t.Description, scopesJSON); err != nil {
-			return fmt.Errorf("upsert role template %q: %w", t.Name, err)
+			return fmt.Errorf("upsert role template %q into %s: %w", t.Name, table, err)
 		}
 	}
 	return nil

--- a/backend/internal/db/repositories/role_template_seed_test.go
+++ b/backend/internal/db/repositories/role_template_seed_test.go
@@ -46,8 +46,8 @@ func TestSeedSystemRoleTemplates_UpsertsEachTemplate(t *testing.T) {
 		t.Fatalf("expected %d Exec calls, got %d", len(templates), len(f.calls))
 	}
 	for i, call := range f.calls {
-		if call.query != upsertSystemRoleTemplateQuery {
-			t.Errorf("call %d: query did not match the upsert statement", i)
+		if call.query != upsertSystemRoleTemplateSQL(registryRoleTemplateTable) {
+			t.Errorf("call %d: query did not match the upsert statement for %s", i, registryRoleTemplateTable)
 		}
 		if len(call.args) != 4 {
 			t.Fatalf("call %d: expected 4 args, got %d", i, len(call.args))
@@ -80,17 +80,60 @@ func TestSeedSystemRoleTemplates_UpsertsEachTemplate(t *testing.T) {
 // TestSeedSystemRoleTemplates_GuardedUpsertSQL locks the shape of the bootstrap
 // write: it must be a guarded ON CONFLICT upsert that reaches is_system rows and
 // no-ops when nothing changed.
+//
+// Both tables, and the ON CONFLICT TARGET asserted explicitly. Conflicting on
+// (name) rather than (id) is what lets the seed update the row the reconcile
+// already inserted under the identity copy's id, instead of inserting a second
+// row under a fresh uuid that no membership names — which would silently strip
+// every member of their role (terraform-suite-identity#206, phase 3b).
 func TestSeedSystemRoleTemplates_GuardedUpsertSQL(t *testing.T) {
-	q := upsertSystemRoleTemplateQuery
-	for _, want := range []string{
-		"INSERT INTO role_templates",
-		"ON CONFLICT (name) DO UPDATE SET",
-		"is_system    = true",
-		"IS DISTINCT FROM",
-	} {
-		if !strings.Contains(q, want) {
-			t.Errorf("upsert query is missing %q", want)
+	for _, table := range []string{registryRoleTemplateTable, sharedRoleTemplateTable} {
+		q := upsertSystemRoleTemplateSQL(table)
+		for _, want := range []string{
+			"INSERT INTO " + table + " (id, name, display_name, description, scopes, is_system, created_at, updated_at)",
+			"ON CONFLICT (name) DO UPDATE SET",
+			"is_system    = true",
+			table + ".scopes       IS DISTINCT FROM EXCLUDED.scopes",
+		} {
+			if !strings.Contains(q, want) {
+				t.Errorf("%s upsert query is missing %q", table, want)
+			}
 		}
+	}
+}
+
+// TestSeedRoleTemplates_TargetsAreDistinctTables is the property phase 3b turns
+// on: the seed that feeds registry's authorization and the seed that keeps the
+// shared table current for the state manager and for a rollback must write
+// DIFFERENT tables. A refactor that collapsed them back onto one would restore
+// exactly the cross-application collision TFR_SUITE_ROLE_SEED_OWNER exists to
+// arbitrate, and every test above would still pass.
+func TestSeedRoleTemplates_TargetsAreDistinctTables(t *testing.T) {
+	templates := []models.RoleTemplate{{Name: "viewer", DisplayName: "Viewer", Scopes: []string{"modules:read"}}}
+
+	own := &fakeExecer{}
+	if err := SeedSystemRoleTemplates(context.Background(), own, templates); err != nil {
+		t.Fatalf("SeedSystemRoleTemplates: %v", err)
+	}
+	shared := &fakeExecer{}
+	if err := SeedSharedIdentityRoleTemplates(context.Background(), shared, templates); err != nil {
+		t.Fatalf("SeedSharedIdentityRoleTemplates: %v", err)
+	}
+
+	if len(own.calls) != 1 || len(shared.calls) != 1 {
+		t.Fatalf("expected one call each, got own=%d shared=%d", len(own.calls), len(shared.calls))
+	}
+	if !strings.Contains(own.calls[0].query, "INSERT INTO registry_role_templates") {
+		t.Errorf("SeedSystemRoleTemplates must write registry's own table; query was:\n%s", own.calls[0].query)
+	}
+	if strings.Contains(own.calls[0].query, "INSERT INTO role_templates") {
+		t.Errorf("SeedSystemRoleTemplates still writes the shared table; query was:\n%s", own.calls[0].query)
+	}
+	if !strings.Contains(shared.calls[0].query, "INSERT INTO role_templates") {
+		t.Errorf("SeedSharedIdentityRoleTemplates must write the shared table; query was:\n%s", shared.calls[0].query)
+	}
+	if own.calls[0].query == shared.calls[0].query {
+		t.Error("both seeds issue the same statement — they are writing one table, not two")
 	}
 }
 
@@ -132,14 +175,14 @@ func TestSeedSystemRoleTemplates_Idempotent_NoOpReRun(t *testing.T) {
 
 	// First run: every template upsert inserts a row (RowsAffected = 1).
 	for range templates {
-		mock.ExpectExec("INSERT INTO role_templates").
+		mock.ExpectExec("INSERT INTO registry_role_templates").
 			WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 	}
 	// Second run with identical values: the guarded WHERE suppresses every write,
 	// so each upsert reports 0 rows affected — the steady-state no-op.
 	for range templates {
-		mock.ExpectExec("INSERT INTO role_templates").
+		mock.ExpectExec("INSERT INTO registry_role_templates").
 			WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 	}

--- a/backend/internal/db/repositories/user_repository.go
+++ b/backend/internal/db/repositories/user_repository.go
@@ -1,13 +1,135 @@
-// Package repositories - user_repository.go aliases the UserRepository from the
-// shared identity store. The constructor is re-exported so existing call sites
-// (repositories.NewUserRepository) are unchanged. The active schema is determined
-// by the connection passed in.
+// Package repositories - user_repository.go wraps the UserRepository from the
+// shared identity store.
+//
+// It was a type ALIAS until the read cutover (sethbacon/terraform-suite-identity#206,
+// phase 3b) and is a wrapper now for one reason: three of the store's user
+// accessors return the user's MEMBERSHIPS, each carrying a role template and its
+// scopes, and since the cutover that role has to come from registry's own tables
+// like every other. An alias cannot override anything, so those three reads were
+// the one authorization surface the cutover could not reach -- GET
+// /api/v1/users/:id and the admin user list would have kept answering from
+// `organization_members.role_template_id` while every enforcement path answered
+// from registry's tables. Two answers to one question, differing only on the rows
+// that are wrong.
+//
+// The constructor keeps its name and signature, so no call site changes.
 package repositories
 
-import identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+import (
+	"context"
+	"database/sql"
+
+	identitystore "github.com/sethbacon/terraform-suite-identity/identity/store"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
 
 // UserRepository handles user database operations.
-type UserRepository = identitystore.UserRepository
+//
+// It embeds the shared store's repository, so every accessor that does NOT
+// return a role -- which is most of them -- is promoted unchanged. The three
+// that do are overridden below, and user_role_read_class_test.go fails if the
+// pinned module grows a fourth.
+type UserRepository struct {
+	*identitystore.UserRepository
+
+	// roles reads registry's own authorization tables. Same connection as the
+	// embedded repository, for the same reason as OrganizationRepository.roles.
+	roles *MemberRoleReader
+}
 
 // NewUserRepository constructs a UserRepository over the given connection.
-var NewUserRepository = identitystore.NewUserRepository
+func NewUserRepository(db *sql.DB) *UserRepository {
+	return &UserRepository{
+		UserRepository: identitystore.NewUserRepository(db),
+		roles:          NewMemberRoleReader(db),
+	}
+}
+
+// GetUserWithOrgRoles returns the user with their memberships, each carrying
+// the role registry's own tables hold for it.
+func (r *UserRepository) GetUserWithOrgRoles(ctx context.Context, userID string, scope identitystore.OrgScope) (*models.UserWithOrgRoles, error) {
+	user, err := r.UserRepository.GetUserWithOrgRoles(ctx, userID, scope)
+	if err != nil {
+		return nil, err
+	}
+	if len(user.Memberships) == 0 {
+		return user, nil
+	}
+	roles, err := r.roles.RolesForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	overlayMemberships(ctx, "GetUserWithOrgRoles", userID, user.Memberships, roles)
+	return user, nil
+}
+
+// ListUsersWithMemberships returns a page of users with registry's own roles.
+//
+// Overridden even though the store implements it in terms of an unexported
+// helper: Go promotes it otherwise, and the promoted version resolves roles from
+// the identity tables. The overlay is applied to the RESULT rather than inside
+// the helper, which is not reachable from here -- and which is the right place
+// anyway, because one bulk read for the whole page preserves the 2-query shape
+// the store went to trouble to get.
+func (r *UserRepository) ListUsersWithMemberships(ctx context.Context, limit, offset int, scope identitystore.OrgScope) ([]*models.UserWithOrgRoles, int, error) {
+	users, total, err := r.UserRepository.ListUsersWithMemberships(ctx, limit, offset, scope)
+	if err != nil {
+		return nil, total, err
+	}
+	if err := r.overlayUsers(ctx, "ListUsersWithMemberships", users); err != nil {
+		return nil, total, err
+	}
+	return users, total, nil
+}
+
+// SearchWithMemberships returns matching users with registry's own roles.
+func (r *UserRepository) SearchWithMemberships(ctx context.Context, query string, limit, offset int, scope identitystore.OrgScope) ([]*models.UserWithOrgRoles, error) {
+	users, err := r.UserRepository.SearchWithMemberships(ctx, query, limit, offset, scope)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.overlayUsers(ctx, "SearchWithMemberships", users); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
+// overlayUsers replaces the roles on a page of users with registry's, in one
+// bulk read.
+func (r *UserRepository) overlayUsers(ctx context.Context, accessor string, users []*models.UserWithOrgRoles) error {
+	ids := make([]string, 0, len(users))
+	for _, u := range users {
+		if len(u.Memberships) > 0 {
+			ids = append(ids, u.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	byUser, err := r.roles.RolesForUsers(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for _, u := range users {
+		overlayMemberships(ctx, accessor, u.ID, u.Memberships, byUser[u.ID])
+	}
+	return nil
+}
+
+// overlayMemberships rewrites each membership's role fields from registry's
+// tables, reporting any disagreement.
+//
+// The slice is of VALUES, not pointers, so the loop indexes rather than ranges
+// over copies -- ranging by value here would compare and overwrite a temporary
+// and leave every caller reading identity's role, which is the whole defect
+// this file exists to prevent and would produce no test failure anywhere.
+func overlayMemberships(ctx context.Context, accessor, userID string, memberships []models.UserMembership, roles map[string]*MirroredRole) {
+	for i := range memberships {
+		m := &memberships[i]
+		role := roles[m.OrganizationID]
+		compareRole(ctx, accessor, m.OrganizationID, userID, m.RoleTemplateID, role)
+		applyMirroredRole(role, &m.RoleTemplateID, &m.RoleTemplateName,
+			&m.RoleTemplateDisplayName, &m.RoleTemplateScopes)
+	}
+}

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -935,6 +935,8 @@ var memberWithRoleCols = []string{
 func expectKeyOwnerMembership(mock sqlmock.Sqlmock, orgID, userID string, roleScopes []byte) {
 	q := mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN")
 	if roleScopes == nil {
+		// No membership: the store answers ErrNotFound and the accessor returns
+		// before it ever asks registry's tables, so no mirrored read follows.
 		q.WillReturnRows(sqlmock.NewRows(memberWithRoleCols))
 		return
 	}
@@ -942,6 +944,67 @@ func expectKeyOwnerMembership(mock sqlmock.Sqlmock, orgID, userID string, roleSc
 		orgID, userID, "rt-1", time.Now(),
 		"Test User", "test@example.com",
 		"viewer", "Viewer", roleScopes))
+	// Same template, same scopes: the membership this fixture describes is
+	// unchanged, only the table the ROLE half of it is read from.
+	expectRegistryRoleFor(mock, "rt-1", "viewer", "Viewer", roleScopes)
+}
+
+// ---------------------------------------------------------------------------
+// Registry's own role tables (sethbacon/terraform-suite-identity#206, phase 3b)
+//
+// repositories.OrganizationRepository still asks the shared identity store for
+// the membership FACT -- which is what every `organization_members` expectation
+// in this package supplies, and why none of them may be dropped -- and then
+// issues ONE MORE query against registry's own `organization_member_roles` /
+// `registry_role_templates`, returning THAT role. So a fixture that seeds a
+// member row has to seed the mirrored role immediately after it, on the same
+// mock, in the same order.
+//
+// The mirrored row must carry the SAME role_template_id and the SAME scopes as
+// the identity row it follows. A different value is the DIVERGENCE case:
+// compareRole logs an ERROR and increments registry_role_read_divergence_total,
+// and the authorization outcome silently becomes a statement about drift rather
+// than about the access-control rule the test was written for.
+// ---------------------------------------------------------------------------
+
+// registryRoleCols is member_role_reader.go's mirroredRoleColumns projection:
+// role_template_id (nullable), name, display_name, scopes (JSON array).
+var registryRoleCols = []string{"role_template_id", "name", "display_name", "scopes"}
+
+// expectRegistryRoleFor queues the single-membership read (MemberRoleReader
+// .RoleFor) that follows GetMember and GetMemberWithRole -- and, through them,
+// CheckMembership and GetUserScopesForOrg. A nil scopes slice means registry
+// holds no mirrored row for the membership, which confers nothing.
+func expectRegistryRoleFor(mock sqlmock.Sqlmock, roleTemplateID, name, displayName string, scopes []byte) {
+	rows := sqlmock.NewRows(registryRoleCols)
+	if scopes != nil {
+		rows.AddRow(roleTemplateID, name, displayName, scopes)
+	}
+	mock.ExpectQuery(`SELECT omr\.role_template_id.*FROM organization_member_roles.*WHERE omr\.organization_id = \$1 AND omr\.user_id = \$2`).
+		WillReturnRows(rows)
+}
+
+// registryRoleForOrg is one organization's mirrored role in a whole-user read.
+type registryRoleForOrg struct {
+	OrganizationID string
+	RoleTemplateID string
+	Name           string
+	DisplayName    string
+	Scopes         []byte
+}
+
+// expectRegistryRolesForUser queues the whole-user read (MemberRoleReader
+// .RolesForUser) that follows GetUserMemberships -- and, through it,
+// GetUserCombinedScopes and OrgScopeForUser. The store's own read runs first
+// and this one only when that returned at least one membership, so pass one
+// registryRoleForOrg per membership the store fixture seeded.
+func expectRegistryRolesForUser(mock sqlmock.Sqlmock, roles ...registryRoleForOrg) {
+	rows := sqlmock.NewRows(append([]string{"organization_id"}, registryRoleCols...))
+	for _, role := range roles {
+		rows.AddRow(role.OrganizationID, role.RoleTemplateID, role.Name, role.DisplayName, role.Scopes)
+	}
+	mock.ExpectQuery(`SELECT omr\.organization_id,.*FROM organization_member_roles.*WHERE omr\.user_id = \$1`).
+		WillReturnRows(rows)
 }
 
 // apiKeyAuthRouter wires AuthMiddleware over mocked repositories and returns

--- a/backend/internal/middleware/namespace_authz_test.go
+++ b/backend/internal/middleware/namespace_authz_test.go
@@ -101,6 +101,14 @@ func memberRow(orgID, userID string, roleScopes string) *sqlmock.Rows {
 	)
 }
 
+// expectMirroredMemberRole queues the registry-side half of a memberRow: the
+// SAME template and the SAME scopes, because the identity row supplies the
+// membership fact while the role itself is now read from registry's own tables
+// (see the helpers in auth_test.go).
+func expectMirroredMemberRole(mock sqlmock.Sqlmock, roleScopes string) {
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(roleScopes))
+}
+
 func doNamespaceReq(r *gin.Engine, method, path string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(method, path, nil))
@@ -163,6 +171,7 @@ func TestRequireNamespaceAccessFromPath_SameOrgPublisher_Allowed(t *testing.T) {
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub User", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 
 	r := gin.New()
 	r.DELETE("/modules/:namespace/:name/:system",
@@ -228,6 +237,7 @@ func TestRequireNamespaceAccessFromPath_APIKeyOrgMatch_Allowed(t *testing.T) {
 	// membership and role scopes decide it.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 
 	r := gin.New()
 	r.DELETE("/modules/:namespace/:name/:system",
@@ -387,6 +397,10 @@ func TestRequirePublishAccessFromForm_FirstClaim_BindsToCallerOrg(t *testing.T) 
 		WillReturnRows(sqlmock.NewRows(userMembershipCols).AddRow(
 			nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`),
 		)) // single membership → unambiguous caller org
+	expectRegistryRolesForUser(mock, registryRoleForOrg{
+		OrganizationID: nsOrgA, RoleTemplateID: "role-pub",
+		Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`),
+	})
 	mock.ExpectExec("INSERT INTO namespace_claims").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
@@ -395,6 +409,7 @@ func TestRequirePublishAccessFromForm_FirstClaim_BindsToCallerOrg(t *testing.T) 
 	// which is also what enforces the required scope on this path.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 
 	r := gin.New()
 	r.POST("/modules",
@@ -445,6 +460,7 @@ func TestRequirePublishAccessFromForm_ExistingClaimSameOrg_Allowed(t *testing.T)
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 
 	r := gin.New()
 	r.POST("/modules",
@@ -488,6 +504,11 @@ func TestRequirePublishAccessFromForm_AmbiguousMemberships_NonAdminDenied(t *tes
 		WillReturnRows(sqlmock.NewRows(userMembershipCols).
 			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)).
 			AddRow(nsOrgB, "Org B", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+	expectRegistryRolesForUser(mock,
+		registryRoleForOrg{OrganizationID: nsOrgA, RoleTemplateID: "role-pub",
+			Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`)},
+		registryRoleForOrg{OrganizationID: nsOrgB, RoleTemplateID: "role-pub",
+			Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`)})
 
 	r := gin.New()
 	r.POST("/modules",
@@ -547,6 +568,7 @@ func TestRequirePublishAccessFromForm_APIKeyOwned_FirstClaim_ReverifiesMembershi
 	// resolveCallerOrg re-verifies before the claim is created.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 	mock.ExpectExec("INSERT INTO namespace_claims").
 		WithArgs("ci-team", nsOrgA, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -555,6 +577,7 @@ func TestRequirePublishAccessFromForm_APIKeyOwned_FirstClaim_ReverifiesMembershi
 	// authorizeOrgAccess re-verifies against the claim's owner, unconditionally.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 
 	r := gin.New()
 	r.POST("/modules",
@@ -618,6 +641,7 @@ func TestRequirePublishAccessFromForm_APIKeyOwnerDowngraded_FirstClaimDenied(t *
 	// Still a member, but the role template no longer grants modules:write.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:read"]`))
+	expectMirroredMemberRole(mock, `["modules:read"]`)
 
 	r := gin.New()
 	r.POST("/modules",
@@ -646,6 +670,7 @@ func TestRequireNamespaceAccessFromPath_APIKeyOwnerDowngraded_Denied(t *testing.
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("acme", nsOrgA, nil, time.Now()))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:read"]`))
+	expectMirroredMemberRole(mock, `["modules:read"]`)
 
 	r := gin.New()
 	r.DELETE("/modules/:namespace/:name/:system",
@@ -680,6 +705,11 @@ func TestRequirePublishAccessFromForm_MultiOrgAdmin_NoExplicitOrg_FailsClosed(t 
 		WillReturnRows(sqlmock.NewRows(userMembershipCols).
 			AddRow(nsOrgA, "Org A", "role-adm", time.Now(), "admin", "Administrator", []byte(`["admin"]`)).
 			AddRow(nsOrgB, "Org B", "role-adm", time.Now(), "admin", "Administrator", []byte(`["admin"]`)))
+	expectRegistryRolesForUser(mock,
+		registryRoleForOrg{OrganizationID: nsOrgA, RoleTemplateID: "role-adm",
+			Name: "admin", DisplayName: "Administrator", Scopes: []byte(`["admin"]`)},
+		registryRoleForOrg{OrganizationID: nsOrgB, RoleTemplateID: "role-adm",
+			Name: "admin", DisplayName: "Administrator", Scopes: []byte(`["admin"]`)})
 
 	r := gin.New()
 	r.POST("/modules",
@@ -743,6 +773,11 @@ func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_Member_Claims(t *testi
 		WillReturnRows(sqlmock.NewRows(userMembershipCols).
 			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)).
 			AddRow(nsOrgB, "Org B", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+	expectRegistryRolesForUser(mock,
+		registryRoleForOrg{OrganizationID: nsOrgA, RoleTemplateID: "role-pub",
+			Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`)},
+		registryRoleForOrg{OrganizationID: nsOrgB, RoleTemplateID: "role-pub",
+			Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`)})
 	mock.ExpectExec("INSERT INTO namespace_claims").
 		WithArgs("newteam", nsOrgB, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -752,6 +787,7 @@ func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_Member_Claims(t *testi
 	// chosen org; the unconditional post-claim check supplies that.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN.*role_templates").
 		WillReturnRows(memberRow(nsOrgB, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 
 	r := gin.New()
 	r.POST("/modules",
@@ -781,6 +817,10 @@ func TestRequirePublishAccessFromForm_NonAdminExplicitOrg_NotMember_Denied(t *te
 	mock.ExpectQuery("SELECT.*FROM organization_members.*JOIN organizations").
 		WillReturnRows(sqlmock.NewRows(userMembershipCols).
 			AddRow(nsOrgA, "Org A", "role-pub", time.Now(), "publisher", "Publisher", []byte(`["modules:write"]`)))
+	expectRegistryRolesForUser(mock, registryRoleForOrg{
+		OrganizationID: nsOrgA, RoleTemplateID: "role-pub",
+		Name: "publisher", DisplayName: "Publisher", Scopes: []byte(`["modules:write"]`),
+	})
 
 	r := gin.New()
 	r.POST("/modules",
@@ -813,6 +853,7 @@ func TestRequirePublishAccessFromForm_APIKeyOrg_IgnoresExplicitOrg(t *testing.T)
 	// row is written, once afterwards against the claim's actual owner.
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 	mock.ExpectExec("INSERT INTO namespace_claims").
 		WithArgs("ci-team", nsOrgA, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -820,6 +861,7 @@ func TestRequirePublishAccessFromForm_APIKeyOrg_IgnoresExplicitOrg(t *testing.T)
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("ci-team", nsOrgA, nil, time.Now()))
 	mock.ExpectQuery("SELECT.*FROM organization_members.*LEFT JOIN").
 		WillReturnRows(memberRow(nsOrgA, nsUserID, `["modules:write"]`))
+	expectMirroredMemberRole(mock, `["modules:write"]`)
 
 	r := gin.New()
 	r.POST("/modules",
@@ -858,6 +900,7 @@ func TestRequirePublishAccessFromJSON_BodyRestoredForHandler(t *testing.T) {
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 
 	var gotNamespace string
 	r := gin.New()
@@ -896,6 +939,7 @@ func TestRequirePublishAccessFromJSON_OrgOverrideMismatch_Denied(t *testing.T) {
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 
 	r := gin.New()
 	r.POST("/admin/providers",
@@ -1002,6 +1046,7 @@ func TestRequireProviderAccessByID_SameOrg_Allowed(t *testing.T) {
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["providers:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["providers:write"]`))
 
 	r := gin.New()
 	r.PUT("/admin/providers/:id",
@@ -1031,6 +1076,7 @@ func TestRequireModuleUpdateAccess_MoveToUnclaimedNamespace_ClaimsForCurrentOrg(
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 	// Target namespace "newhome" is unclaimed and has no artifacts.
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols))
@@ -1073,6 +1119,7 @@ func TestRequireModuleUpdateAccess_MoveToOtherOrgNamespace_Denied(t *testing.T) 
 			nsOrgA, nsUserID, "role-pub", time.Now(),
 			"Pub", "pub@test.com", "publisher", "Publisher", []byte(`["modules:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-pub", "publisher", "Publisher", []byte(`["modules:write"]`))
 	// Target namespace "rivals" is owned by org B.
 	mock.ExpectQuery("SELECT.*FROM namespace_claims").
 		WillReturnRows(sqlmock.NewRows(claimCols).AddRow("rivals", nsOrgB, nil, time.Now()))

--- a/backend/internal/middleware/org_resource_authz_test.go
+++ b/backend/internal/middleware/org_resource_authz_test.go
@@ -62,6 +62,7 @@ func TestRequireOrgScopeForResource_SameOrg_Allowed(t *testing.T) {
 			nsOrgA, nsUserID, "role-devops", time.Now(),
 			"Dev", "dev@test.com", "devops", "DevOps", []byte(`["scm:manage"]`),
 		))
+	expectRegistryRoleFor(mock, "role-devops", "devops", "DevOps", []byte(`["scm:manage"]`))
 
 	resolve, _ := resolverFor(nsOrgA, true, nil)
 	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),
@@ -81,6 +82,7 @@ func TestRequireOrgScopeForResource_MemberWithoutScopeInOwningOrg_Denied(t *test
 			nsOrgA, nsUserID, "role-viewer", time.Now(),
 			"View", "view@test.com", "viewer", "Viewer", []byte(`["scm:read"]`),
 		))
+	expectRegistryRoleFor(mock, "role-viewer", "viewer", "Viewer", []byte(`["scm:read"]`))
 
 	resolve, _ := resolverFor(nsOrgA, true, nil)
 	r := resourceRouter(authz.RequireOrgScopeForResource(auth.ScopeSCMManage, resolve),

--- a/backend/internal/middleware/rbac_org_path_test.go
+++ b/backend/internal/middleware/rbac_org_path_test.go
@@ -130,6 +130,7 @@ func TestRequireOrgScopeForPathOrg_SameOrgAllowed(t *testing.T) {
 			orgMWOrgID, orgMWUserID, "role-1", time.Now(),
 			"User Name", "user@test.com", "user_manager", "User Manager", []byte(`["organizations:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-1", "user_manager", "User Manager", []byte(`["organizations:write"]`))
 
 	w := doGetPath(pathOrgRouter(mid, []string{"organizations:write"}, orgMWUserID), "/organizations/"+orgMWOrgID)
 	if w.Code != http.StatusOK {
@@ -151,6 +152,7 @@ func TestRequireOrgScopeForPathOrg_InsufficientOrgScope(t *testing.T) {
 			orgMWOrgID, orgMWUserID, "role-1", time.Now(),
 			"User Name", "user@test.com", "viewer", "Viewer", []byte(`["organizations:read"]`),
 		))
+	expectRegistryRoleFor(mock, "role-1", "viewer", "Viewer", []byte(`["organizations:read"]`))
 
 	w := doGetPath(pathOrgRouter(mid, []string{"organizations:write"}, orgMWUserID), "/organizations/"+orgMWOrgID)
 	if w.Code != http.StatusForbidden {
@@ -239,6 +241,7 @@ func TestRequireOrgScopeForPathOrg_KeyBoundToTargetOrgAllowed(t *testing.T) {
 			orgMWOrgID, orgMWUserID, "role-1", time.Now(),
 			"User Name", "user@test.com", "user_manager", "User Manager", []byte(`["organizations:write"]`),
 		))
+	expectRegistryRoleFor(mock, "role-1", "user_manager", "User Manager", []byte(`["organizations:write"]`))
 
 	r := gin.New()
 	r.GET("/organizations/:id",

--- a/backend/internal/services/user_service.go
+++ b/backend/internal/services/user_service.go
@@ -139,12 +139,21 @@ func (s *UserService) ExportUserData(ctx context.Context, userID string) (*UserD
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
 
-	// 2. Organization memberships
+	// 2. Organization memberships.
+	//
+	// The membership and the organization are identity's; the ROLE comes from
+	// registry's own tables (terraform-suite-identity#206, phase 3b). A GDPR
+	// export must describe the authority the subject actually holds in this
+	// application, and since the read cutover that is what
+	// `organization_member_roles` says -- naming the identity table's role here
+	// would export a role the product no longer acts on.
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT o.id, o.name, COALESCE(rt.name, 'none')
+		SELECT o.id, o.name, COALESCE(rrt.name, 'none')
 		FROM organization_members om
 		JOIN organizations o ON o.id = om.organization_id
-		LEFT JOIN role_templates rt ON rt.id = om.role_template_id
+		LEFT JOIN organization_member_roles omr
+		       ON omr.organization_id = om.organization_id AND omr.user_id = om.user_id
+		LEFT JOIN registry_role_templates rrt ON rrt.id = omr.role_template_id
 		WHERE om.user_id = $1
 	`, userID)
 	if err == nil {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1284,7 +1284,7 @@ Optional runtime coupling to a sibling Suite app (Terraform State Manager). With
 | --------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `TFR_SUITE_SIBLING_URL`           | string   | —       | Sibling app URL (e.g. `https://tfstate.example.com`). Empty = standalone.                                                                                                                                                                                    |
 | `TFR_SUITE_POLL_INTERVAL`         | duration | `60s`   | How often the sibling manifest is polled.                                                                                                                                                                                                                    |
-| `TFR_SUITE_ROLE_SEED_OWNER`       | string   | `self`  | Which app seeds shared identity role templates: `self`, `registry`, or `tsm`. With a shared identity DB, exactly one app must own the seed.                                                                                                                  |
+| `TFR_SUITE_ROLE_SEED_OWNER`       | string   | `self`  | Which app seeds the **shared** identity role templates: `self`, `registry`, or `tsm`. With a shared identity DB, exactly one app must own the seed. Registry no longer *reads* that table — see the note below — but the flag is still load-bearing.          |
 | `TFR_SUITE_IDENTITY_SHARED_STORE` | bool     | `false` | Operator assertion that this app uses the shared identity store + single IdP (advertised in the manifest).                                                                                                                                                   |
 | `TFR_SUITE_SIBLING_TOKEN`         | string   | —       | Shared secret (`X-Suite-Service-Token`) for cross-app reads (the "Consumed by" panel). Set to the same value as the sibling's service token.                                                                                                                 |
 | `TFR_SUITE_TRUSTED_ISSUERS`       | []string | `[]`    | Comma-separated additional JWT `iss` values this app accepts, on top of its own (`terraform-registry`). Only relevant when `TFR_JWT_SECRET` is shared with a sibling app — without an entry here, a sibling's tokens are rejected even with the same secret. |
@@ -1292,3 +1292,20 @@ Optional runtime coupling to a sibling Suite app (Terraform State Manager). With
 **A shared `TFR_JWT_SECRET` alone does not grant cross-app trust.** JWT validation always
 pins `iss` to this app's own issuer plus whatever `TFR_SUITE_TRUSTED_ISSUERS` lists — a
 token minted by another app sharing the secret is rejected until its issuer is added here.
+
+**`TFR_SUITE_ROLE_SEED_OWNER` cannot be retired yet, and the reason has moved.** It exists
+because `role_templates.name` is globally `UNIQUE`, so two applications seeding the shared
+table overwrite each other on restart. Registry's own authorization no longer reads that
+table — it reads `registry_role_templates`
+([`docs/identity-schema.md`](identity-schema.md)) — so the collision the flag arbitrates no
+longer decides what registry enforces. Two things still depend on it:
+
+- **The state manager still reads the shared table.** It has not done its own read cutover,
+  so whether registry writes those rows still changes another application's roles.
+- **Registry's own table is still *derived* from the shared one** by the startup reconcile,
+  which is what makes rollback a plain redeploy. So the same flag gates both seeds: seeding
+  one without the other would make the two copies disagree by construction and leave
+  `role-drift` permanently non-zero on a healthy deployment.
+
+Both dependencies end in phase 4 of `sethbacon/terraform-suite-identity#206`, which drops
+the shared table and the reconcile together. The flag goes with them.

--- a/docs/identity-schema.md
+++ b/docs/identity-schema.md
@@ -137,97 +137,128 @@ They exist because identity is shared across the suite while authorization is
 per-application (design: `sethbacon/terraform-suite-identity#206`). Eventually
 `organization_members` carries membership only, and the role moves here.
 
-**Today they are written and not read.** Every authorization decision still comes from
-`organization_members.role_template_id` joined to `role_templates`, wherever this
-deployment's `search_path` puts them. The application dual-writes both tables, and
-re-derives them from the live identity tables on every start, so that the later read
-cutover has a copy it can trust.
+**These tables are now what registry reads.** Every role and every scope set behind
+every authorization decision comes from `organization_member_roles` joined to
+`registry_role_templates`. The identity tables are still **written** — every role
+assignment lands in `organization_members.role_template_id` first and is mirrored here
+only on success — and that is deliberate: it is what makes the rollback below real, and
+what the state manager still reads.
+
+What has **not** moved is the membership *fact*. "Is this principal a member of this
+organization at all" is still answered by `organization_members`, and every accessor asks
+that first. A stale row in `organization_member_roles` for somebody who is not a member
+therefore confers nothing today; it becomes reachable only in phase 4, which is why the
+drift check reports it now.
 
 `registry_role_templates` carries a prefix only because `public.role_templates` still
-exists and is still what registry reads; it takes the unprefixed name when that duplicate
-is dropped. Neither table has a foreign key into identity — identity may be another schema
-or another database, where such a key cannot be expressed at all (same reasoning as
-`000046` and `000051`).
+exists; it takes the unprefixed name when that duplicate is dropped. Neither table has a
+foreign key into identity — identity may be another schema or another database, where
+such a key cannot be expressed at all (same reasoning as `000046` and `000051`).
 
-### Divergence query — run this before trusting the copy
+### `role-drift` — the gate, and the standing check
 
-This is the gate on the read cutover. **It must return zero rows.** Run it on the
-connection that owns registry's tables; under the schema cutover, replace
-`public.organization_members` with `identity.organization_members` and
-`public.role_templates` with `identity.role_templates` so you are comparing against the
-copy this deployment actually reads.
-
-```sql
--- Memberships whose registry role does not match the identity role.
--- FULL OUTER JOIN so a mirrored row with no membership is reported too:
--- that direction GRANTS authority the product never issued.
-SELECT COALESCE(om.organization_id, omr.organization_id) AS organization_id,
-       COALESCE(om.user_id, omr.user_id)                 AS user_id,
-       om.role_template_id                               AS identity_role,
-       omr.role_template_id                              AS registry_role,
-       CASE WHEN om.user_id  IS NULL THEN 'mirrored row with no membership'
-            WHEN omr.user_id IS NULL THEN 'membership never mirrored'
-            ELSE 'roles disagree'
-       END AS problem
-  FROM public.organization_members om
-  FULL OUTER JOIN organization_member_roles omr
-    ON  omr.organization_id = om.organization_id
-    AND omr.user_id         = om.user_id
- WHERE om.user_id IS NULL
-    OR omr.user_id IS NULL
-    OR om.role_template_id IS DISTINCT FROM omr.role_template_id
-
-UNION ALL
-
--- Role templates that differ, are missing, or are left over.
-SELECT NULL, COALESCE(rt.id, rrt.id), NULL, NULL,
-       CASE WHEN rt.id  IS NULL THEN 'mirrored template no longer exists'
-            WHEN rrt.id IS NULL THEN 'template never mirrored'
-            ELSE 'scopes disagree'
-       END
-  FROM public.role_templates rt
-  FULL OUTER JOIN registry_role_templates rrt ON rrt.id = rt.id
- WHERE rt.id IS NULL
-    OR rrt.id IS NULL
-    OR rt.scopes IS DISTINCT FROM rrt.scopes;
+```console
+$ role-drift            # exits 0 only if the two copies agree
+$ role-drift -v         # also prints what was compared
 ```
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | the two copies agree |
+| `1` | they disagree; every disagreement is printed |
+| `2` | the comparison could not be made — unreachable table, bad config |
+
+`2` is not `1`. "Could not check" must never be spelled the same way as "checked and
+found nothing", or a misconfigured run gates a cutover open.
+
+It reads the same config file and the same `TFR_IDENTITY_*` environment as the server, so
+it compares what the server compares rather than deciding the topology for itself. It
+also works when identity is a **separate database**, which the single-statement SQL
+version this replaces could not: no statement can join two databases.
+
+What it reports:
+
+| Kind | Meaning |
+| --- | --- |
+| `mirror_without_membership` | registry holds a role for a non-member. Inert today; **grants** authority the product never issued once phase 4 lands. |
+| `role_differs` | both copies have the membership and name different templates. |
+| `membership_not_mirrored` | identity has the membership, registry has no row — the principal is served **no role**. |
+| `template_scopes_differ` | same template id, different scope sets: every holder's authority differs. |
+| `template_name_differs` | same id, different name. Registry resolves templates by name in the group-mapping reconciliation and the admin API. |
+| `template_not_mirrored` / `mirrored_template_orphaned` | a template exists on one side only. |
+| `membership_role_missing_template` | an identity membership names a template that does not exist **in identity**. The source data is wrong; the reconcile mirrors it with no role rather than inventing one. |
+| `unparseable_row` | a source row whose `organization_id` or `user_id` is not a UUID. It can never be mirrored, so it is permanently unreconciled. |
+
+The last four are cases the pre-3b SQL query could not see at all.
 
 ### What an operator does about a non-empty result
 
-Rows here are a report, not an outage: nothing reads these tables, so authorization is
-unaffected either way. In order of cost:
+Rows here now **do** affect authorization — that is what changed. In order of cost:
 
-1. **Restart the backend.** The startup reconcile re-derives both tables from the live
-   identity tables and is the intended repair for anything a transient write failure left
-   behind. Re-run the query; most results clear here.
+1. **Restart the backend.** The startup reconcile re-derives both tables from the identity
+   tables and is the intended repair for anything a transient mirror-write failure left
+   behind. Re-run `role-drift`; most results clear here.
 2. **If rows persist, read the boot log.** `registry role tables reconciled` reports what
-   the last pass did, including `orphaned_role_refs` (a membership naming a role template
-   that does not exist — mirrored with **no** role, deliberately, because inventing an
-   assignment is worse than recording none) and `unparseable_rows`. A membership whose
-   role template is missing is an inconsistency in the *identity* data; decide what that
-   member's role should be and set it through the normal member API, which repairs both
-   sides.
-3. **If the log says the tables are not reachable**, identity is in a separate database
-   (`TFR_IDENTITY_DATABASE_*`) — see the limitation below.
-4. **Do not enable the read cutover while the query returns rows.** That is the entire
-   purpose of running it.
+   the last pass did, including `orphaned_role_refs` and `unparseable_rows`. A membership
+   whose role template is missing is an inconsistency in the *identity* data; decide what
+   that member's role should be and set it through the normal member API, which repairs
+   both sides.
+3. **A `mirror_without_membership` row is worth understanding before deleting.** It means a
+   membership was removed without its mirror row, or a role was written for somebody who
+   was never a member.
 
-### Limitation: a separate identity database
+### Divergence is also reported at request time
 
-When identity lives in its own database, the identity connection cannot see registry's
-tables, so the live dual-write has nowhere to land. The backend says so at boot:
+`role-drift` runs when somebody runs it. Between runs, the read path reports disagreement
+on the request that is actually being served the wrong role, because every accessor still
+has both answers in hand — the identity columns it queried and registry's:
+
+- metric `registry_role_read_divergence_total{accessor,kind}`, where `kind` is
+  `missing_mirror` or `role_differs`. **Steady state is zero.** Alert on
+  `increase(...) > 0`, not on a threshold.
+- an `ERROR` log naming the organization, the user, and both role template ids.
+
+What it does **not** catch, stated as limits rather than claims:
+
+- a principal nobody authenticates as. It fires on reads; a dormant account is invisible
+  until `role-drift` runs.
+- `mirror_without_membership`. Every accessor asks the store for the membership first, so
+  a mirrored row for a non-member is never reached — which is also why it confers nothing.
+  Only `role-drift` sees it.
+- two templates that agree by id and differ in scopes. The per-request comparison is on the
+  role template **id**, because that is what both sides carry per membership; scope
+  equality is a property of the template tables and is `role-drift`'s second half.
+
+### Rollback
+
+**Deploy the previous image.** That is the whole mechanism, and there is nothing
+finer-grained — no flag, no environment variable, no per-request switch.
+
+It works because the previous image reads `organization_members.role_template_id` joined
+to `role_templates`, and this release never stopped writing them: every role assignment
+still lands there first, the shared role templates are still seeded, and nothing has been
+dropped. A deployment that rolls back therefore returns to a copy that has been kept
+current the whole time, with no data step.
+
+Rolling **forward** again needs no step either: the startup reconcile re-derives
+registry's tables from the identity tables on every boot.
+
+### A separate identity database now refuses to boot
+
+When identity lives in its own database, the connection registry resolves identity reads
+through cannot see registry's own tables. Before this release that was logged and
+survivable, because nothing read them. It is not survivable now — every principal would
+resolve to no role — so the backend refuses to start:
 
 ```text
-ERROR registry's own role tables are not reachable from the identity connection;
-      role assignments will not be mirrored until they are.
+FATAL registry's own role tables (migration 000055) are not reachable from the connection
+      this process resolves identity reads through ...
 ```
 
-Reads are unaffected, and the startup reconcile still populates both tables correctly —
-it reads through the identity connection and writes through registry's own. So the copy
-converges at each restart but drifts between restarts. That topology needs the mirror
-tables reachable from the identity connection before the read cutover, and it is the same
-topology in which migration `000051`'s backfill and `000054`'s assertions are already
-inoperative for the same reason.
+Create `registry_role_templates` and `organization_member_roles` where that connection can
+resolve them, or run identity in the registry database. This is the same topology in which
+migration `000051`'s backfill and `000054`'s assertions are already inoperative, and in
+which registry issue #883 applies.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,6 +116,45 @@ psql -U registry -d terraform_registry \
   -c "UPDATE api_keys SET key_hash='$HASH' WHERE prefix='tfr_myap';"
 ```
 
+### cmd/role-drift — compare registry's authorization tables against identity's
+
+Registry resolves every role and scope set from its own `organization_member_roles`
+and `registry_role_templates`, which are derived from the identity tables and kept in
+step by a dual-write (`sethbacon/terraform-suite-identity#206`). This reports every way
+the two copies disagree.
+
+Unlike the tools above it reads the **server's config file** and the `TFR_IDENTITY_*`
+environment as well as `TFR_DATABASE_*`, because which schema and which database hold
+the live identity rows is decided at process start. Point it at the same configuration
+the server runs with, or it will compare something the server does not.
+
+```bash
+cd backend
+
+go run ./cmd/role-drift                          # compare, print, exit 0 only if clean
+go run ./cmd/role-drift -config /etc/tfr.yaml    # the server's config file
+go run ./cmd/role-drift -v                       # also print what was compared
+```
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | the two copies agree |
+| `1` | they disagree; every disagreement is printed |
+| `2` | the comparison could not be made — unreachable table, bad config |
+
+`2` is deliberately not `1`: "could not check" must never be reported the same way as
+"checked and found nothing".
+
+**A non-empty result affects authorization.** In order of cost: restart the backend
+(the startup reconcile re-derives both tables and repairs anything a transient mirror
+write failure left behind), then re-run this; if rows persist, read the boot log's
+`registry role tables reconciled` line. Full remediation, including which rows an
+operator must decide rather than repair, is in
+[`docs/identity-schema.md`](identity-schema.md).
+
+Between runs, the read path reports the same disagreement per request via the
+`registry_role_read_divergence_total` metric and an `ERROR` log. Steady state is zero.
+
 ### cmd/api-test — end-to-end API smoke test
 
 Runs a full suite of HTTP requests against a live registry, covering modules,


### PR DESCRIPTION
Phase 3b of the identity-model refactor, registry side. Phase 3a (#887) created `registry_role_templates` and `organization_member_roles`, backfilled them and dual-wrote every role-assignment path; reads still came from `organization_members.role_template_id` joined to `role_templates`. **This flips the reads.** Registry's authorization is now per-app in fact.

> **This is breaking, for exactly one topology.** A separate identity database now refuses to boot when registry's role tables are not reachable. See the footer on the commit and the section at the bottom.

## What moved, and what deliberately did not

| | Before | After |
| --- | --- | --- |
| role → scopes | `role_templates` | **`registry_role_templates`** |
| membership → role | `organization_members.role_template_id` | **`organization_member_roles`** |
| membership FACT | `organization_members` | `organization_members` — unchanged until phase 4 |
| every role WRITE | identity first, then mirror | unchanged |

Writes are untouched on purpose. Every assignment still lands in the identity tables first and is mirrored only on success, so identity remains by construction at least as current as the mirror. That is what makes the rollback a plain redeploy, and it is why the startup reconcile is still correct to run (3a's comment predicted it would have to go; it does not, until the dual-write does).

The membership fact staying put is load-bearing: every accessor asks the store "is this principal a member" **before** consulting registry's tables. A stale mirrored row for a non-member is therefore unreachable today — the one drift direction that *grants* — and `TestEquivalence_MirrorRowWithoutMembershipConfersNothing` pins that it is a property of the ordering rather than a coincidence.

## How the flip is gated

**1. `role-drift` must be zero.** A re-runnable verb, the `bind-secrets verify` shape: `0` agree, `1` disagree (every row printed), `2` could not check. `2` is separate from `1` deliberately — "could not check" must never be spelled like "checked and found nothing", or a misconfigured run gates the cutover open. It reads the same config and `TFR_IDENTITY_*` as the server, so it compares what the server compares.

It replaces the SQL query 3a shipped, which was correct as far as it reached and could not reach far enough:

| 3a's query could not see | `role-drift` reports |
| --- | --- |
| anything, when identity is a separate database (no statement joins two databases) | works — comparison is in Go, over both connections |
| a template renamed but otherwise identical | `template_name_differs` (registry resolves templates by name in the group-mapping guard and the admin API) |
| a membership naming a template that does not exist **at the source** | `membership_role_missing_template` — the identity data is wrong, not the mirror |
| a row whose `organization_id`/`user_id` is not a UUID | `unparseable_row` — never mirrorable, so permanently unreconciled; a gate that ignores these returns zero forever |

It also refuses, loudly, if either side does not resolve, and reports how many rows it compared — a gate that says "clean" without saying it looked at something is the failure it exists to prevent.

**2. Divergence after the flip is not silent.** Every accessor already holds both answers — the identity columns it still queries, and registry's — so the comparison costs **no extra query**. On disagreement: `registry_role_read_divergence_total{accessor,kind}` (kinds `missing_mirror`, `role_differs`) plus an ERROR log naming the organization, the user and both ids. Steady state is zero; alert on `increase(...) > 0`.

Stated as limits rather than claims — it does **not** catch a dormant principal nobody authenticates as, a mirrored row with no membership (never reached, see above), or two templates that agree by id and differ in scopes. `role-drift` covers all three. All of this is in `docs/identity-schema.md` rather than implied.

**3. Rollback is a redeploy of the previous image.** There is nothing finer-grained — no flag, no env var, no per-request switch — and the PR says so rather than implying one exists. It works because the previous image reads the shared tables and this release never stopped writing them.

## Equivalence evidence

`member_role_equivalence_pg_test.go` resolves effective scopes **both ways** for an estate chosen to distinguish a correct cutover from a plausible one: a user in two organizations with *different* roles (collapsing that is cross-org escalation), a membership with **no** role, a template with an **empty** scope list, and two members sharing one template. For each it compares `GetUserScopesForOrg`, `GetMemberWithRole`, `GetMember`, `CheckMembership`, `GetUserCombinedScopes`, `GetUserMemberships` and `OrgScopeForUser` against the pre-cutover SQL — exact scope sets and exact role ids, never `err != nil`.

Then it falsifies itself. Five corruptions, each requiring the comparison **and** the gate to notice, and the reconcile to repair:

And it exercises the real startup sequence — reconcile, then seed, then the gate — in **both** topologies, twice each, asserting per system template that registry resolves what the identity tables hold. That test is what caught the seed defect above; a seed that inserted a second row under a fresh uuid instead of updating the reconciled one would fail it rather than silently strip every holder of their role.

| Corruption | equivalence | `role-drift` | reconcile repairs |
| --- | --- | --- | --- |
| mirrored row deleted | fails | `membership_not_mirrored` | yes |
| mirrored row names another template | fails | `role_differs` | yes |
| mirrored role cleared | fails | `role_differs` | yes |
| mirrored template's scopes stale | fails | `template_scopes_differ` | yes |
| mirrored template renamed | n/a (scopes unchanged — which is *why* the gate compares names) | `template_name_differs` | yes |

## The cutover is structural

`OrganizationRepository` overrides all 9 role-bearing store reads. `UserRepository` **was a type alias** — nothing could override it, so its three membership-returning accessors (`GetUserWithOrgRoles`, `ListUsersWithMemberships`, `SearchWithMemberships`) were the one authorization surface the cutover could not reach; it is now a wrapper. Constructor names and signatures are unchanged.

Four class guards, all failing on an empty universe:

1. every store role reader has an override — derived from the pinned module's source, so a dependency bump that adds one fails on the bump;
2. every override actually reaches `r.roles`;
3. every override reaches `compareRole`;
4. **no file in the module reads the shared `role_templates` by hand.**

Guard 4 is the one that earned its place. Guards 1–3 reason about the wrapper types and are structurally blind to a handler with its own SQL — and two had exactly that: `role_ceiling.go`'s `checkRoleAssignment` (which decides whether a role may be assigned at all, and refuses the platform-admin template) and `group_mapping_guard.go`'s `guardProvisionableRole` (which decides what an IdP group claim confers, and supplies the retention filter for the credential sweep). Both are authorization decisions, both would have kept computing from the copy registry no longer enforces, and no behavioural test could have found them because the two copies agree until they do not.

Guards 2 and 3 were **inert on first write** and mutation found it: matching on the bare method name could not tell `r.OrganizationRepository.GetMemberWithRole` (delegation) from `r.GetMemberWithRole` (a sibling call), so an override gutted to nothing but its delegation still "reached a reader". They are receiver-aware now, with a fixpoint over sibling calls, and the two named overlay helpers the fixpoint trusts are themselves verified.

Also flipped: `adminfloor`'s two invariant reads (both LEFT JOINs, so a member with no mirrored role still counts as a member and not as an administrator — fail-closed for invariant B), the credential-invalidation sweep, the role-template CRUD reads, and the GDPR export's role name.

## `TFR_SUITE_ROLE_SEED_OWNER` — not yet

The flag exists because `role_templates.name` is globally `UNIQUE` and two apps seeding it overwrite each other. Registry no longer reads that table, so the collision no longer decides what registry enforces — but two things still depend on it:

- **the state manager still reads the shared table** (it has not done its own phase 3), so registry's seed still changes another app's roles;
- **registry's own table is still *derived* from the shared one** by the reconcile, which is what makes rollback a redeploy. Seeding one without the other would make the copies disagree by construction and leave `role-drift` permanently non-zero on a healthy deployment.

So both seeds are gated on the same flag — **and on the identity-schema cutover**, which is the only topology either was ever for. Gating on the flag alone was a real defect, caught by the boot-sequence test rather than by review: in the default topology the seed stripped `scanning:read` from `devops` and `auditor` on every boot (migration `000018` added it; the Go list never caught up), leaving permanent drift on a healthy deployment and making `role-drift` un-passable. In that topology the migrations are the policy and the reconcile has already copied them. The stale list is a pre-existing defect in the cutover topology and is filed as #891 rather than fixed here — correcting it changes what two role templates confer.

The flag retires in phase 4, with the shared table and the reconcile.

## Mutation table

Every guard broken, watched fail, restored from a `cp` backup. **All 12 compile.**

| # | Mutation | Guard | Result |
| --- | --- | --- | --- |
| M1 | delete the `GetMemberWithRole` override | reader-is-overridden | FAIL, names it |
| M2 | override delegates, never reads registry's tables | override-reads-registry | FAIL *(inert on first write — fixed)* |
| M3 | override overlays without comparing | override-reports-divergence | FAIL *(inert on first write — fixed)* |
| M4 | write path reads back through the override | mirrors-the-source | FAIL |
| M5 | `overlayMemberships` stops comparing | helpers-reach-both | FAIL |
| M6 | empty the derived universe | all three | FAIL, refuses to certify |
| M7 | seed targets the shared table again | seed-targets-are-distinct | FAIL |
| M8 | drop the mirror-without-membership direction | drift classification | FAIL |
| M9 | `compareRole` stops counting a missing mirror | divergence metric | FAIL |
| M10 | drift check stops refusing an unreachable source | gate refusal | FAIL *(inert on first write — my own bare `err != nil`; now asserts the message)* |
| M11 | gate stops probing registry's tables | gate refusal | FAIL |
| M12 | `role_ceiling.go` reads the shared table again | no-hand-written-read | FAIL, names the file |

Plus the five equivalence corruptions above, and the two subagent-run fixture mutations (neutering the `api/admin` helpers → 76 failures; forcing `middleware` mirrored scopes empty → 17).

M2, M3 and M10 are the interesting rows: three guards written that day were inert, exactly as the runbook warns, and only mutation showed it.

## What CI does not cover

- **`TFR_TEST_DATABASE_URL` is set by no workflow (#886)**, so **the entire equivalence proof, all five falsification cases, the boot-sequence test and every drift-check-against-a-real-database test SKIP on this PR.** They were run locally against `postgres:16`: 5 equivalence subtests, 4 union subtests, 5 corruption subtests, 2 boot-sequence subtests, the mirror-without-membership case and the whole pre-existing reconcile suite — all green. **This is the gap that matters most here**: the boot-sequence test is the one that found a defect review had missed, and CI cannot run it. CI runs the sqlmock half, the four class guards and the drift classification unit tests.
- **`cmd/role-drift` has no automated end-to-end run.** Its comparison (`CheckMemberRoleDrift`) is tested both ways; the binary's flag parsing, config load and exit-code mapping are not.
- **The boot refusal is not tested.** It is a `log.Fatalf` in `NewRouter`, which no test harness can exercise without a process boundary.
- The one local full-suite failure, `TestJWTSecretFileRotation_RejectsAWeakUpdate`, is this machine's inotify instance limit under full parallelism; it passes in isolation and is unrelated.

## Breaking change, and its blast radius

A deployment with identity in a **separate database** (`TFR_IDENTITY_DATABASE_*` with `TFR_IDENTITY_SCHEMA_ENABLED=true`) now **refuses to start** when registry's role tables are not reachable from the connection it resolves identity reads through. Before the cutover that was logged and survivable, because nothing read those tables. It is not survivable now: booting would resolve every principal to no role — a total authorization outage that presents as a permissions problem. Refusing is the smaller failure and the one an operator can act on.

Remedy: create `registry_role_templates` and `organization_member_roles` where that connection can resolve them, or run identity in the registry database. **No other topology is affected** — the default and the shared-schema cutover both resolve them already. This is the same topology in which `000051`'s backfill and `000054`'s assertions are already inoperative, and in which #883 applies.

Nothing is dropped: `identity.organization_members.role_template_id`, `identity.role_templates` and `public.role_templates` all stay for TSM and the rollback path.

Refs sethbacon/terraform-suite-identity#206