### PR TITLE
fix(api)!: refuse organization deletion while SCM providers or mirrors remain

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -10016,7 +10016,7 @@
                         }
                     },
                     "409": {
-                        "description": "Organization still owns namespace claims, or deleting it would leave the deployment with no platform administrator",
+                        "description": "Organization still owns namespace claims, modules/providers, SCM providers or mirror configurations, or deleting it would leave the deployment with no platform administrator",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8093,7 +8093,7 @@
                         }
                     },
                     "409": {
-                        "description": "Organization still owns namespace claims, or deleting it would leave the deployment with no platform administrator",
+                        "description": "Organization still owns namespace claims, modules/providers, SCM providers or mirror configurations, or deleting it would leave the deployment with no platform administrator",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/attribution_columns_test.go
+++ b/backend/internal/api/admin/attribution_columns_test.go
@@ -1,0 +1,277 @@
+package admin
+
+import (
+	"database/sql/driver"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/services"
+)
+
+// The four attribution columns that were ALWAYS NULL (issue #899).
+//
+// middleware.AuthMiddleware stores the principal as `c.Set("user_id", user.ID)`
+// and models.User.ID is a STRING. These four sites asserted
+// `userID.(uuid.UUID)`, so the assertion never succeeded, the value was
+// silently dropped, and the column was written NULL on every request:
+//
+//	admin/mirror.go            -> mirror_configurations.created_by
+//	admin/storage.go (create)  -> storage_config.created_by
+//	admin/storage.go (update)  -> storage_config.updated_by
+//	admin/storage_migration.go -> storage_migrations.created_by
+//
+// A type assertion that fails yields the zero value and no error, which is why
+// nothing ever surfaced — and why three of the foreign keys migration 000056
+// dropped looked harmless: they were constraints on columns nothing populated.
+//
+// Every test below drives the handler with the context value the MIDDLEWARE
+// actually sets (a string) and asserts on the bound SQL argument, because the
+// bug was invisible at every other layer: the response, the status code and
+// the model in memory were all correct.
+//
+// admin/storage.go's activate path is not here. It always handled both types,
+// and its switch is the spelling currentUserNullUUID now shares with the four.
+// setup/handlers.go is not here either: it passes uuid.Nil deliberately, and
+// StorageConfigRepository.SetStorageConfigured documents NULLIF treating that
+// as NULL because no user exists yet during first-run setup. Neither is this
+// defect.
+
+const attributionUserID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+// argsWithAttribution builds an argument matcher list of the given width where
+// every position matches anything except the one under test.
+//
+// The alternative — spelling out all 29 arguments of the storage_config insert
+// — would make the test fail for reasons that have nothing to do with the
+// column it exists to pin.
+func argsWithAttribution(width, index int, want driver.Value) []driver.Value {
+	args := make([]driver.Value, width)
+	for i := range args {
+		args[i] = sqlmock.AnyArg()
+	}
+	args[index] = want
+	return args
+}
+
+// ---------------------------------------------------------------------------
+// mirror_configurations.created_by
+// ---------------------------------------------------------------------------
+
+func newAttributionMirrorRouter(t *testing.T, userID any) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	h := NewMirrorHandler(repositories.NewMirrorRepository(sqlxDB),
+		repositories.NewOrganizationRepository(db),
+		repositories.NewProviderRepository(db))
+
+	r := gin.New()
+	r.POST("/mirrors", func(c *gin.Context) {
+		if userID != nil {
+			c.Set("user_id", userID)
+		}
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+		h.CreateMirrorConfig(c)
+	})
+	return mock, r
+}
+
+func createMirror(mock sqlmock.Sqlmock, r *gin.Engine, createdBy driver.Value) *httptest.ResponseRecorder {
+	mock.ExpectQuery("SELECT.*FROM mirror_configurations WHERE name").
+		WillReturnRows(sqlmock.NewRows(mirrorCfgCols))
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
+		WillReturnRows(sqlmock.NewRows(orgCols))
+	// created_by is the last of the insert's eighteen arguments.
+	mock.ExpectExec("INSERT INTO mirror_configurations").
+		WithArgs(argsWithAttribution(18, 17, createdBy)...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/mirrors",
+		jsonBody(map[string]interface{}{
+			"name":                  "attributed-mirror",
+			"upstream_registry_url": "https://registry.terraform.io",
+		})))
+	return w
+}
+
+func TestAttribution_MirrorCreatedByRecordsTheCaller(t *testing.T) {
+	mock, r := newAttributionMirrorRouter(t, attributionUserID)
+	w := createMirror(mock, r, attributionUserID)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("mirror_configurations.created_by was not the caller: %v", err)
+	}
+}
+
+// The uuid.UUID spelling still works. Nothing in production sets it, but tests
+// do, and accepting only one of the two is how the original defect survived.
+func TestAttribution_MirrorCreatedByAcceptsUUIDContextValue(t *testing.T) {
+	mock, r := newAttributionMirrorRouter(t, uuid.MustParse(attributionUserID))
+	w := createMirror(mock, r, attributionUserID)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("mirror_configurations.created_by was not the caller: %v", err)
+	}
+}
+
+// No principal (an API key with no user binding) still writes NULL, which is
+// the honest answer rather than a zero UUID standing in for somebody.
+func TestAttribution_MirrorCreatedByIsNullWithoutAPrincipal(t *testing.T) {
+	mock, r := newAttributionMirrorRouter(t, nil)
+	w := createMirror(mock, r, nil)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("mirror_configurations.created_by was not NULL: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// storage_config.created_by / .updated_by
+// ---------------------------------------------------------------------------
+
+func newAttributionStorageRouter(t *testing.T) (sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+	db, mock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	h := NewStorageHandlers(&config.Config{},
+		repositories.NewStorageConfigRepository(sqlx.NewDb(db, "sqlmock")), nil)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("user_id", attributionUserID) })
+	r.POST("/storage/configs", h.CreateStorageConfig)
+	r.PUT("/storage/configs/:id", h.UpdateStorageConfig)
+	return mock, r
+}
+
+func TestAttribution_StorageConfigCreatedByRecordsTheCaller(t *testing.T) {
+	mock, r := newAttributionStorageRouter(t)
+	mock.ExpectQuery("SELECT storage_configured FROM system_settings").
+		WillReturnRows(sqlmock.NewRows([]string{"storage_configured"}))
+	// created_by and updated_by are the last two of the insert's twenty-nine
+	// arguments; both are stamped from the creating principal.
+	args := argsWithAttribution(29, 27, attributionUserID)
+	args[28] = attributionUserID
+	mock.ExpectExec("INSERT INTO storage_config").
+		WithArgs(args...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/storage/configs",
+		jsonBody(map[string]interface{}{
+			"backend_type":    "local",
+			"local_base_path": "/tmp/storage",
+		})))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("storage_config.created_by/updated_by were not the caller: %v", err)
+	}
+}
+
+func TestAttribution_StorageConfigUpdatedByRecordsTheCaller(t *testing.T) {
+	mock, r := newAttributionStorageRouter(t)
+	mock.ExpectQuery("SELECT.*FROM storage_config WHERE id").
+		WillReturnRows(sampleStorageCfgRow())
+	// updated_by is the last of the update's twenty-seven arguments.
+	mock.ExpectExec("UPDATE storage_config SET").
+		WithArgs(argsWithAttribution(27, 26, attributionUserID)...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/storage/configs/"+knownUUID,
+		jsonBody(map[string]interface{}{
+			"backend_type":    "local",
+			"local_base_path": "/data",
+		})))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("storage_config.updated_by was not the caller: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// storage_migrations.created_by
+// ---------------------------------------------------------------------------
+
+func TestAttribution_StorageMigrationCreatedByRecordsTheCaller(t *testing.T) {
+	db, mock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+
+	svc := services.NewStorageMigrationService(
+		repositories.NewStorageMigrationRepository(sqlxDB),
+		repositories.NewStorageConfigRepository(sqlxDB),
+		nil, nil, nil, &config.Config{})
+	h := NewStorageMigrationHandler(svc)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("user_id", attributionUserID) })
+	r.POST("/migrations", h.StartMigration)
+
+	srcID := "11111111-1111-1111-1111-111111111111"
+	tgtID := "22222222-2222-2222-2222-222222222222"
+
+	// source and target storage configs
+	mock.ExpectQuery("SELECT.*FROM storage_config WHERE id").
+		WillReturnRows(sampleStorageCfgRow())
+	mock.ExpectQuery("SELECT.*FROM storage_config WHERE id").
+		WillReturnRows(sampleStorageCfgRow())
+	// nothing to move, so no items insert follows
+	mock.ExpectQuery("SELECT id, storage_path FROM module_versions").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "storage_path"}))
+	mock.ExpectQuery("SELECT id, storage_path FROM provider_platforms").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "storage_path"}))
+	// created_by is the last of the insert's thirteen arguments.
+	mock.ExpectExec("INSERT INTO storage_migrations").
+		WithArgs(argsWithAttribution(13, 12, attributionUserID)...).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/migrations",
+		jsonBody(map[string]interface{}{
+			"source_config_id": srcID,
+			"target_config_id": tgtID,
+		})))
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("storage_migrations.created_by was not the caller: %v", err)
+	}
+}

