### PR TITLE
ci: fail the OSV gate closed when the scanner errors instead of reading it as clean

### DIFF
--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -124,7 +124,7 @@ jobs:
         id: osv_triage_weekly
         if: steps.osv.outcome == 'failure' && github.event_name == 'schedule'
         continue-on-error: true
-        run: python3 backend/scripts/osv_triage.py osv-results.json --issue-body osv-report.md
+        run: python3 backend/scripts/osv_triage.py osv-results.json --scanner-failed --issue-body osv-report.md
 
       - name: Create issue on new vulnerabilities
         # Only when something is actually actionable — osv_triage.py exits
@@ -167,7 +167,7 @@ jobs:
         # surfaced as warnings + job summary instead (and the govulncheck job
         # covers whether they're actually reachable).
         if: steps.osv.outcome == 'failure' && github.event_name != 'schedule'
-        run: python3 backend/scripts/osv_triage.py osv-results.json
+        run: python3 backend/scripts/osv_triage.py osv-results.json --scanner-failed
 
   # ── govulncheck (reachability-aware scan) ─────────────
   # OSV-Scanner flags every known-vulnerable version in go.sum regardless of whether

--- a/backend/scripts/osv_triage.py
+++ b/backend/scripts/osv_triage.py
@@ -111,8 +111,26 @@ def render(fixable: list[dict], unfixable: list[dict]) -> str:
 
 
 def main() -> int:
+    # The report uses non-ASCII (— ❌ ⚠️). CI runners are UTF-8, but a redirected
+    # stdout on a cp1252 console is not, and the crash exits 1 — which looks
+    # exactly like "fixable findings" and silently changes the gate's answer.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
     args = sys.argv[1:]
     issue_body_path = None
+    # OSV-Scanner's documented exit codes: 0 = packages scanned, nothing found;
+    # 1 = packages scanned, findings; 127 = general error; 128 = no packages
+    # found. The GitHub action surfaces none of that -- continue-on-error
+    # collapses every non-zero into outcome == 'failure' -- so a scan that never
+    # reached the OSV API still writes a syntactically valid `{"results": []}`
+    # and would read here as a clean result. Callers that only run this script
+    # because the scanner reported failure pass --scanner-failed, which makes
+    # "failed but found nothing" the contradiction it actually is.
+    scanner_failed = "--scanner-failed" in args
+    if scanner_failed:
+        args.remove("--scanner-failed")
     if "--issue-body" in args:
         i = args.index("--issue-body")
         if i + 1 >= len(args):
@@ -122,7 +140,8 @@ def main() -> int:
         del args[i : i + 2]
     if len(args) != 1:
         print(
-            "usage: osv_triage.py <osv-results.json> [--issue-body <path>]",
+            "usage: osv_triage.py <osv-results.json> [--issue-body <path>] "
+            "[--scanner-failed]",
             file=sys.stderr,
         )
         return 2
@@ -159,6 +178,13 @@ def main() -> int:
         return _bail(f"OSV results file is not valid JSON: {exc}")
 
     fixable, unfixable = triage(data)
+
+    if scanner_failed and not fixable and not unfixable:
+        return _bail(
+            "OSV-Scanner reported failure but the results contain no findings — "
+            "exit 1 always carries at least one, so this was a scanner error "
+            "(127/128), not a clean scan"
+        )
 
     for entry in unfixable:
         print(f"::warning::{_describe(entry)}")


### PR DESCRIPTION
## The gap

The weekly OSV gate passes when the scan never happens.

`osv-scanner` distinguishes its outcomes purely by exit code:

| exit | meaning |
|---|---|
| `0` | packages scanned, nothing found |
| `1` | packages scanned, **findings** |
| `127` | general error |
| `128` | no packages found |
| `129-255` | non-result errors |

`google/osv-scanner-action` is a plain docker action and **exposes no outputs**, so the only thing the
workflow can see is `continue-on-error` collapsing every non-zero into `outcome == 'failure'`. A run that
errors out still writes a syntactically valid results file with an empty `results` array — and the triage
step reads that as a clean scan, prints "No vulnerabilities reported", and exits `0`.

Net effect: **`127` and `0` are indistinguishable to the gate.**

## Reproduced, not theorised

A local scan blocked from `api.osv.dev` by TLS interception exited `127` and produced exactly this:

```json
{ "results": [], "experimental_config": { "licenses": { "summary": false, "allowlist": null } } }
```

Fed to the triage script, that returned `No vulnerabilities reported` and exit `0`. Green gate, no scan.

## The fix

No heuristic, no output parsing — it uses the contract that already exists:

- the triage steps only run **because** the scanner reported failure, and
- exit `1` (the only failing outcome that is a real result) **always carries at least one finding**.

So "reported failure but the results contain no findings" is a contradiction that can only mean `127`/`128`.
`--scanner-failed` makes it one. Without the flag the behaviour is unchanged, so an empty file on the
success path still reads as clean, which is correct.

## Second bug, found by the test

The report prints non-ASCII (`—`, `❌`, `⚠️`). On a non-UTF-8 stdout that raises `UnicodeEncodeError`,
which exits `1` — **indistinguishable from "fixable findings"**, so it silently changes the gate's answer.

It surfaced while testing the change above, and the way it surfaced is the point:

- the **unfixable-finding** case failed outright (`got 1 want 0` — would have gated on an unactionable finding)
- the **fixable-finding** case *passed for the wrong reason* — the crash's exit `1` happened to match the expected `1`

Same class of bug as the one fixed in `govulncheck_triage.py`, same one-line guard. CI runners are UTF-8 so
this was latent here, but it makes the script's answer environment-dependent, which is not a property a gate
should have.

## Verification

Eight cases against fixtures, including a byte-for-byte copy of the `127` output above:

| case | expected | result |
|---|---|---|
| broken scan + scanner reported failure | `1` | PASS |
| empty results, scanner did *not* report failure | `0` | PASS |
| fixable finding + scanner failure | `1` | PASS |
| unfixable finding + scanner failure | `0` | PASS |
| fixable finding, no flag | `1` | PASS |
| unfixable finding, no flag | `0` | PASS |
| missing file | `1` | PASS |
| invalid JSON | `1` | PASS |

The two triage scripts are byte-identical across both backends; this lands in both.

## Follow-up, not in scope here

`--output` is deprecated in osv-scanner v2.5.0 in favour of `--output-file`. Left alone deliberately to keep
the two repos identical — worth one PR touching both together.
