### PR TITLE
ci: run the Postgres-backed tests, and fail if they skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,82 @@ jobs:
           message: ${{ steps.badge.outputs.percent }}%
           color: ${{ steps.badge.outputs.color }}
 
+  # ── Postgres-backed tests (issue #886) ────────────────
+  # Twelve test files in backend/ read TFR_TEST_DATABASE_URL and t.Skip when it
+  # is unset. Until this job existed NO workflow set it, so every guarantee they
+  # prove -- the platform-admin carrier, the audit outbox's deferred constraint
+  # trigger, migration round-trips, the member-role equivalence proof that gated
+  # a BREAKING authorization change -- was verified only on developer machines.
+  # Several of them say so in their own header comments.
+  #
+  # This job carries its own anti-false-green check, because the failure mode it
+  # is fixing is precisely a green result that proved nothing: if the DSN were
+  # wrong or the service unreachable, every one of these tests would SKIP and
+  # the job would pass. `go test` exits 0 on a suite that skipped everything.
+  postgres-tests:
+    name: Postgres-backed tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        # Without a health check the job races the container and the tests skip
+        # on an unreachable DSN -- green, and meaningless.
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go toolchain
+        uses: ./.github/actions/setup-backend
+
+      - name: Run the Postgres-backed tests
+        working-directory: backend
+        env:
+          # This repo has NO build tags; the gate is this variable plus t.Skip.
+          TFR_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+        # Deliberately NO -run filter. A name filter that matches nothing exits
+        # 0 and reports "ok" per package, which is the same false green this
+        # job exists to remove -- and it is easy to get wrong, since the twelve
+        # files share no naming convention. Running the whole set costs a few
+        # minutes and cannot silently select zero tests.
+        run: go test ./internal/... -v 2>&1 | tee /tmp/pg-tests.log
+
+      - name: Fail if the Postgres tests skipped
+        run: |
+          # The guard on the guard. A skipped suite and a passing suite are the
+          # same exit code, so assert on the transcript instead: no test may
+          # skip citing the DSN, and at least one must actually have run.
+          if grep -q 'TFR_TEST_DATABASE_URL not set' /tmp/pg-tests.log; then
+            echo "::error::Postgres tests SKIPPED on an unset DSN -- this job proved nothing."
+            grep -n 'TFR_TEST_DATABASE_URL not set' /tmp/pg-tests.log | head -5
+            exit 1
+          fi
+          if grep -qE 'TFR_TEST_DATABASE_URL is not reachable|not reachable' /tmp/pg-tests.log; then
+            echo "::error::Postgres tests SKIPPED on an unreachable DSN -- this job proved nothing."
+            exit 1
+          fi
+          passed=$(grep -c '^--- PASS' /tmp/pg-tests.log || true)
+          echo "Postgres-backed tests passed: $passed"
+          if [ "$passed" -lt 1 ]; then
+            echo "::error::No Postgres-backed test ran. An empty universe is not a clean one."
+            exit 1
+          fi
+
   swagger-docs-sync:
     name: Sync generated Swagger/OpenAPI docs
     runs-on: ubuntu-latest

--- a/backend/internal/db/platform_admin_carrier_only_migration_test.go
+++ b/backend/internal/db/platform_admin_carrier_only_migration_test.go
@@ -16,8 +16,6 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/lib/pq"
 )
 
 // Issue #766, migration 000054 — the breaking migration, applied, refused,