--- a/backend/internal/api/admin/context_user.go
+++ b/backend/internal/api/admin/context_user.go
@@ -1,0 +1,73 @@
+// context_user.go holds the single spelling of "who is making this request",
+// read from the gin context the auth middleware populates.
+//
+// WHY THIS FILE EXISTS (issue #899)
+//
+// middleware.AuthMiddleware stores the principal as `c.Set("user_id", user.ID)`
+// and models.User.ID is a STRING. Four attribution sites asserted
+// `userID.(uuid.UUID)` instead, so the assertion never succeeded, the value was
+// silently dropped, and the column was written NULL on every request:
+//
+//	admin/storage.go           -> storage_config.created_by / .updated_by
+//	admin/storage_migration.go -> storage_migrations.created_by
+//	admin/mirror.go            -> mirror_configurations.created_by
+//
+// Nothing failed and nothing logged; the columns simply never held a value.
+// That is also why migration 000056 (issue #883) could drop the foreign keys on
+// three of them as "on a column that is always NULL" -- the constraints looked
+// harmless because the bug upstream of them made them unreachable.
+//
+// Both concrete types are accepted rather than only the string the middleware
+// writes. Tests set a uuid.UUID directly (TestMirrorCreate_WithUserIDContext),
+// and accepting one spelling while the codebase contains both is exactly how
+// the original defect survived: the failure mode of a type assertion here is a
+// missing value, never an error.
+package admin
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// currentUserID extracts the authenticated user's UUID from the gin context,
+// or nil when absent/unparsable (e.g. API-key auth without a user binding).
+func currentUserID(c *gin.Context) *uuid.UUID {
+	v, ok := c.Get("user_id")
+	if !ok {
+		return nil
+	}
+	switch id := v.(type) {
+	case string:
+		parsed, err := uuid.Parse(id)
+		if err != nil {
+			return nil
+		}
+		return &parsed
+	case uuid.UUID:
+		if id == uuid.Nil {
+			return nil
+		}
+		return &id
+	}
+	return nil
+}
+
+// currentUserNullUUID is currentUserID in the shape the storage-config columns
+// take: a uuid.NullUUID that is Valid only when a principal was resolved, so an
+// unattributable request still writes SQL NULL rather than the zero UUID.
+func currentUserNullUUID(c *gin.Context) uuid.NullUUID {
+	if id := currentUserID(c); id != nil {
+		return uuid.NullUUID{UUID: *id, Valid: true}
+	}
+	return uuid.NullUUID{}
+}
+
+// currentUserIDString is currentUserID for the call sites that pass the
+// principal on as a string. Empty means "no principal", which every consumer
+// already renders as NULL.
+func currentUserIDString(c *gin.Context) string {
+	if id := currentUserID(c); id != nil {
+		return id.String()
+	}
+	return ""
+}

--- a/backend/internal/api/admin/mirror.go
+++ b/backend/internal/api/admin/mirror.go
@@ -132,14 +132,10 @@ func (h *MirrorHandler) CreateMirrorConfig(c *gin.Context) {
 		return
 	}
 
-	// Get user ID from context (set by auth middleware)
-	userID, _ := c.Get("user_id")
-	var createdBy *uuid.UUID
-	if userID != nil {
-		if uid, ok := userID.(uuid.UUID); ok {
-			createdBy = &uid
-		}
-	}
+	// Get user ID from context (set by auth middleware). The middleware stores
+	// a string; this site asserted uuid.UUID, so mirror_configurations
+	// .created_by was written NULL on every create (issue #899).
+	createdBy := currentUserID(c)
 
 	// Set defaults
 	enabled := true

--- a/backend/internal/api/admin/org_delete_integration_guard_test.go
+++ b/backend/internal/api/admin/org_delete_integration_guard_test.go
@@ -1,0 +1,239 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// GUARD org-owns-integrations (issue #899).
+//
+// Migration 000056 dropped scm_providers.organization_id and
+// mirror_configurations.organization_id, both ON DELETE CASCADE, because no
+// foreign key can span the identity topologies (issue #883). Those two were the
+// sole mechanism holding their invariant, so after the drop
+// DELETE /organizations/:id left behind:
+//
+//   - an SCM provider holding client_secret_encrypted and webhook_secret, which
+//     the UNAUTHENTICATED webhook endpoint keeps honouring with no organization
+//     check at all; and
+//   - a mirror configuration that keeps syncing on schedule, stamping every
+//     provider it creates with the dead organization id, invisible to every
+//     non-platform administrator because tenantscope.Permits denies a foreign
+//     organization.
+//
+// The handler now REFUSES rather than sweeping. These tests pin both refusals,
+// both of their fail-closed error paths, and — the half that a guard test
+// usually forgets — that a clean organization still deletes.
+//
+// The two connections are separate sqlmocks ON PURPOSE, matching production:
+// organizations are read on the identity connection, scm_providers and
+// mirror_configurations on the registry's own. A single mock would hide a
+// wiring mistake that only appears once identity moves.
+
+const guardOrgUUID = "9f8e7d6c-5b4a-4321-8fed-cba987654321"
+
+func guardOrgRow() *sqlmock.Rows {
+	return sqlmock.NewRows(orgCols).
+		AddRow(guardOrgUUID, "acme", "Acme", nil, nil, time.Now(), time.Now())
+}
+
+// newOrgRouterWithIntegrationGuards builds the delete route with the two
+// registry-connection repositories wired, and returns the identity mock and the
+// registry mock in that order.
+func newOrgRouterWithIntegrationGuards(t *testing.T) (sqlmock.Sqlmock, sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+
+	identityDB, identityMock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock (identity): %v", err)
+	}
+	t.Cleanup(func() { identityDB.Close() })
+
+	registryDB, registryMock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock (registry): %v", err)
+	}
+	t.Cleanup(func() { registryDB.Close() })
+
+	registrySqlx := sqlx.NewDb(registryDB, "sqlmock")
+
+	h := NewOrganizationHandlers(&config.Config{}, identityDB,
+		repositories.NewNamespaceClaimRepository(identityDB), nil).
+		WithOrgIntegrationGuards(
+			repositories.NewSCMRepository(registrySqlx),
+			repositories.NewMirrorRepository(registrySqlx),
+		)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("scopes", []string{string(auth.ScopeAdmin)}) })
+	r.DELETE("/organizations/:id", h.DeleteOrganizationHandler())
+	return identityMock, registryMock, r
+}
+
+// expectPassesExistingGuards queues the two refusals that already existed, both
+// answering "nothing here", so the request reaches the new ones.
+func expectPassesExistingGuards(identityMock sqlmock.Sqlmock) {
+	identityMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(guardOrgRow())
+	identityMock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	identityMock.ExpectQuery("SELECT EXISTS.*FROM modules").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+}
+
+func deleteGuardOrg(r *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/"+guardOrgUUID, nil))
+	return w
+}
+
+// An organization that still owns an SCM provider must not be deletable.
+//
+// No DELETE FROM organizations is queued on the identity mock, so if the guard
+// stopped refusing, the handler would reach a statement sqlmock has no
+// expectation for and answer 500 — this asserting 409 is itself the proof that
+// the row survived.
+func TestDeleteOrganization_BlockedBySCMProviders(t *testing.T) {
+	identityMock, registryMock, r := newOrgRouterWithIntegrationGuards(t)
+	expectPassesExistingGuards(identityMock)
+	registryMock.ExpectQuery("SELECT COUNT.*FROM scm_providers").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	w := deleteGuardOrg(r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "SCM providers") {
+		t.Errorf("body does not name the blocking resource: %s", w.Body.String())
+	}
+	if err := identityMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("identity expectations not met: %v", err)
+	}
+	if err := registryMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("registry expectations not met: %v", err)
+	}
+}
+
+// Same for a mirror configuration, reached only once the SCM count is clean —
+// which also pins the order, so a deployment whose only asset is a mirror gets
+// the message about mirrors.
+func TestDeleteOrganization_BlockedByMirrorConfigurations(t *testing.T) {
+	identityMock, registryMock, r := newOrgRouterWithIntegrationGuards(t)
+	expectPassesExistingGuards(identityMock)
+	registryMock.ExpectQuery("SELECT COUNT.*FROM scm_providers").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	registryMock.ExpectQuery("SELECT COUNT.*FROM mirror_configurations").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	w := deleteGuardOrg(r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "mirror configurations") {
+		t.Errorf("body does not name the blocking resource: %s", w.Body.String())
+	}
+	if err := registryMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("registry expectations not met: %v", err)
+	}
+}
+
+// A count that cannot be taken must not be read as "nothing there". This is the
+// direction that matters: the registry connection is a different database from
+// the identity one in the topology this whole issue comes from, so it can be
+// down while organizations reads fine.
+func TestDeleteOrganization_SCMProviderCountDBError(t *testing.T) {
+	identityMock, registryMock, r := newOrgRouterWithIntegrationGuards(t)
+	expectPassesExistingGuards(identityMock)
+	registryMock.ExpectQuery("SELECT COUNT.*FROM scm_providers").
+		WillReturnError(errDB)
+
+	w := deleteGuardOrg(r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+	// Pinned to the guard's own message: a 500 from any earlier step would
+	// satisfy the status code alone and let this pass for the wrong reason.
+	if !strings.Contains(w.Body.String(), "Failed to check organization SCM providers") {
+		t.Errorf("500 did not come from the SCM guard: %s", w.Body.String())
+	}
+}
+
+func TestDeleteOrganization_MirrorCountDBError(t *testing.T) {
+	identityMock, registryMock, r := newOrgRouterWithIntegrationGuards(t)
+	expectPassesExistingGuards(identityMock)
+	registryMock.ExpectQuery("SELECT COUNT.*FROM scm_providers").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	registryMock.ExpectQuery("SELECT COUNT.*FROM mirror_configurations").
+		WillReturnError(errDB)
+
+	w := deleteGuardOrg(r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Failed to check organization mirror configurations") {
+		t.Errorf("500 did not come from the mirror guard: %s", w.Body.String())
+	}
+}
+
+// The other half of a refusal: an organization owning neither still deletes.
+// Without this, "always 409" would pass every test above.
+func TestDeleteOrganization_SucceedsWithNoIntegrations(t *testing.T) {
+	identityMock, registryMock, r := newOrgRouterWithIntegrationGuards(t)
+	expectPassesExistingGuards(identityMock)
+	registryMock.ExpectQuery("SELECT COUNT.*FROM scm_providers").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	registryMock.ExpectQuery("SELECT COUNT.*FROM mirror_configurations").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	identityMock.ExpectExec("DELETE FROM organizations").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	w := deleteGuardOrg(r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: body=%s", w.Code, w.Body.String())
+	}
+	if err := identityMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("identity expectations not met (the delete never ran): %v", err)
+	}
+	if err := registryMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("registry expectations not met (a count was skipped): %v", err)
+	}
+}
+
+// An organization id the repositories cannot key on fails closed. Counting zero
+// of everything for an unparsable id is exactly the silent pass this guard
+// exists to prevent.
+func TestDeleteOrganization_IntegrationGuardNonUUIDOrgID(t *testing.T) {
+	identityMock, _, r := newOrgRouterWithIntegrationGuards(t)
+	identityMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sqlmock.NewRows(orgCols).
+			AddRow("org-1", "acme", "Acme", nil, nil, time.Now(), time.Now()))
+	identityMock.ExpectQuery("SELECT COUNT.*FROM namespace_claims").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	identityMock.ExpectQuery("SELECT EXISTS.*FROM modules").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("DELETE", "/organizations/org-1", nil))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Failed to check organization integrations") {
+		t.Errorf("500 did not come from the guard's id parse: %s", w.Body.String())
+	}
+}

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/adminfloor"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
@@ -48,6 +49,47 @@ type OrganizationHandlers struct {
 	// WithAdminFloor, and admin_floor_class_test.go for the check that stops
 	// the router from quietly leaving it unset.
 	floor *adminfloor.Guard
+
+	// scmProviders and mirrors hold the two invariants migration 000056 took
+	// away and nothing replaced (issue #899). Both tables carried
+	// organization_id ON DELETE CASCADE into organizations until #883 dropped
+	// it, and both outlive their organization now that it is gone:
+	//
+	//	scm_providers      -- client_secret_encrypted + webhook_secret, and the
+	//	                      SCM webhook endpoint is UNAUTHENTICATED and does
+	//	                      no organization check, so an orphan keeps
+	//	                      publishing into a tenant that no longer exists.
+	//	mirror_configurations -- MirrorSyncJob keeps running it on schedule and
+	//	                      stamps every provider it creates with the dead
+	//	                      organization id, while tenantscope.Permits hides
+	//	                      the row from every non-platform administrator who
+	//	                      might have stopped it.
+	//
+	// DELIBERATELY ON THE REGISTRY CONNECTION, unlike every other field here.
+	// Both are registry feature tables that stay in the registry's schema at
+	// the identity cutover; reading them through identityDB would resolve
+	// tables that are not there in the separate-identity-database topology.
+	// Same deliberate exception WithUserSCMTokens makes on the /users family.
+	//
+	// May be nil in tests, on the "wired as a unit" convention above; the
+	// checks are then skipped. org_delete_guard_wiring_test.go is what stops
+	// the router from leaving them unset.
+	scmProviders *repositories.SCMRepository
+	mirrors      *repositories.MirrorRepository
+}
+
+// WithOrgIntegrationGuards injects the registry-connection repositories that
+// DeleteOrganizationHandler consults before it will delete an organization
+// (issue #899).
+//
+// One option rather than two: the two refusals are one rule -- an organization
+// is not deletable while it still owns an outbound integration -- and a
+// deployment that wired one without the other would enforce half of it while
+// reporting the same 200.
+func (h *OrganizationHandlers) WithOrgIntegrationGuards(scmProviders *repositories.SCMRepository, mirrors *repositories.MirrorRepository) *OrganizationHandlers {
+	h.scmProviders = scmProviders
+	h.mirrors = mirrors
+	return h
 }
 
 // WithAdminFloor injects the never-zero administrator guard (issue #766).
