### PR TITLE
ci(security): restore exit 0 as the OSV scan's normal state

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -77,9 +77,37 @@ jobs:
           # JSON (not table) so the triage step below can tell an advisory
           # with a published fix from one without; the triage step prints a
           # human-readable summary in its place.
+          #
+          # --no-call-analysis=go is deliberate, and is required for this job to
+          # be able to report success at all. The scanner image ships its own Go
+          # toolchain (1.26.2 in v2.3.8) and invokes it with GOTOOLCHAIN=local,
+          # so it cannot build a module whose `go` directive names a newer
+          # release — backend/go.mod is well past it. Its internal call-analysis
+          # pass then aborts with
+          #   "go.mod requires go >= 1.26.6 (running go 1.26.2; GOTOOLCHAIN=local)"
+          # and osv-scanner exits 127 — its ERROR code, distinct from the exit 1
+          # that means "vulnerabilities found".
+          #
+          # That abort has been happening on every run, masked: exit 1 wins
+          # whenever any finding exists, and this repo always had one
+          # (GO-2026-5932). Now that backend/osv-scanner.toml suppresses it, the
+          # abort would have surfaced as a permanent exit 127 — swapping a
+          # detector that is red for a known reason for one that is red for a
+          # hidden reason. Verified in the pinned v2.3.8 image with these exact
+          # arguments: suppression alone gives 127; suppression plus this flag
+          # gives 0.
+          #
+          # Nothing is lost. Reachability is the `govulncheck` job's
+          # responsibility below, and that job resolves its toolchain from
+          # backend/go.mod, so it always matches the module. This step keeps
+          # doing the flat known-vulnerability sweep of go.mod/go.sum, which
+          # needs no toolchain at all. osv_triage.py never read the analysis
+          # field, so no reporting here loses information — unlike the sibling
+          # repos, this job never claimed reachability it had not computed.
           scan-args: |-
             --recursive
             ./backend
+            --no-call-analysis=go
             --format=json
             --output=osv-results.json
 

