### PR TITLE
fix(api): clamp per_page to the maximum instead of the default

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -591,7 +591,7 @@
                         }
                     },
                     {
-                        "description": "Items per page, max 200 (default 25)",
+                        "description": "Items per page, max 200 (default 25). A larger value is served as 200.",
                         "name": "per_page",
                         "in": "query",
                         "schema": {
@@ -6951,7 +6951,7 @@
                         }
                     },
                     {
-                        "description": "Max results (default 100, max 500)",
+                        "description": "Max results (default 100, max 500). A larger value is served as 500.",
                         "name": "limit",
                         "in": "query",
                         "schema": {
@@ -8520,7 +8520,7 @@
                         }
                     },
                     {
-                        "description": "Maximum results to return (default 20, max 100)",
+                        "description": "Maximum results to return (default 20, max 100). A larger value is served as 100.",
                         "name": "limit",
                         "in": "query",
                         "schema": {
@@ -9581,7 +9581,7 @@
                         }
                     },
                     {
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query",
                         "schema": {
@@ -9735,7 +9735,7 @@
                         }
                     },
                     {
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query",
                         "schema": {
@@ -10575,7 +10575,7 @@
                         }
                     },
                     {
-                        "description": "Maximum results to return (default 20, max 100)",
+                        "description": "Maximum results to return (default 20, max 100). A larger value is served as 100.",
                         "name": "limit",
                         "in": "query",
                         "schema": {
@@ -14100,7 +14100,7 @@
                         }
                     },
                     {
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query",
                         "schema": {
@@ -14302,7 +14302,7 @@
                         }
                     },
                     {
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query",
                         "schema": {
@@ -14846,7 +14846,7 @@
                         }
                     },
                     {
-                        "description": "Page size (max 200)",
+                        "description": "Page size, max 200. A larger value is served as 200.",
                         "name": "count",
                         "in": "query",
                         "schema": {
@@ -17833,6 +17833,10 @@
             "admin.PaginationMeta": {
                 "type": "object",
                 "properties": {
+                    "has_more": {
+                        "description": "HasMore reports whether any rows follow this page.",
+                        "type": "boolean"
+                    },
                     "page": {
                         "type": "integer"
                     },
@@ -17840,6 +17844,7 @@
                         "type": "integer"
                     },
                     "total": {
+                        "description": "Total is the number of matching rows across all pages, or null when the\nendpoint does not count.",
                         "type": "integer"
                     }
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -489,7 +489,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page, max 200 (default 25)",
+                        "description": "Items per page, max 200 (default 25). A larger value is served as 200.",
                         "name": "per_page",
                         "in": "query"
                     },
@@ -5580,7 +5580,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Max results (default 100, max 500)",
+                        "description": "Max results (default 100, max 500). A larger value is served as 500.",
                         "name": "limit",
                         "in": "query"
                     },
@@ -6913,7 +6913,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum results to return (default 20, max 100)",
+                        "description": "Maximum results to return (default 20, max 100). A larger value is served as 100.",
                         "name": "limit",
                         "in": "query"
                     },
@@ -7754,7 +7754,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query"
                     }
@@ -7879,7 +7879,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query"
                     }
@@ -8561,7 +8561,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum results to return (default 20, max 100)",
+                        "description": "Maximum results to return (default 20, max 100). A larger value is served as 100.",
                         "name": "limit",
                         "in": "query"
                     },
@@ -11428,7 +11428,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query"
                     }
@@ -11592,7 +11592,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Items per page, max 100 (default 20)",
+                        "description": "Items per page, max 100 (default 20). A larger value is served as 100.",
                         "name": "per_page",
                         "in": "query"
                     }
@@ -12027,7 +12027,7 @@
                     {
                         "type": "integer",
                         "default": 100,
-                        "description": "Page size (max 200)",
+                        "description": "Page size, max 200. A larger value is served as 200.",
                         "name": "count",
                         "in": "query"
                     },
@@ -14575,6 +14575,10 @@
         "admin.PaginationMeta": {
             "type": "object",
             "properties": {
+                "has_more": {
+                    "description": "HasMore reports whether any rows follow this page.",
+                    "type": "boolean"
+                },
                 "page": {
                     "type": "integer"
                 },
@@ -14582,6 +14586,7 @@
                     "type": "integer"
                 },
                 "total": {
+                    "description": "Total is the number of matching rows across all pages, or null when the\nendpoint does not count.",
                     "type": "integer"
                 }
             }

--- a/backend/internal/api/admin/audit_logs.go
+++ b/backend/internal/api/admin/audit_logs.go
@@ -4,7 +4,6 @@ package admin
 import (
 	"database/sql"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,6 +11,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // AuditLogHandlers handles audit log read endpoints
@@ -39,7 +39,7 @@ func NewAuditLogHandlers(db *sql.DB) *AuditLogHandlers {
 // @Accept       json
 // @Produce      json
 // @Param        page           query  int     false  "Page number (default 1)"
-// @Param        per_page       query  int     false  "Items per page, max 200 (default 25)"
+// @Param        per_page       query  int     false  "Items per page, max 200 (default 25). A larger value is served as 200."
 // @Param        action         query  string  false  "Filter by action string (exact match)"
 // @Param        resource_type  query  string  false  "Filter by resource type (module, provider, user, mirror, api_key, organization)"
 // @Param        user_id        query  string  false  "Filter by actor user ID (exact match)"
@@ -56,16 +56,12 @@ func NewAuditLogHandlers(db *sql.DB) *AuditLogHandlers {
 // GET /api/v1/admin/audit-logs
 func (h *AuditLogHandlers) ListAuditLogsHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Pagination
-		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-		perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "25"))
-		if page < 1 {
-			page = 1
-		}
-		if perPage < 1 || perPage > 200 {
-			perPage = 25
-		}
-		offset := (page - 1) * perPage
+		// GUARD per-page-clamps-to-max (issue #893). Same clamp, same defect:
+		// an operator exporting a wide audit window with `?per_page=500` was
+		// served 25 rows, having asked for twenty times the default.
+		page := pagination.ClampPage(queryInt(c, "page"))
+		perPage := pagination.ClampPerPage(queryInt(c, "per_page"), auditPerPageDefault, auditPerPageMax)
+		offset := pagination.Offset(page, perPage)
 
 		// Build filters
 		filters := repositories.AuditFilters{}
@@ -150,12 +146,8 @@ func (h *AuditLogHandlers) ListAuditLogsHandler() gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, AuditLogListResponse{
-			Logs: items,
-			Pagination: PaginationMeta{
-				Page:    page,
-				PerPage: perPage,
-				Total:   int64(total),
-			},
+			Logs:       items,
+			Pagination: countedPage(page, perPage, offset, len(items), total),
 		})
 	}
 }

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,6 +16,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 	"github.com/terraform-registry/terraform-registry/internal/validation"
 )
 
@@ -319,7 +319,7 @@ func (h *OrganizationHandlers) GetNamespaceOwnershipHandler() gin.HandlerFunc {
 // @Security     Bearer
 // @Produce      json
 // @Param        page      query  int  false  "Page number (default 1)"
-// @Param        per_page  query  int  false  "Items per page, max 100 (default 20)"
+// @Param        per_page  query  int  false  "Items per page, max 100 (default 20). A larger value is served as 100."
 // @Success      200  {object}  admin.ListOrganizationsResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
@@ -328,18 +328,15 @@ func (h *OrganizationHandlers) GetNamespaceOwnershipHandler() gin.HandlerFunc {
 // GET /api/v1/organizations?page=1&per_page=20
 func (h *OrganizationHandlers) ListOrganizationsHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Parse pagination parameters
-		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-		perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
-
-		if page < 1 {
-			page = 1
-		}
-		if perPage < 1 || perPage > 100 {
-			perPage = 20
-		}
-
-		offset := (page - 1) * perPage
+		// GUARD per-page-clamps-to-max (issue #893). This clamp used to reset
+		// an over-large per_page to the DEFAULT of 20, so `?per_page=200`
+		// returned 20 rows — fewer than `?per_page=50` — against a swagger
+		// annotation that said "max 100". The sibling frontend's OIDC group
+		// mapping asks for 200 precisely to get every organization and has been
+		// silently served 20 ever since.
+		page := pagination.ClampPage(queryInt(c, "page"))
+		perPage := pagination.ClampPerPage(queryInt(c, "per_page"), orgPerPageDefault, orgPerPageMax)
+		offset := pagination.Offset(page, perPage)
 
 		// GUARD organization-list-scope (issue #719). This is the batch's own
 		// sibling-asymmetry test failing: every /organizations/:id route carries
@@ -377,13 +374,13 @@ func (h *OrganizationHandlers) ListOrganizationsHandler() gin.HandlerFunc {
 			})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{
-			"organizations": orgs,
-			"pagination": gin.H{
-				"page":     page,
-				"per_page": perPage,
-				"total":    total,
-			},
+		c.JSON(http.StatusOK, ListOrganizationsResponse{
+			Organizations: orgs,
+			// countedPage, not a hand-built gin.H: the meta this endpoint
+			// already emitted carried `total` and nothing that said whether the
+			// page was the end of the list, so every consumer had to re-derive
+			// it — and the sibling frontend's pickers did not (issue #893).
+			Pagination: countedPage(page, perPage, offset, len(orgs), total),
 		})
 	}
 }