@@ -743,6 +785,115 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 	}
 }
 
+// refuseIfOwnsIntegrations refuses an organization deletion while the
+// organization still owns an SCM provider or a mirror configuration, and
+// reports whether the caller must stop. It writes its own response when it
+// returns true.
+//
+// REFUSE RATHER THAN SWEEP (issue #899), and the argument is the same for both
+// resources even though their hazards differ.
+//
+// Both columns were ON DELETE CASCADE until migration 000056 (issue #883), so
+// restoring the cascade in application code -- delete the rows, then delete the
+// organization -- is the obvious port, and it is what DeleteUserHandler does
+// for scm_oauth_tokens. It is the wrong shape here:
+//
+//  1. NOT ATOMIC, AND THE FAILURE DESTROYS DATA. organizations may live in a
+//     different SCHEMA or a different DATABASE from these two registry tables
+//     -- that is precisely why 000056 could not keep the foreign keys -- so a
+//     sweep and the delete cannot share a transaction. Sweeping first and then
+//     failing the delete leaves a LIVE organization stripped of its SCM
+//     connection and its mirrors, and client_secret_encrypted is not
+//     recoverable from the registry once the row is gone. Refusing has no such
+//     failure mode: it is a read, and a read that fails 500s without deleting
+//     anything.
+//  2. THE INVARIANT BECOMES STRUCTURAL. A refusal makes it impossible to reach
+//     orgRepo.Delete while either row exists, so this path cannot produce an
+//     orphan at all. A best-effort sweep can only promise that it usually does
+//     not.
+//  3. IT MATCHES THE TWO REFUSALS ABOVE. This handler's established answer to
+//     "the organization still owns something substantive" is 409 with an
+//     actionable message, not a silent cascade.
+//  4. IT IS ACTIONABLE. Both resources have first-class delete endpoints --
+//     DELETE /admin/scm/providers/:id and DELETE /admin/mirrors/:id -- so the
+//     operator can do exactly what the message asks, and deleting them THERE
+//     cascades their dependents (scm_oauth_tokens, scm_provider_tokens,
+//     module_scm_repos; mirror_sync_history, mirrored_providers) through
+//     foreign keys that still exist because they stay inside the registry's own
+//     schema.
+//
+// Why this differs from the scm_oauth_tokens sweep DeleteUserHandler does: a
+// user's OAuth token is a per-user credential whose only meaning is the
+// principal being destroyed, it is re-obtainable by re-running the OAuth flow
+// at no operator cost, and there is no endpoint an admin could be told to call
+// first -- nobody can delete another user's tokens. An SCM provider and a
+// mirror configuration are organization-level configuration objects with their
+// own CRUD, carrying secrets and schedules an operator should decommission
+// deliberately. A 409 is a usable instruction there; it would not have been on
+// the user path.
+//
+// A nil repository means the dependency was not wired (tests, and any caller
+// predating this issue), which skips the check rather than refusing -- the same
+// convention creds, floor and h.scmTokens follow. The router is held to wiring
+// it by org_delete_guard_wiring_test.go.
+func (h *OrganizationHandlers) refuseIfOwnsIntegrations(c *gin.Context, orgID string) bool {
+	if h.scmProviders == nil && h.mirrors == nil {
+		return false
+	}
+
+	// Both repositories key on a uuid.UUID. A non-UUID organization id is not
+	// reachable through the routes -- the id was just used to load the
+	// organization -- but it would silently count zero of everything, so it
+	// fails rather than passing.
+	oid, err := uuid.Parse(orgID)
+	if err != nil {
+		slog.Error("cannot check an organization's integrations for a non-UUID organization id",
+			"organization_id", orgID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to check organization integrations",
+		})
+		return true
+	}
+
+	if h.scmProviders != nil {
+		n, countErr := h.scmProviders.CountProvidersByOrganization(c.Request.Context(), oid)
+		if countErr != nil {
+			slog.Error("failed to count an organization's SCM providers; refusing to delete the organization",
+				"organization_id", orgID, "error", countErr)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to check organization SCM providers",
+			})
+			return true
+		}
+		if n > 0 {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Organization still owns SCM providers; delete them before deleting it",
+			})
+			return true
+		}
+	}
+
+	if h.mirrors != nil {
+		n, countErr := h.mirrors.CountByOrganization(c.Request.Context(), oid)
+		if countErr != nil {
+			slog.Error("failed to count an organization's mirror configurations; refusing to delete the organization",
+				"organization_id", orgID, "error", countErr)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to check organization mirror configurations",
+			})
+			return true
+		}
+		if n > 0 {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Organization still owns mirror configurations; delete them before deleting it",
+			})
+			return true
+		}
+	}
+
+	return false
+}
+
 // @Summary      Delete organization
 // @Description  Remove an organization and its associated records.
 // @Tags         Organizations
