### PR TITLE
ci: allow the deps and security PR title types the release config expects

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,29 @@ jobs:
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in step with .release-please-config.json's changelog-sections:
+          # a type missing here can never be used, and a type missing there
+          # merges without cutting a release.
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            deps
+            security
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: >-
+            The PR title must have a non-empty description after the type
+            (e.g. "feat: add login page", not "feat:").
 
   dependency-review:
     name: Dependency review


### PR DESCRIPTION
## The drift

`.release-please-config.json` here declares changelog sections for **`deps`** and **`security`**:

```json
{ "type": "deps",     "section": "Dependencies" },
{ "type": "security", "section": "Security" }
```

But the PR title check passes **no `types:` input at all**, so it silently falls back to
`amannn/action-semantic-pull-request`'s defaults:

```
feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
```

Neither `deps` nor `security` is in that set. Two of the eight sections this repo configures name
types its own gate rejects.

## It has been costing something

`### Dependencies` has **never once** appeared in this repo's CHANGELOG — 0 occurrences, against 25–29
`### Features` as a control.

`### Security` *has* appeared. Those entries got there by hand, retyping the squash-commit subject at
merge time. release-please reads the **commit**, not the PR title:

| PR | title (what the gate saw) | commit that landed |
|---|---|---|
| #904 | `ci: triage govulncheck findings…` | `security: triage govulncheck findings…` |
| #724 | `fix(security): tenant-scope provider/audit…` | `security: tenant-scope provider/audit…` |
| #722 | `fix(security): per-org authorization…` | `security: enforce per-org authorization…` |
| #701 | `fix(security): fail-closed per-org API key…` | `security: fail-closed per-org API key…` |
| #487 | `fix(server): redact webhook secrets…` | `security: redact webhook secrets…` |

That workaround works right up until someone forgets — and then a security or dependency change
merges under a type release-please treats as not user facing, and is skipped with no release and no
changelog entry. That is not hypothetical either: it just happened in `terraform-suite-identity`,
where the lib/pq→pgx migration merged as `build:` and release-please logged
`No user facing commits found since 4139ec45 - skipping`.

## Scope

An estate audit of all 22 non-archived repos found this in **exactly three**: this one,
`terraform-state-manager-backend` and `terraform-suite-identity`. The other thirteen that run this
check — including **both frontends** — already pass the list explicitly. The sibling pairing is the
tell: `terraform-registry-frontend` is configured correctly and its backend is not.

The list added here is copied from those frontends, so the three repos now match the estate. Every
type the release config names is reachable; `build`/`chore`/`ci`/`test`/`style` remain allowed but
non-releasing, which is correct — they aren't user facing.

The comment on the block records the coupling, since the failure mode is that the two files drift
apart silently.

## Two related findings, deliberately not fixed here

- `4cloudguru/cloud-suite-ui` has a release-please config with `deps`/`security` sections but **no PR
  title check at all** — its `pr-checks.yml` only runs the breaking-change-footer job.
- `terraform-provider-registry` is also on the action defaults, but has no release-please config yet,
  so nothing is broken today. It would inherit this the moment one is added.

Both are separate calls — say the word and I'll raise them.