--- a/backend/osv-scanner.toml
+++ b/backend/osv-scanner.toml
@@ -1,0 +1,80 @@
+# OSV-Scanner configuration for the backend Go module.
+#
+# osv-scanner v2 discovers this file next to go.mod and applies it to the scan
+# that .github/workflows/weekly-security.yml runs as `--recursive ./backend`.
+#
+# Entries here suppress a finding. Every entry must state WHY, in enough detail
+# that it can be RE-CHECKED rather than re-litigated, and must name the
+# condition that should make someone delete it. Suppress by advisory ID only —
+# never a whole package or ecosystem — so both scanners stay live for
+# everything else.
+#
+# Why suppressing at all, rather than leaving the finding visible: the scan step
+# runs under `continue-on-error: true`, so a single permanent, unfixable finding
+# makes `steps.osv.outcome == 'failure'` the normal weekly result forever. A
+# detector that is red every week is exactly as uninformative as one that is
+# green every week — a genuine scanner breakage becomes indistinguishable from
+# business as usual. Suppressing the one advisory nobody can ever act on
+# restores exit 0 as this repo's normal state, so a future non-zero exit means
+# something again.
+#
+# Reachability is NOT decided here. The `govulncheck` job in
+# .github/workflows/weekly-security.yml is this repo's reachability oracle: it
+# resolves its toolchain from backend/go.mod (via .github/actions/setup-backend),
+# so it always matches the module and can actually build a call graph.
+# OSV-Scanner does the flat known-vulnerability sweep of go.mod/go.sum, which
+# needs no toolchain at all.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = """
+golang.org/x/crypto/openpgp — never linked into anything this repo ships, and
+unfixable by construction.
+
+1. No fix exists, and none ever will. The advisory's single affected entry has
+   one range event, `introduced: 0`, and NO `fixed` event — so no version of
+   golang.org/x/crypto resolves it and no dependency bump can ever clear this
+   finding. govulncheck prints "Fixed in: N/A". The advisory is a blanket
+   deprecation notice for an unmaintained package ("unsafe by design"), not a
+   specific defect with a patch. Waiting for an upgrade is waiting forever.
+
+2. It is not in anything we build. The advisory covers the import paths
+   golang.org/x/crypto/openpgp{,/packet,/armor,/clearsign,/errors,/elgamal,/s2k}.
+   None of them appear in `go list -deps ./...` — the packages that actually
+   link into the server, the CLI helpers, and the container image. The only
+   golang.org/x/crypto package this repo imports in its own source is
+   golang.org/x/crypto/bcrypt (cmd/hash, cmd/server, internal/middleware/setup.go,
+   scripts/generate-key.go).
+
+3. It IS in the test-only graph, and that is the whole of its presence here.
+   `go list -deps -test ./...` does resolve golang.org/x/crypto/openpgp and five
+   of its subpackages, through exactly one edge:
+
+       internal/mirror.test  (internal/mirror/attestation_test.go)
+         -> github.com/sigstore/sigstore-go/pkg/testing/ca
+         -> github.com/sigstore/rekor/pkg/pki
+         -> github.com/sigstore/rekor/pkg/pki/pgp
+         -> golang.org/x/crypto/openpgp
+
+   sigstore-go's `pkg/testing/ca` is a test fixture helper (a virtual Sigstore
+   CA); rekor's pki registry enumerates every PGP format it can verify. That
+   code compiles into `go test` binaries only. It is not reachable from any
+   production entry point, and it is not shipped.
+
+   govulncheck agrees on the classification: it reports GO-2026-5932 under
+   "Module Results" — required in the module graph, never imported or called by
+   the analysed packages — and exits 0.
+
+4. Do not be misled by a grep for "openpgp". This tree genuinely does contain
+   openpgp packages in its SHIPPING dependency graph — seventeen of them — but
+   they are all github.com/ProtonMail/go-crypto/openpgp/*, the maintained fork
+   that exists precisely to replace the deprecated x/crypto package. Different
+   module, not covered by this advisory. A grep is how this entry gets wrongly
+   reopened; `go list -deps ./... | grep '^golang.org/x/crypto/openpgp'` is the
+   check that actually answers the question, and it returns nothing.
+
+Delete this entry if either becomes true:
+  * OSV publishes a `fixed` event for GO-2026-5932 (then bump and drop this), or
+  * `go list -deps ./... | grep '^golang.org/x/crypto/openpgp'` returns anything
+    (then it is in a shipped binary and must be fixed properly, not suppressed).
+"""


### PR DESCRIPTION
## Summary

This repo's OSV scanner is **not blind** — but it has been saturated. It reports `outcome == 'failure'` every single week on one advisory that no action can ever clear, so a real scanner break would look exactly like every previous Monday. A permanently-red detector is as uninformative as a permanently-green one.

Verified against `origin/main` by running CI's exact arguments in the pinned `v2.3.8` image: **exit 1, JSON written, exactly one finding — `GO-2026-5932` (`golang.org/x/crypto/openpgp`)**. `osv_triage.py` exits non-zero only for advisories with a published fix, so it correctly files nothing; the redness is pure noise with no consumer.

This is the cheap correctness fix. The estate-wide residual — six other repos with the same structural defect — is #894, which this PR does not close.

## What `GO-2026-5932` actually is

Each point checked against this repo rather than carried over from the sibling PRs, and written into `backend/osv-scanner.toml` so it survives without the PR description:

1. **No fix exists, and none ever will.** The OSV record's single `affected` entry has one range event, `introduced: 0`, and **no `fixed` event**. `govulncheck` prints `Fixed in: N/A`. It is a blanket deprecation notice for an unmaintained package, not a defect with a patch — waiting for an upgrade is waiting forever.

2. **It is not in anything this repo ships.** None of the advisory's import paths — `golang.org/x/crypto/openpgp{,/packet,/armor,/clearsign,/errors,/elgamal,/s2k}` — appear in `go list -deps ./...`. The only `x/crypto` package imported by this repo's own source is `golang.org/x/crypto/bcrypt` (`cmd/hash`, `cmd/server`, `internal/middleware/setup.go`, `scripts/generate-key.go`).

3. **It *is* in the test-only graph — and the brief for this work said it was not, so this is worth stating exactly.** `go list -deps -test ./...` does resolve `golang.org/x/crypto/openpgp` and five subpackages, through exactly one edge:

   ```
   internal/mirror.test  (internal/mirror/attestation_test.go)
     -> github.com/sigstore/sigstore-go/pkg/testing/ca
     -> github.com/sigstore/rekor/pkg/pki
     -> github.com/sigstore/rekor/pkg/pki/pgp
     -> golang.org/x/crypto/openpgp
   ```

   `pkg/testing/ca` is a virtual-Sigstore test fixture helper; rekor's `pki` registry enumerates every PGP format it can verify. That compiles into `go test` binaries only — never into the server, the CLI helpers, or the container image. `govulncheck ./...` agrees on the classification: **Module Results, exit 0** — required in the module graph, never imported or called by the analysed packages.

   So the suppression is still right, but the honest reason is "not linked into anything we ship", not "absent from the dependency graph".

4. **The reopening trap is real here.** This tree contains **seventeen** `openpgp` packages in its *shipping* graph — all `github.com/ProtonMail/go-crypto/openpgp/*`, the maintained fork that exists precisely to replace the deprecated `x/crypto` package. Different module, not covered by this advisory. A grep for "openpgp" hits all seventeen and proves nothing; `go list -deps ./... | grep '^golang.org/x/crypto/openpgp'` is the check that answers the question, and it returns nothing. The file says so, because that grep is how this gets wrongly reopened.

The file also records the two conditions that should make someone delete the entry: OSV publishing a `fixed` event, or that `go list` grep ever returning something.

## Suppression alone was not enough, and that is the substantive finding

Suppressing the advisory does **not** restore exit 0 here. It turns exit 1 into **exit 127**.

The scanner image ships Go 1.26.2 and invokes it with `GOTOOLCHAIN=local`, so it cannot build a module whose `go` directive names a newer release — `backend/go.mod` is at 1.26.6. Its call-analysis pass aborts:

```
Failed to run code analysis (govulncheck) on '/github/workspace/backend/go.mod' because
govulncheck: loading packages: err: exit status 1: stderr:
go: go.mod requires go >= 1.26.6 (running go 1.26.2; GOTOOLCHAIN=local)
```

**This has been happening on every run of this repo already, masked** — exactly as in `terraform-provider-registry`, where exit 1 won because findings existed. Removing the one finding would have unmasked it as a permanent exit 127: trading a detector that is red for a known reason for one that is red for a *hidden* reason, and specifically for the error code that produced the false issue in `terraform-state-manager-backend#334`.

So `--no-call-analysis=go` is added alongside, matching what sethbacon/terraform-state-manager-backend#390 and sethbacon/terraform-provider-registry#110 shipped. Nothing is lost:

- the `govulncheck` job below resolves its toolchain from `backend/go.mod` via `.github/actions/setup-backend`, so it always matches the module and remains this repo's reachability oracle;
- `osv_triage.py` never read `experimental_analysis`, and says so in its own docstring. **Unlike the two sibling repos, this job never claimed reachability it had not computed** — so there is no misreport to correct here, only an error code to stop hiding.

## Before / after

Pinned `ghcr.io/google/osv-scanner-action:v2.3.8`, CI's exact arguments, against `origin/main`:

| | exit | findings |
|---|---|---|
| **Before** (`--recursive ./backend --format=json --output=osv-results.json`) | **1** | **1** — `GO-2026-5932` |
| Suppression only | 127 | 0 |
| **After** (` … --no-call-analysis=go … `, with `osv-scanner.toml`) | **0** | **0** |

`osv_triage.py` on the after-report: `No vulnerabilities reported.`, exit 0 — no issue filed, and exit 0 is once again this repo's normal weekly state, so a future non-zero exit means something.

## Mutation check

A suppression that quietly swallowed more than its one ID would be worse than the problem it fixes, so it was broken on purpose. With `backend/osv-scanner.toml` in place, a planted vulnerable lockfile (`lodash@4.17.20`) inside the scanned tree gives:

- scanner **exit 1**, **3 findings** reported (`GHSA-35jh-r3h4-6jhm` and two others),
- `GO-2026-5932` still filtered, `Filtered 1 vulnerability from output`,
- `osv_triage.py` **exit 1** — which is the condition that files the issue.

The entry is scoped to the single advisory ID and the detector still fires. The planted lockfile was removed and is not part of this change.

## Verification

- `actionlint .github/workflows/weekly-security.yml` — clean.
- `backend/osv-scanner.toml` parses (`tomllib`); the workflow parses as YAML.
- Scanner log confirms the file is picked up: `Loaded filter from: /github/workspace/backend/osv-scanner.toml`.
- `govulncheck ./...` (v1.1.4, CI's version) on `origin/main` — **exit 0**, Module Results only.
- `go build ./...` — clean. No Go source, dependency, or runtime behaviour is touched; the diff is one CI argument plus a comment, and one new configuration file.

## Not addressed here

The six other repos running this workflow, and the shared composite action that would let any of them detect a scanner that stopped working. Tracked in #894 — deliberately **not** closed by this PR, which fixes one repo's signal-to-noise and does not build that mechanism.

## Changelog

- chore: suppress the unfixable, never-shipped `GO-2026-5932` and stop the OSV scan aborting its call-analysis pass, so a non-zero weekly exit means something again

## Checklist

- [x] `go test ./...` passes — unchanged; no Go source touched
- [x] `go fmt ./...` and `go vet ./...` clean — no Go source touched
- [x] No new `gosec` findings — no Go source touched
- [x] PR targets `main`
- [x] Remote branch will be deleted after merge

Refs #894
