### PR TITLE
ci: stop Dependabot proposing Go release candidates for the builder image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,16 @@ updates:
       - docker
     commit-message:
       prefix: "chore(deps)"
+    # Go tags release candidates as `1.27rc2`, with no separator before `rc`.
+    # Dependabot's Docker prerelease detection is a heuristic that expects the
+    # `-rc1` form, so an RC reads as an ordinary minor bump and gets proposed.
+    # Go only ever publishes RCs for a new minor, never for a patch, so
+    # declining minor and major here declines every RC while leaving the 1.26.x
+    # patch releases -- which is where the security fixes land -- to update on
+    # their own. Taking a new Go minor stays a deliberate change.
+    ignore:
+      - dependency-name: "golang"
+        update-types: [ "version-update:semver-minor", "version-update:semver-major" ]
     cooldown:
       default-days: 7
 


### PR DESCRIPTION
Declines minor and major bumps of the `golang` builder image so Dependabot stops proposing Go release candidates.

## What happened

Dependabot opened `terraform-registry-backend#914` and `terraform-state-manager-backend#409` to move the builder image from `golang:1.26.6-alpine` to **`1.27rc2-alpine`** — a release candidate.

Dependabot's Docker pre-release detection is a heuristic that looks for the usual separator form; GitHub's own reference lists the examples as `nginx@1.25.0-rc1`, `node@20.0.0-alpha.1`. Go doesn't tag that way — a candidate is `1.27rc2`, with **no separator before `rc`** — so it reads as an ordinary minor bump and gets proposed like any other release.

## Why not just ignore the version pattern

`ignore.versions` can't express this. In `dependabot-core`, `dependency-name` is matched with `WildcardMatcher`, but `versions` is turned into a **version requirement**, and for Docker that means Bundler syntax — which has no way to say "any pre-release". So `versions: ["*rc*"]` isn't a supported construct here.

## Why declining minor and major is exact, not blunt

Go publishes release candidates **only ahead of a new minor**, never for a patch. So:

- no candidate can ever reach us as a patch bump;
- `1.26.x` patch releases — which is where Go's security fixes land — keep updating automatically;
- taking a new Go minor becomes a deliberate change, which it already was in practice.

```yaml
ignore:
  - dependency-name: "golang"
    update-types: [ "version-update:semver-minor", "version-update:semver-major" ]
```

The `alpine` runtime image is unaffected and still updates at every level.

## Follow-up

Once this is in, `#914` / `#409` can be closed; Dependabot will not re-raise them.