@@ -752,7 +903,7 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 // @Success      200  {object}  admin.MessageResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Organization not found"
-// @Failure      409  {object}  map[string]interface{}  "Organization still owns namespace claims, or deleting it would leave the deployment with no platform administrator"
+// @Failure      409  {object}  map[string]interface{}  "Organization still owns namespace claims, modules/providers, SCM providers or mirror configurations, or deleting it would leave the deployment with no platform administrator"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/organizations/{id} [delete]
 // DeleteOrganizationHandler deletes an organization
@@ -831,6 +982,14 @@ func (h *OrganizationHandlers) DeleteOrganizationHandler() gin.HandlerFunc {
 			c.JSON(http.StatusConflict, gin.H{
 				"error": "Organization still owns modules or providers; remove or reassign them before deleting it",
 			})
+			return
+		}
+
+		// GUARD org-owns-integrations (issue #899). Third and fourth refusals,
+		// for the two constraints migration 000056 dropped that were the sole
+		// mechanism holding their invariant. See refuseIfOwnsIntegrations for
+		// why these REFUSE rather than sweep.
+		if h.refuseIfOwnsIntegrations(c, orgID) {
 			return
 		}
 

--- a/backend/internal/api/admin/storage.go
+++ b/backend/internal/api/admin/storage.go
@@ -192,14 +192,10 @@ func (h *StorageHandlers) CreateStorageConfig(c *gin.Context) {
 		return
 	}
 
-	// Get user ID from context (set by auth middleware)
-	userID, exists := c.Get("user_id")
-	var userUUID uuid.NullUUID
-	if exists {
-		if uid, ok := userID.(uuid.UUID); ok {
-			userUUID = uuid.NullUUID{UUID: uid, Valid: true}
-		}
-	}
+	// Get user ID from context (set by auth middleware). Shared spelling: the
+	// middleware stores a string, and this site asserted uuid.UUID, so
+	// storage_config.created_by was written NULL on every create (issue #899).
+	userUUID := currentUserNullUUID(c)
 
 	// Check if this is the first storage configuration (initial setup)
 	configured, err := h.storageConfigRepo.IsStorageConfigured(ctx)
@@ -303,14 +299,9 @@ func (h *StorageHandlers) UpdateStorageConfig(c *gin.Context) {
 		return
 	}
 
-	// Get user ID from context
-	userID, exists := c.Get("user_id")
-	var userUUID uuid.NullUUID
-	if exists {
-		if uid, ok := userID.(uuid.UUID); ok {
-			userUUID = uuid.NullUUID{UUID: uid, Valid: true}
-		}
-	}
+	// Get user ID from context. Same defect and same fix as the create path:
+	// storage_config.updated_by was written NULL on every update (issue #899).
+	userUUID := currentUserNullUUID(c)
 
 	// Update the config
 	if err := h.updateStorageConfigFromInput(existing, &input, userUUID); err != nil {
@@ -410,18 +401,11 @@ func (h *StorageHandlers) ActivateStorageConfig(c *gin.Context) {
 		return
 	}
 
-	// Get user ID from context. User.ID is stored as a string by the auth
-	// middleware, so we must handle both string and uuid.UUID types.
-	userIDVal, _ := c.Get("user_id")
-	var userUUID uuid.NullUUID
-	switch v := userIDVal.(type) {
-	case string:
-		if parsed, parseErr := uuid.Parse(v); parseErr == nil {
-			userUUID = uuid.NullUUID{UUID: parsed, Valid: true}
-		}
-	case uuid.UUID:
-		userUUID = uuid.NullUUID{UUID: v, Valid: true}
-	}
+	// Get user ID from context. This site always had it right -- User.ID is
+	// stored as a string by the auth middleware, so both types must be handled
+	// -- and currentUserNullUUID is now that same switch, in one place, shared
+	// with the two sites nine lines above that did not (issue #899).
+	userUUID := currentUserNullUUID(c)
 
 	if err := h.storageConfigRepo.ActivateStorageConfig(ctx, id, userUUID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to activate storage configuration"})

--- a/backend/internal/api/admin/storage_migration.go
+++ b/backend/internal/api/admin/storage_migration.go
@@ -86,12 +86,10 @@ func (h *StorageMigrationHandler) StartMigration(c *gin.Context) {
 		return
 	}
 
-	var userID string
-	if uid, exists := c.Get("user_id"); exists {
-		if u, ok := uid.(uuid.UUID); ok {
-			userID = u.String()
-		}
-	}
+	// The auth middleware stores the principal as a string; this site asserted
+	// uuid.UUID, so storage_migrations.created_by was written NULL on every
+	// migration ever started (issue #899).
+	userID := currentUserIDString(c)
 
 	migration, err := h.service.StartMigration(c.Request.Context(), req.SourceConfigID, req.TargetConfigID, userID)
 	if err != nil {

--- a/backend/internal/api/admin/version_approvals.go
+++ b/backend/internal/api/admin/version_approvals.go
@@ -63,24 +63,6 @@ func (h *VersionApprovalHandler) tenantFilter(c *gin.Context) (repositories.Vers
 	return repositories.VersionApprovalFilter{Scope: scope.OrgScope()}, true
 }
 
-// currentUserID extracts the authenticated user's UUID from the gin context,
-// or nil when absent/unparsable (e.g. API-key auth without a user binding).
-func currentUserID(c *gin.Context) *uuid.UUID {
-	v, ok := c.Get("user_id")
-	if !ok {
-		return nil
-	}
-	s, ok := v.(string)
-	if !ok || s == "" {
-		return nil
-	}
-	id, err := uuid.Parse(s)
-	if err != nil {
-		return nil
-	}
-	return &id
-}
-
 // @Summary      List version approvals
 // @Description  Lists mirrored provider and terraform versions that are subject to the approval gate, filtered by status, type, and mirror config.
 // @Tags         Version Approvals

--- a/backend/internal/api/org_delete_guard_wiring_test.go
+++ b/backend/internal/api/org_delete_guard_wiring_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"go/ast"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #899 — the two guards that replace the dropped foreign keys are only
+// as good as their wiring, and the wiring is exactly what no behavioural test
+// can see.
+//
+// Both guards skip when their dependency is nil, on this codebase's standing
+// "an unwired optional dependency is a no-op, not a refusal" convention (creds,
+// floor, scmTokens all behave that way, and dozens of handler tests rely on
+// it). That convention is safe only while something holds the router to
+// actually wiring them — otherwise organization deletion silently stops
+// refusing, and the unauthenticated webhook silently stops checking, with every
+// test still green.
+//
+// The CONNECTION each repository is built on is load-bearing and is the second
+// half of this check:
+//
+//	scm_providers and mirror_configurations are registry feature tables that
+//	stay in the registry's schema at the identity cutover, so their repositories
+//	must come off sqlxDB. Building them on identityDB would resolve tables that
+//	do not exist in the separate-identity-database topology — the very topology
+//	that made migration 000056 drop the foreign keys in the first place.
+//
+//	organizations is the opposite: it MOVES to the identity schema, so the
+//	webhook's existence lookup must come off identityDB or it would ask the
+//	wrong database whether a tenant still exists and answer "no" for every one
+//	of them — turning a fail-closed guard into a total outage of the webhook
+//	route.
+//
+// Structural, like identity_db_wiring_test.go beside it, and for the same
+// reason: the failure is invisible until two schemas exist.
+
+// repoConnections are the repository constructions this guard pins, mapped to
+// the connection each MUST be built on.
+var repoConnections = map[string]string{
+	"scmRepo":    "sqlxDB",
+	"mirrorRepo": "sqlxDB",
+	"orgRepo":    "identityDB",
+}
+
+// guardWirings are the wiring calls that must appear, mapped to the arguments
+// they must be handed, in order.
+var guardWirings = map[string][]string{
+	"WithOrgIntegrationGuards":  {"scmRepo", "mirrorRepo"},
+	"WithOrganizationExistence": {"orgRepo"},
+}
+
+func TestRouterWiresOrgDeletionAndWebhookOrphanGuards(t *testing.T) {
+	path := filepath.Join("router.go")
+	_, file := parseGoFile(t, path)
+
+	// 1. Each repository is built on the connection its tables actually live on.
+	seenRepo := map[string]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		name := exprString(assign.Lhs[0])
+		if _, watched := repoConnections[name]; !watched {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		seenRepo[name] = exprString(call.Args[0])
+		return true
+	})
+	for name, wantConn := range repoConnections {
+		got, ok := seenRepo[name]
+		if !ok {
+			t.Errorf("%s is no longer constructed in router.go; the guard that depends on it may be unwired", name)
+			continue
+		}
+		if got != wantConn {
+			t.Errorf("%s is built on %s, want %s — it would resolve the wrong database once identity moves",
+				name, got, wantConn)
+		}
+	}
+
+	// 2. Each guard is actually handed those repositories.
+	seenWiring := map[string][]string{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if _, watched := guardWirings[sel.Sel.Name]; !watched {
+			return true
+		}
+		args := make([]string, 0, len(call.Args))
+		for _, a := range call.Args {
+			args = append(args, exprString(a))
+		}
+		seenWiring[sel.Sel.Name] = args
+		return true
+	})
+	for method, wantArgs := range guardWirings {
+		got, ok := seenWiring[method]
+		if !ok {
+			t.Errorf("router.go never calls %s: the guard it enables is a no-op in production", method)
+			continue
+		}
+		if len(got) != len(wantArgs) {
+			t.Errorf("%s got %d arguments %v, want %d %v", method, len(got), got, len(wantArgs), wantArgs)
+			continue
+		}
+		for i := range wantArgs {
+			if got[i] != wantArgs[i] {
+				t.Errorf("%s argument %d is %q, want %q", method, i, got[i], wantArgs[i])
+			}
+		}
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -736,7 +736,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		// and scm_oauth_tokens stays in the registry's schema at cutover.
 		admin.WithUserSCMTokens(scmRepo))
 	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB, nsClaimRepo, userTokenRevocationRepo).
-		WithAdminFloor(adminFloor)
+		WithAdminFloor(adminFloor).
+		// scmRepo and mirrorRepo, deliberately: both are built on the REGISTRY
+		// connection above, and scm_providers / mirror_configurations stay in
+		// the registry's schema at the identity cutover. Organization deletion
+		// refuses while either still holds a row for the organization -- the
+		// invariant migration 000056 could not keep in SQL (issues #883, #899).
+		WithOrgIntegrationGuards(scmRepo, mirrorRepo)
 	statsHandlers := admin.NewStatsHandler(identitySqlxDB, &cfg.Scanning).WithOrgRepo(orgRepo)
 	mirrorHandlers := admin.NewMirrorHandler(mirrorRepo, orgRepo, providerRepo)
 	mirrorHandlers.SetSyncJob(mirrorSyncJob) // Connect sync job for manual triggers
@@ -886,7 +892,13 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	policyAdminHandler := admin.NewPolicyHandler(policyEngine, cfg.Policy)
 
 	// Initialize SCM webhook handler
-	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher, tokenCipher)
+	// orgRepo, deliberately on the IDENTITY connection: the webhook route is
+	// unauthenticated and acts on scm_providers.webhook_secret on the row's own
+	// authority, so it has to be able to ask whether the row's organization is
+	// still there. Migration 000056 dropped the foreign key that used to make
+	// the question unaskable (issues #883, #899).
+	scmWebhookHandler := webhooks.NewSCMWebhookHandler(scmRepo, scmPublisher, tokenCipher).
+		WithOrganizationExistence(orgRepo)
 	approvalWebhookHandler := webhooks.NewApprovalHandler(rbacRepo)
 
 	// Build per-principal override rate limiters (if configured)