@@ -1300,7 +1297,7 @@ func stringPtrEqual(a, b *string) bool {
 // @Produce      json
 // @Param        q         query  string  true   "Search query"
 // @Param        page      query  int     false  "Page number (default 1)"
-// @Param        per_page  query  int     false  "Items per page, max 100 (default 20)"
+// @Param        per_page  query  int     false  "Items per page, max 100 (default 20). A larger value is served as 100."
 // @Success      200  {object}  admin.ListOrganizationsResponse
 // @Failure      400  {object}  map[string]interface{}  "Search query is required"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
@@ -1318,18 +1315,12 @@ func (h *OrganizationHandlers) SearchOrganizationsHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Parse pagination
-		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-		perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
-
-		if page < 1 {
-			page = 1
-		}
-		if perPage < 1 || perPage > 100 {
-			perPage = 20
-		}
-
-		offset := (page - 1) * perPage
+		// GUARD per-page-clamps-to-max (issue #893), the list axis's sibling:
+		// the same clamp, verbatim, with the same "asking for more gets you
+		// less" behaviour.
+		page := pagination.ClampPage(queryInt(c, "page"))
+		perPage := pagination.ClampPerPage(queryInt(c, "per_page"), orgPerPageDefault, orgPerPageMax)
+		offset := pagination.Offset(page, perPage)
 
 		// GUARD organization-search-scope (issue #719): the same asymmetry as
 		// the list axis, and strictly worse — search turns the census into a
@@ -1346,19 +1337,23 @@ func (h *OrganizationHandlers) SearchOrganizationsHandler() gin.HandlerFunc {
 		// which is what the second, in-memory matcher that used to live here was
 		// guarding against by hand, against the same two fields, with its own
 		// case-folding rules.
-		orgs, err := h.orgRepo.Search(c.Request.Context(), query, perPage, offset, scope.OrgScope())
+		//
+		// pagination.Probe asks for ONE row more than the caller wants. The
+		// identity store has no search-counting query, so this axis emitted
+		// `{page, per_page}` and nothing else — a consumer could not tell a
+		// last page from a truncated one at all (issue #893). The probe row is
+		// trimmed off below and never served; its presence is has_more.
+		orgs, err := h.orgRepo.Search(c.Request.Context(), query, pagination.Probe(perPage), offset, scope.OrgScope())
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to search organizations",
 			})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{
-			"organizations": orgs,
-			"pagination": gin.H{
-				"page":     page,
-				"per_page": perPage,
-			},
+		orgs, hasMore := pagination.Trim(orgs, perPage)
+		c.JSON(http.StatusOK, ListOrganizationsResponse{
+			Organizations: orgs,
+			Pagination:    probedPage(page, perPage, hasMore),
 		})
 	}
 }

--- a/backend/internal/api/admin/pagination.go
+++ b/backend/internal/api/admin/pagination.go
@@ -1,0 +1,61 @@
+// pagination.go holds the page-window parsing this package's list endpoints
+// share, and the two ways they build PaginationMeta.
+//
+// It exists because issue #893 was one defect copy-pasted into five handlers:
+// each parsed `page`/`per_page` by hand and each collapsed an over-large
+// per_page to the endpoint's DEFAULT instead of its MAXIMUM, so asking for more
+// rows returned fewer. Parsing it once is what stops the sixth copy.
+package admin
+
+import (
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
+)
+
+// Per-endpoint page-size limits. Each pair is what the endpoint's swagger
+// annotation promises, and the clamp is now the same promise in code: below the
+// range you get the default, above it you get the maximum.
+const (
+	orgPerPageDefault = 20
+	orgPerPageMax     = 100
+
+	userPerPageDefault = 20
+	userPerPageMax     = 100
+
+	auditPerPageDefault = 25
+	auditPerPageMax     = 200
+)
+
+// queryInt reads a query parameter as an int.
+//
+// An absent or unparseable parameter yields 0, which every pagination clamp
+// resolves to the endpoint's default — so the "?per_page=lots" case needs no
+// branch of its own, and cannot be given a different answer by one handler than
+// by its siblings.
+func queryInt(c *gin.Context, name string) int {
+	n, _ := strconv.Atoi(c.Query(name))
+	return n
+}
+
+// countedPage builds the pagination meta for an endpoint that has an exact
+// total, deriving has_more from it so that no consumer has to.
+func countedPage(page, perPage, offset, returned, total int) PaginationMeta {
+	t := int64(total)
+	return PaginationMeta{
+		Page:    page,
+		PerPage: perPage,
+		HasMore: pagination.HasMore(offset, returned, total),
+		Total:   &t,
+	}
+}
+
+// probedPage builds the pagination meta for an endpoint with no total, where
+// has_more came from pagination.Probe/Trim instead.
+//
+// Total stays nil: the search axes have no counting query on the identity
+// store, and reporting 0 there would be a count nobody performed.
+func probedPage(page, perPage int, hasMore bool) PaginationMeta {
+	return PaginationMeta{Page: page, PerPage: perPage, HasMore: hasMore}
+}

