### PR TITLE
fix(rbac)!: carry scanning:read on devops and auditor, and derive the guard from the migrations

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -540,10 +540,25 @@ func serve(cfg *config.Config) error {
 		// REGISTRY NO LONGER READS THIS TABLE (terraform-suite-identity#206,
 		// phase 3b): authorization comes from registry's own
 		// `registry_role_templates`, seeded in internal/api/router.go after the
-		// reconcile. This call stays because the STATE MANAGER still reads the
-		// shared table, and because it is the surface a rollback to the previous
-		// image reads -- both of which need it current. It is the one call
-		// suite.role_seed_owner still gates.
+		// reconcile. This call stays because what it writes still reaches other
+		// readers, and both of them need it current:
+		//
+		//   * THE STATE MANAGER. It has since done its own phase 3b, so it no
+		//     longer authorizes from this table directly -- but its boot adopts
+		//     from it every role name its own list does not define, and `devops`
+		//     and `auditor` are two such names. Whatever this seed leaves here is
+		//     what those templates mean over there. Its rollback lever
+		//     (TSM_AUTHZ_ROLE_SOURCE=identity) puts every one of its
+		//     authorization decisions back on this table outright.
+		//   * A ROLLBACK OF THIS APPLICATION. The previous image reads it.
+		//
+		// It is the one call suite.role_seed_owner still gates.
+		//
+		// It writes models.PredefinedRoleTemplates(), the same list router.go
+		// seeds registry's own table with, and that is load-bearing rather than
+		// incidental: two lists would mean two policies, one per table, and a
+		// correction to either would silently leave the other stating the old one
+		// (issue #891).
 		if cfg.Suite.ShouldSeedRoles("registry") {
 			if err := repositories.SeedSharedIdentityRoleTemplates(
 				context.Background(), identityDB, models.PredefinedRoleTemplates(),

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -280,18 +280,18 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// was ever for. It exists because the shared identity module seeds role
 	// templates with identity-core scopes only, so registry layers its own
 	// domain scopes on top. In the DEFAULT topology the templates are seeded by
-	// registry's own migrations and have been amended by them since -- migration
-	// 000018 added `scanning:read` to `devops` and `auditor`, which
-	// models.PredefinedRoleTemplates() does not carry -- so running the seed
-	// there would strip that scope from both roles on every boot. The migrations
-	// are the more current statement of registry's policy in that topology, and
-	// the reconcile above has already copied them.
+	// registry's own migrations and have been amended by them since, and the
+	// reconcile above has already copied that result into this table.
 	//
-	// (That mismatch is a PRE-EXISTING defect in the cutover topology, where
-	// this list has always been what gets seeded. It is not made better or worse
-	// here, and it is not this change's to fix: correcting the list changes what
-	// two role templates confer, which a read cutover gated on equivalence must
-	// not do quietly.)
+	// THE GO LIST AND THE MIGRATIONS MUST AGREE, and until issue #891 they did
+	// not: migration 000018 granted `scanning:read` to `devops` and `auditor`,
+	// models.PredefinedRoleTemplates() never carried it, and because the upsert
+	// below sets `scopes = EXCLUDED.scopes` this seed REMOVED the scope from
+	// both roles on every boot of a cutover deployment. The list now carries it,
+	// and internal/db/rolepolicy derives the policy back out of the migration
+	// files so a test can require the two to keep agreeing -- in both
+	// directions, since the drift that adds a scope no migration granted widens
+	// authority instead of narrowing it and does not fail safe.
 	//
 	// identityDB != db is the cutover test. NewRouter is handed the same handle
 	// twice when identity data lives in the app's own schema, and a distinct one

--- a/backend/internal/db/models/role_template.go
+++ b/backend/internal/db/models/role_template.go
@@ -10,6 +10,38 @@ import identitymodels "github.com/sethbacon/terraform-suite-identity/identity/mo
 type RoleTemplate = identitymodels.RoleTemplate
 
 // PredefinedRoleTemplates returns the registry's default role templates.
+//
+// THIS LIST AND THE MIGRATIONS ARE TWO STATEMENTS OF ONE POLICY, and they must
+// not disagree. Registry says who may do what twice: here, and as SQL in
+// migration 000001's seed plus every migration that has amended it since. Only
+// one of the two is exercised in any given topology -- the migrations own the
+// default one, this list owns the identity-schema cutover -- so a disagreement
+// produces no error anywhere and simply changes what a role confers.
+//
+// BOTH SEEDS UPSERT THIS LIST WITH `scopes = EXCLUDED.scopes`, so whichever way
+// the two drift, this list wins wherever it runs:
+//
+//   - repositories.SeedSystemRoleTemplates writes registry's own
+//     `registry_role_templates`, which is what every authorization decision in
+//     this application reads since terraform-suite-identity#206 phase 3b.
+//   - repositories.SeedSharedIdentityRoleTemplates writes the shared
+//     `role_templates`. Registry no longer reads it; the STATE MANAGER adopts
+//     from it every role name it does not define itself (`devops` and `auditor`
+//     among them), and it is the surface a rollback to the previous image reads.
+//
+// Issue #891 was that drift, in the direction that REMOVES authority: migration
+// 000018 granted `scanning:read` to `devops` and `auditor`, this list never
+// learned it, and every boot in the cutover topology took it back off both
+// templates in both tables. The mirror-image drift -- a scope here that no
+// migration ever granted -- would silently widen a role instead, which does not
+// fail safe.
+//
+// internal/db/rolepolicy is the guard. It replays the role-template DML out of
+// the migration files and a test diffs the result against this function in both
+// directions, so a migration that changes a template's scopes without this list
+// following cannot reach main. Nothing in it is a hand-written list of scopes:
+// it derives them, so it covers the migration that lands tomorrow rather than
+// the one that prompted it.
 func PredefinedRoleTemplates() []RoleTemplate {
 	viewerDesc := "Read-only access to modules, providers, mirrors, organizations, and SCM configurations"
 	publisherDesc := "Can upload and manage modules and providers"
@@ -20,10 +52,10 @@ func PredefinedRoleTemplates() []RoleTemplate {
 	// nothing (the auth middleware strips it) and would be refused by every
 	// membership write.
 	//
-	// This list is not decoration: SeedSystemRoleTemplates upserts it by name on
-	// boot under TFR_IDENTITY_SCHEMA_ENABLED, so leaving `admin` here would put
-	// the scope back on the template the migration just cleaned, on the next
-	// restart, for exactly the deployments the migration could reach least well.
+	// This list is not decoration: both seeds upsert it by name on boot in the
+	// identity-schema cutover, so leaving `admin` here would put the scope back
+	// on the template the migration just cleaned, on the next restart, for
+	// exactly the deployments the migration could reach least well.
 	//
 	// The scopes are the `org_owner` set, matching what migration 000054 writes:
 	// everything the template conferred except the platform-wide reach, so its
@@ -31,6 +63,11 @@ func PredefinedRoleTemplates() []RoleTemplate {
 	adminDesc := "Full management of an organization's modules, providers, mirrors, SCM integrations, " +
 		"and membership. Platform-wide administration is granted through POST /api/v1/admin/platform-admins (issue #766)"
 	userManagerDesc := "Can manage user accounts and memberships"
+	// `devops` and `auditor` carry `scanning:read` because migration 000018
+	// granted it to both -- long before the identity-schema cutover existed -- and
+	// this list did not follow (issue #891). It has to be stated here as well as
+	// there, because in the cutover topology the seed, not the migration, is what
+	// reaches the tables these roles are read from.
 	auditorDesc := "Read-only access with audit log visibility for security and compliance review"
 	orgOwnerDesc := "Full management of a single organization's modules, providers, mirrors, SCM integrations, and membership, without platform-wide admin privileges"
 	orgProvisionerDesc := "Can provision new top-level organizations without platform-wide admin privileges"
@@ -54,7 +91,7 @@ func PredefinedRoleTemplates() []RoleTemplate {
 			Name:        "devops",
 			DisplayName: "DevOps",
 			Description: &devOpsDesc,
-			Scopes:      []string{"modules:read", "modules:write", "providers:read", "providers:write", "mirrors:read", "mirrors:manage", "organizations:read", "scm:read", "scm:manage"},
+			Scopes:      []string{"modules:read", "modules:write", "providers:read", "providers:write", "mirrors:read", "mirrors:manage", "organizations:read", "scm:read", "scm:manage", "scanning:read"},
 			IsSystem:    true,
 		},
 		{
@@ -76,7 +113,7 @@ func PredefinedRoleTemplates() []RoleTemplate {
 			Name:        "auditor",
 			DisplayName: "Auditor",
 			Description: &auditorDesc,
-			Scopes:      []string{"modules:read", "providers:read", "mirrors:read", "organizations:read", "scm:read", "audit:read"},
+			Scopes:      []string{"modules:read", "providers:read", "mirrors:read", "organizations:read", "scm:read", "audit:read", "scanning:read"},
 			IsSystem:    true,
 		},
 		{

--- a/backend/internal/db/repositories/role_template_policy_pg_test.go
+++ b/backend/internal/db/repositories/role_template_policy_pg_test.go
@@ -1,0 +1,226 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/rolepolicy"
+)
+
+// Issue #891, against real PostgreSQL and the real migrations.
+//
+// CI DOES NOT RUN THIS. No workflow sets TFR_TEST_DATABASE_URL (issue #886), so
+// everything below skips on a PR, exactly as the rest of this package's
+// database-backed tests do. It is evidence produced locally against postgres:16
+// and named as such in the pull request. The guard that runs on every PR is
+// internal/db/rolepolicy's, which needs no database.
+//
+// It is here anyway because seeding is DATABASE behaviour. The static model in
+// internal/db/rolepolicy is an interpretation of the migration files, and an
+// interpretation nothing ever checks against the engine is a second opinion, not
+// a fact. The first test below is what makes it a fact.
+
+const policyMigrationsDir = "../migrations"
+
+// scratchAtHead applies every migration, deriving head from the files rather
+// than carrying a number that goes stale the next time one lands.
+func scratchAtHead(t *testing.T) *sql.DB {
+	t.Helper()
+	head, err := rolepolicy.HeadVersion(policyMigrationsDir)
+	if err != nil {
+		t.Fatalf("HeadVersion: %v", err)
+	}
+	db, _ := reconcileScratchDB(t, uint(head))
+	return db
+}
+
+// systemScopesIn reads name -> scopes for the system templates of one table.
+func systemScopesIn(t *testing.T, db *sql.DB, table string) map[string][]string {
+	t.Helper()
+	rows, err := db.Query(`SELECT name, scopes FROM ` + table + ` WHERE is_system = true`)
+	if err != nil {
+		t.Fatalf("read %s: %v", table, err)
+	}
+	defer rows.Close()
+	out := map[string][]string{}
+	for rows.Next() {
+		var name string
+		var raw []byte
+		if scanErr := rows.Scan(&name, &raw); scanErr != nil {
+			t.Fatalf("scan %s: %v", table, scanErr)
+		}
+		var scopes []string
+		if jsonErr := json.Unmarshal(raw, &scopes); jsonErr != nil {
+			t.Fatalf("decode %s.%s scopes %q: %v", table, name, raw, jsonErr)
+		}
+		out[name] = rolepolicy.Normalize(scopes)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s: %v", table, err)
+	}
+	return out
+}
+
+// TestPolicy_TheStaticModelMatchesWhatPostgresActuallyHolds validates the guard
+// that runs in CI against the engine that runs in production.
+//
+// internal/db/rolepolicy evaluates the migrations' role-template DML in Go. If
+// its reading of a statement were wrong -- a predicate it evaluates differently
+// from Postgres, a `||` it de-duplicates where jsonb does not -- the PR-time
+// guard would be comparing the Go list against a policy no database ever holds,
+// and would be equally confident while doing it. This is the only test that can
+// tell those apart, and it is why the model fails closed rather than guessing.
+func TestPolicy_TheStaticModelMatchesWhatPostgresActuallyHolds(t *testing.T) {
+	db := scratchAtHead(t)
+
+	derived, err := rolepolicy.FromMigrations(policyMigrationsDir)
+	if err != nil {
+		t.Fatalf("FromMigrations: %v", err)
+	}
+	model := derived[rolepolicy.RoleTemplatesTable].SystemScopes()
+	actual := systemScopesIn(t, db, "role_templates")
+
+	if len(actual) == 0 {
+		t.Fatal("the migrations seeded no system role templates; the comparison is vacuous")
+	}
+	for _, name := range unionOfKeys(model, actual) {
+		want, inModel := model[name]
+		got, inDB := actual[name]
+		switch {
+		case inModel && !inDB:
+			t.Errorf("rolepolicy derives a system template %q the migrations do not "+
+				"actually leave in the database", name)
+		case inDB && !inModel:
+			t.Errorf("the migrations leave a system template %q that rolepolicy did not "+
+				"derive: the PR-time guard is reasoning about fewer roles than exist "+
+				"(scopes in the database: %v)", name, got)
+		case !reflect.DeepEqual(want, got):
+			t.Errorf("rolepolicy and PostgreSQL disagree about %q.\n  model    : %v\n  database : %v\n"+
+				"The static model is what gates every PR; when it is wrong the gate is wrong "+
+				"in the same direction and just as quietly.", name, want, got)
+		}
+	}
+}
+
+// TestPolicy_TheMigratedDatabaseAgreesWithTheGoList is issue #891 stated as the
+// database property it actually is: the default topology, seeded entirely by the
+// migrations, must hold exactly what the identity-schema cutover's seed would
+// write. Before the fix `devops` and `auditor` differ by `scanning:read`.
+func TestPolicy_TheMigratedDatabaseAgreesWithTheGoList(t *testing.T) {
+	db := scratchAtHead(t)
+
+	actual := systemScopesIn(t, db, "role_templates")
+	fromGo := map[string][]string{}
+	for _, tmpl := range models.PredefinedRoleTemplates() {
+		if tmpl.IsSystem {
+			fromGo[tmpl.Name] = rolepolicy.Normalize(tmpl.Scopes)
+		}
+	}
+	for _, name := range unionOfKeys(actual, fromGo) {
+		if !reflect.DeepEqual(actual[name], fromGo[name]) {
+			t.Errorf("role template %q: migrated database has %v, the seed would write %v",
+				name, actual[name], fromGo[name])
+		}
+	}
+}
+
+// TestPolicy_NeitherSeedRemovesAScopeTheMigrationsGranted is the defect itself,
+// exercised on BOTH write paths in one database, because a fix that covers one
+// leaves the other live -- and the two feed different readers.
+//
+//	SeedSharedIdentityRoleTemplates -> role_templates.          Registry stopped
+//	   reading this table at phase 3b. The STATE MANAGER's boot adopts from it
+//	   every role name it does not define itself, and `devops` and `auditor` are
+//	   two such names, so whatever this seed leaves here is what those two
+//	   templates mean in the sibling application. It is also what a rollback to
+//	   the previous registry image authorizes from.
+//
+//	SeedSystemRoleTemplates -> registry_role_templates.         Every
+//	   authorization decision this application makes reads that table.
+//
+// Both are run in the order internal/api/router.go and cmd/server/main.go run
+// them, including the reconcile between, since the reconcile re-derives
+// registry's table from the shared one and a seed that ran before it would be
+// undone on the same boot.
+func TestPolicy_NeitherSeedRemovesAScopeTheMigrationsGranted(t *testing.T) {
+	db := scratchAtHead(t)
+	ctx := context.Background()
+
+	granted := systemScopesIn(t, db, "role_templates")
+	if len(granted) == 0 {
+		t.Fatal("no system role templates after migrating; nothing to preserve")
+	}
+
+	// cmd/server/main.go, before NewRouter.
+	if err := SeedSharedIdentityRoleTemplates(ctx, db, models.PredefinedRoleTemplates()); err != nil {
+		t.Fatalf("SeedSharedIdentityRoleTemplates: %v", err)
+	}
+	// internal/api/router.go: reconcile, then seed registry's own table.
+	if _, err := ReconcileMemberRoles(ctx, db, db); err != nil {
+		t.Fatalf("ReconcileMemberRoles: %v", err)
+	}
+	if err := SeedSystemRoleTemplates(ctx, db, models.PredefinedRoleTemplates()); err != nil {
+		t.Fatalf("SeedSystemRoleTemplates: %v", err)
+	}
+
+	for _, tc := range []struct {
+		table  string
+		reader string
+	}{
+		{"role_templates", "the state manager's adopt pass, and a rollback to the previous image"},
+		{"registry_role_templates", "every authorization decision this application makes"},
+	} {
+		after := systemScopesIn(t, db, tc.table)
+		for name, want := range granted {
+			got, ok := after[name]
+			if !ok {
+				t.Errorf("%s: template %q is gone after the boot sequence (%s reads this table)",
+					tc.table, name, tc.reader)
+				continue
+			}
+			for _, scope := range want {
+				if !containsScope(got, scope) {
+					t.Errorf("%s: the boot sequence REMOVED %q from %q, which migration "+
+						"policy grants it. %s reads this table.\n  granted : %v\n  after   : %v",
+						tc.table, scope, name, tc.reader, want, got)
+				}
+			}
+			for _, scope := range got {
+				if !containsScope(want, scope) {
+					t.Errorf("%s: the boot sequence GRANTED %q to %q, which no migration "+
+						"grants it. %s reads this table.\n  granted : %v\n  after   : %v",
+						tc.table, scope, name, tc.reader, want, got)
+				}
+			}
+		}
+	}
+}
+
+func containsScope(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func unionOfKeys(maps ...map[string][]string) []string {
+	seen := map[string]struct{}{}
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/internal/db/repositories/role_template_seed_call_sites_test.go
+++ b/backend/internal/db/repositories/role_template_seed_call_sites_test.go
@@ -1,0 +1,169 @@
+package repositories
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// backendRoot is this package's distance to the module root.
+const backendRoot = "../../.."
+
+// seedFunctions are the two writes of the registry's role -> scope policy, and
+// the reason issue #891 needed a guard rather than an edit.
+//
+// They target DIFFERENT TABLES and are called from DIFFERENT FILES:
+//
+//	SeedSystemRoleTemplates         -> registry_role_templates  (internal/api/router.go)
+//	SeedSharedIdentityRoleTemplates -> role_templates           (cmd/server/main.go)
+//
+// The first is what this application authorizes against. The second is what the
+// STATE MANAGER adopts every role name it does not define itself from, and what
+// a rollback to the previous image reads. A policy correction applied to one of
+// them leaves the other stating the old policy, on a table another application
+// reads -- which is a fix that looks complete and is not.
+var seedFunctions = map[string]string{
+	"SeedSystemRoleTemplates":         "registry_role_templates",
+	"SeedSharedIdentityRoleTemplates": "role_templates",
+}
+
+// policyFunc is the single source both seeds must be handed.
+const policyFunc = "PredefinedRoleTemplates"
+
+// TestEverySeedCallSiteUsesTheOnePolicyList walks the whole backend and requires
+// that every call to either seed passes models.PredefinedRoleTemplates() as its
+// templates argument.
+//
+// WHAT IT ACTUALLY PREVENTS. #891's fix is one edit to one Go list precisely
+// BECAUSE both paths read that list. Nothing enforced that. A future change that
+// hands one seed a filtered slice, a topology-specific list, or a second
+// definition of "the system roles" would re-open the defect on one table only --
+// and it would present, exactly as #891 did, as an application whose pages are
+// empty for a role that ought to be able to see them, with no error anywhere.
+//
+// It also fails on an EMPTY universe. A source-walking guard that finds no call
+// sites passes silently, which is the failure mode that makes such a guard worse
+// than none: it certifies whatever it could not see.
+func TestEverySeedCallSiteUsesTheOnePolicyList(t *testing.T) {
+	root, err := filepath.Abs(backendRoot)
+	if err != nil {
+		t.Fatalf("resolve the backend root: %v", err)
+	}
+
+	type site struct {
+		file string
+		fn   string
+		ok   bool
+		arg  string
+	}
+	var sites []site
+
+	fset := token.NewFileSet()
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "testdata", ".git", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Production call sites only: a test may legitimately drive the seeds
+		// with a hand-built slice, which is what makes them testable.
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return nil // not this guard's business
+		}
+		rel, _ := filepath.Rel(root, path)
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, isCall := n.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			name := calleeName(call.Fun)
+			if _, watched := seedFunctions[name]; !watched {
+				return true
+			}
+			s := site{file: rel, fn: name}
+			if len(call.Args) >= 3 {
+				s.arg = exprString(call.Args[2])
+				s.ok = calleeName(underlyingCall(call.Args[2])) == policyFunc
+			}
+			sites = append(sites, s)
+			return true
+		})
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walking %s: %v", root, walkErr)
+	}
+
+	seen := map[string]bool{}
+	for _, s := range sites {
+		seen[s.fn] = true
+		if !s.ok {
+			t.Errorf("%s calls %s with %q, not models.%s(). The registry's role -> scope "+
+				"policy is one list, written to %s by this path and to the other table by "+
+				"the other; a second definition re-opens issue #891 on whichever table it "+
+				"reaches.", s.file, s.fn, s.arg, policyFunc, seedFunctions[s.fn])
+		}
+	}
+	for _, fn := range sortedSeedNames(seedFunctions) {
+		if !seen[fn] {
+			t.Errorf("found no production call site for %s, which writes %s. Either the "+
+				"seed was removed and this guard should go with it, or the walk is not "+
+				"seeing the tree -- and a guard that sees nothing passes everything.",
+				fn, seedFunctions[fn])
+		}
+	}
+}
+
+// calleeName is the identifier a call resolves to, through a package selector.
+func calleeName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	}
+	return ""
+}
+
+// underlyingCall unwraps `models.PredefinedRoleTemplates()` to its Fun.
+func underlyingCall(e ast.Expr) ast.Expr {
+	if c, ok := e.(*ast.CallExpr); ok {
+		return c.Fun
+	}
+	return e
+}
+
+func exprString(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.CallExpr:
+		return exprString(v.Fun) + "()"
+	case *ast.SelectorExpr:
+		return exprString(v.X) + "." + v.Sel.Name
+	case *ast.Ident:
+		return v.Name
+	}
+	return "<expression>"
+}
+
+func sortedSeedNames(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/internal/db/rolepolicy/deriver_forms_test.go
+++ b/backend/internal/db/rolepolicy/deriver_forms_test.go
@@ -1,0 +1,203 @@
+package rolepolicy
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The constructs below are not all used by a migration in this tree today. They
+// are covered anyway, because the deriver's job is to be right about the
+// migration that has not been written yet -- and an unexercised branch in a
+// guard is a blind spot in the guard, not spare capacity.
+func TestDeriverHandlesEachStatementForm(t *testing.T) {
+	base := `INSERT INTO role_templates (name, display_name, scopes, is_system) VALUES
+		('viewer',    'Viewer',    '["modules:read"]'::jsonb, true),
+		('devops',    'DevOps',    '["modules:read", "scm:manage"]'::jsonb, true),
+		('auditor',   'Auditor',   '["audit:read"]'::jsonb, true),
+		('scratch',   'Scratch',   '["modules:read"]'::jsonb, false);`
+
+	for _, tc := range []struct {
+		name string
+		sql  string
+		want map[string][]string // nil entry means "template must be gone"
+	}{
+		{
+			name: "DELETE with a name predicate",
+			sql:  `DELETE FROM role_templates WHERE name = 'scratch';`,
+			want: map[string][]string{"scratch": nil},
+		},
+		{
+			name: "DELETE selecting on is_system",
+			sql:  `DELETE FROM public.role_templates WHERE is_system = false;`,
+			want: map[string][]string{"scratch": nil, "viewer": {"modules:read"}},
+		},
+		{
+			name: "TRUNCATE empties the table",
+			sql:  `TRUNCATE TABLE role_templates;`,
+			want: map[string][]string{"viewer": nil, "devops": nil, "auditor": nil, "scratch": nil},
+		},
+		{
+			name: "name IN (...)",
+			sql: `UPDATE role_templates SET scopes = scopes || '["scanning:read"]'::jsonb
+			      WHERE name IN ('devops', 'auditor');`,
+			want: map[string][]string{
+				"devops":  {"modules:read", "scanning:read", "scm:manage"},
+				"auditor": {"audit:read", "scanning:read"},
+				"viewer":  {"modules:read"},
+			},
+		},
+		{
+			name: "name <> excludes exactly one row",
+			sql: `UPDATE role_templates SET scopes = '["only:this"]'::jsonb
+			      WHERE name <> 'viewer' AND is_system = true;`,
+			want: map[string][]string{
+				"viewer":  {"modules:read"},
+				"devops":  {"only:this"},
+				"auditor": {"only:this"},
+				"scratch": {"modules:read"},
+			},
+		},
+		{
+			name: "is_system IS true",
+			sql: `UPDATE role_templates SET scopes = scopes || '["everywhere:read"]'::jsonb
+			      WHERE is_system IS true;`,
+			want: map[string][]string{
+				"viewer":  {"everywhere:read", "modules:read"},
+				"scratch": {"modules:read"},
+			},
+		},
+		{
+			name: "the literal is on the left of ||",
+			sql: `UPDATE role_templates SET scopes = '["first:read"]'::jsonb || scopes
+			      WHERE name = 'viewer';`,
+			want: map[string][]string{"viewer": {"first:read", "modules:read"}},
+		},
+		{
+			name: "subtracting a text ARRAY removes several",
+			sql: `UPDATE role_templates SET scopes = scopes - ARRAY['modules:read', 'scm:manage']
+			      WHERE name = 'devops';`,
+			want: map[string][]string{"devops": {}},
+		},
+		{
+			name: "subtracting one text literal removes one",
+			sql:  `UPDATE role_templates SET scopes = scopes - 'scm:manage' WHERE name = 'devops';`,
+			want: map[string][]string{"devops": {"modules:read"}},
+		},
+		{
+			name: "no WHERE clause means every row",
+			sql:  `UPDATE role_templates SET scopes = '["flat"]'::jsonb;`,
+			want: map[string][]string{
+				"viewer": {"flat"}, "devops": {"flat"}, "auditor": {"flat"}, "scratch": {"flat"},
+			},
+		},
+		{
+			name: "an UPDATE that never touches scopes needs no model",
+			sql: `UPDATE role_templates SET display_name = initcap(display_name)
+			      WHERE id IN (SELECT role_template_id FROM organization_members);`,
+			want: map[string][]string{"viewer": {"modules:read"}},
+		},
+		{
+			name: "reads of the table are not writes",
+			sql: `INSERT INTO some_report (n) SELECT count(*) FROM role_templates rt
+			      JOIN organization_members om ON om.role_template_id = rt.id
+			      WHERE rt.scopes @> '["admin"]'::jsonb;`,
+			want: map[string][]string{"viewer": {"modules:read"}},
+		},
+		{
+			name: "INSERT ... ON CONFLICT DO NOTHING keeps the existing row",
+			sql: `INSERT INTO role_templates (name, display_name, scopes, is_system)
+			      VALUES ('viewer', 'Viewer', '["clobbered"]'::jsonb, true)
+			      ON CONFLICT (name) DO NOTHING;`,
+			want: map[string][]string{"viewer": {"modules:read"}},
+		},
+		{
+			name: "a block comment and a dollar-quoted tag do not confuse the scanner",
+			sql: `/* a /* nested */ comment mentioning role_templates and scopes */
+			      DO $tag$
+			      BEGIN
+			        UPDATE role_templates SET scopes = '["from:tag"]'::jsonb WHERE name = 'viewer';
+			      END
+			      $tag$;`,
+			want: map[string][]string{"viewer": {"from:tag"}},
+		},
+		{
+			name: "a semicolon inside a string literal does not end the statement",
+			sql: `UPDATE role_templates SET description = 'one; two', scopes = '["kept"]'::jsonb
+			      WHERE name = 'viewer';`,
+			want: map[string][]string{"viewer": {"kept"}},
+		},
+		{
+			name: "identity's copy is deliberately not modelled",
+			sql:  `UPDATE identity.role_templates SET scopes = ARRAY['ignored'] WHERE name = 'viewer';`,
+			want: map[string][]string{"viewer": {"modules:read"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			write(t, dir, "000001_base.up.sql", base)
+			write(t, dir, "000002_case.up.sql", tc.sql)
+
+			policies, err := FromMigrations(dir)
+			if err != nil {
+				t.Fatalf("FromMigrations: %v", err)
+			}
+			got := policies[RoleTemplatesTable]
+			for name, wantScopes := range tc.want {
+				tmpl, present := got[name]
+				if wantScopes == nil {
+					if present {
+						t.Errorf("template %q survived, scopes %v", name, tmpl.Scopes)
+					}
+					continue
+				}
+				if !present {
+					t.Errorf("template %q is missing", name)
+					continue
+				}
+				if len(tmpl.Scopes) == 0 && len(wantScopes) == 0 {
+					continue
+				}
+				if !reflect.DeepEqual(tmpl.Scopes, wantScopes) {
+					t.Errorf("template %q scopes = %v, want %v", name, tmpl.Scopes, wantScopes)
+				}
+			}
+		})
+	}
+}
+
+// TestUnmodelledErrorNamesTheFileAndTheStatement: the message is the whole
+// remedy. A guard that fails without saying which migration it choked on gets
+// worked around rather than taught.
+func TestUnmodelledErrorNamesTheFileAndTheStatement(t *testing.T) {
+	e := &UnmodelledError{
+		File:   "000099_probe.up.sql",
+		Reason: "SET scopes = mystery(scopes)",
+		Stmt:   "UPDATE role_templates SET scopes = mystery(scopes)",
+	}
+	msg := e.Error()
+	for _, want := range []string{"000099_probe.up.sql", "mystery(scopes)", "rolepolicy"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the message does not mention %q:\n%s", want, msg)
+		}
+	}
+	long := &UnmodelledError{File: "f", Reason: "r", Stmt: strings.Repeat("x ", 900)}
+	if len(long.Error()) > 1500 {
+		t.Errorf("an oversized statement is not truncated; message is %d bytes", len(long.Error()))
+	}
+}
+
+// TestFromMigrationsRefusesAnEmptyDirectory: a deriver pointed at nothing
+// reports a policy of nothing, which agrees with every Go list there is.
+func TestFromMigrationsRefusesAnEmptyDirectory(t *testing.T) {
+	if _, err := FromMigrations(t.TempDir()); err == nil {
+		t.Fatal("FromMigrations accepted a directory with no migrations")
+	}
+	if _, err := FromMigrations(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Fatal("FromMigrations accepted a directory that does not exist")
+	}
+	if _, err := HeadVersion(t.TempDir()); err == nil {
+		t.Fatal("HeadVersion accepted a directory with no migrations")
+	}
+}

--- a/backend/internal/db/rolepolicy/rolepolicy.go
+++ b/backend/internal/db/rolepolicy/rolepolicy.go
@@ -1,0 +1,770 @@
+// Package rolepolicy derives, from the registry's own migration files, the
+// role -> scope policy those migrations leave behind in `role_templates`.
+//
+// # Why this exists
+//
+// The registry states one policy TWICE. Once in SQL, as the seed in migration
+// 000001 and every migration that has amended it since; once in Go, as
+// models.PredefinedRoleTemplates(). Only ONE of the two is exercised in any
+// given topology -- the migrations in the default one, the Go list in the
+// identity-schema cutover -- so the pair can disagree for a long time without
+// anything failing. Issue #891 is exactly that: migration 000018 granted
+// `scanning:read` to `devops` and `auditor`, the Go list was never updated, and
+// because the seed upserts with `scopes = EXCLUDED.scopes` it REMOVED the scope
+// the migration had granted, on every boot, in the topology where it runs.
+//
+// So this package replays the migrations' role-template DML in memory and hands
+// back what they leave. A test then diffs that against the Go list, in BOTH
+// directions -- the drift that removes authority fails safe and the drift that
+// grants it does not, and neither should be able to reach main.
+//
+// # Derived, not typed
+//
+// Nothing here enumerates a scope. The policy comes out of the migration files,
+// so a migration that lands tomorrow is covered the moment it exists, without
+// anybody remembering to extend a list. That is the difference between a guard
+// for THIS defect and a guard for its class.
+//
+// # It fails closed, and that is the important property
+//
+// A statement that writes role-template scopes in a form the model does not
+// understand is an ERROR, never a silent skip. A guard that quietly ignores what
+// it cannot parse reports "clean" for exactly the migrations most likely to be
+// doing something interesting, which is indistinguishable from a guard that is
+// not running at all.
+//
+// The one deliberate exception is `identity.`-qualified statements: that table
+// belongs to the shared identity module, is TEXT[] rather than JSONB there, and
+// registry's migrations only mirror into it what they have already done to its
+// own table. The Go list is compared against the copy registry OWNS.
+//
+// # What it does not model
+//
+// Only `scopes`. `display_name` and `description` drift is cosmetic -- it
+// changes what the role picker reads, not what a principal may do -- and
+// including it would make the guard fire on wording, which is how guards get
+// switched off.
+package rolepolicy
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// The two role-template tables registry's OWN migrations write. `role_templates`
+// is the one 000001 creates and seeds and is what the default topology
+// authorizes against; `registry_role_templates` is registry's per-app copy from
+// 000055, created empty and populated at runtime.
+const (
+	RoleTemplatesTable         = "role_templates"
+	RegistryRoleTemplatesTable = "registry_role_templates"
+)
+
+// Template is one role template as the migrations leave it.
+type Template struct {
+	Name     string
+	Scopes   []string // sorted, de-duplicated
+	IsSystem bool
+}
+
+// Policy is one table's role templates, keyed by name.
+type Policy map[string]Template
+
+// SystemScopes returns name -> scopes for the system templates only, which is
+// the surface models.PredefinedRoleTemplates() states.
+func (p Policy) SystemScopes() map[string][]string {
+	out := make(map[string][]string, len(p))
+	for name, t := range p {
+		if t.IsSystem {
+			out[name] = append([]string(nil), t.Scopes...)
+		}
+	}
+	return out
+}
+
+// UnmodelledError is returned when a migration writes role-template scopes in a
+// form this package cannot evaluate. It is a request to teach the model, and it
+// deliberately blocks rather than degrading to a pass.
+type UnmodelledError struct {
+	File   string
+	Reason string
+	Stmt   string
+}
+
+func (e *UnmodelledError) Error() string {
+	stmt := strings.Join(strings.Fields(e.Stmt), " ")
+	if len(stmt) > 400 {
+		stmt = stmt[:400] + " ..."
+	}
+	return fmt.Sprintf(
+		"%s writes role-template scopes in a form internal/db/rolepolicy cannot evaluate (%s). "+
+			"This is not a pass: the derived policy would be wrong and the guard comparing it to "+
+			"the Go list in models.PredefinedRoleTemplates would be answering about a migration "+
+			"it never read. "+
+			"Either write the statement in a form the model understands (INSERT ... VALUES, or "+
+			"UPDATE ... SET scopes = <jsonb literal | scopes || <literal> | scopes - '<scope>'> "+
+			"WHERE <name/is_system/scopes @> conjunction>), or extend rolepolicy to evaluate it. "+
+			"Statement: %s", e.File, e.Reason, stmt)
+}
+
+// FromMigrations replays every *.up.sql in dir, in version order, and returns
+// what they leave in each tracked role-template table.
+func FromMigrations(dir string) (map[string]Policy, error) {
+	files, err := UpMigrations(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		// An empty universe is a broken guard, not a clean one.
+		return nil, fmt.Errorf("no *.up.sql migrations found under %s", dir)
+	}
+	state := map[string]Policy{
+		RoleTemplatesTable:         {},
+		RegistryRoleTemplatesTable: {},
+	}
+	for _, f := range files {
+		body, readErr := os.ReadFile(f.Path)
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", f.Path, readErr)
+		}
+		if applyErr := applyFile(state, f.Name, string(body)); applyErr != nil {
+			return nil, applyErr
+		}
+	}
+	return state, nil
+}
+
+// Migration is one up-migration file.
+type Migration struct {
+	Version uint64
+	Name    string
+	Path    string
+}
+
+var migrationNameRe = regexp.MustCompile(`^(\d+)_.*\.up\.sql$`)
+
+// UpMigrations lists dir's up-migrations in version order. Exported because the
+// database-backed cross-check needs the head version and must derive it rather
+// than carry a number that goes stale on the next migration.
+func UpMigrations(dir string) ([]Migration, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read migrations directory %s: %w", dir, err)
+	}
+	var out []Migration
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := migrationNameRe.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		v, convErr := strconv.ParseUint(m[1], 10, 64)
+		if convErr != nil {
+			return nil, fmt.Errorf("migration %s has a non-numeric version: %w", e.Name(), convErr)
+		}
+		out = append(out, Migration{Version: v, Name: e.Name(), Path: filepath.Join(dir, e.Name())})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
+	return out, nil
+}
+
+// HeadVersion is the highest migration version in dir.
+func HeadVersion(dir string) (uint64, error) {
+	files, err := UpMigrations(dir)
+	if err != nil {
+		return 0, err
+	}
+	if len(files) == 0 {
+		return 0, fmt.Errorf("no *.up.sql migrations found under %s", dir)
+	}
+	return files[len(files)-1].Version, nil
+}
+
+func applyFile(state map[string]Policy, file, body string) error {
+	for _, stmt := range splitStatements(body) {
+		if err := applyStatement(state, file, stmt, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var doBlockRe = regexp.MustCompile(`(?is)^\s*do\s+(\$[a-z0-9_]*\$)`)
+
+func applyStatement(state map[string]Policy, file, stmt string, consts map[string][]string) error {
+	// A DO block is a statement whose body is more statements. Recurse into it
+	// rather than treating the whole thing as opaque -- migration 000054 does
+	// its entire role-template edit inside one.
+	if m := doBlockRe.FindStringSubmatch(stmt); m != nil {
+		tag := m[1]
+		start := strings.Index(stmt, tag) + len(tag)
+		end := strings.LastIndex(stmt, tag)
+		if end <= start {
+			return &UnmodelledError{File: file, Reason: "unterminated DO block", Stmt: stmt}
+		}
+		inner := stmt[start:end]
+		scoped := mergeConstants(consts, declaredJSONConstants(inner))
+		for _, sub := range splitStatements(inner) {
+			if err := applyStatement(state, file, sub, scoped); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if m := insertRe.FindStringSubmatchIndex(stmt); m != nil {
+		schema, table := group(stmt, m, 1), strings.ToLower(group(stmt, m, 2))
+		if skipSchema(schema) {
+			return nil
+		}
+		return applyInsert(state[table], file, stmt, stmt[m[1]:])
+	}
+	if m := updateRe.FindStringSubmatchIndex(stmt); m != nil {
+		schema, table := group(stmt, m, 1), strings.ToLower(group(stmt, m, 2))
+		if skipSchema(schema) {
+			return nil
+		}
+		return applyUpdate(state[table], file, stmt, stmt[m[1]:], consts)
+	}
+	if m := deleteRe.FindStringSubmatchIndex(stmt); m != nil {
+		schema, table := group(stmt, m, 1), strings.ToLower(group(stmt, m, 2))
+		if skipSchema(schema) {
+			return nil
+		}
+		return applyDelete(state[table], file, stmt, stmt[m[1]:])
+	}
+	if m := truncateRe.FindStringSubmatchIndex(stmt); m != nil {
+		schema, table := group(stmt, m, 1), strings.ToLower(group(stmt, m, 2))
+		if skipSchema(schema) {
+			return nil
+		}
+		for name := range state[table] {
+			delete(state[table], name)
+		}
+		return nil
+	}
+	// An ALTER that rewrites the column (ALTER COLUMN scopes TYPE ... USING ...)
+	// changes every row's scopes without being DML. Refuse rather than miss it.
+	if alterScopesRe.MatchString(stmt) {
+		return &UnmodelledError{File: file, Reason: "ALTER TABLE mentioning `scopes`", Stmt: stmt}
+	}
+	return nil
+}
+
+// group returns capture n of a FindStringSubmatchIndex result, or "" when the
+// group did not participate -- an optional schema qualifier reports (-1, -1),
+// and slicing on that panics.
+func group(s string, m []int, n int) string {
+	if 2*n+1 >= len(m) || m[2*n] < 0 {
+		return ""
+	}
+	return s[m[2*n]:m[2*n+1]]
+}
+
+// skipSchema reports whether a qualified statement targets a table this package
+// deliberately does not model. `identity.` is the shared identity module's, and
+// registry's migrations only mirror there what they have already done here.
+func skipSchema(schema string) bool {
+	switch strings.ToLower(schema) {
+	case "", "public":
+		return false
+	default:
+		return true
+	}
+}
+
+const tableAlt = `(role_templates|registry_role_templates)`
+
+var (
+	insertRe   = regexp.MustCompile(`(?is)\binsert\s+into\s+(?:([a-z_][a-z0-9_]*)\s*\.\s*)?` + tableAlt + `\b`)
+	updateRe   = regexp.MustCompile(`(?is)\bupdate\s+(?:only\s+)?(?:([a-z_][a-z0-9_]*)\s*\.\s*)?` + tableAlt + `\b`)
+	deleteRe   = regexp.MustCompile(`(?is)\bdelete\s+from\s+(?:only\s+)?(?:([a-z_][a-z0-9_]*)\s*\.\s*)?` + tableAlt + `\b`)
+	truncateRe = regexp.MustCompile(`(?is)\btruncate\s+(?:table\s+)?(?:([a-z_][a-z0-9_]*)\s*\.\s*)?` + tableAlt + `\b`)
+
+	alterScopesRe = regexp.MustCompile(`(?is)\balter\s+table\s+(?:only\s+)?(?:[a-z_][a-z0-9_]*\s*\.\s*)?` +
+		tableAlt + `\b[^;]*\bscopes\b`)
+)
+
+// ---------------------------------------------------------------------------
+// INSERT
+// ---------------------------------------------------------------------------
+
+func applyInsert(p Policy, file, stmt, rest string) error {
+	cols, after, ok := parenGroup(rest)
+	if !ok {
+		return &UnmodelledError{File: file, Reason: "INSERT without an explicit column list", Stmt: stmt}
+	}
+	colNames := make([]string, 0, 8)
+	for _, c := range splitTopLevel(cols, ',') {
+		colNames = append(colNames, strings.ToLower(strings.TrimSpace(c)))
+	}
+
+	after = strings.TrimSpace(after)
+	if !hasLeadingKeyword(after, "values") {
+		return &UnmodelledError{File: file, Reason: "INSERT ... SELECT, or a VALUES clause this model cannot find", Stmt: stmt}
+	}
+	after = strings.TrimSpace(after[len("values"):])
+
+	// ON CONFLICT changes what the statement means; only DO NOTHING is modelled,
+	// because that is the only arm whose effect does not need an EXCLUDED row.
+	tail := ""
+	if idx := indexTopLevelKeyword(after, "on conflict"); idx >= 0 {
+		tail = after[idx:]
+		after = after[:idx]
+	}
+	if tail != "" && indexTopLevelKeyword(strings.ToLower(tail), "do nothing") < 0 {
+		return &UnmodelledError{File: file, Reason: "ON CONFLICT DO UPDATE", Stmt: stmt}
+	}
+	if idx := indexTopLevelKeyword(after, "returning"); idx >= 0 {
+		after = after[:idx]
+	}
+
+	for len(strings.TrimSpace(after)) > 0 {
+		tuple, next, tOK := parenGroup(after)
+		if !tOK {
+			return &UnmodelledError{File: file, Reason: "malformed VALUES tuple", Stmt: stmt}
+		}
+		vals := splitTopLevel(tuple, ',')
+		if len(vals) != len(colNames) {
+			return &UnmodelledError{File: file, Reason: "VALUES tuple does not match the column list", Stmt: stmt}
+		}
+		t := Template{}
+		for i, col := range colNames {
+			raw := strings.TrimSpace(vals[i])
+			switch col {
+			case "name":
+				s, sOK := stringLiteral(raw)
+				if !sOK {
+					return &UnmodelledError{File: file, Reason: "non-literal `name`", Stmt: stmt}
+				}
+				t.Name = s
+			case "scopes":
+				scopes, sOK := jsonArrayLiteral(raw)
+				if !sOK {
+					return &UnmodelledError{File: file, Reason: "non-literal `scopes`", Stmt: stmt}
+				}
+				t.Scopes = scopes
+			case "is_system":
+				b, bOK := boolLiteral(raw)
+				if !bOK {
+					return &UnmodelledError{File: file, Reason: "non-literal `is_system`", Stmt: stmt}
+				}
+				t.IsSystem = b
+			}
+		}
+		if t.Name == "" {
+			return &UnmodelledError{File: file, Reason: "INSERT does not set `name`", Stmt: stmt}
+		}
+		if _, exists := p[t.Name]; !exists || tail == "" {
+			t.Scopes = normalize(t.Scopes)
+			p[t.Name] = t
+		}
+		after = strings.TrimSpace(next)
+		after = strings.TrimPrefix(after, ",")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// UPDATE
+// ---------------------------------------------------------------------------
+
+func applyUpdate(p Policy, file, stmt, rest string, consts map[string][]string) error {
+	setIdx := indexTopLevelKeyword(rest, "set")
+	if setIdx < 0 {
+		return &UnmodelledError{File: file, Reason: "UPDATE with no SET this model can find", Stmt: stmt}
+	}
+	alias := strings.TrimSpace(rest[:setIdx])
+	alias = strings.TrimSpace(strings.TrimPrefix(strings.ToLower(alias), "as"))
+	body := rest[setIdx+len("set"):]
+
+	if fromIdx := indexTopLevelKeyword(body, "from"); fromIdx >= 0 {
+		if whereIdx := indexTopLevelKeyword(body, "where"); whereIdx < 0 || fromIdx < whereIdx {
+			return &UnmodelledError{File: file, Reason: "UPDATE ... FROM", Stmt: stmt}
+		}
+	}
+	assignments := body
+	where := ""
+	if whereIdx := indexTopLevelKeyword(body, "where"); whereIdx >= 0 {
+		assignments = body[:whereIdx]
+		where = body[whereIdx+len("where"):]
+	}
+	if retIdx := indexTopLevelKeyword(where, "returning"); retIdx >= 0 {
+		where = where[:retIdx]
+	}
+
+	var scopeExpr string
+	found := false
+	for _, a := range splitTopLevel(assignments, ',') {
+		eq := indexTopLevelRune(a, '=')
+		if eq < 0 {
+			return &UnmodelledError{File: file, Reason: "SET item that is not `col = expr`", Stmt: stmt}
+		}
+		col := strings.ToLower(strings.TrimSpace(a[:eq]))
+		col = strings.TrimPrefix(col, strings.ToLower(alias)+".")
+		if col == "scopes" {
+			scopeExpr = a[eq+1:]
+			found = true
+		}
+	}
+	// An UPDATE that never assigns `scopes` cannot move the policy, whatever
+	// else it does, so it needs no model at all.
+	if !found {
+		return nil
+	}
+
+	names, ok := evalWhere(p, where)
+	if !ok {
+		return &UnmodelledError{File: file, Reason: "WHERE clause this model cannot evaluate", Stmt: stmt}
+	}
+	// A statement that selects nothing changes nothing, so its right-hand side
+	// never has to be understood. That is what lets migration 000054's second,
+	// jsonb_agg-shaped UPDATE be modelled exactly: by the time it runs, its own
+	// `scopes @> '["admin"]'` predicate matches no template.
+	if len(names) == 0 {
+		return nil
+	}
+	for _, name := range names {
+		t := p[name]
+		next, err := evalScopeExpr(t.Scopes, scopeExpr, consts)
+		if err != nil {
+			return &UnmodelledError{File: file, Reason: "SET scopes = " + strings.Join(strings.Fields(scopeExpr), " "), Stmt: stmt}
+		}
+		t.Scopes = normalize(next)
+		p[name] = t
+	}
+	return nil
+}
+
+func applyDelete(p Policy, file, stmt, rest string) error {
+	where := ""
+	if whereIdx := indexTopLevelKeyword(rest, "where"); whereIdx >= 0 {
+		where = rest[whereIdx+len("where"):]
+	}
+	names, ok := evalWhere(p, where)
+	if !ok {
+		return &UnmodelledError{File: file, Reason: "DELETE with a WHERE clause this model cannot evaluate", Stmt: stmt}
+	}
+	for _, n := range names {
+		delete(p, n)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Expression and predicate evaluation
+// ---------------------------------------------------------------------------
+
+var errUnmodelled = errors.New("unmodelled expression")
+
+var (
+	concatLeftRe   = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\s*\.\s*)?scopes\s*\|\|\s*(.+?)\s*$`)
+	concatRightRe  = regexp.MustCompile(`(?is)^\s*(.+?)\s*\|\|\s*(?:[a-z_][a-z0-9_]*\s*\.\s*)?scopes\s*$`)
+	minusRe        = regexp.MustCompile(`(?is)^\s*(?:[a-z_][a-z0-9_]*\s*\.\s*)?scopes\s*-\s*(.+?)\s*$`)
+	identRe        = regexp.MustCompile(`(?is)^\s*([a-z_][a-z0-9_]*)\s*$`)
+	arrayLiteralRe = regexp.MustCompile(`(?is)^array\s*\[(.*)\]$`)
+	castedJSONBRe  = regexp.MustCompile(`(?is)::\s*jsonb\s*$`)
+)
+
+func evalScopeExpr(cur []string, expr string, consts map[string][]string) ([]string, error) {
+	expr = strings.TrimSpace(expr)
+	if lit, ok := jsonArrayLiteral(expr); ok {
+		return lit, nil
+	}
+	if m := identRe.FindStringSubmatch(expr); m != nil {
+		if v, ok := consts[strings.ToLower(m[1])]; ok {
+			return append([]string(nil), v...), nil
+		}
+		return nil, errUnmodelled
+	}
+	if m := concatLeftRe.FindStringSubmatch(expr); m != nil {
+		add, err := evalScopeOperand(m[1], consts)
+		if err != nil {
+			return nil, err
+		}
+		return append(append([]string(nil), cur...), add...), nil
+	}
+	if m := concatRightRe.FindStringSubmatch(expr); m != nil {
+		add, err := evalScopeOperand(m[1], consts)
+		if err != nil {
+			return nil, err
+		}
+		return append(append([]string(nil), add...), cur...), nil
+	}
+	if m := minusRe.FindStringSubmatch(expr); m != nil {
+		// `jsonb - text` removes one element, `jsonb - text[]` removes several.
+		// There is no `jsonb - jsonb`, so a jsonb-cast operand is NOT a set of
+		// keys to remove and must not be read as one -- reading it that way
+		// silently removed nothing, which is the direction that leaves a scope
+		// in the derived policy that the database does not have.
+		drop, dErr := textOperandList(strings.TrimSpace(m[1]))
+		if dErr != nil {
+			return nil, dErr
+		}
+		out := make([]string, 0, len(cur))
+		for _, s := range cur {
+			if !contains(drop, s) {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	}
+	return nil, errUnmodelled
+}
+
+// textOperandList reads the right-hand side of `scopes - X`: a single text
+// literal, or an ARRAY[...] of them. Anything else is refused.
+func textOperandList(expr string) ([]string, error) {
+	expr = strings.TrimSpace(expr)
+	if m := arrayLiteralRe.FindStringSubmatch(expr); m != nil {
+		var out []string
+		for _, item := range splitTopLevel(m[1], ',') {
+			s, ok := stringLiteral(strings.TrimSpace(item))
+			if !ok {
+				return nil, errUnmodelled
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	}
+	// A jsonb-cast operand is not a key list; refuse rather than misread it.
+	if castedJSONBRe.MatchString(expr) {
+		return nil, errUnmodelled
+	}
+	if s, ok := stringLiteral(expr); ok {
+		return []string{s}, nil
+	}
+	return nil, errUnmodelled
+}
+
+func evalScopeOperand(expr string, consts map[string][]string) ([]string, error) {
+	if lit, ok := jsonArrayLiteral(expr); ok {
+		return lit, nil
+	}
+	if m := identRe.FindStringSubmatch(expr); m != nil {
+		if v, ok := consts[strings.ToLower(m[1])]; ok {
+			return append([]string(nil), v...), nil
+		}
+	}
+	return nil, errUnmodelled
+}
+
+var (
+	predNameEqRe    = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?name\s*=\s*('(?:[^']|'')*')$`)
+	predNameNeRe    = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?name\s*(?:<>|!=)\s*('(?:[^']|'')*')$`)
+	predIsSystemRe  = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?is_system\s*=\s*(true|false)$`)
+	predIsSystemBRe = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?is_system\s+is\s+(true|false)$`)
+	predContainsRe  = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?scopes\s*@>\s*(.+)$`)
+	predNameInRe    = regexp.MustCompile(`(?is)^(?:[a-z_][a-z0-9_]*\s*\.\s*)?name\s+in\s*\((.*)\)$`)
+)
+
+// evalWhere returns the template names the predicate selects. ok is false when
+// any conjunct is not understood -- never "assume it matches nothing", which
+// would turn an unreadable migration into a silent pass.
+func evalWhere(p Policy, where string) (names []string, ok bool) {
+	where = strings.TrimSpace(where)
+	candidates := make([]string, 0, len(p))
+	for name := range p {
+		candidates = append(candidates, name)
+	}
+	sort.Strings(candidates)
+	if where == "" {
+		return candidates, true
+	}
+	if indexTopLevelKeyword(where, "or") >= 0 {
+		return nil, false
+	}
+	for _, conj := range splitTopLevelKeyword(where, "and") {
+		conj = strings.TrimSpace(conj)
+		for strings.HasPrefix(conj, "(") && strings.HasSuffix(conj, ")") {
+			inner, rest, gOK := parenGroup(conj)
+			if !gOK || strings.TrimSpace(rest) != "" {
+				break
+			}
+			conj = strings.TrimSpace(inner)
+		}
+		pred, pOK := compilePredicate(conj)
+		if !pOK {
+			return nil, false
+		}
+		kept := candidates[:0:0]
+		for _, name := range candidates {
+			if pred(p[name]) {
+				kept = append(kept, name)
+			}
+		}
+		candidates = kept
+	}
+	return candidates, true
+}
+
+func compilePredicate(conj string) (func(Template) bool, bool) {
+	if m := predNameEqRe.FindStringSubmatch(conj); m != nil {
+		want, ok := stringLiteral(m[1])
+		if !ok {
+			return nil, false
+		}
+		return func(t Template) bool { return t.Name == want }, true
+	}
+	if m := predNameNeRe.FindStringSubmatch(conj); m != nil {
+		want, ok := stringLiteral(m[1])
+		if !ok {
+			return nil, false
+		}
+		return func(t Template) bool { return t.Name != want }, true
+	}
+	if m := predIsSystemRe.FindStringSubmatch(conj); m != nil {
+		want := strings.EqualFold(m[1], "true")
+		return func(t Template) bool { return t.IsSystem == want }, true
+	}
+	if m := predIsSystemBRe.FindStringSubmatch(conj); m != nil {
+		want := strings.EqualFold(m[1], "true")
+		return func(t Template) bool { return t.IsSystem == want }, true
+	}
+	if m := predNameInRe.FindStringSubmatch(conj); m != nil {
+		var want []string
+		for _, item := range splitTopLevel(m[1], ',') {
+			s, ok := stringLiteral(strings.TrimSpace(item))
+			if !ok {
+				return nil, false
+			}
+			want = append(want, s)
+		}
+		return func(t Template) bool { return contains(want, t.Name) }, true
+	}
+	if m := predContainsRe.FindStringSubmatch(conj); m != nil {
+		want, ok := jsonArrayLiteral(m[1])
+		if !ok {
+			return nil, false
+		}
+		return func(t Template) bool {
+			for _, w := range want {
+				if !contains(t.Scopes, w) {
+					return false
+				}
+			}
+			return true
+		}, true
+	}
+	return nil, false
+}
+
+// declaredJSONConstants picks up `<name> CONSTANT jsonb := '<literal>'::jsonb`
+// from a plpgsql DECLARE section. CONSTANT only: a plain variable can be
+// reassigned later in the block, and this package does not execute control flow.
+var declaredConstRe = regexp.MustCompile(
+	`(?is)\b([a-z_][a-z0-9_]*)\s+constant\s+jsonb\s*:=\s*('(?:[^']|'')*')\s*::\s*jsonb`)
+
+func declaredJSONConstants(body string) map[string][]string {
+	out := map[string][]string{}
+	for _, m := range declaredConstRe.FindAllStringSubmatch(body, -1) {
+		if arr, ok := jsonArrayLiteral(m[2]); ok {
+			out[strings.ToLower(m[1])] = arr
+		}
+	}
+	return out
+}
+
+func mergeConstants(outer, inner map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(outer)+len(inner))
+	for k, v := range outer {
+		out[k] = v
+	}
+	for k, v := range inner {
+		out[k] = v
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Literals
+// ---------------------------------------------------------------------------
+
+var castSuffixRe = regexp.MustCompile(`(?is)\s*::\s*[a-z_][a-z0-9_]*(\s*\[\s*\])?\s*$`)
+
+func stripCasts(s string) string {
+	s = strings.TrimSpace(s)
+	for {
+		next := castSuffixRe.ReplaceAllString(s, "")
+		if next == s {
+			return strings.TrimSpace(s)
+		}
+		s = strings.TrimSpace(next)
+	}
+}
+
+func stringLiteral(raw string) (string, bool) {
+	s := stripCasts(raw)
+	if len(s) < 2 || s[0] != '\'' || s[len(s)-1] != '\'' {
+		return "", false
+	}
+	inner := s[1 : len(s)-1]
+	// A lone quote inside would mean this is two literals, not one.
+	if strings.Contains(strings.ReplaceAll(inner, "''", ""), "'") {
+		return "", false
+	}
+	return strings.ReplaceAll(inner, "''", "'"), true
+}
+
+func jsonArrayLiteral(raw string) ([]string, bool) {
+	s, ok := stringLiteral(raw)
+	if !ok {
+		return nil, false
+	}
+	var arr []string
+	if err := json.Unmarshal([]byte(s), &arr); err != nil {
+		return nil, false
+	}
+	return arr, true
+}
+
+func boolLiteral(raw string) (bool, bool) {
+	switch strings.ToLower(stripCasts(raw)) {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// normalize sorts and de-duplicates. Postgres' `||` on jsonb arrays appends
+// without de-duplicating, so a re-granted scope can appear twice in the real
+// column; a repeated scope confers nothing extra, and comparing sets rather
+// than sequences keeps the guard about authority instead of about ordering.
+func normalize(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Normalize is normalize, for callers comparing a database's or the Go list's
+// scopes against a derived policy on the same terms.
+func Normalize(in []string) []string { return normalize(in) }

--- a/backend/internal/db/rolepolicy/rolepolicy_test.go
+++ b/backend/internal/db/rolepolicy/rolepolicy_test.go
@@ -1,0 +1,334 @@
+package rolepolicy
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+)
+
+const migrationsDir = "../migrations"
+
+// TestTheGoListAndTheMigrationsStateTheSamePolicy is issue #891's guard, and the
+// half of #891 that outlives the one-line list fix.
+//
+// THE DEFECT IT EXISTS FOR. Registry states its role -> scope policy twice:
+// once as SQL (migration 000001's seed and every migration that has amended it),
+// once as models.PredefinedRoleTemplates(). Only one of the two is exercised in
+// any given topology, so they can disagree indefinitely without anything
+// failing. Migration 000018 granted `scanning:read` to `devops` and `auditor`;
+// the Go list never learned it; and because both seeds upsert with
+// `scopes = EXCLUDED.scopes`, every boot in the topology where they run REMOVED
+// a scope a migration had granted.
+//
+// WHY IT IS A CLASS GUARD AND NOT A SPELLING OF THIS ONE BUG. Nothing below
+// names a scope, a template, or a migration. The expectation is DERIVED from
+// whatever the migration files currently say, so a migration that lands tomorrow
+// is covered the moment it exists. Verified by adding a scratch migration that
+// grants an unrelated scope and watching this fail -- a guard whose universe is
+// a list somebody has to remember to extend is inert against exactly the case it
+// was written for.
+//
+// BOTH DIRECTIONS, DELIBERATELY. Today's drift removes authority, which fails
+// safe: the auditor sees an empty scanning page. The mirror-image drift -- a Go
+// list carrying a scope the migrations never granted -- would silently WIDEN
+// what a role confers on every deployment the seed reaches, which does not fail
+// safe at all. The diff below is symmetric so neither can land.
+func TestTheGoListAndTheMigrationsStateTheSamePolicy(t *testing.T) {
+	policies, err := FromMigrations(migrationsDir)
+	if err != nil {
+		t.Fatalf("deriving the role-template policy from the migrations: %v", err)
+	}
+
+	fromSQL := policies[RoleTemplatesTable].SystemScopes()
+	if len(fromSQL) == 0 {
+		// An empty expectation passes every comparison. That is not a clean
+		// guard, it is a blind one.
+		t.Fatalf("derived no system role templates from %s at all; the guard would "+
+			"pass regardless of what the Go list says", migrationsDir)
+	}
+
+	fromGo := map[string][]string{}
+	for _, tmpl := range models.PredefinedRoleTemplates() {
+		if !tmpl.IsSystem {
+			continue
+		}
+		fromGo[tmpl.Name] = Normalize(tmpl.Scopes)
+	}
+
+	for _, name := range sortedKeys(fromSQL, fromGo) {
+		sqlScopes, inSQL := fromSQL[name]
+		goScopes, inGo := fromGo[name]
+		switch {
+		case inSQL && !inGo:
+			t.Errorf("role template %q is seeded by the migrations and missing from "+
+				"models.PredefinedRoleTemplates(); the seed cannot restate it and the "+
+				"cutover topology will not have it. Migration scopes: %v", name, sqlScopes)
+		case inGo && !inSQL:
+			t.Errorf("role template %q is in models.PredefinedRoleTemplates() and is not "+
+				"seeded by any migration; the seed CREATES it in the cutover topology and "+
+				"the default topology has never had it. Go scopes: %v", name, goScopes)
+		case !reflect.DeepEqual(sqlScopes, goScopes):
+			removed, added := diff(sqlScopes, goScopes)
+			t.Errorf("role template %q: the two statements of one policy disagree.\n"+
+				"  migrations grant : %v\n"+
+				"  the Go list says : %v\n"+
+				"  the seed would REMOVE : %v\n"+
+				"  the seed would GRANT  : %v\n"+
+				"Both seeds upsert with `scopes = EXCLUDED.scopes`, so whichever column "+
+				"this leaves is what the role actually confers. Removing is an outage that "+
+				"presents as an empty page; granting is a silent privilege widening. Fix "+
+				"models.PredefinedRoleTemplates() (or, if the migration is the mistake, "+
+				"write the migration that corrects it).",
+				name, sqlScopes, goScopes, removed, added)
+		}
+	}
+}
+
+// TestRegistrysOwnTableIsNotSeededBehindTheGuardsBack covers the second write
+// path. `registry_role_templates` (migration 000055) is created empty and filled
+// at runtime; if a migration ever starts seeding it too, that becomes a third
+// statement of the same policy and has to agree with the other two.
+func TestRegistrysOwnTableIsNotSeededBehindTheGuardsBack(t *testing.T) {
+	policies, err := FromMigrations(migrationsDir)
+	if err != nil {
+		t.Fatalf("deriving the role-template policy from the migrations: %v", err)
+	}
+	own := policies[RegistryRoleTemplatesTable].SystemScopes()
+	if len(own) == 0 {
+		return
+	}
+	fromGo := map[string][]string{}
+	for _, tmpl := range models.PredefinedRoleTemplates() {
+		fromGo[tmpl.Name] = Normalize(tmpl.Scopes)
+	}
+	for name, scopes := range own {
+		if !reflect.DeepEqual(scopes, fromGo[name]) {
+			t.Errorf("a migration now seeds %s.%s with %v, which is not what "+
+				"models.PredefinedRoleTemplates() says (%v). Registry authorizes from that "+
+				"table, so the two must agree.",
+				RegistryRoleTemplatesTable, name, scopes, fromGo[name])
+		}
+	}
+}
+
+// TestTheDeriverFailsClosed is the guard on the guard. A model that silently
+// skips what it cannot read reports "clean" for precisely the migrations doing
+// something interesting, and is indistinguishable from one that never ran.
+func TestTheDeriverFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sql  string
+	}{
+		{
+			"UPDATE whose scopes expression is a function call",
+			`UPDATE role_templates SET scopes = some_function(scopes) WHERE name = 'devops';`,
+		},
+		{
+			"UPDATE whose WHERE clause is a subquery",
+			`UPDATE role_templates SET scopes = '["x:read"]'::jsonb
+			   WHERE id IN (SELECT role_template_id FROM organization_members);`,
+		},
+		{
+			"INSERT ... SELECT",
+			`INSERT INTO role_templates (name, display_name, scopes, is_system)
+			 SELECT name, display_name, scopes, true FROM some_other_table;`,
+		},
+		{
+			"ON CONFLICT DO UPDATE",
+			`INSERT INTO role_templates (name, display_name, scopes, is_system)
+			 VALUES ('x', 'X', '["a:read"]'::jsonb, true)
+			 ON CONFLICT (name) DO UPDATE SET scopes = EXCLUDED.scopes;`,
+		},
+		{
+			"ALTER that rewrites the scopes column",
+			`ALTER TABLE role_templates ALTER COLUMN scopes TYPE jsonb USING to_jsonb(scopes);`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			write(t, dir, "000001_base.up.sql",
+				`INSERT INTO role_templates (name, display_name, scopes, is_system)
+				 VALUES ('devops', 'DevOps', '["modules:read"]'::jsonb, true);`)
+			write(t, dir, "000002_probe.up.sql", tc.sql)
+
+			_, err := FromMigrations(dir)
+			if err == nil {
+				t.Fatalf("the deriver accepted a role-template write it cannot evaluate; "+
+					"it would report a policy that is not what %q leaves behind", tc.name)
+			}
+			var unmodelled *UnmodelledError
+			if !asUnmodelled(err, &unmodelled) {
+				t.Fatalf("expected an *UnmodelledError naming the file, got %T: %v", err, err)
+			}
+			if unmodelled.File != "000002_probe.up.sql" {
+				t.Errorf("UnmodelledError.File = %q, want the offending migration", unmodelled.File)
+			}
+		})
+	}
+}
+
+// TestTheDeriverModelsTheFormsTheMigrationsUse pins the constructs the real
+// migrations are written in, so a refactor of the scanner cannot quietly stop
+// understanding them and start reporting a policy assembled from fewer
+// statements than the tree actually contains.
+func TestTheDeriverModelsTheFormsTheMigrationsUse(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "000001_seed.up.sql", `
+-- a comment with an apostrophe: the organization's roles
+INSERT INTO role_templates (name, display_name, description, scopes, is_system) VALUES
+('viewer', 'Viewer', 'Read-only', '["modules:read"]'::jsonb, true),
+('devops', 'DevOps', 'CI/CD', '["modules:read", "scm:manage"]'::jsonb, true),
+('admin',  'Administrator', 'Full access', '["admin"]'::jsonb, true),
+('custom', 'Custom', 'not a system role', '["modules:read"]'::jsonb, false);`)
+
+	write(t, dir, "000002_grant.up.sql", `
+UPDATE role_templates
+SET scopes = scopes || '["scanning:read"]'::jsonb
+WHERE name = 'devops' AND is_system = true;`)
+
+	write(t, dir, "000003_revoke.up.sql", `
+UPDATE public.role_templates SET scopes = scopes - 'scm:manage' WHERE name = 'devops';`)
+
+	// The shape migration 000054 uses: a DO block, a plpgsql CONSTANT holding the
+	// replacement, and a follow-up statement whose SET expression is not
+	// modellable but whose predicate selects nothing by the time it runs.
+	write(t, dir, "000004_carrier_only.up.sql", `
+DO $$
+DECLARE
+  org_owner_scopes CONSTANT jsonb := '["organizations:write", "modules:read"]'::jsonb;
+BEGIN
+  UPDATE public.role_templates
+     SET scopes = org_owner_scopes, description = 'rewritten'
+   WHERE name = 'admin' AND scopes @> '["admin"]'::jsonb;
+
+  UPDATE public.role_templates rt
+     SET scopes = COALESCE((SELECT jsonb_agg(d.s ORDER BY d.s)
+                              FROM (SELECT DISTINCT s FROM (
+                                      SELECT jsonb_array_elements_text(rt.scopes) AS s) a
+                                    WHERE s <> 'admin') d), '[]'::jsonb)
+   WHERE rt.scopes @> '["admin"]'::jsonb;
+
+  -- identity's copy is deliberately not modelled
+  UPDATE identity.role_templates SET scopes = ARRAY['whatever'] WHERE name = 'admin';
+END $$;`)
+
+	policies, err := FromMigrations(dir)
+	if err != nil {
+		t.Fatalf("FromMigrations: %v", err)
+	}
+	got := policies[RoleTemplatesTable]
+
+	want := map[string][]string{
+		"viewer": {"modules:read"},
+		"devops": {"modules:read", "scanning:read"},
+		"admin":  {"modules:read", "organizations:write"},
+		"custom": {"modules:read"},
+	}
+	for name, wantScopes := range want {
+		tmpl, ok := got[name]
+		if !ok {
+			t.Errorf("template %q was not derived at all", name)
+			continue
+		}
+		if !reflect.DeepEqual(tmpl.Scopes, wantScopes) {
+			t.Errorf("template %q scopes = %v, want %v", name, tmpl.Scopes, wantScopes)
+		}
+	}
+	if got["custom"].IsSystem {
+		t.Error("a non-system template was derived as a system one")
+	}
+	if _, ok := got.SystemScopes()["custom"]; ok {
+		t.Error("SystemScopes() returned a non-system template")
+	}
+}
+
+// TestTheDeriverSeesEveryUpMigration fails on an empty or truncated universe:
+// a deriver pointed at nothing reports a policy of nothing and agrees with
+// everything.
+func TestTheDeriverSeesEveryUpMigration(t *testing.T) {
+	files, err := UpMigrations(migrationsDir)
+	if err != nil {
+		t.Fatalf("UpMigrations: %v", err)
+	}
+	onDisk, err := filepath.Glob(filepath.Join(migrationsDir, "*.up.sql"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) != len(onDisk) {
+		t.Fatalf("UpMigrations read %d files, %d *.up.sql are on disk: the deriver is "+
+			"reasoning about a subset of the migrations", len(files), len(onDisk))
+	}
+	if len(files) == 0 {
+		t.Fatal("no migrations found; every comparison against this policy is vacuous")
+	}
+	for i := 1; i < len(files); i++ {
+		if files[i].Version <= files[i-1].Version {
+			t.Fatalf("migrations are not in version order at %s", files[i].Name)
+		}
+	}
+	head, err := HeadVersion(migrationsDir)
+	if err != nil {
+		t.Fatalf("HeadVersion: %v", err)
+	}
+	if head != files[len(files)-1].Version {
+		t.Errorf("HeadVersion = %d, want %d", head, files[len(files)-1].Version)
+	}
+}
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func asUnmodelled(err error, out **UnmodelledError) bool {
+	u, ok := err.(*UnmodelledError)
+	if ok {
+		*out = u
+	}
+	return ok
+}
+
+func sortedKeys(maps ...map[string][]string) []string {
+	seen := map[string]struct{}{}
+	for _, m := range maps {
+		for k := range m {
+			seen[k] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// diff reports what a seed carrying `have` would take away from, and add to, a
+// row currently holding `base`.
+func diff(base, have []string) (removed, added []string) {
+	in := func(hay []string, s string) bool {
+		for _, h := range hay {
+			if h == s {
+				return true
+			}
+		}
+		return false
+	}
+	for _, s := range base {
+		if !in(have, s) {
+			removed = append(removed, s)
+		}
+	}
+	for _, s := range have {
+		if !in(base, s) {
+			added = append(added, s)
+		}
+	}
+	return removed, added
+}

--- a/backend/internal/db/rolepolicy/sqlscan.go
+++ b/backend/internal/db/rolepolicy/sqlscan.go
@@ -1,0 +1,341 @@
+package rolepolicy
+
+import "strings"
+
+// A deliberately small SQL scanner: enough to find statement boundaries,
+// top-level keywords, balanced parentheses and string literals without
+// mistaking a `;` inside a dollar-quoted plpgsql body -- or an apostrophe inside
+// a `--` comment -- for either.
+//
+// It is not a parser and does not try to be. Everything it cannot account for
+// reaches applyStatement, which fails closed.
+
+// splitStatements returns dir-order statements with comments removed.
+func splitStatements(sql string) []string {
+	var out []string
+	var b strings.Builder
+	rs := []rune(sql)
+	flush := func() {
+		if s := strings.TrimSpace(b.String()); s != "" {
+			out = append(out, s)
+		}
+		b.Reset()
+	}
+	for i := 0; i < len(rs); {
+		c := rs[i]
+		switch {
+		case c == '-' && i+1 < len(rs) && rs[i+1] == '-':
+			for i < len(rs) && rs[i] != '\n' {
+				i++
+			}
+			b.WriteRune(' ')
+		case c == '/' && i+1 < len(rs) && rs[i+1] == '*':
+			depth := 1
+			i += 2
+			for i < len(rs) && depth > 0 {
+				switch {
+				case rs[i] == '/' && i+1 < len(rs) && rs[i+1] == '*':
+					depth++
+					i += 2
+				case rs[i] == '*' && i+1 < len(rs) && rs[i+1] == '/':
+					depth--
+					i += 2
+				default:
+					i++
+				}
+			}
+			b.WriteRune(' ')
+		case c == '\'':
+			b.WriteRune(c)
+			i++
+			for i < len(rs) {
+				if rs[i] == '\'' {
+					if i+1 < len(rs) && rs[i+1] == '\'' {
+						b.WriteString("''")
+						i += 2
+						continue
+					}
+					b.WriteRune('\'')
+					i++
+					break
+				}
+				b.WriteRune(rs[i])
+				i++
+			}
+		case c == '$':
+			tag, ok := dollarTag(rs, i)
+			if !ok {
+				b.WriteRune(c)
+				i++
+				continue
+			}
+			b.WriteString(tag)
+			i += len([]rune(tag))
+			closeAt := indexRunes(rs, []rune(tag), i)
+			if closeAt < 0 {
+				b.WriteString(string(rs[i:]))
+				i = len(rs)
+				continue
+			}
+			b.WriteString(string(rs[i:closeAt]))
+			b.WriteString(tag)
+			i = closeAt + len([]rune(tag))
+		case c == ';':
+			flush()
+			i++
+		default:
+			b.WriteRune(c)
+			i++
+		}
+	}
+	flush()
+	return out
+}
+
+// dollarTag recognises `$$` and `$tag$`. `$1` is a bind placeholder, not a tag,
+// so a tag may not start with a digit.
+func dollarTag(rs []rune, i int) (string, bool) {
+	if rs[i] != '$' {
+		return "", false
+	}
+	j := i + 1
+	// `$1` is a bind placeholder, not a dollar-quote tag.
+	if j < len(rs) && rs[j] >= '0' && rs[j] <= '9' {
+		return "", false
+	}
+	for j < len(rs) && isIdentRune(rs[j]) {
+		j++
+	}
+	if j < len(rs) && rs[j] == '$' {
+		return string(rs[i : j+1]), true
+	}
+	return "", false
+}
+
+func isIdentRune(r rune) bool {
+	return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func indexRunes(hay, needle []rune, from int) int {
+	if len(needle) == 0 {
+		return -1
+	}
+	for i := from; i+len(needle) <= len(hay); i++ {
+		match := true
+		for j := range needle {
+			if hay[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// scan walks s calling visit at every index that is outside a string literal,
+// with the parenthesis depth at that point. visit returning false stops the walk.
+func scan(s string, visit func(i, depth int) bool) {
+	rs := []rune(s)
+	depth := 0
+	for i := 0; i < len(rs); {
+		switch rs[i] {
+		case '\'':
+			i++
+			for i < len(rs) {
+				if rs[i] == '\'' {
+					if i+1 < len(rs) && rs[i+1] == '\'' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case '$':
+			if tag, ok := dollarTag(rs, i); ok {
+				closeAt := indexRunes(rs, []rune(tag), i+len([]rune(tag)))
+				if closeAt < 0 {
+					return
+				}
+				i = closeAt + len([]rune(tag))
+				continue
+			}
+		// Brackets nest exactly like parentheses here: a comma inside an
+		// `ARRAY['a', 'b']` constructor is not a top-level separator, and
+		// counting only parentheses split such an operand in half.
+		case '(', '[':
+			depth++
+		case ')', ']':
+			depth--
+		}
+		if !visit(runeToByteIndex(s, i), depth) {
+			return
+		}
+		i++
+	}
+}
+
+// runeToByteIndex is O(n) per call in general; the fragments here are short
+// statements, and correctness on multi-byte characters matters more than the
+// constant factor.
+func runeToByteIndex(s string, runeIdx int) int {
+	n := 0
+	for i := range s {
+		if n == runeIdx {
+			return i
+		}
+		n++
+	}
+	return len(s)
+}
+
+// indexTopLevelKeyword returns the byte index of kw (a lower-case word, possibly
+// several words separated by single spaces) at parenthesis depth zero, outside
+// any string literal, on a word boundary. -1 when absent.
+func indexTopLevelKeyword(s, kw string) int {
+	lower := strings.ToLower(s)
+	found := -1
+	scan(s, func(i, depth int) bool {
+		if depth != 0 {
+			return true
+		}
+		if !matchKeywordAt(lower, i, kw) {
+			return true
+		}
+		found = i
+		return false
+	})
+	return found
+}
+
+// matchKeywordAt compares against a keyword whose internal spacing may be any
+// run of whitespace in the source.
+func matchKeywordAt(lower string, i int, kw string) bool {
+	if i > 0 && isIdentByte(lower[i-1]) {
+		return false
+	}
+	j := i
+	for k := 0; k < len(kw); k++ {
+		if kw[k] == ' ' {
+			consumed := false
+			for j < len(lower) && isSpaceByte(lower[j]) {
+				j++
+				consumed = true
+			}
+			if !consumed {
+				return false
+			}
+			continue
+		}
+		if j >= len(lower) || lower[j] != kw[k] {
+			return false
+		}
+		j++
+	}
+	return j >= len(lower) || !isIdentByte(lower[j])
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// hasLeadingKeyword reports whether s begins with kw on a word boundary.
+func hasLeadingKeyword(s, kw string) bool {
+	return matchKeywordAt(strings.ToLower(s), 0, kw)
+}
+
+// indexTopLevelRune finds r at depth zero outside string literals.
+func indexTopLevelRune(s string, r rune) int {
+	found := -1
+	scan(s, func(i, depth int) bool {
+		if depth != 0 || rune(s[i]) != r {
+			return true
+		}
+		// `<=`, `>=`, `!=`, `<>` and `:=` are not assignment separators.
+		if r == '=' {
+			if i > 0 && strings.ContainsRune("<>!:", rune(s[i-1])) {
+				return true
+			}
+			if i+1 < len(s) && s[i+1] == '=' {
+				return true
+			}
+		}
+		found = i
+		return false
+	})
+	return found
+}
+
+// splitTopLevel splits on sep at depth zero outside string literals.
+func splitTopLevel(s string, sep rune) []string {
+	var cuts []int
+	scan(s, func(i, depth int) bool {
+		if depth == 0 && rune(s[i]) == sep {
+			cuts = append(cuts, i)
+		}
+		return true
+	})
+	out := make([]string, 0, len(cuts)+1)
+	prev := 0
+	for _, c := range cuts {
+		out = append(out, s[prev:c])
+		prev = c + 1
+	}
+	out = append(out, s[prev:])
+	return out
+}
+
+// splitTopLevelKeyword splits on a keyword at depth zero outside string literals.
+func splitTopLevelKeyword(s, kw string) []string {
+	lower := strings.ToLower(s)
+	type cut struct{ start, end int }
+	var cuts []cut
+	scan(s, func(i, depth int) bool {
+		if depth != 0 || !matchKeywordAt(lower, i, kw) {
+			return true
+		}
+		if len(cuts) > 0 && i < cuts[len(cuts)-1].end {
+			return true
+		}
+		cuts = append(cuts, cut{i, i + len(kw)})
+		return true
+	})
+	out := make([]string, 0, len(cuts)+1)
+	prev := 0
+	for _, c := range cuts {
+		out = append(out, s[prev:c.start])
+		prev = c.end
+	}
+	out = append(out, s[prev:])
+	return out
+}
+
+// parenGroup reads a balanced `( ... )` from the front of s (after leading
+// whitespace) and returns its contents and whatever follows.
+func parenGroup(s string) (inner, rest string, ok bool) {
+	trimmed := strings.TrimLeft(s, " \t\r\n")
+	if !strings.HasPrefix(trimmed, "(") {
+		return "", s, false
+	}
+	closeAt := -1
+	scan(trimmed, func(i, depth int) bool {
+		if trimmed[i] == ')' && depth == 0 {
+			closeAt = i
+			return false
+		}
+		return true
+	})
+	if closeAt < 0 {
+		return "", s, false
+	}
+	return trimmed[1:closeAt], trimmed[closeAt+1:], true
+}

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -94,7 +94,9 @@ If issues are found after upgrade:
 > `⚠ BREAKING CHANGES` heading.
 >
 > Concretely, across every release from `0.10.1` to `3.5.0` there are exactly **two**
-> breaking changes, both captured below. Absence of a note for your specific version
+> breaking changes, both captured below. `5.0.0` carries two further ones, each with its
+> own note: the platform-admin carrier move (#766) and the `devops`/`auditor` role-template
+> scope correction (#891). Absence of a note for your specific version
 > pair means there was nothing version-specific to do beyond the standard procedure
 > above — not that the note is missing.
 
@@ -129,6 +131,66 @@ user deletion now destroys the principal's SCM OAuth tokens explicitly.
 validates the whole table and would fail on exactly the deployments the up migration
 repaired, leaving the migration version dirty; `NOT VALID` would silently restore the
 outage for new writes. The `.down.sql` carries the reasoning and by-hand restore SQL.
+
+### 4.x → 5.0.0 — the `devops` and `auditor` role templates gain `scanning:read`
+
+**Breaking, and it bites one topology only.** Issue #891. Independent of the
+platform-admin carrier change below, which is the other breaking change in this
+major; both touch role templates and neither depends on the other.
+
+**Applies to:** deployments running the identity-schema cutover
+(`TFR_IDENTITY_SCHEMA_ENABLED=true`) with `TFR_SUITE_ROLE_SEED_OWNER` naming this
+application. **Default-topology deployments are unaffected** — their role templates have
+carried `scanning:read` since migration `000018`, and neither role-template seed runs
+there.
+
+#### What was wrong
+
+Registry states its role → scope policy twice: as SQL, in the migrations, and as Go, in
+`models.PredefinedRoleTemplates()`. Migration `000018` granted `scanning:read` to `devops`
+and `auditor`; the Go list never followed. Both seeds upsert that list with
+`scopes = EXCLUDED.scopes`, so on a cutover deployment **every boot removed the scope from
+both templates**, in both tables:
+
+- `registry_role_templates` — what this application authorizes against since the phase-3b
+  read cutover.
+- `role_templates` — what the state manager adopts `devops` and `auditor` from (it defines
+  neither name itself), and what a rollback to a pre-3b registry image authorizes against.
+
+It presented as "the scanning pages are empty for our auditors", never as an error, because
+it removed authority rather than granting it.
+
+#### What changes on upgrade
+
+On the first boot of this release, principals holding `devops` or `auditor` in an affected
+deployment gain `scanning:read`: the per-version scan result, `GET
+/api/v1/admin/scanning/stats`, `GET /api/v1/admin/scanning/scans/{id}`, and the
+scanner-version endpoints. That is what migration `000018` granted them and what the seed
+has been taking back on every restart since.
+
+Scan records are tenant-scoped (issue #783), so this is read access within the organizations
+a principal already belongs to, not across the deployment.
+
+The same seed also writes the shared `role_templates`, so the state manager's copies of
+`devops` and `auditor` gain the scope too. It confers nothing there — `scanning:read` is not
+in that application's scope vocabulary — but it will appear in its role-template listings.
+
+#### If you do not want it
+
+Move the affected members to a role template of your own that omits `scanning:read`. Editing
+the **system** template instead does not hold: the seed overwrites system templates by name
+on the next boot, which is the whole mechanism this note is about.
+
+#### Migrations, rollback, and the guard
+
+- **Migrations:** none. Migration `000018` already made this change in SQL; this release
+  makes the Go list agree with it.
+- **Rollback:** deploy the previous image. Its seed removes the scope again on its first
+  boot, which is the pre-upgrade behaviour.
+- **Guard:** `internal/db/rolepolicy` derives the role → scope policy back out of the
+  migration files, and a test diffs it against the Go list in both directions. A migration
+  that grants a scope the list omits, and a list that grants a scope no migration granted,
+  both turn a PR red.
 
 ### 4.x → 5.0.0 — platform-admin authority moves to the `platform_admins` carrier
 


### PR DESCRIPTION
## What

`models.PredefinedRoleTemplates()` did not carry `scanning:read`, which migration `000018` granted to `devops` and `auditor`. Both role-template seeds upsert that list with `scopes = EXCLUDED.scopes`, so on every boot of an identity-schema-cutover deployment the seed **removed** a scope a migration had granted.

This adds the scope, and — the part that outlives it — derives a guard from the migrations so the two statements of one policy cannot drift apart again.

## The blast radius, which #891 states incorrectly

The issue names one seed, one table, and `TFR_IDENTITY_SCHEMA_ENABLED=true` as the gate. All three have moved since it was filed. What is actually true on `main`:

| | writes | gate | who reads it |
|---|---|---|---|
| `SeedSystemRoleTemplates` | `registry_role_templates` | `internal/api/router.go`: `identityDB != db && cfg.Suite.ShouldSeedRoles("registry")` | every authorization decision **this** application makes |
| `SeedSharedIdentityRoleTemplates` | `role_templates` | `cmd/server/main.go`, inside `identitySchemaEnabled()`, `ShouldSeedRoles("registry")` | the **state manager**, and a rollback to a pre-3b registry image |

Both paths are cutover-only, and **both were stripping**, from the same list. The default topology is untouched — neither seed runs there, which is why this went unnoticed.

### What the state manager actually sees

`main.go`'s standing comment says the state manager "still reads the shared table". That is now imprecise, and I corrected it rather than repeating it. TSM has since done its own phase 3b (`TSM_AUTHZ_ROLE_SOURCE` defaults to `app`), so it no longer authorizes from `role_templates` directly. It still consumes it two ways, and both matter here:

- `approles.Reconcile`'s **adopt pass** takes every role name TSM's own `auth.AppRoleTemplates()` does not define, *scopes unchanged* — and `devops` and `auditor` are two such names. Whatever registry's seed leaves in the shared table is what those two templates mean inside the state manager.
- `TSM_AUTHZ_ROLE_SOURCE=identity`, its phase-3b rollback lever, puts **every** TSM authorization decision back on that table.

So the scope now propagates into TSM's `devops`/`auditor` rows. It confers nothing there — `scanning:read` is not in that application's scope vocabulary and its checker is exact-match plus `admin` — but it will show up in its role-template listings. Called out in the upgrade note.

## The guard

`internal/db/rolepolicy` replays the role-template DML out of the migration files and returns the policy they leave: `INSERT ... VALUES`, `UPDATE ... SET scopes`, `DELETE`, `TRUNCATE`, and the plpgsql `DO` block migration `000054` does its edit inside (including its `CONSTANT jsonb` and its second, `jsonb_agg`-shaped `UPDATE`, whose own predicate selects nothing by the time it runs — so its unmodellable right-hand side never has to be evaluated).

**Nothing in it enumerates a scope, a template, or a migration.** The expectation is derived, so a migration that lands tomorrow is covered the moment it exists.

**It fails closed.** A role-template write it cannot evaluate is an error naming the file and the statement, never a silent skip — the failure mode where a guard reports "clean" for exactly the migrations doing something interesting.

Three guards stand on it:

1. `TestTheGoListAndTheMigrationsStateTheSamePolicy` — the two must agree, diffed **in both directions**. Today's drift removes authority and fails safe; the mirror image grants a scope no migration granted, and does not.
2. `TestEverySeedCallSiteUsesTheOnePolicyList` — walks the backend with `go/ast` and requires every production call of either seed to be handed `models.PredefinedRoleTemplates()`. One edit closed both paths *because* both read one list; nothing enforced that. Fails on an empty universe as well as a wrong one.
3. Three PostgreSQL-backed tests — the static model must equal what the migrations actually produce, and neither seed may add or remove a scope relative to them.

## Mutation verification

Every guard was broken and watched to fail, then restored.

| mutation | guard | result |
|---|---|---|
| scratch migration `000057` grants `mutation:probe` to `viewer` | rolepolicy + postgres | RED — *this is the class proof: a migration that did not exist when the guard was written* |
| Go list grants `mutation:probe`, no migration does | rolepolicy + postgres | RED (the widening direction) |
| the `scanning:read` fix reverted | rolepolicy + postgres | RED, naming `devops` and `auditor` on **both** tables |
| `router.go` hands `SeedSystemRoleTemplates` a different slice | call-site | RED |
| a seed call site removed entirely | call-site | RED ("a guard that sees nothing passes everything") |
| migration writes `scopes = jsonb_strip_nulls(scopes)` | rolepolicy | RED — fail-closed, names the file |

Baseline green before and after each.

## Postgres tests: run locally, not in CI

The three `TestPolicy_*` tests gate on `TFR_TEST_DATABASE_URL` + `t.Skip`, and **no workflow sets it (#886)** — they will skip on this PR. I ran them locally against `postgres:16-alpine`, migrating the real migration set to a derived head version in a scratch database:

```
--- PASS: TestPolicy_TheStaticModelMatchesWhatPostgresActuallyHolds (2.05s)
--- PASS: TestPolicy_TheMigratedDatabaseAgreesWithTheGoList (2.03s)
--- PASS: TestPolicy_NeitherSeedRemovesAScopeTheMigrationsGranted (2.11s)
```

The first is the important one: it proves the static model — the thing that gates every PR — is bit-identical to what the engine actually produces. An interpretation of SQL that nothing ever checks against Postgres is a second opinion, not a fact.

Reverting the list fix and re-running them locally reproduces the defect as a database observation on both tables:

```
role_templates:          the boot sequence REMOVED "scanning:read" from "devops"  / "auditor"
registry_role_templates: the boot sequence REMOVED "scanning:read" from "devops"  / "auditor"
```

## Breaking, deliberately

Marked `fix(rbac)!` with a single `BREAKING CHANGE:` footer. Two role templates confer more than they did, and scan findings are security-sensitive; an operator should be made to read that rather than discover it. Precedent: #766's role-template change was announced the same way, and its `4.x → 5.0.0` note already sits in the upgrade guide — this adds a second note under the same major, not a second footer in one commit. `docs/upgrade-guide.md` covers what changes, who is affected (cutover topology only), how to opt out, rollback, and the guard.

## Also corrected

Two standing comments that asserted this defect was live and unfixable here (`router.go`) and that the state manager reads the shared table outright (`main.go`).

Closes #891