--- a/backend/internal/api/webhooks/scm_webhook.go
+++ b/backend/internal/api/webhooks/scm_webhook.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/terraform-registry/terraform-registry/internal/crypto"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/scm"
 	"github.com/terraform-registry/terraform-registry/internal/services"
@@ -28,6 +29,26 @@ type SCMWebhookHandler struct {
 	publisher   *services.SCMPublisher
 	connectors  map[scm.ProviderType]scm.Connector
 	tokenCipher *crypto.TokenCipher
+
+	// orgExists reports whether an SCM provider's owning organization still
+	// resolves in the identity store (issue #899).
+	//
+	// This route is the only UNAUTHENTICATED one that acts on a credential, and
+	// until migration 000056 (issue #883) scm_providers.organization_id was
+	// ON DELETE CASCADE, so an SCM provider could not outlive its organization
+	// and the question never arose. It can now, in every topology, and nothing
+	// else on this path asks it: the provider is loaded by id from the payload
+	// URL and its webhook_secret is honoured on its own authority.
+	//
+	// A function rather than a repository: organizations live on the IDENTITY
+	// connection, which may be another schema or another database, while
+	// everything else this handler touches is the registry's. Closing over the
+	// lookup keeps that seam at the wiring site (WithOrganizationExistence)
+	// instead of putting a second connection inside the handler.
+	//
+	// nil means unwired, which skips the check -- the same convention the
+	// admin handlers' optional dependencies follow.
+	orgExists func(ctx context.Context, orgID string) (bool, error)
 }
 
 // NewSCMWebhookHandler creates a new webhook handler
@@ -38,6 +59,34 @@ func NewSCMWebhookHandler(scmRepo *repositories.SCMRepository, publisher *servic
 		connectors:  make(map[scm.ProviderType]scm.Connector),
 		tokenCipher: tokenCipher,
 	}
+}
+
+// WithOrganizationExistence wires the identity-connection lookup that decides
+// whether an SCM provider's organization is still there (issue #899).
+//
+// The repository MUST be built on the identity connection, unlike scmRepo:
+// organizations move to the identity schema at cutover and may live in a
+// separate database entirely, which is the whole reason no foreign key can
+// hold this invariant any more.
+//
+// OrgScopeAllOrganizations is deliberate and is not an authorization decision.
+// The caller here is an SCM server with no principal at all; the question being
+// asked is "does this row's owner still exist", which is a platform fact.
+func (h *SCMWebhookHandler) WithOrganizationExistence(orgRepo *repositories.OrganizationRepository) *SCMWebhookHandler {
+	if orgRepo == nil {
+		return h
+	}
+	h.orgExists = func(ctx context.Context, orgID string) (bool, error) {
+		org, err := orgRepo.GetByID(ctx, orgID, repositories.OrgScopeAllOrganizations())
+		if identityerr.Missing(org, err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return h
 }
 
 // @Summary      Receive SCM webhook
@@ -144,6 +193,43 @@ func (h *SCMWebhookHandler) HandleWebhook(c *gin.Context) {
 	if provider == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "SCM provider not found"})
 		return
+	}
+
+	// GUARD webhook-provider-org-exists (issue #899). Refuse to act on an SCM
+	// provider whose organization has been deleted.
+	//
+	// DeleteOrganizationHandler now refuses that deletion, so no NEW orphan can
+	// be created through the API -- but this check is what covers the ones that
+	// already exist (any deployment that deleted an organization while
+	// migration 000056 was in place and this guard was not) and the ones no
+	// registry handler is involved in at all, since organizations may live in
+	// another database where they can be removed without this service ever
+	// seeing the verb.
+	//
+	// Placed here, after the URL-embedded secret has been verified and before
+	// the client secret is decrypted: the caller has already proved it holds
+	// the link's secret, so this leaks nothing new, and an orphaned provider's
+	// ciphertext is never opened.
+	//
+	// A zero organization_id is the single-tenant deployment (the column is
+	// nullable and google/uuid scans NULL to uuid.Nil), which is owned by no
+	// organization and has nothing to check.
+	if h.orgExists != nil && provider.OrganizationID != uuid.Nil {
+		exists, orgErr := h.orgExists(c.Request.Context(), provider.OrganizationID.String())
+		if orgErr != nil {
+			// Fail CLOSED. The alternative -- treating a lookup failure as
+			// "probably still there" -- publishes into a tenant on the strength
+			// of a database error, on an unauthenticated route.
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to verify SCM provider organization"})
+			return
+		}
+		if !exists {
+			// Same answer as a missing provider, deliberately: an orphaned
+			// provider is indistinguishable from one that was deleted properly,
+			// so this adds no new signal for an anonymous caller.
+			c.JSON(http.StatusNotFound, gin.H{"error": "SCM provider not found"})
+			return
+		}
 	}
 
 	// Build connector for this provider