--- a/backend/internal/api/admin/pagination_clamp_class_test.go
+++ b/backend/internal/api/admin/pagination_clamp_class_test.go
@@ -1,0 +1,332 @@
+package admin
+
+// pagination_clamp_class_test.go drives EVERY paginated axis in this package
+// through the same table, because issue #893 was reported against exactly one
+// of them.
+//
+// The reported defect — `?per_page=200` on GET /api/v1/organizations serving 20
+// rows — was one instance of a clamp copy-pasted into five handlers here (and
+// four more elsewhere in the module; internal/pagination/clamp_sweep_test.go is
+// the signature that covers those). A test written against the organization
+// list alone would have gone green while /users, /users/search and
+// /admin/audit-logs stayed broken, which is how a closed issue reopens next to
+// its patched sibling.
+//
+// Each axis is asserted at two levels, which is what makes the test hard to
+// satisfy accidentally:
+//
+//  1. The `per_page` the response REPORTS.
+//  2. The LIMIT the STORE was asked for, pinned through sqlmock's WithArgs. A
+//     handler that reported 100 and queried 20 would pass on (1) alone, and
+//     that divergence is exactly what a caller cannot see from outside.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
+)
+
+// paginationAxis is one paginated endpoint, described by everything the clamp
+// table needs in order to drive it.
+type paginationAxis struct {
+	name string
+	// newRouter builds the axis's router over a fresh mocked connection.
+	newRouter func(*testing.T) (sqlmock.Sqlmock, *gin.Engine)
+	// url renders the request for a raw per_page parameter; the empty string
+	// means "send no per_page at all".
+	url func(perPage string) string
+	// def and max are what the endpoint's swagger annotation promises.
+	def, max int
+	// storeLimit maps the page size the caller is served to the LIMIT the store
+	// is asked for. Identity on the counted axes; Probe on the two search axes,
+	// which fetch one extra row to answer has_more without a count query.
+	storeLimit func(perPage int) int
+	// queue seeds the mocked store for exactly one request, pinning that LIMIT.
+	queue func(mock sqlmock.Sqlmock, limit int)
+}
+
+func countRows(total int) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"count"}).AddRow(total)
+}
+
+// orgRows returns n organization rows, so a probe axis can be given the extra
+// row that means "more follow".
+func orgRows(n int) *sqlmock.Rows {
+	rows := sqlmock.NewRows(orgCols)
+	for i := 0; i < n; i++ {
+		rows.AddRow(fmt.Sprintf("org-%d", i), fmt.Sprintf("org%d", i), "Org", nil, nil, time.Now(), time.Now())
+	}
+	return rows
+}
+
+func identityLimit(perPage int) int { return perPage }
+
+func paginationAxes() []paginationAxis {
+	return []paginationAxis{
+		{
+			// The axis issue #893 was filed against.
+			name:       "GET /organizations",
+			newRouter:  newOrgRouter,
+			url:        func(p string) string { return "/organizations" + perPageQuery(p, "?") },
+			def:        orgPerPageDefault,
+			max:        orgPerPageMax,
+			storeLimit: identityLimit,
+			queue: func(mock sqlmock.Sqlmock, limit int) {
+				mock.ExpectQuery("SELECT.*FROM organizations.*ORDER BY").WithArgs(limit, 0).
+					WillReturnRows(orgRows(1))
+				mock.ExpectQuery("SELECT COUNT.*FROM organizations").WillReturnRows(countRows(137))
+			},
+		},
+		{
+			name:       "GET /organizations/search",
+			newRouter:  newOrgRouter,
+			url:        func(p string) string { return "/organizations/search?q=acme" + perPageQuery(p, "&") },
+			def:        orgPerPageDefault,
+			max:        orgPerPageMax,
+			storeLimit: pagination.Probe,
+			queue: func(mock sqlmock.Sqlmock, limit int) {
+				mock.ExpectQuery("SELECT.*FROM organizations").WithArgs("%acme%", limit, 0).
+					WillReturnRows(orgRows(1))
+			},
+		},
+		{
+			name:       "GET /users",
+			newRouter:  newUserRouter,
+			url:        func(p string) string { return "/users" + perPageQuery(p, "?") },
+			def:        userPerPageDefault,
+			max:        userPerPageMax,
+			storeLimit: identityLimit,
+			queue: func(mock sqlmock.Sqlmock, limit int) {
+				mock.ExpectQuery("SELECT COUNT").WillReturnRows(countRows(137))
+				mock.ExpectQuery("SELECT").WithArgs(limit, 0).WillReturnRows(sampleUserRow())
+				mock.ExpectQuery("ANY").WillReturnRows(emptyBulkMembershipRows())
+			},
+		},
+		{
+			name:       "GET /users/search",
+			newRouter:  newUserRouter,
+			url:        func(p string) string { return "/users/search?q=alice" + perPageQuery(p, "&") },
+			def:        userPerPageDefault,
+			max:        userPerPageMax,
+			storeLimit: pagination.Probe,
+			queue: func(mock sqlmock.Sqlmock, limit int) {
+				mock.ExpectQuery("SELECT").WithArgs("%alice%", limit, 0).WillReturnRows(sampleUserRow())
+				mock.ExpectQuery("ANY").WillReturnRows(emptyBulkMembershipRows())
+			},
+		},
+		{
+			name:       "GET /admin/audit-logs",
+			newRouter:  newAuditLogRouter,
+			url:        func(p string) string { return "/audit-logs" + perPageQuery(p, "?") },
+			def:        auditPerPageDefault,
+			max:        auditPerPageMax,
+			storeLimit: identityLimit,
+			queue: func(mock sqlmock.Sqlmock, limit int) {
+				mock.ExpectQuery(`SELECT COUNT\(\*\) FROM audit_logs`).WillReturnRows(countRows(137))
+				mock.ExpectQuery(`SELECT al\.id`).WithArgs(limit, 0).WillReturnRows(sampleAuditLogListRows())
+			},
+		},
+	}
+}
+
+// perPageQuery renders the per_page parameter, or nothing at all for the
+// "caller expressed no preference" case.
+func perPageQuery(raw, sep string) string {
+	if raw == "" {
+		return ""
+	}
+	return sep + "per_page=" + raw
+}
+
+// metaOf pulls the pagination block out of a list response. Every axis emits it
+// under the same key, whichever list key sits beside it.
+func metaOf(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v (body=%s)", err, w.Body.String())
+	}
+	meta, ok := body["pagination"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("response has no 'pagination' object: %s", w.Body.String())
+	}
+	return meta
+}
+
+func metaInt(t *testing.T, meta map[string]interface{}, key string) int {
+	t.Helper()
+	n, ok := meta[key].(float64)
+	if !ok {
+		t.Fatalf("pagination.%s is %#v, want a number", key, meta[key])
+	}
+	return int(n)
+}
+
+func TestPaginationClampClass_OverMaximumClampsToMaximum(t *testing.T) {
+	for _, axis := range paginationAxes() {
+		// Each case is (raw per_page, the size that must be served). The names
+		// are the promise the endpoint's swagger makes, restated as behaviour.
+		cases := []struct {
+			name string
+			raw  string
+			want int
+		}{
+			// ISSUE #893. Every one of these returned `def` before the fix, so
+			// asking for more than the maximum returned fewer rows than asking
+			// for anything in range.
+			{"twice the maximum is served as the maximum", strconv.Itoa(axis.max * 2), axis.max},
+			{"one over the maximum is served as the maximum", strconv.Itoa(axis.max + 1), axis.max},
+			{"a size that overflows an int is served as the maximum", "99999999999999999999", axis.max},
+
+			// Unchanged behaviour, kept under test so the fix cannot be
+			// mistaken for "the clamp was deleted".
+			{"the maximum itself is served whole", strconv.Itoa(axis.max), axis.max},
+			{"an in-range size is served unchanged", strconv.Itoa(axis.max - 1), axis.max - 1},
+			{"no per_page takes the default", "", axis.def},
+			{"zero takes the default", "0", axis.def},
+			{"a negative size takes the default", "-5", axis.def},
+			{"an unparseable size takes the default", "lots", axis.def},
+		}
+
+		for _, tc := range cases {
+			t.Run(axis.name+"/"+tc.name, func(t *testing.T) {
+				mock, r := axis.newRouter(t)
+				axis.queue(mock, axis.storeLimit(tc.want))
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("GET", axis.url(tc.raw), nil))
+
+				if w.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+				}
+				if got := metaInt(t, metaOf(t, w), "per_page"); got != tc.want {
+					t.Errorf("per_page=%q served %d rows per page, want %d",
+						tc.raw, got, tc.want)
+				}
+				// The store half of the assertion: WithArgs above pins the
+				// LIMIT, and an unmet expectation here means the handler
+				// reported one page size and queried another.
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Errorf("the store was not asked for LIMIT %d: %v",
+						axis.storeLimit(tc.want), err)
+				}
+			})
+		}
+	}
+}
+
+// TestPaginationClampClass_CompletenessSignal is the other half of #893: a
+// clamp that is now honest still leaves an administrator looking at a list with
+// no way to know it ends there.
+//
+// has_more answers that directly on every axis — including the two search axes,
+// which have no total at all because the identity store has no counting query
+// for them.
+func TestPaginationClampClass_CompletenessSignal(t *testing.T) {
+	t.Run("a counted axis reports has_more and the total", func(t *testing.T) {
+		mock, r := newOrgRouter(t)
+		mock.ExpectQuery("SELECT.*FROM organizations.*ORDER BY").WithArgs(100, 0).
+			WillReturnRows(orgRows(100))
+		mock.ExpectQuery("SELECT COUNT.*FROM organizations").WillReturnRows(countRows(137))
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/organizations?per_page=200", nil))
+
+		meta := metaOf(t, w)
+		if meta["has_more"] != true {
+			t.Errorf("has_more = %#v, want true — 100 of 137 organizations were served, "+
+				"and a picker showing them has no other way to know 37 are missing", meta["has_more"])
+		}
+		if got := metaInt(t, meta, "total"); got != 137 {
+			t.Errorf("total = %d, want 137", got)
+		}
+	})
+
+	t.Run("a counted axis whose page is the whole list reports has_more false", func(t *testing.T) {
+		mock, r := newOrgRouter(t)
+		mock.ExpectQuery("SELECT.*FROM organizations.*ORDER BY").WithArgs(20, 0).
+			WillReturnRows(orgRows(3))
+		mock.ExpectQuery("SELECT COUNT.*FROM organizations").WillReturnRows(countRows(3))
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/organizations", nil))
+
+		if meta := metaOf(t, w); meta["has_more"] != false {
+			t.Errorf("has_more = %#v, want false — all 3 organizations were served", meta["has_more"])
+		}
+	})
+
+	t.Run("an uncounted axis reports has_more and a null total", func(t *testing.T) {
+		// The probe row (21 rows for a page of 20) is what makes has_more exact
+		// here, and it must not be served: a caller asked for 20.
+		mock, r := newOrgRouter(t)
+		mock.ExpectQuery("SELECT.*FROM organizations").WithArgs("%acme%", 21, 0).
+			WillReturnRows(orgRows(21))
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/organizations/search?q=acme", nil))
+
+		var body struct {
+			Organizations []map[string]interface{} `json:"organizations"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(body.Organizations) != 20 {
+			t.Errorf("served %d organizations, want 20 — the probe row is a question, not a result",
+				len(body.Organizations))
+		}
+
+		meta := metaOf(t, w)
+		if meta["has_more"] != true {
+			t.Errorf("has_more = %#v, want true — a 21st row came back", meta["has_more"])
+		}
+		if total, present := meta["total"]; !present || total != nil {
+			t.Errorf("total = %#v, want an explicit null — this axis has no counting query, "+
+				"and reporting 0 would be a count nobody performed", total)
+		}
+	})
+
+	t.Run("an uncounted axis whose page is exactly full still reports has_more false", func(t *testing.T) {
+		// The case a "did the page come back full?" heuristic gets wrong, and
+		// the reason the probe row exists.
+		mock, r := newOrgRouter(t)
+		mock.ExpectQuery("SELECT.*FROM organizations").WithArgs("%acme%", 21, 0).
+			WillReturnRows(orgRows(20))
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/organizations/search?q=acme", nil))
+
+		if meta := metaOf(t, w); meta["has_more"] != false {
+			t.Errorf("has_more = %#v, want false — exactly 20 rows matched, so this full page "+
+				"is the end of the list", meta["has_more"])
+		}
+	})
+
+	t.Run("every axis emits has_more", func(t *testing.T) {
+		// The field is only useful if a client can rely on it being there. An
+		// axis that omits it sends a consumer straight back to comparing counts
+		// by hand, which is the state #893 was filed about.
+		for _, axis := range paginationAxes() {
+			t.Run(axis.name, func(t *testing.T) {
+				mock, r := axis.newRouter(t)
+				axis.queue(mock, axis.storeLimit(axis.def))
+
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, httptest.NewRequest("GET", axis.url(""), nil))
+
+				if _, present := metaOf(t, w)["has_more"]; !present {
+					t.Errorf("pagination has no has_more field: %s", w.Body.String())
+				}
+			})
+		}
+	})
+}

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -115,11 +115,30 @@ type ListBranchesResponse struct {
 	Branches interface{} `json:"branches"`
 }
 
-// PaginationMeta carries page / per_page / total counts used in paginated list responses.
+// PaginationMeta carries the page window and, crucially, whether the page is
+// the end of the list.
+//
+// HasMore is the field that makes the difference between "this deployment has
+// 20 organizations" and "this page shows 20 organizations" (issue #893). Total
+// alone did not: it left every consumer to re-derive `page*per_page < total` by
+// hand, and the consumers that forgot — the organization pickers in the sibling
+// frontend — rendered a truncated list with nothing to say it was truncated.
+// HasMore is false if and only if there is nothing after this page, on every
+// endpoint that emits this shape, whether or not that endpoint can count.
+//
+// Total is a POINTER, and never omitempty, so that "not counted" (null) stays
+// distinguishable from "a total of zero". The two search axes have no counting
+// query on the identity store and send null; under the previous
+// `int64,omitempty` an uncounted list and an empty one were byte-identical,
+// which is the same class of silence this struct exists to end.
 type PaginationMeta struct {
-	Page    int   `json:"page"`
-	PerPage int   `json:"per_page"`
-	Total   int64 `json:"total,omitempty"`
+	Page    int  `json:"page"`
+	PerPage int  `json:"per_page"`
+	// HasMore reports whether any rows follow this page.
+	HasMore bool `json:"has_more"`
+	// Total is the number of matching rows across all pages, or null when the
+	// endpoint does not count.
+	Total *int64 `json:"total"`
 }
 
 // UserItem is the shape of a user in list/get/create/update responses.

--- a/backend/internal/api/admin/users.go
+++ b/backend/internal/api/admin/users.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sethbacon/terraform-suite-identity/identity/auditoutbox"
@@ -20,6 +19,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // UserHandlers handles user management endpoints
@@ -191,7 +191,7 @@ func (h *UserHandlers) revokePlatformAdminCarrier(c *gin.Context, userID string)
 // @Accept       json
 // @Produce      json
 // @Param        page      query  int  false  "Page number (default 1)"
-// @Param        per_page  query  int  false  "Items per page, max 100 (default 20)"
+// @Param        per_page  query  int  false  "Items per page, max 100 (default 20). A larger value is served as 100."
 // @Success      200  {object}  admin.ListUsersResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
@@ -200,18 +200,11 @@ func (h *UserHandlers) revokePlatformAdminCarrier(c *gin.Context, userID string)
 // GET /api/v1/users?page=1&per_page=20
 func (h *UserHandlers) ListUsersHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Parse pagination parameters
-		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-		perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
-
-		if page < 1 {
-			page = 1
-		}
-		if perPage < 1 || perPage > 100 {
-			perPage = 20
-		}
-
-		offset := (page - 1) * perPage
+		// GUARD per-page-clamps-to-max (issue #893). The organization list's
+		// clamp, copy-pasted: `?per_page=200` served 20 users.
+		page := pagination.ClampPage(queryInt(c, "page"))
+		perPage := pagination.ClampPerPage(queryInt(c, "per_page"), userPerPageDefault, userPerPageMax)
+		offset := pagination.Offset(page, perPage)
 
 		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
 		if !ok {
@@ -228,12 +221,8 @@ func (h *UserHandlers) ListUsersHandler() gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, gin.H{
-			"users": users,
-			"pagination": gin.H{
-				"page":     page,
-				"per_page": perPage,
-				"total":    total,
-			},
+			"users":      users,
+			"pagination": countedPage(page, perPage, offset, len(users), total),
 		})
 	}
 }
@@ -619,7 +608,7 @@ func (h *UserHandlers) DeleteUserHandler() gin.HandlerFunc {
 // @Produce      json
 // @Param        q         query  string  true   "Search query"
 // @Param        page      query  int     false  "Page number (default 1)"
-// @Param        per_page  query  int     false  "Items per page, max 100 (default 20)"
+// @Param        per_page  query  int     false  "Items per page, max 100 (default 20). A larger value is served as 100."
 // @Success      200  {object}  admin.ListUsersResponse
 // @Failure      400  {object}  map[string]interface{}  "Search query is required"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
@@ -637,18 +626,10 @@ func (h *UserHandlers) SearchUsersHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Parse pagination
-		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-		perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
-
-		if page < 1 {
-			page = 1
-		}
-		if perPage < 1 || perPage > 100 {
-			perPage = 20
-		}
-
-		offset := (page - 1) * perPage
+		// GUARD per-page-clamps-to-max (issue #893), the user list's sibling.
+		page := pagination.ClampPage(queryInt(c, "page"))
+		perPage := pagination.ClampPerPage(queryInt(c, "per_page"), userPerPageDefault, userPerPageMax)
+		offset := pagination.Offset(page, perPage)
 
 		// Search users with memberships
 		scope, ok := userAxisScope(c, h.orgRepo, auth.ScopeUsersRead)
@@ -656,20 +637,21 @@ func (h *UserHandlers) SearchUsersHandler() gin.HandlerFunc {
 			return
 		}
 
-		users, err := h.userRepo.SearchWithMemberships(c.Request.Context(), query, perPage, offset, scope)
+		// Probe one row past the page: this axis has no counting query either,
+		// so it emitted `{page, per_page}` and left a consumer no way to tell a
+		// last page from a truncated one (issue #893).
+		users, err := h.userRepo.SearchWithMemberships(c.Request.Context(), query, pagination.Probe(perPage), offset, scope)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to search users",
 			})
 			return
 		}
+		users, hasMore := pagination.Trim(users, perPage)
 
 		c.JSON(http.StatusOK, gin.H{
-			"users": users,
-			"pagination": gin.H{
-				"page":     page,
-				"per_page": perPage,
-			},
+			"users":      users,
+			"pagination": probedPage(page, perPage, hasMore),
 		})
 	}
 }

--- a/backend/internal/api/admin/version_approvals.go
+++ b/backend/internal/api/admin/version_approvals.go
@@ -89,7 +89,7 @@ func currentUserID(c *gin.Context) *uuid.UUID {
 // @Param        status     query  string  false  "Filter by status (pending_approval, approved, rejected)"
 // @Param        type       query  string  false  "Filter by type (provider, terraform)"
 // @Param        config_id  query  string  false  "Filter by mirror config UUID"
-// @Param        limit      query  int     false  "Max results (default 100, max 500)"
+// @Param        limit      query  int     false  "Max results (default 100, max 500). A larger value is served as 500."
 // @Param        offset     query  int     false  "Offset for pagination"
 // @Success      200  {object}  models.VersionApprovalListResponse
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"

--- a/backend/internal/api/admin/version_approvals_pagination_test.go
+++ b/backend/internal/api/admin/version_approvals_pagination_test.go
@@ -1,0 +1,86 @@
+package admin
+
+// version_approvals_pagination_test.go covers the version-approval axis of
+// issue #893.
+//
+// This one is not in pagination_clamp_class_test.go's table because its clamp
+// does not live in the handler: the `limit` query parameter travels into
+// VersionApprovalFilter and is clamped by the REPOSITORY
+// (internal/db/repositories/version_approval_repository.go). The defect was
+// identical — "max 500" in the swagger, with anything above 500 served as the
+// default of 100 — and it is asserted here, through the handler, because that
+// is the path a caller actually takes.
+//
+// The repository interpolates LIMIT into the statement text rather than binding
+// it, so the assertion is on the SQL itself.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+func TestVAHandler_List_LimitClampsToMaximumNotDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		// ISSUE #893: each of these served 100 before the fix, so an operator
+		// draining a large approval queue asked for 1000 and was handed the
+		// default page, with nothing to say it had been clamped.
+		{"above the maximum is served as the maximum", "limit=5000", 500},
+		{"one above the maximum is served as the maximum", "limit=501", 500},
+
+		{"the maximum itself is served whole", "limit=500", 500},
+		{"an in-range limit is served unchanged", "limit=42", 42},
+		{"no limit takes the default", "", 100},
+		{"zero takes the default", "limit=0", 100},
+		{"a negative limit takes the default", "limit=-1", 100},
+		{"an unparseable limit takes the default", "limit=all", 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, mock := newVersionApprovalRouter(t)
+
+			mock.ExpectQuery(`SELECT COUNT\(\*\) FROM`).
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(137))
+			// The LIMIT is interpolated into the statement, so matching the
+			// statement text is what pins the clamp end to end.
+			mock.ExpectQuery(`LIMIT ` + strconv.Itoa(tc.want) + ` OFFSET 0`).
+				WillReturnRows(sqlmock.NewRows(vaCols).AddRow(
+					uuid.New(), "provider", "5.0.0", "pending_approval", nil,
+					"hashicorp", "aws", "prod", uuid.New(), true, true, time.Now(),
+				))
+
+			url := "/admin/version-approvals"
+			if tc.raw != "" {
+				url += "?" + tc.raw
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest("GET", url, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+			var body models.VersionApprovalListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if body.Total != 137 {
+				t.Errorf("total = %d, want 137 — the count a caller pages against", body.Total)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("?%s did not query LIMIT %d: %v", tc.raw, tc.want, err)
+			}
+		})
+	}
+}

--- a/backend/internal/api/modules/pagination_clamp_test.go
+++ b/backend/internal/api/modules/pagination_clamp_test.go
@@ -1,0 +1,72 @@
+package modules
+
+// pagination_clamp_test.go covers this package's share of issue #893.
+//
+// GET /api/v1/modules/search advertises "default 20, max 100" and used to serve
+// 20 for any limit above 100 — so a client asking for everything it could get
+// was given the smallest page on offer, with no error and no marker. The class
+// signature that keeps the shape from returning lives in
+// internal/pagination/clamp_sweep_test.go; this is the behaviour half.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+func searchMetaLimit(t *testing.T, body []byte) int {
+	t.Helper()
+	var resp struct {
+		Meta struct {
+			Limit int `json:"limit"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, body)
+	}
+	return resp.Meta.Limit
+}
+
+func TestSearchHandler_LimitClampsToMaximumNotDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		// ISSUE #893: each of these served 20 before the fix.
+		{"above the maximum is served as the maximum", "limit=500", 100},
+		{"one above the maximum is served as the maximum", "limit=101", 100},
+
+		{"the maximum itself is served whole", "limit=100", 100},
+		{"an in-range limit is served unchanged", "limit=42", 42},
+		{"no limit takes the default", "", 20},
+		{"zero takes the default", "limit=0", 20},
+		{"a negative limit takes the default", "limit=-1", 20},
+		{"an unparseable limit takes the default", "limit=all", 20},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock, r := newSearchRouter(t, &config.Config{})
+			mock.ExpectQuery("SELECT COUNT.*FROM modules").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+			mock.ExpectQuery("SELECT.*FROM modules.*ORDER BY").
+				WillReturnRows(sampleModuleSearchRowFTS())
+
+			url := "/v1/modules/search?q=consul"
+			if tc.raw != "" {
+				url += "&" + tc.raw
+			}
+			w := doGET(r, url)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+			}
+			if got := searchMetaLimit(t, w.Body.Bytes()); got != tc.want {
+				t.Errorf("?%s served meta.limit = %d, want %d", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/modules/search.go
+++ b/backend/internal/api/modules/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // validModuleSortFields defines the allowed values for the sort query parameter.
@@ -31,7 +32,7 @@ var validModuleSortFields = map[string]bool{
 // @Param        system     query  string  false  "Filter by target system"
 // @Param        sort       query  string  false  "Sort field: relevance, name, downloads, created, updated"
 // @Param        order      query  string  false  "Sort order: asc or desc (default desc)"
-// @Param        limit      query  int     false  "Maximum results to return (default 20, max 100)"
+// @Param        limit      query  int     false  "Maximum results to return (default 20, max 100). A larger value is served as 100."
 // @Param        offset     query  int     false  "Offset for pagination (default 0)"
 // @Success      200  {object}  modules.ModuleSearchResponse
 // @Failure      400  {object}  map[string]interface{}  "Invalid sort parameter"
@@ -60,16 +61,15 @@ func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			return
 		}
 
-		// Pagination parameters
-		limitStr := c.DefaultQuery("limit", "20")
-		offsetStr := c.DefaultQuery("offset", "0")
+		// GUARD per-page-clamps-to-max (issue #893). This clamp reset an
+		// over-large limit to the DEFAULT of 20 rather than to the documented
+		// maximum of 100, so `?limit=500` returned fewer modules than
+		// `?limit=50`. ClampPerPage absorbs the unparseable case too: Atoi
+		// returns 0 on failure, and 0 takes the default.
+		limit, _ := strconv.Atoi(c.Query("limit"))
+		limit = pagination.ClampPerPage(limit, 20, 100)
 
-		limit, err := strconv.Atoi(limitStr)
-		if err != nil || limit < 1 || limit > 100 {
-			limit = 20 // Default to 20, max 100
-		}
-
-		offset, err := strconv.Atoi(offsetStr)
+		offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
 		if err != nil || offset < 0 {
 			offset = 0
 		}

--- a/backend/internal/api/providers/pagination_clamp_test.go
+++ b/backend/internal/api/providers/pagination_clamp_test.go
@@ -1,0 +1,71 @@
+package providers
+
+// pagination_clamp_test.go covers this package's share of issue #893.
+//
+// GET /api/v1/providers/search carried the module search axis's clamp verbatim:
+// "default 20, max 100", with any limit above 100 served as 20. The class
+// signature that keeps the shape from returning lives in
+// internal/pagination/clamp_sweep_test.go; this is the behaviour half.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+func searchMetaLimit(t *testing.T, body []byte) int {
+	t.Helper()
+	var resp struct {
+		Meta struct {
+			Limit int `json:"limit"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, body)
+	}
+	return resp.Meta.Limit
+}
+
+func TestSearchHandler_LimitClampsToMaximumNotDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		// ISSUE #893: each of these served 20 before the fix.
+		{"above the maximum is served as the maximum", "limit=500", 100},
+		{"one above the maximum is served as the maximum", "limit=101", 100},
+
+		{"the maximum itself is served whole", "limit=100", 100},
+		{"an in-range limit is served unchanged", "limit=42", 42},
+		{"no limit takes the default", "", 20},
+		{"zero takes the default", "limit=0", 20},
+		{"a negative limit takes the default", "limit=-1", 20},
+		{"an unparseable limit takes the default", "limit=all", 20},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock, r := newSearchRouter(t, &config.Config{})
+			mock.ExpectQuery("SELECT COUNT.*FROM providers").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+			mock.ExpectQuery("SELECT.*FROM providers.*ORDER BY").
+				WillReturnRows(sampleProviderSearchRowFTS())
+
+			url := "/v1/providers/search?q=aws"
+			if tc.raw != "" {
+				url += "&" + tc.raw
+			}
+			w := doGET(r, url)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+			}
+			if got := searchMetaLimit(t, w.Body.Bytes()); got != tc.want {
+				t.Errorf("?%s served meta.limit = %d, want %d", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/providers/search.go
+++ b/backend/internal/api/providers/search.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // validProviderSortFields defines the allowed values for the sort query parameter.
@@ -30,7 +31,7 @@ var validProviderSortFields = map[string]bool{
 // @Param        namespace  query  string  false  "Filter by namespace"
 // @Param        sort       query  string  false  "Sort field: relevance, name, downloads, created, updated"
 // @Param        order      query  string  false  "Sort order: asc or desc (default desc)"
-// @Param        limit      query  int     false  "Maximum results to return (default 20, max 100)"
+// @Param        limit      query  int     false  "Maximum results to return (default 20, max 100). A larger value is served as 100."
 // @Param        offset     query  int     false  "Offset for pagination (default 0)"
 // @Success      200  {object}  providers.ProviderSearchResponse
 // @Failure      400  {object}  map[string]interface{}  "Invalid sort parameter"
@@ -58,16 +59,15 @@ func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			return
 		}
 
-		// Pagination parameters
-		limitStr := c.DefaultQuery("limit", "20")
-		offsetStr := c.DefaultQuery("offset", "0")
+		// GUARD per-page-clamps-to-max (issue #893). The module search axis's
+		// clamp, verbatim: an over-large limit fell back to the DEFAULT of 20
+		// instead of the documented maximum of 100. ClampPerPage absorbs the
+		// unparseable case too: Atoi returns 0 on failure, and 0 takes the
+		// default.
+		limit, _ := strconv.Atoi(c.Query("limit"))
+		limit = pagination.ClampPerPage(limit, 20, 100)
 
-		limit, err := strconv.Atoi(limitStr)
-		if err != nil || limit < 1 || limit > 100 {
-			limit = 20 // Default to 20, max 100
-		}
-
-		offset, err := strconv.Atoi(offsetStr)
+		offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
 		if err != nil || offset < 0 {
 			offset = 0
 		}

--- a/backend/internal/api/scim/handlers.go
+++ b/backend/internal/api/scim/handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // SCIM Schema URIs
@@ -30,6 +31,13 @@ const (
 	SchemaListResp = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
 	SchemaError    = "urn:ietf:params:scim:api:messages:2.0:Error"
 	SchemaPatchOp  = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+)
+
+// SCIM page-size limits for the `count` parameter, as the swagger annotation
+// on ListUsers advertises them.
+const (
+	scimCountDefault = 100
+	scimCountMax     = 200
 )
 
 // Handlers provides SCIM 2.0 REST endpoints.
@@ -202,7 +210,7 @@ type SCIMOperation struct {
 // @Security     Bearer
 // @Produce      json
 // @Param        startIndex  query  int     false  "1-based start index"  default(1)
-// @Param        count       query  int     false  "Page size (max 200)"  default(100)
+// @Param        count       query  int     false  "Page size, max 200. A larger value is served as 200."  default(100)
 // @Param        filter      query  string  false  "SCIM filter expression"
 // @Success      200  {object}  scim.SCIMListResponse  "SCIM list response"
 // @Failure      401  {object}  scim.SCIMError  "Unauthorized"
@@ -211,14 +219,17 @@ type SCIMOperation struct {
 // ListUsers handles GET /scim/v2/Users
 func (h *Handlers) ListUsers() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// GUARD per-page-clamps-to-max (issue #893). An over-large `count` fell
+		// back to the DEFAULT of 100 rather than to the advertised maximum of
+		// 200, so an IdP syncing with `?count=1000` was served 100 —
+		// indistinguishable, to the provisioning client, from a directory that
+		// simply has 100 users, and RFC 7644 gives it no way to notice.
+		// totalResults is what lets a SCIM client page correctly, and it is
+		// still reported below.
 		startIndex, _ := strconv.Atoi(c.DefaultQuery("startIndex", "1"))
-		count, _ := strconv.Atoi(c.DefaultQuery("count", "100"))
-		if startIndex < 1 {
-			startIndex = 1
-		}
-		if count < 1 || count > 200 {
-			count = 100
-		}
+		count, _ := strconv.Atoi(c.Query("count"))
+		startIndex = pagination.ClampPage(startIndex)
+		count = pagination.ClampPerPage(count, scimCountDefault, scimCountMax)
 		filter := c.Query("filter")
 		offset := startIndex - 1
 		ctx := c.Request.Context()

--- a/backend/internal/api/scim/pagination_clamp_test.go
+++ b/backend/internal/api/scim/pagination_clamp_test.go
@@ -1,0 +1,108 @@
+package scim
+
+// pagination_clamp_test.go covers the SCIM half of issue #893.
+//
+// GET /scim/v2/Users advertises "count, max 200" and used to serve 100 for any
+// count above 200 — so an IdP syncing a directory with `?count=1000` was handed
+// 100 users. RFC 7644 gives the client nothing to distinguish that from a
+// directory with 100 users in it except totalResults, which is asserted here
+// alongside the clamp for exactly that reason.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// scimListRouter mounts the SCIM user list behind a platform administrator, the
+// principal for whom the whole-directory view is the intended behaviour. Tenant
+// scoping on this family is asserted separately by tenant_scope_class_test.go.
+func scimListRouter(t *testing.T) (*gin.Engine, sqlmock.Sqlmock) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	h := NewHandlers(&config.Config{}, db)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		c.Set("user_id", scimCallerID)
+	})
+	r.GET("/scim/v2/Users", h.ListUsers())
+	return r, mock
+}
+
+func TestSCIMListUsers_CountClampsToMaximumNotDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		// ISSUE #893: each of these served 100 before the fix, so an IdP asking
+		// for a bigger page than the maximum got the default one instead.
+		{"above the maximum is served as the maximum", "1000", 200},
+		{"one above the maximum is served as the maximum", "201", 200},
+
+		{"the maximum itself is served whole", "200", 200},
+		{"an in-range count is served unchanged", "150", 150},
+		{"no count takes the default", "", 100},
+		{"zero takes the default", "0", 100},
+		{"a negative count takes the default", "-1", 100},
+		{"an unparseable count takes the default", "everyone", 100},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, mock := scimListRouter(t)
+			// ListUsers counts, then pages. The page query's LIMIT is the
+			// clamped count, pinned here so a handler that REPORTED the right
+			// itemsPerPage while querying another cannot pass.
+			mock.ExpectQuery("SELECT COUNT").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(137))
+			mock.ExpectQuery("SELECT").WithArgs(tc.want, 0).
+				WillReturnRows(sqlmock.NewRows(scimUserCols).
+					AddRow(scimTargetID, "jane@example.com", "Jane", nil, time.Now(), time.Now()))
+
+			url := "/scim/v2/Users"
+			if tc.raw != "" {
+				url += "?count=" + tc.raw
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest("GET", url, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+			}
+
+			var resp SCIMListResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("unmarshal: %v (body=%s)", err, w.Body.String())
+			}
+			if resp.ItemsPerPage != tc.want {
+				t.Errorf("?count=%s served itemsPerPage = %d, want %d",
+					tc.raw, resp.ItemsPerPage, tc.want)
+			}
+			// totalResults is a SCIM client's only completeness signal, and it
+			// has to survive the clamp change.
+			if resp.TotalResults != 137 {
+				t.Errorf("totalResults = %d, want 137", resp.TotalResults)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("the store was not asked for LIMIT "+strconv.Itoa(tc.want)+": %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/db/repositories/version_approval_repository.go
+++ b/backend/internal/db/repositories/version_approval_repository.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // VersionApprovalRepository handles version approval queries and mutations.
@@ -172,10 +173,13 @@ func (r *VersionApprovalRepository) List(ctx context.Context, f VersionApprovalF
 		return nil, 0, fmt.Errorf("failed to count version approvals: %w", err)
 	}
 
-	limit := f.Limit
-	if limit <= 0 || limit > 500 {
-		limit = 100
-	}
+	// GUARD per-page-clamps-to-max (issue #893). f.Limit is the `limit` query
+	// parameter of GET /api/v1/admin/version-approvals, whose swagger says
+	// "max 500" — but an over-large value used to fall back to the DEFAULT of
+	// 100, so an operator draining a large approval queue with `?limit=1000`
+	// was served 100 rows and had no way to tell that was a clamp rather than
+	// the end of the queue.
+	limit := pagination.ClampPerPage(f.Limit, 100, 500)
 	offset := f.Offset
 	if offset < 0 {
 		offset = 0

--- a/backend/internal/pagination/clamp_sweep_test.go
+++ b/backend/internal/pagination/clamp_sweep_test.go
@@ -1,0 +1,201 @@
+package pagination_test
+
+// clamp_sweep_test.go is the re-runnable signature for issue #893's defect
+// class, and the reason this package exists rather than nine corrected
+// one-liners.
+//
+// The defect is a range guard whose OVER-MAXIMUM branch collapses to the
+// endpoint's default:
+//
+//	if perPage < 1 || perPage > 100 {
+//		perPage = 20          // <- 200 requested, 20 served
+//	}
+//
+// It is invisible in review — it reads as an ordinary two-sided bounds check —
+// it fails silently with a 200 and a well-formed body, and it had been
+// copy-pasted into nine sites before anyone noticed the one that mattered. A
+// list of the nine would have been obsolete at the tenth, so this walks the
+// source for the SHAPE instead, and fails when it reappears.
+//
+// What it matches: an `if` whose condition contains `X > LIT` and whose body is
+// exactly `X = OTHER`, where OTHER is not LIT. That is "over the maximum, take
+// something other than the maximum", which is always either this bug or a
+// deliberate decision worth writing down in clampsAllowedToCollapse below.
+//
+// What it deliberately does not match, so the signature stays crisp rather than
+// noisy:
+//   - `if x > max { x = max }` — the correct clamp, and the shape every fixed
+//     site now has (via ClampPerPage, which has no such `if` at all).
+//   - `if x < 1 || x > max { return error }` — validation, not clamping; the
+//     body assigns nothing. Config port checks live here.
+//   - `>=` comparisons. The honest replacement for `x >= n` is `n-1`, which
+//     cannot be recognised textually, and the estate has no instance of it.
+//     A future clamp written with `>=` would slip past: that is a known edge of
+//     this signature, not an oversight.
+//
+// EMPTY IS THE FINISH LINE for `found`, but clampsAllowedToCollapse is not
+// expected to empty out — each entry there is a claim that collapsing to the
+// default is right for that call site, and the claim has to survive review.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// clampsAllowedToCollapse maps a repo-relative file to how many
+// collapse-to-default clamps in it are DELIBERATE, with the reason.
+//
+// Both entries are SCM connectors normalising a page size for an upstream API,
+// and both are exempt for the same verifiable reason: no user input reaches
+// them. Every production construction of scm.Pagination in this module is
+// scm.DefaultPagination() —
+//
+//	grep -rn 'Pagination{' --include='*.go' internal/ | grep -v _test
+//
+// returns exactly one hit, DefaultPagination's own literal — so PageSize is
+// always 30 and the over-maximum branch is unreachable. There is no caller that
+// can ask for more and be given less, which is the whole defect. Falling back
+// to each API's documented default (GitHub/GitLab 30, Bitbucket 25) rather than
+// to its maximum is the better behaviour for a client that has expressed no
+// preference at all.
+//
+// If either connector ever takes a caller-supplied page size, it leaves this
+// map and goes through ClampPerPage.
+var clampsAllowedToCollapse = map[string]int{
+	"internal/scm/connector.go":           1, // ClampPagination — GitHub/GitLab, 1..100 else 30
+	"internal/scm/bitbucket/connector.go": 1, // clampWindow — Bitbucket DC, 1..100 else 25
+}
+
+// collapsingClamp reports whether an if-statement is the defect shape, i.e.
+// `if ... X > LIT ... { X = OTHER }` with OTHER != LIT.
+func collapsingClamp(stmt *ast.IfStmt) bool {
+	if stmt.Else != nil || stmt.Body == nil || len(stmt.Body.List) != 1 {
+		return false
+	}
+	assign, ok := stmt.Body.List[0].(*ast.AssignStmt)
+	if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return false
+	}
+	// `=` and `:=` both count; a clamp written either way is the same defect.
+	target := types.ExprString(assign.Lhs[0])
+	replacement := types.ExprString(assign.Rhs[0])
+
+	for _, disjunct := range disjuncts(stmt.Cond) {
+		cmp, ok := disjunct.(*ast.BinaryExpr)
+		if !ok || cmp.Op != token.GTR {
+			continue
+		}
+		if types.ExprString(cmp.X) != target {
+			continue
+		}
+		if types.ExprString(cmp.Y) != replacement {
+			return true
+		}
+	}
+	return false
+}
+
+// disjuncts flattens a `||` tree into its operands, so that the over-maximum
+// comparison is found whether it is written first, last, or behind an
+// `err != nil` guard.
+func disjuncts(expr ast.Expr) []ast.Expr {
+	if bin, ok := expr.(*ast.BinaryExpr); ok && bin.Op == token.LOR {
+		return append(disjuncts(bin.X), disjuncts(bin.Y)...)
+	}
+	if paren, ok := expr.(*ast.ParenExpr); ok {
+		return disjuncts(paren.X)
+	}
+	return []ast.Expr{expr}
+}
+
+func TestNoClampsCollapseToTheDefault(t *testing.T) {
+	root := moduleRoot(t)
+	found := map[string]int{}
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		ast.Inspect(file, func(n ast.Node) bool {
+			if stmt, ok := n.(*ast.IfStmt); ok && collapsingClamp(stmt) {
+				found[rel]++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// A signature that can no longer see anything looks exactly like a clean
+	// tree. Refuse to certify one: the exempt sites below are the sweep's own
+	// positive control, and their disappearance means the matcher broke, not
+	// that the estate got tidy.
+	if len(found) == 0 {
+		t.Error("the sweep found no collapse-to-default clamps AT ALL, including the two " +
+			"deliberate ones in clampsAllowedToCollapse. That is not a clean tree, it is a " +
+			"blind matcher: collapsingClamp is no longer recognising the shape it exists to " +
+			"recognise. Fix the matcher before trusting this test's green.")
+	}
+
+	for file, n := range found {
+		want, listed := clampsAllowedToCollapse[file]
+		if !listed {
+			t.Errorf("%s has %d clamp(s) that collapse to the default instead of the maximum.\n"+
+				"That is issue #893: a caller asking for more than the maximum is served the "+
+				"DEFAULT, so asking for more returns less — silently, with a 200. Use "+
+				"pagination.ClampPerPage(requested, default, max), or add the file to "+
+				"clampsAllowedToCollapse with the reason no caller can trigger it.", file, n)
+			continue
+		}
+		if n != want {
+			t.Errorf("%s has %d collapse-to-default clamp(s), expected %d.\n"+
+				"A NEW one needs pagination.ClampPerPage. A REMOVED one means the count here "+
+				"should come down.", file, n, want)
+		}
+	}
+
+	for file, want := range clampsAllowedToCollapse {
+		if _, ok := found[file]; !ok {
+			t.Errorf("clampsAllowedToCollapse lists %s (expecting %d) but it has no "+
+				"collapse-to-default clamps left. Remove the entry — a stale exemption is an "+
+				"exemption nobody re-justified.", file, want)
+		}
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatal("could not locate the module root (no go.mod found walking up)")
+	return ""
+}

--- a/backend/internal/pagination/pagination.go
+++ b/backend/internal/pagination/pagination.go
@@ -1,0 +1,98 @@
+// Package pagination resolves the page parameters a caller supplies into the
+// window a handler actually reads, and answers the one question a paginated
+// response has to answer honestly: is this the whole list?
+//
+// It exists because of a defect shape that had been copy-pasted across nine
+// handlers (issue #893):
+//
+//	if perPage < 1 || perPage > 100 {
+//		perPage = 20
+//	}
+//
+// Both out-of-range directions collapse to the DEFAULT. For "less than one"
+// that is right. For "more than the maximum" it is the opposite of what the
+// caller asked for and the opposite of what the endpoint's own documentation
+// promised ("max 100"): a request for 200 returned 20, so asking for more got
+// you less — and got it silently, with a 200 and a well-formed body.
+//
+// Every clamp in this repo goes through ClampPerPage instead, and
+// clamp_sweep_test.go fails the build when the raw idiom reappears.
+package pagination
+
+// ClampPerPage resolves a requested page size against an endpoint's default and
+// maximum.
+//
+//   - A size of zero or less — which includes an unparseable parameter, since
+//     strconv.Atoi returns 0 on failure — means "no preference", and resolves
+//     to defaultSize.
+//   - A size above maxSize resolves to MAXSIZE, not to defaultSize. This is the
+//     whole point of the function: an over-large request is a caller asking for
+//     as much as it can get, and the honest answer to it is the most this
+//     endpoint will serve.
+//   - Anything in range is returned unchanged.
+//
+// A value so large it overflows an int is handled by the same maxSize branch:
+// strconv.Atoi returns math.MaxInt alongside its range error, and MaxInt is
+// above every maxSize in this repo.
+//
+// maxSize is assumed to be at least 1 and at least defaultSize; both hold at
+// every call site, and clamp_sweep_test.go's inventory is where a new one is
+// declared.
+func ClampPerPage(requested, defaultSize, maxSize int) int {
+	if requested < 1 {
+		return defaultSize
+	}
+	if requested > maxSize {
+		return maxSize
+	}
+	return requested
+}
+
+// ClampPage forces a 1-based page number to at least 1.
+//
+// There is no maximum: a page past the end of the data is a legitimate request
+// that legitimately returns nothing, and capping it would silently serve some
+// other page's rows under the number the caller asked for.
+func ClampPage(requested int) int {
+	if requested < 1 {
+		return 1
+	}
+	return requested
+}
+
+// Offset converts a clamped 1-based page and page size into a row offset.
+func Offset(page, perPage int) int {
+	return (page - 1) * perPage
+}
+
+// HasMore reports whether rows remain beyond the page just built, for an
+// endpoint that knows its exact total.
+//
+// This is the completeness signal a client needs and could not previously get:
+// `total` alone forces every consumer to re-derive `offset+len < total` by
+// hand, and a consumer that forgets — which is exactly what happened to the
+// organization pickers in the sibling frontend — shows a truncated list with no
+// sign it is truncated.
+func HasMore(offset, returned, total int) bool {
+	return offset+returned < total
+}
+
+// Probe is the page size to REQUEST from a store when the endpoint has no total
+// to compare against: one row more than the caller asked for.
+//
+// Pair it with Trim. Fetching the extra row is what makes has_more exact rather
+// than "the page came back full, so there are probably more" — a guess that is
+// wrong for every list whose length is an exact multiple of the page size,
+// which is precisely the case a picker's "load more" control gets stuck on.
+func Probe(perPage int) int {
+	return perPage + 1
+}
+
+// Trim cuts a Probe result back to the page the caller asked for and reports
+// whether the probe row was there, i.e. whether more rows follow this page.
+func Trim[T any](rows []T, perPage int) (page []T, hasMore bool) {
+	if len(rows) > perPage {
+		return rows[:perPage], true
+	}
+	return rows, false
+}

--- a/backend/internal/pagination/pagination_test.go
+++ b/backend/internal/pagination/pagination_test.go
@@ -1,0 +1,144 @@
+package pagination
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestClampPerPage(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		// The defect this package exists for: issue #893. Before the fix every
+		// one of these over-maximum cases returned the DEFAULT of 20, so a
+		// caller asking for 200 got fewer rows than one asking for 50.
+		{"above the maximum clamps to the maximum, not the default", 200, 100},
+		{"one above the maximum clamps to the maximum", 101, 100},
+		{"the maximum itself is served whole", 100, 100},
+		{"an in-range size is served unchanged", 57, 57},
+		{"one is a legitimate page size", 1, 1},
+
+		// The other direction, which was always right and stays right.
+		{"zero means no preference and takes the default", 0, 20},
+		{"a negative size takes the default", -5, 20},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClampPerPage(tc.requested, 20, 100); got != tc.want {
+				t.Errorf("ClampPerPage(%d, 20, 100) = %d, want %d", tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClampPerPage_AtoiFailureModes pins the two ways a query parameter reaches
+// ClampPerPage without being a plain in-range integer, because every caller
+// discards strconv.Atoi's error and relies on this function to absorb both.
+func TestClampPerPage_AtoiFailureModes(t *testing.T) {
+	t.Run("unparseable takes the default", func(t *testing.T) {
+		n, err := strconv.Atoi("all-of-them")
+		if err == nil {
+			t.Fatal("expected a parse error for the fixture")
+		}
+		if got := ClampPerPage(n, 20, 100); got != 20 {
+			t.Errorf("ClampPerPage(%d, 20, 100) = %d, want 20", n, got)
+		}
+	})
+
+	t.Run("overflowing takes the maximum", func(t *testing.T) {
+		// Atoi returns math.MaxInt *and* ErrRange here. Discarding the error
+		// therefore leaves a value above every maximum in this repo, which must
+		// clamp DOWN to the maximum rather than fall back to the default —
+		// otherwise "?per_page=99999999999999999999" is the #893 defect again.
+		n, err := strconv.Atoi("99999999999999999999")
+		if err == nil {
+			t.Fatal("expected a range error for the fixture")
+		}
+		if n != math.MaxInt {
+			t.Fatalf("Atoi range failure returned %d, want math.MaxInt — this test's premise changed", n)
+		}
+		if got := ClampPerPage(n, 20, 100); got != 100 {
+			t.Errorf("ClampPerPage(math.MaxInt, 20, 100) = %d, want 100", got)
+		}
+	})
+}
+
+func TestClampPage(t *testing.T) {
+	for requested, want := range map[int]int{-3: 1, 0: 1, 1: 1, 9: 9} {
+		if got := ClampPage(requested); got != want {
+			t.Errorf("ClampPage(%d) = %d, want %d", requested, got, want)
+		}
+	}
+}
+
+func TestOffset(t *testing.T) {
+	if got := Offset(1, 20); got != 0 {
+		t.Errorf("Offset(1, 20) = %d, want 0", got)
+	}
+	if got := Offset(3, 100); got != 200 {
+		t.Errorf("Offset(3, 100) = %d, want 200", got)
+	}
+}
+
+func TestHasMore(t *testing.T) {
+	tests := []struct {
+		name                    string
+		offset, returned, total int
+		want                    bool
+	}{
+		{"a full first page of a longer list has more", 0, 20, 137, true},
+		{"the exact last page has no more", 120, 17, 137, false},
+		{"a full page that exactly exhausts the list has no more", 100, 37, 137, false},
+		{"an empty list has no more", 0, 0, 0, false},
+		{"a page past the end has no more", 500, 0, 137, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasMore(tc.offset, tc.returned, tc.total); got != tc.want {
+				t.Errorf("HasMore(%d, %d, %d) = %v, want %v",
+					tc.offset, tc.returned, tc.total, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProbeAndTrim(t *testing.T) {
+	if got := Probe(20); got != 21 {
+		t.Errorf("Probe(20) = %d, want 21", got)
+	}
+
+	t.Run("a probe row present means more follow and is not served", func(t *testing.T) {
+		rows := []int{1, 2, 3, 4}
+		page, hasMore := Trim(rows, 3)
+		if !hasMore {
+			t.Error("hasMore = false, want true — the probe row was there")
+		}
+		if len(page) != 3 {
+			t.Errorf("page has %d rows, want 3 — the probe row must not be served", len(page))
+		}
+	})
+
+	t.Run("an exactly-full page with no probe row is the end", func(t *testing.T) {
+		// The case a "did the page come back full?" heuristic gets wrong, and
+		// the reason Probe exists at all.
+		rows := []int{1, 2, 3}
+		page, hasMore := Trim(rows, 3)
+		if hasMore {
+			t.Error("hasMore = true, want false — a full page is not evidence of more")
+		}
+		if len(page) != 3 {
+			t.Errorf("page has %d rows, want 3", len(page))
+		}
+	})
+
+	t.Run("a short page is the end", func(t *testing.T) {
+		page, hasMore := Trim([]int{1}, 3)
+		if hasMore || len(page) != 1 {
+			t.Errorf("Trim([1], 3) = (%v, %v), want ([1], false)", page, hasMore)
+		}
+	})
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -199,6 +199,28 @@ List endpoints accept `page` (1-based) and `per_page` (default 20, max 100) quer
 GET /api/v1/modules?page=2&per_page=50
 ```
 
+A `per_page` **above** the endpoint's maximum is served **as that maximum**; only a
+value below 1 (or an unparseable one) falls back to the default. Each endpoint's
+own default and maximum are on its entry in the OpenAPI spec — `/admin/audit-logs`
+is 25/200, the SCIM `count` parameter is 100/200, and `/admin/version-approvals`
+is 100/500.
+
+Admin list responses carry a `pagination` object:
+
+```json
+{
+  "pagination": { "page": 1, "per_page": 100, "has_more": true, "total": 137 }
+}
+```
+
+- **`has_more`** is the completeness signal: `false` means this page is the end of
+  the list. Read it rather than comparing `page * per_page` against `total` — it is
+  present on every paginated admin response, including the search endpoints that
+  cannot report a total.
+- **`total`** is the number of matching rows across all pages, or `null` on the
+  endpoints that have no counting query (`/organizations/search`, `/users/search`).
+  `null` means "not counted"; `0` means "none matched".
+
 ### Error Responses
 
 All errors return JSON with a `status` field matching the HTTP status code and a `message` field:


### PR DESCRIPTION
## The defect

`GET /api/v1/organizations` reset an out-of-range `per_page` to the **default** of 20 rather than to the documented **maximum** of 100:

```go
if perPage < 1 || perPage > 100 {
    perPage = 20
}
```

So `?per_page=200` returned 20 rows — fewer than `?per_page=50`. Asking for more got you less, with a 200 and a well-formed body and nothing to indicate a clamp had happened.

## Why the class, not the instance

The clamp had been copy-pasted. Enumerating first found **nine** user-reachable sites with the same shape, of which the issue named two:

| Site | max | over-max used to serve | now serves |
|---|---|---|---|
| `admin/organizations.go` `ListOrganizationsHandler` | 100 | 20 | 100 |
| `admin/organizations.go` `SearchOrganizationsHandler` | 100 | 20 | 100 |
| `admin/users.go` `ListUsersHandler` | 100 | 20 | 100 |
| `admin/users.go` `SearchUsersHandler` | 100 | 20 | 100 |
| `admin/audit_logs.go` `ListAuditLogsHandler` | 200 | 25 | 200 |
| `modules/search.go` `SearchHandler` | 100 | 20 | 100 |
| `providers/search.go` `SearchHandler` | 100 | 20 | 100 |
| `scim/handlers.go` `ListUsers` (`count`) | 200 | 100 | 200 |
| `db/repositories/version_approval_repository.go` `List` | 500 | 100 | 500 |

All nine now call `internal/pagination.ClampPerPage(requested, default, max)`: below 1 (or unparseable, or a value that overflows `int`) takes the default; above the maximum takes the maximum.

### Two instances deliberately left alone

`scm.ClampPagination` and Bitbucket's `clampWindow` have the same *shape* but are not the same *defect*: they normalise a page size for an **upstream** API, and every production construction of `scm.Pagination` in this module is `DefaultPagination()` — so `PageSize` is always 30 and the over-maximum branch is unreachable. No caller can ask for more and be given less. They are recorded in the sweep's inventory with that reason rather than left to be rediscovered.

One further site was examined and is **out of class**: `admin/storage_migration.go` `ListMigrations` accepts a `limit` with **no maximum at all**. That is an unbounded page, not "ask for more, get less", so it is not touched here.

## The signature

`internal/pagination/clamp_sweep_test.go` walks `internal/` for the **pattern**, not a file list: an `if` whose condition contains `X > LIT` and whose body is exactly `X = OTHER` with `OTHER != LIT`. A tenth copy fails at the point it is written.

It refuses to certify an empty result. The two exempt connectors are its positive control — if the sweep stops seeing them, the matcher has broken rather than the tree having got tidy, and a blind axis is indistinguishable from a clean one.

## Can a client now tell a truncated list from a complete one?

Yes, without comparing counts. `PaginationMeta` gains **`has_more`** — false if and only if nothing follows this page — on every axis that emits the shape:

- **counted axes** (`/organizations`, `/users`, `/admin/audit-logs`) derive it from the `total` they already computed;
- **the two search axes** have no counting query on the identity store, so they fetch one row past the page and report whether it was there. That is exact, where "did the page come back full?" is wrong for every list whose length is a multiple of the page size — precisely the case a picker's "load more" gets stuck on.

`total` becomes a pointer and loses `omitempty`, so **`null` ("not counted") is distinguishable from `0` ("none matched")**; previously an uncounted list and an empty one were byte-identical.

```json
{ "pagination": { "page": 1, "per_page": 100, "has_more": true, "total": 137 } }
```

**Not breaking.** No field is removed or retyped from a value a client could already read: `has_more` is new, and `total` was already absent on the axes that now send `null`.

## Verification

Every guard was mutation-verified — broken, observed red, restored:

| Mutation | Guard | Result |
|---|---|---|
| `ClampPerPage` over-max returns the default again | helper unit + all 5 axis suites | RED |
| Each of the 9 call sites loses its own maximum, one at a time | the axis's own test, and it named that axis | RED ×9 |
| `collapsingClamp` blinded to always return false | sweep | RED (blind-matcher branch) |
| A **fresh** copy of the idiom added to a file the sweep had never seen | sweep | RED, naming the new file |
| Allowlist count drifts 1 → 2 | sweep | RED |
| Allowlist gains a stale entry | sweep | RED |
| `HasMore` hard-wired false | helper unit + completeness test | RED |
| Probe row removed (`Probe(n) == n`) | helper unit + completeness test | RED |
| `Trim` serves the probe row instead of reporting it | helper unit + completeness test | RED |
| Uncounted axis reports `total: 0` instead of `null` | completeness test | RED |
| `has_more` dropped from the JSON shape | completeness test | RED |

The first pass of the per-site harness reported all five admin sites GREEN. They were not green, they were **blind**: the axis names contain a `/`, so the `-run` filter nested one level too deep and Go printed "no tests to run" and exited 0. The harness now refuses a vacuous run and requires the failure to name the axis under mutation.

There are **no build tags anywhere in this module**, and every test added here is `sqlmock`-based, so none of this sits behind the Postgres gate in #886 — it runs in the ordinary `go test ./internal/... ./pkg/...` CI step.

Local: `go mod tidy` clean, `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (v2.12.2, 0 issues), full `-race` suite green. Swagger/OpenAPI regenerated with the CI-pinned `swag` v1.16.6.

Closes #893
