### PR TITLE
ci(release-please): call the shared workflow, and gain least privilege

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,5 +30,10 @@ permissions:
 
 jobs:
   release-please:
-    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@e6b8910c879d79817a93035d4d982b3850cbe252
-    secrets: inherit
+    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@d1ccad25f0aa386d582af09966c1cb1df1303b4a
+    # Exactly one secret, named. NOT `secrets: inherit` -- that forwards EVERY
+    # secret in this repository to a workflow in another owner's repository,
+    # which zizmor flags (secrets-inherit) and which would have been an
+    # over-grant introduced by a change whose whole point is least privilege.
+    secrets:
+      RELEASE_DISPATCH_APP_KEY: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,23 @@
+---
+# Delegates to the shared definition in 4cloudguru/shared-workflows.
+#
+# This file used to be a local copy. There were TWELVE copies of it across two
+# owners and seven distinct versions -- all with the same config-file,
+# manifest-file, App id variable and App key secret. The only substantive
+# difference was the permission model, and this repo had the looser one:
+# contents: write for the whole workflow, where seven other repos already
+# elevated on the token step alone. Nobody decided that; somebody tightened it
+# in one family and this repo never heard.
+#
+# Calling the shared workflow adopts the least-privilege model as a consequence
+# rather than as a separate change to remember.
+#
+# PINNED BY SHA, not by a tag or @main. A shared workflow is itself something
+# that drifts, and repos on different pins is HARDER to see than divergent
+# files -- every repo looks like it is using "the shared one".
+#
+# `vars` resolves against THIS repository, so RELEASE_DISPATCH_APP_ID is
+# unchanged and nothing about the App installation moves.
 name: Release Please
 
 on:
@@ -6,24 +26,9 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
-    name: Release Please
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get GitHub App token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: token
-        with:
-          client-id: ${{ vars.RELEASE_DISPATCH_APP_ID }}
-          private-key: ${{ secrets.RELEASE_DISPATCH_APP_KEY }}
-
-      - name: Run release-please
-        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
-        with:
-          token: ${{ steps.token.outputs.token }}
-          config-file: .release-please-config.json
-          manifest-file: .release-please-manifest.json
+    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@e6b8910c879d79817a93035d4d982b3850cbe252
+    secrets: inherit


### PR DESCRIPTION
Replaces this repo's local `release-please.yml` with a call to [`4cloudguru/shared-workflows`](https://github.com/4cloudguru/shared-workflows), pinned by SHA.

## What was measured

`release-please.yml` existed in **twelve repositories across two owners**, in **seven distinct versions** (comments stripped). Every copy used the same `config-file`, the same `manifest-file`, the same App id variable and the same App key secret.

The only substantive difference was the permission model:

| model | repos |
| --- | --- |
| **least privilege** — `contents: read`, elevated on the token step alone | 7 |
| **broad** — `contents: write` for the whole workflow | 5 (including this one) |

**Nobody decided the five should be more permissive.** Somebody tightened it in the extension family and the suite repos never heard — the same shape as the egress fix that reached one of three hand-copied HTTP clients, the carrier fix that reached one of three dev-admin seeds, and the tfx validation fix that would have reached one of three marketplace publish scripts.

Calling the shared definition **adopts the tighter model as a consequence**, rather than as five separate edits somebody has to remember to keep in step.

## What does not change

- `vars` resolves against **this** repository, so `RELEASE_DISPATCH_APP_ID` and the App installation are untouched.
- `secrets: inherit` forwards `RELEASE_DISPATCH_APP_KEY` exactly as before.
- Triggers, config paths and manifest paths are identical.

## Pinned by SHA, deliberately

Not a tag, not `@main`.

A shared workflow is itself something that drifts, and repos sitting on **different pins** is the same defect wearing a new hat — *harder* to see than divergent files, because every repo then looks like it is using "the shared one". A pin-parity signature is the follow-up that makes that claim enforceable rather than aspirational.

## Verification

`actionlint` clean. Two things it caught while the shared workflow was being written, both now avoided: a description containing `secrets: inherit` parses as a YAML mapping unless quoted, and a reusable workflow only has the secrets it **declares** in scope — an undeclared fallback reference reads fine and can never resolve at runtime.