--- a/backend/internal/api/webhooks/scm_webhook_org_orphan_test.go
+++ b/backend/internal/api/webhooks/scm_webhook_org_orphan_test.go
@@ -1,0 +1,185 @@
+package webhooks
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/sethbacon/terraform-suite-identity/identity/pgxparam"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// GUARD webhook-provider-org-exists (issue #899).
+//
+// This is the serious half of the issue. /webhooks/scm/:link/:secret is the
+// only UNAUTHENTICATED route in the service that acts on a stored credential:
+// it loads the SCM provider by id from the payload URL and verifies the
+// delivery against provider.WebhookSecret, on the row's own authority.
+//
+// scm_providers.organization_id was ON DELETE CASCADE until migration 000056
+// (issue #883), so the row could not outlive its organization and the question
+// never had to be asked. It can now — in every topology — and a repository
+// still pointing at the registry would otherwise keep triggering module
+// publishes into a tenant that no longer exists, indefinitely, using a
+// client secret and a webhook secret nobody can see in the UI any more.
+//
+// DeleteOrganizationHandler refuses to create such a row (GUARD
+// org-owns-integrations), but these are the orphans that already exist, and the
+// ones no registry handler is involved in at all: organizations may live in a
+// separate database with a lifecycle this service never observes.
+
+func newWebhookSQLMock() (*sql.DB, sqlmock.Sqlmock, error) {
+	return sqlmock.New(sqlmock.ValueConverterOption(pgxparam.Converter{}))
+}
+
+var orphanOrgCols = []string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}
+
+// orphanProviderRow is sampleProviderRow with a caller-chosen organization_id,
+// which is the column under test here.
+func orphanProviderRow(t *testing.T, id, orgID uuid.UUID, providerType string) *sqlmock.Rows {
+	t.Helper()
+	baseURL := "https://bitbucket.example.com"
+	encryptedSecret, err := testTokenCipher(t).Seal("test-client-secret")
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	return sqlmock.NewRows(scmProviderCols).AddRow(
+		id, orgID, providerType, "Test Provider",
+		&baseURL, nil, "client-id",
+		encryptedSecret, "",
+		true, time.Now(), time.Now(),
+	)
+}
+
+// newWebhookRouterWithOrgLookup wires the real identity-connection repository
+// through WithOrganizationExistence, so the production closure is what these
+// tests drive rather than a stand-in. Returns the registry mock and the
+// identity mock in that order.
+func newWebhookRouterWithOrgLookup(t *testing.T) (sqlmock.Sqlmock, sqlmock.Sqlmock, *gin.Engine) {
+	t.Helper()
+
+	registryDB, registryMock, err := newWebhookSQLMock()
+	if err != nil {
+		t.Fatalf("sqlmock.New (registry): %v", err)
+	}
+	t.Cleanup(func() { registryDB.Close() })
+
+	identityDB, identityMock, err := newWebhookSQLMock()
+	if err != nil {
+		t.Fatalf("sqlmock.New (identity): %v", err)
+	}
+	t.Cleanup(func() { identityDB.Close() })
+
+	h := NewSCMWebhookHandler(
+		repositories.NewSCMRepository(sqlx.NewDb(registryDB, "sqlmock")),
+		nil, // publisher: every test here stops before publishing
+		testTokenCipher(t),
+	).WithOrganizationExistence(repositories.NewOrganizationRepository(identityDB))
+
+	r := gin.New()
+	r.POST("/webhooks/scm/:module_source_repo_id/:secret", h.HandleWebhook)
+	return registryMock, identityMock, r
+}
+
+func expectLinkAndProvider(registryMock sqlmock.Sqlmock, t *testing.T, providerID, orgID uuid.UUID) {
+	t.Helper()
+	registryMock.ExpectQuery("SELECT.*FROM module_scm_repos WHERE id").
+		WillReturnRows(sampleModuleSourceRepoRowWithURL(providerID,
+			"https://registry.example.com/webhooks/scm/"+webhookTestUUID+"/secret123"))
+	registryMock.ExpectQuery("SELECT.*FROM scm_providers WHERE id").
+		WillReturnRows(orphanProviderRow(t, providerID, orgID, "bitbucket_dc"))
+}
+
+func postWebhook(r *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/webhooks/scm/"+webhookTestUUID+"/secret123", nil))
+	return w
+}
+
+// An SCM provider whose organization is gone is answered exactly as a provider
+// that does not exist — the same 404, so an anonymous caller learns nothing new
+// — and the handler stops before the client secret is ever decrypted.
+func TestWebhook_RefusesProviderWhoseOrganizationIsGone(t *testing.T) {
+	registryMock, identityMock, r := newWebhookRouterWithOrgLookup(t)
+	providerID, orgID := uuid.New(), uuid.New()
+	expectLinkAndProvider(registryMock, t, providerID, orgID)
+	identityMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WithArgs(orgID.String()).
+		WillReturnRows(sqlmock.NewRows(orphanOrgCols)) // no such organization
+
+	w := postWebhook(r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (orphaned provider must not be honoured): body=%s",
+			w.Code, w.Body.String())
+	}
+	if err := identityMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the organization was never looked up: %v", err)
+	}
+	if err := registryMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("registry expectations not met: %v", err)
+	}
+}
+
+// A lookup that fails is NOT read as "probably still there". On this route that
+// would mean honouring a credential on the strength of a database error, with
+// no principal anywhere in the request.
+func TestWebhook_OrganizationLookupErrorFailsClosed(t *testing.T) {
+	registryMock, identityMock, r := newWebhookRouterWithOrgLookup(t)
+	providerID, orgID := uuid.New(), uuid.New()
+	expectLinkAndProvider(registryMock, t, providerID, orgID)
+	identityMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnError(webhookErrDB)
+
+	w := postWebhook(r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (fail closed): body=%s", w.Code, w.Body.String())
+	}
+}
+
+// The other half: a live organization must still be served. bitbucket_dc builds
+// a connector without OAuth credentials, and the fixture's webhook_secret is
+// empty, so a request with no signature reaches 401 — which is proof the guard
+// let it through rather than proof of anything about signatures.
+func TestWebhook_ProceedsWhenOrganizationLives(t *testing.T) {
+	registryMock, identityMock, r := newWebhookRouterWithOrgLookup(t)
+	providerID, orgID := uuid.New(), uuid.New()
+	expectLinkAndProvider(registryMock, t, providerID, orgID)
+	identityMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sqlmock.NewRows(orphanOrgCols).
+			AddRow(orgID.String(), "acme", "Acme", nil, nil, time.Now(), time.Now()))
+
+	w := postWebhook(r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (guard must not block a live organization): body=%s",
+			w.Code, w.Body.String())
+	}
+}
+
+// A provider with no organization at all is the single-tenant deployment: the
+// column is nullable and scans to uuid.Nil, it is owned by nobody, and there is
+// nothing to outlive. No identity query is queued, so a check made here would
+// fail the request instead of passing it.
+func TestWebhook_SingleTenantProviderSkipsOrganizationCheck(t *testing.T) {
+	registryMock, identityMock, r := newWebhookRouterWithOrgLookup(t)
+	providerID := uuid.New()
+	expectLinkAndProvider(registryMock, t, providerID, uuid.Nil)
+
+	w := postWebhook(r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (unowned provider must not be blocked): body=%s",
+			w.Code, w.Body.String())
+	}
+	if err := identityMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("identity expectations not met: %v", err)
+	}
+}

--- a/backend/internal/db/repositories/mirror_repository.go
+++ b/backend/internal/db/repositories/mirror_repository.go
@@ -183,6 +183,30 @@ func (r *MirrorRepository) Update(ctx context.Context, config *models.MirrorConf
 	return nil
 }
 