@@ -300,16 +298,32 @@ var backfillBlock = regexp.MustCompile(`(?s)WITH granted AS \(.*?FROM granted g;
 // postgres-tests job found. Handling both types is not defensive clutter: the
 // two drivers genuinely coexist here, one in the application and one inside
 // golang-migrate, and which one surfaces is not this test's choice.
+// Matched on the INTERFACE both drivers implement rather than on either
+// concrete type. jackc/pgx's *pgconn.PgError and lib/pq's *pq.Error both have
+// SQLState() string, so this needs no import of either -- which matters: this
+// module has just migrated OFF lib/pq, and importing it here to satisfy a test
+// assertion would promote it from `// indirect` back to a direct dependency of
+// the repository that removed it.
+//
+// It is also the more durable shape. Naming a concrete driver type is exactly
+// what broke: the assertion was correct for the driver the application uses
+// and wrong for the one golang-migrate uses internally, and a third driver
+// would break it again.
+type sqlStateError interface {
+	SQLState() string
+	Error() string
+}
+
 func driverErrorFields(err error) (code, message string, ok bool) {
-	var pgxErr *pgconn.PgError
-	if errors.As(err, &pgxErr) {
-		return string(pgxErr.Code), pgxErr.Message, true
+	var se sqlStateError
+	if !errors.As(err, &se) {
+		return "", "", false
 	}
-	var pqErr *pq.Error
-	if errors.As(err, &pqErr) {
-		return string(pqErr.Code), pqErr.Message, true
-	}
-	return "", "", false
+	// se.Error() is the DRIVER's rendering -- the PostgreSQL message alone.
+	// Only golang-migrate's database.Error wrapper appends the migration SQL,
+	// and that wrapper is unwrapped past before we get here, so the caller's
+	// substring check still cannot be satisfied by a syntax error in the file.
+	return se.SQLState(), se.Error(), true
 }
 
 func raisedRefusal(err error) (bool, string) {

--- a/backend/internal/db/platform_admin_carrier_only_migration_test.go
+++ b/backend/internal/db/platform_admin_carrier_only_migration_test.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
 )
 
 // Issue #766, migration 000054 — the breaking migration, applied, refused,
@@ -287,20 +288,43 @@ var backfillBlock = regexp.MustCompile(`(?s)WITH granted AS \(.*?FROM granted g;
 // test passed with the transition guard replaced by `IF FALSE`. Matching the
 // SQLSTATE and the raised message on the driver error is what makes the
 // assertion about the refusal instead of about the source code.
+// TWO DRIVER ERROR TYPES, deliberately. The application migrated off lib/pq to
+// jackc/pgx (#905, landed as #910), and this file's assertion moved to
+// *pgconn.PgError with it -- but golang-migrate's own postgres driver still
+// uses lib/pq internally, so the error arriving here is a *pq.Error. The
+// assertion silently stopped matching, and a CORRECT refusal carrying the
+// CORRECT SQLSTATE 23514 was reported as "a different failure".
+//
+// Nothing caught it, because no workflow set TFR_TEST_DATABASE_URL and this
+// test has never run in CI (issue #886). It is the first thing the new
+// postgres-tests job found. Handling both types is not defensive clutter: the
+// two drivers genuinely coexist here, one in the application and one inside
+// golang-migrate, and which one surfaces is not this test's choice.
+func driverErrorFields(err error) (code, message string, ok bool) {
+	var pgxErr *pgconn.PgError
+	if errors.As(err, &pgxErr) {
+		return string(pgxErr.Code), pgxErr.Message, true
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return string(pqErr.Code), pqErr.Message, true
+	}
+	return "", "", false
+}
+
 func raisedRefusal(err error) (bool, string) {
-	var pqErr *pgconn.PgError
-	if !errors.As(err, &pqErr) {
+	code, message, ok := driverErrorFields(err)
+	if !ok {
 		var dbErr database.Error
-		if errors.As(err, &dbErr) {
-			if !errors.As(dbErr.OrigErr, &pqErr) {
-				return false, fmt.Sprintf("%v", dbErr.OrigErr)
-			}
-		} else {
+		if !errors.As(err, &dbErr) {
 			return false, err.Error()
 		}
+		if code, message, ok = driverErrorFields(dbErr.OrigErr); !ok {
+			return false, fmt.Sprintf("%v", dbErr.OrigErr)
+		}
 	}
-	detail := string(pqErr.Code) + ": " + pqErr.Message
-	return pqErr.Code == "23514" && strings.Contains(pqErr.Message, "migration 000054 REFUSED"), detail
+	detail := code + ": " + message
+	return code == "23514" && strings.Contains(message, "migration 000054 REFUSED"), detail
 }
 
 // TestMigration000054_RefusesWhenTheBackfillDidNotRun is property 1's


### PR DESCRIPTION
Twelve test files read `TFR_TEST_DATABASE_URL` and `t.Skip` when it is unset. **No workflow set it**, so every guarantee they prove — the platform-admin carrier, the audit outbox's deferred constraint trigger, migration round-trips, the member-role equivalence proof that gated a **breaking** authorization change — was verified only on developer machines. Several of the files say so in their own header comments.

## The job guards itself

The failure this fixes *is* a green that proved nothing: with a wrong DSN or an unreachable service, every one of these tests skips and `go test` exits 0. So the job asserts on its transcript — no test may skip citing the DSN, and at least one must actually have run.

Two deliberate choices in the same spirit:

- **No `-run` filter.** A name filter matching nothing also exits 0, reporting `ok` per package, and the twelve files share no naming convention. Running the whole set costs a few minutes and cannot silently select zero tests.
- **A service health check.** Without it the job races the container, every test skips on an unreachable DSN, and the result is green.

## What it found immediately

`TestMigration000054_RefusesWhenTheBackfillDidNotRun` was **failing**, and is fixed here — the job cannot become a required check while red.

The application migrated off `lib/pq` to `jackc/pgx` (#905, landed as #910) and this assertion moved to `*pgconn.PgError` with it. But `golang-migrate`'s own postgres driver still uses `lib/pq`, so the error arriving is a `*pq.Error`. The type assertion silently stopped matching, and a **correct** refusal carrying the **correct** SQLSTATE 23514 was reported as "a different failure". `raisedRefusal` now reads the SQLSTATE and message from either driver's error type.

Note what it deliberately does *not* do: fall back to matching `err.Error()`. That helper's own comment explains why, and it is right — `golang-migrate` renders the entire migration SQL into the error, so `strings.Contains(err, "000054 REFUSED")` is true for a mere **syntax** error, and this test once passed with the transition guard replaced by `IF FALSE`.

**That break landed today and nothing could see it.** It is this issue's cost in a single example.

## Verification

Against `postgres:16-alpine` locally: **4318 tests pass, 0 skipped on an unset DSN, 0 failures.**

## Needs a branch-protection change

`main` currently requires 7 contexts (`strict=true`). This job runs but gates nothing until **`Postgres-backed tests`** is added to that list — otherwise it is the same shape as a check that claims to gate and does not.

Closes #886