+// CountByOrganization counts the mirror configurations an organization owns.
+//
+// mirror_configurations.organization_id used to carry ON DELETE CASCADE into
+// organizations; migration 000056 dropped it (issue #883) because no foreign
+// key can span the identity topologies. Nothing then stopped a mirror from
+// outliving its organization -- and an orphaned mirror keeps syncing on
+// schedule, stamping every provider it creates with the dead organization id,
+// while tenantscope.Permits hides it from every non-platform administrator who
+// might have stopped it. DeleteOrganizationHandler calls this to refuse that
+// deletion instead (issue #899).
+//
+// A NULL organization_id is the deliberate "global mirror" (see the column's
+// comment in 000001_initial_schema) and is owned by nobody, so `= $1` is the
+// correct comparison: it never matches, and a global mirror is never counted
+// against any organization's deletion.
+func (r *MirrorRepository) CountByOrganization(ctx context.Context, orgID uuid.UUID) (int, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM mirror_configurations WHERE organization_id = $1`
+	if err := r.db.GetContext(ctx, &count, query, orgID); err != nil {
+		return 0, fmt.Errorf("failed to count mirror configurations for organization: %w", err)
+	}
+	return count, nil
+}
+
 // Delete deletes a mirror configuration
 func (r *MirrorRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM mirror_configurations WHERE id = $1`

--- a/backend/internal/db/repositories/org_integration_counts_test.go
+++ b/backend/internal/db/repositories/org_integration_counts_test.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+)
+
+// The two counts DeleteOrganizationHandler refuses on (issue #899).
+//
+// Both replace an ON DELETE CASCADE that migration 000056 dropped, so the
+// predicate is the whole contract: it must key on organization_id and nothing
+// else, and it must not fold a NULL owner into somebody's total.
+
+var errCountDB = errors.New("db error")
+
+func newCountRepos(t *testing.T) (*SCMRepository, *MirrorRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := newSQLMock()
+	if err != nil {
+		t.Fatalf("newSQLMock: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	sqlxDB := sqlx.NewDb(db, "sqlmock")
+	return NewSCMRepository(sqlxDB), NewMirrorRepository(sqlxDB), mock
+}
+
+func TestCountProvidersByOrganization(t *testing.T) {
+	scmRepo, _, mock := newCountRepos(t)
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT COUNT.*FROM scm_providers WHERE organization_id").
+		WithArgs(orgID.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
+	n, err := scmRepo.CountProvidersByOrganization(context.Background(), orgID)
+	if err != nil {
+		t.Fatalf("CountProvidersByOrganization: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("count = %d, want 3", n)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestCountProvidersByOrganization_DBError(t *testing.T) {
+	scmRepo, _, mock := newCountRepos(t)
+	mock.ExpectQuery("SELECT COUNT.*FROM scm_providers").WillReturnError(errCountDB)
+
+	if _, err := scmRepo.CountProvidersByOrganization(context.Background(), uuid.New()); err == nil {
+		t.Fatal("expected an error, got nil: a failed count must not read as zero")
+	}
+}
+
+func TestMirrorCountByOrganization(t *testing.T) {
+	_, mirrorRepo, mock := newCountRepos(t)
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT COUNT.*FROM mirror_configurations WHERE organization_id").
+		WithArgs(orgID.String()).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	n, err := mirrorRepo.CountByOrganization(context.Background(), orgID)
+	if err != nil {
+		t.Fatalf("CountByOrganization: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1", n)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+func TestMirrorCountByOrganization_DBError(t *testing.T) {
+	_, mirrorRepo, mock := newCountRepos(t)
+	mock.ExpectQuery("SELECT COUNT.*FROM mirror_configurations").WillReturnError(errCountDB)
+
+	if _, err := mirrorRepo.CountByOrganization(context.Background(), uuid.New()); err == nil {
+		t.Fatal("expected an error, got nil: a failed count must not read as zero")
+	}
+}

--- a/backend/internal/db/repositories/scm_repository.go
+++ b/backend/internal/db/repositories/scm_repository.go
@@ -91,6 +91,25 @@ func (r *SCMRepository) ListProviders(ctx context.Context, orgID uuid.UUID) ([]*
 	return providers, err
 }
 
+// CountProvidersByOrganization counts the SCM providers an organization owns.
+//
+// Reads scm_providers on the REGISTRY connection. Its organization_id used to
+// carry ON DELETE CASCADE into organizations; migration 000056 dropped it
+// (issue #883) because no foreign key can span the identity topologies, and
+// with it went the only mechanism that stopped a provider row -- holding
+// client_secret_encrypted and webhook_secret, and honoured by the
+// UNAUTHENTICATED webhook endpoint -- from outliving its organization.
+// DeleteOrganizationHandler calls this to refuse that deletion instead
+// (issue #899).
+func (r *SCMRepository) CountProvidersByOrganization(ctx context.Context, orgID uuid.UUID) (int, error) {
+	var count int
+	query := `SELECT COUNT(*) FROM scm_providers WHERE organization_id = $1`
+	if err := r.db.GetContext(ctx, &count, query, orgID); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 // UpdateProvider updates an SCM provider configuration
 func (r *SCMRepository) UpdateProvider(ctx context.Context, provider *scm.SCMProviderRecord) error {
 	authMode := provider.AuthMode

--- a/backend/internal/jobs/mirror_sync.go
+++ b/backend/internal/jobs/mirror_sync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
+	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 	"github.com/terraform-registry/terraform-registry/internal/mirror"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -223,6 +224,33 @@ func (j *MirrorSyncJob) runScheduledSyncs(ctx context.Context) {
 	log.Printf("Found %d mirrors needing sync", len(mirrors))
 
 	for _, mirror := range mirrors {
+		// GUARD mirror-owner-org-exists (issue #899). Skip a mirror whose
+		// owning organization is gone.
+		//
+		// GetMirrorsNeedingSync applies no tenancy filter and no
+		// organization-existence filter, and until migration 000056 it did not
+		// need one: mirror_configurations.organization_id was ON DELETE CASCADE,
+		// so an orphaned mirror could not exist. Issue #883 dropped that
+		// constraint because no foreign key can span the identity topologies,
+		// and an orphan then keeps running forever -- syncMirror stamps every
+		// provider it creates with the dead organization id, while
+		// tenantscope.Permits hides the row from every non-platform
+		// administrator who might have stopped it.
+		//
+		// DeleteOrganizationHandler now refuses to create such a mirror
+		// (GUARD org-owns-integrations), so this is the fail-safe for the ones
+		// that already exist and for the organizations this service never sees
+		// deleted -- identity may be a separate database with its own
+		// lifecycle.
+		//
+		// In Go rather than in the query, deliberately: organizations may live
+		// in another schema or another database, so the existence test cannot
+		// be a join. j.orgRepo is the identity-connection repository the sync
+		// already consults for the default organization.
+		if !j.ownerOrganizationLives(ctx, mirror) {
+			continue
+		}
+
 		// Check if this mirror is already syncing
 		j.activeSyncsMutex.Lock()
 		if j.activeSyncs[mirror.ID] {
@@ -237,6 +265,41 @@ func (j *MirrorSyncJob) runScheduledSyncs(ctx context.Context) {
 		mirrorCopy := mirror
 		safego.Go(func() { j.syncMirror(ctx, mirrorCopy) })
 	}
+}
+
+// ownerOrganizationLives reports whether a mirror configuration's owning
+// organization still exists, and therefore whether the mirror may run
+// (issue #899).
+//
+// Three cases return true:
+//
+//   - a NULL organization_id, which is the deliberate "global mirror" the
+//     column documents; it is owned by nobody and has nothing to outlive;
+//   - an unwired orgRepo, which is only the tests -- NewMirrorSyncJob takes it
+//     as a required positional argument, so a deployment cannot omit it;
+//   - a FAILED lookup. Fail-open is the right direction for this one guard: a
+//     transient identity-database error would otherwise silently stop every
+//     org-bound mirror in the deployment, which is a much larger outage than
+//     one extra sync cycle of a mirror that is probably fine. The
+//     security-relevant fail-closed decision is on the webhook path, where a
+//     credential is being honoured; here the worst case is a provider row
+//     mirrored one interval late in being stopped.
+func (j *MirrorSyncJob) ownerOrganizationLives(ctx context.Context, config models.MirrorConfiguration) bool {
+	if config.OrganizationID == nil || j.orgRepo == nil {
+		return true
+	}
+	orgID := config.OrganizationID.String()
+	org, err := j.orgRepo.GetByID(ctx, orgID, repositories.OrgScopeAllOrganizations())
+	if identityerr.Missing(org, err) {
+		log.Printf("Skipping mirror %s (ID: %s): its organization %s no longer exists",
+			config.Name, config.ID, orgID)
+		return false
+	}
+	if err != nil {
+		log.Printf("Warning: could not verify organization %s for mirror %s; syncing anyway: %v",
+			orgID, config.Name, err)
+	}
+	return true
 }
 
 // syncMirror performs the actual synchronization of a mirror.

--- a/backend/internal/jobs/mirror_sync_org_orphan_test.go
+++ b/backend/internal/jobs/mirror_sync_org_orphan_test.go
@@ -1,0 +1,170 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+)
+
+// GUARD mirror-owner-org-exists (issue #899).
+//
+// GetMirrorsNeedingSync applies no tenancy filter and no organization-existence
+// filter — verified against the query itself, which selects on enabled, the
+// sync interval and last_sync_status only. Until migration 000056 it did not
+// need one: mirror_configurations.organization_id was ON DELETE CASCADE, so an
+// orphaned mirror could not exist. Issue #883 dropped that constraint, and an
+// orphan now keeps running on schedule forever, stamping every provider it
+// creates with the dead organization id — while tenantscope.Permits denies a
+// foreign organization, so no non-platform administrator can even see the row
+// to stop it.
+
+func newOrphanOrgRepo(t *testing.T) (*repositories.OrganizationRepository, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (identity): %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return repositories.NewOrganizationRepository(db), mock
+}
+
+var errMirrorOrphanDB = errors.New("identity db error")
+
+var orphanOrgCols = []string{"id", "name", "display_name", "idp_type", "idp_name", "created_at", "updated_at"}
+
+func orgBoundMirror(orgID *uuid.UUID) models.MirrorConfiguration {
+	return models.MirrorConfiguration{
+		ID:                  uuid.New(),
+		Name:                "upstream",
+		UpstreamRegistryURL: "https://registry.example.invalid",
+		OrganizationID:      orgID,
+		Enabled:             true,
+		SyncIntervalHours:   24,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ownerOrganizationLives — the guard's decision, in isolation
+// ---------------------------------------------------------------------------
+
+func TestOwnerOrganizationLives_DeletedOrganizationStopsTheMirror(t *testing.T) {
+	orgRepo, mock := newOrphanOrgRepo(t)
+	job := NewMirrorSyncJob(nil, nil, nil, orgRepo, nil, "")
+
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WithArgs(orgID.String()).
+		WillReturnRows(sqlmock.NewRows(orphanOrgCols))
+
+	if job.ownerOrganizationLives(context.Background(), orgBoundMirror(&orgID)) {
+		t.Fatal("a mirror whose organization no longer exists must not sync")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the organization was never looked up: %v", err)
+	}
+}
+
+func TestOwnerOrganizationLives_LiveOrganizationStillSyncs(t *testing.T) {
+	orgRepo, mock := newOrphanOrgRepo(t)
+	job := NewMirrorSyncJob(nil, nil, nil, orgRepo, nil, "")
+
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sqlmock.NewRows(orphanOrgCols).
+			AddRow(orgID.String(), "acme", "Acme", nil, nil, time.Now(), time.Now()))
+
+	if !job.ownerOrganizationLives(context.Background(), orgBoundMirror(&orgID)) {
+		t.Fatal("a mirror whose organization exists must still sync")
+	}
+}
+
+// A global mirror (NULL organization_id) is owned by nobody and has nothing to
+// outlive. No query is queued, so a lookup made here would fail the assertion
+// below rather than silently pass.
+func TestOwnerOrganizationLives_GlobalMirrorIsNotChecked(t *testing.T) {
+	orgRepo, mock := newOrphanOrgRepo(t)
+	job := NewMirrorSyncJob(nil, nil, nil, orgRepo, nil, "")
+
+	if !job.ownerOrganizationLives(context.Background(), orgBoundMirror(nil)) {
+		t.Fatal("a global mirror must sync")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expectations not met: %v", err)
+	}
+}
+
+// Fail OPEN, deliberately and only here: a transient identity-database fault
+// would otherwise stop every organization-bound mirror in the deployment at
+// once, which is a far larger outage than one extra sync of a mirror that is
+// probably fine. The fail-CLOSED decision is on the webhook path, where a
+// credential is being honoured.
+func TestOwnerOrganizationLives_LookupFailureFailsOpen(t *testing.T) {
+	orgRepo, mock := newOrphanOrgRepo(t)
+	job := NewMirrorSyncJob(nil, nil, nil, orgRepo, nil, "")
+
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnError(errMirrorOrphanDB)
+
+	if !job.ownerOrganizationLives(context.Background(), orgBoundMirror(&orgID)) {
+		t.Fatal("a failed lookup must not stop the mirror")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runScheduledSyncs — the decision actually wired into the loop
+// ---------------------------------------------------------------------------
+
+// The sync-history INSERT is queued as a NEGATIVE expectation: syncMirror
+// writes it first thing, so it is the earliest observable proof that a sync
+// started. With the guard in place it must never be reached, which is why this
+// test asserts that the expectation went UNFULFILLED.
+func TestRunScheduledSyncs_SkipsMirrorWhoseOrganizationIsGone(t *testing.T) {
+	mirrorDB, mirrorMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New (registry): %v", err)
+	}
+	t.Cleanup(func() { mirrorDB.Close() })
+	mirrorRepo := repositories.NewMirrorRepository(sqlx.NewDb(mirrorDB, "sqlmock"))
+
+	orgRepo, orgMock := newOrphanOrgRepo(t)
+	job := NewMirrorSyncJob(mirrorRepo, nil, nil, orgRepo, nil, "")
+
+	orgID := uuid.New()
+	mirrorMock.ExpectQuery("SELECT.*FROM mirror_configurations").
+		WillReturnRows(sqlmock.NewRows(mirrorConfigCols).AddRow(
+			uuid.New(), "orphaned", nil, "https://registry.example.invalid", orgID,
+			nil, nil, nil, nil,
+			true, 24, nil, nil,
+			nil, time.Now(), time.Now(), nil,
+		))
+	orgMock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sqlmock.NewRows(orphanOrgCols)) // gone
+	mirrorMock.ExpectExec("INSERT INTO mirror_sync_history").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	job.runScheduledSyncs(context.Background())
+
+	job.activeSyncsMutex.Lock()
+	active := len(job.activeSyncs)
+	job.activeSyncsMutex.Unlock()
+	if active != 0 {
+		t.Errorf("a sync was started for a mirror whose organization is gone (%d active)", active)
+	}
+
+	// Give a mutated build time to reach the insert before the assertion.
+	time.Sleep(200 * time.Millisecond)
+	if err := mirrorMock.ExpectationsWereMet(); err == nil {
+		t.Error("the sync-history insert ran: the orphaned mirror synced anyway")
+	}
+	if err := orgMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the organization was never looked up: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #899

## The residue of #883

Migration `000056` dropped 24 cross-schema foreign keys into the identity tables. Two of them were the sole mechanism holding their invariant, and after the drop `DELETE /api/v1/organizations/:id` left both behind. Verified against `origin/main` before changing anything:

| | verified | consequence |
|---|---|---|
| `scm_providers.organization_id` | `DeleteOrganizationHandler` has two 409 guards (namespace claims, artifact ownership) and **no sweep**; `webhooks.HandleWebhook` loads the provider by id from the payload URL and verifies against `provider.WebhookSecret` with **no organization check anywhere in the flow**, on an **unauthenticated** route | an orphan keeps triggering module publishes into a tenant that no longer exists, on a `client_secret_encrypted` / `webhook_secret` pair nobody can see in the UI any more |
| `mirror_configurations.organization_id` | `GetMirrorsNeedingSync` **really does lack an org filter** — it selects on `enabled`, the sync interval and `last_sync_status`, nothing else | an orphan keeps syncing on schedule and stamps every provider it creates with the dead organization id, while `tenantscope.Permits` hides the row from every non-platform administrator who might have stopped it |

## Decision: refuse, for both

Restoring the cascade in application code is the obvious port and is what `DeleteUserHandler` does for `scm_oauth_tokens`. It is the wrong shape here:

1. **Not atomic, and the failure destroys data.** `organizations` may live in a different schema or a different database from these two registry tables — exactly why `000056` could not keep the foreign keys — so a sweep and the delete cannot share a transaction. Sweeping first and then failing the delete leaves a **live** organization stripped of its SCM connection and its mirrors, and `client_secret_encrypted` is not recoverable once the row is gone. A refusal has no such failure mode: it is a read, and a read that fails 500s without deleting anything.
2. **The invariant becomes structural.** `orgRepo.Delete` is unreachable while either row exists, so this path cannot produce an orphan at all. A best-effort sweep can only promise that it usually does not.
3. **It matches the two refusals already there.** This handler's established answer to "the organization still owns something substantive" is a 409 with an actionable message.
4. **It is actionable.** Both resources have first-class delete endpoints, and deleting them *there* cascades their dependents through foreign keys that still exist, because those stay inside the registry's own schema.

**Why this differs from the `scm_oauth_tokens` precedent:** a user's OAuth token is a per-user credential whose only meaning is the principal being destroyed, it is re-obtainable by re-running the OAuth flow at no operator cost, and there is no endpoint an admin could be told to call first — nobody can delete another user's tokens. An SCM provider and a mirror configuration are organization-level configuration objects with their own CRUD, carrying secrets and schedules an operator should decommission deliberately.

### The invariant

After the handler returns success, no orphaned `scm_providers` or `mirror_configurations` row remains — because it is impossible to reach the delete while one exists. This is held **without** a transaction, which a sweep could not have been.

### Two runtime fail-safes

A refusal cannot reach the orphans that already exist, nor the organizations this service never sees deleted (identity may be a separate database with its own lifecycle). So, independently:

- **`GUARD webhook-provider-org-exists`** — asserts the provider's organization still resolves, *after* the URL-embedded secret is verified and *before* the client secret is decrypted, answering the same 404 as a missing provider so an anonymous caller learns nothing new. **Fail-closed**: honouring a credential on the strength of a database error, with no principal in the request, is not a trade this route may make. Skipped for `organization_id IS NULL` (single-tenant).
- **`GUARD mirror-owner-org-exists`** — `MirrorSyncJob` skips a mirror whose owning organization is gone. **Fail-open** on a lookup error, deliberately and only here: a transient identity fault would otherwise stop every organization-bound mirror in the deployment at once, and no credential is being honoured. Done in Go, not SQL, so it works in the separate-database topology.

## The attribution columns: four, not five

The issue says five. It is **four**. `c.Get("user_id")` stores a **string**; these asserted `.(uuid.UUID)`, so the assertion never succeeded, the value was dropped, and nothing logged:

- `admin/mirror.go:139` → `mirror_configurations.created_by`
- `admin/storage.go:199` → `storage_config.created_by`
- `admin/storage.go:310` → `storage_config.updated_by`
- `admin/storage_migration.go:91` → `storage_migrations.created_by`

`setup/handlers.go:501` is **not** this defect — it passes `uuid.Nil` deliberately, and `storage_config_repository.go` documents `NULLIF` treating that as NULL during first-run setup when no user exists yet.

All four now share one spelling with `admin/storage.go:415`, which already had the correct type switch nine lines from two of the broken ones. That switch moved to `admin/context_user.go` together with the string-only `currentUserID` that lived in `version_approvals.go`; `version_approvals.go` appears in the diff **only** as that relocation — it was never one of the broken sites.

This is why three of the dropped foreign keys looked harmless: they constrained columns nothing populated.

## Mutation verification

Every guard was broken, its covering test watched to fail, and restored.

| # | mutation | test that failed |
|---|---|---|
| M1 | guard call removed from `DeleteOrganizationHandler` | all six org-deletion tests |
| M2 | SCM count decremented (off-by-one) | `BlockedBySCMProviders` |
| M3 | mirror count forced to 0 | `BlockedByMirrorConfigurations` |
| M4 | count error read as "nothing there" | `SCMProviderCountDBError` |
| M5 | unparsable org id passes instead of failing closed | `IntegrationGuardNonUUIDOrgID` |
| W1 | webhook org check disabled | `RefusesProviderWhoseOrganizationIsGone`, `OrganizationLookupErrorFailsClosed` |
| W2 | missing organization treated as present | `RefusesProviderWhoseOrganizationIsGone` |
| W3 | webhook lookup error fails open | `OrganizationLookupErrorFailsClosed` |
| W4 | check applied to unowned providers too | `SingleTenantProviderSkipsOrganizationCheck` |
| S1 | `continue` removed from `runScheduledSyncs` | `SkipsMirrorWhoseOrganizationIsGone` |
| S2 | missing organization treated as live | `DeletedOrganizationStopsTheMirror`, `SkipsMirrorWhoseOrganizationIsGone` |
| S3 | global (NULL-owner) mirror checked anyway | `GlobalMirrorIsNotChecked` |
| S4 | mirror lookup failure fails closed | `LookupFailureFailsOpen` |
| R1 | `WithOrgIntegrationGuards` wiring removed | `RouterWiresOrgDeletionAndWebhookOrphanGuards` |
| R2 | `WithOrganizationExistence` wiring removed | same |
| R3 | `scmRepo` moved to the identity connection | same |
| A1 | `mirror.go` restored to `.(uuid.UUID)` | `MirrorCreatedByRecordsTheCaller` |
| A2/A3 | `storage.go` create+update restored | `StorageConfigCreatedByRecordsTheCaller`, `StorageConfigUpdatedByRecordsTheCaller` |
| A4 | `storage_migration.go` restored | `StorageMigrationCreatedByRecordsTheCaller` |

The router wiring guard is structural because both new dependencies are optional (nil = skip, this codebase's standing convention), and it pins **which connection** each repository is built on — `scm_providers` and `mirror_configurations` on the registry's, `organizations` on identity's. Getting that backwards is invisible until two schemas exist.

## Postgres tests

None. Every test added here is `sqlmock`-backed and runs in CI. Nothing in this change is exercised only by a `TFR_TEST_DATABASE_URL`-gated test, so #886 does not apply to it, and no claim below rests on a test CI never ran.

## Local verification

`go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues), and the full `go test ./... -race` suite green. Coverage reproduced the CI gate locally: **81.4 %** filtered (floor 80) and all per-package floors pass. Swagger/OpenAPI regenerated for the changed 409 description.
