### PR TITLE
chore(ci): enforce workflow hardening, and retry the Go tool installs

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -19,5 +19,6 @@ runs:
 
     - name: Install gosec
       if: inputs.install-gosec == 'true'
-      shell: bash
-      run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+      uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+      with:
+        package: github.com/securego/gosec/v2/cmd/gosec@v2.26.1

--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -38,6 +38,15 @@ jobs:
           --health-retries 5
 
     steps:
+      # hardening-exception: egress-audit — this job downloads Go modules and tools
+      #   from the module proxy, transfers artifacts through the Actions API, and
+      #   clones this repository; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   backend-test:
     name: Backend Tests & Quality
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # contents:read only — this job installs untrusted third-party packages
     # (golangci-lint via `go install`, swag, npm ci for swagger2openapi) and
     # must never hold a write-capable token while doing so (#656). Committing
@@ -30,6 +31,15 @@ jobs:
     permissions:
       contents: read
     steps:
+      # hardening-exception: egress-audit — this job installs from the npm registry,
+      #   downloads Go modules and tools from the module proxy, and transfers
+      #   artifacts through the Actions API; harden-runner has never run in this
+      #   repository, so no endpoint baseline exists and a block policy written
+      #   without one fails closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,18 +65,31 @@ jobs:
         working-directory: backend
         run: go vet ./...
 
+      # Installs split out from the steps that use them so they can be retried:
+      # `go install` reaches the module proxy for the tool AND its whole
+      # dependency tree on every run, uncovered by the module cache keyed on this
+      # repo's go.sum. One transient read took a required check red in
+      # terraform-state-manager-backend on a PR with no Go changes.
+      - name: Install golangci-lint
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        with:
+          package: github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
       - name: Lint
         run: |
           cd backend
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
           golangci-lint run ./...
 
+      # The bespoke GOBIN + GITHUB_PATH dance is gone with this: the action
+      # installs to $(go env GOPATH)/bin, which actions/setup-go already places
+      # on PATH -- the govulncheck step in weekly-security.yml has relied on
+      # exactly that in this repository for as long as it has existed. Dropping
+      # it also removes a write to an environment file, which is a code-execution
+      # vector zizmor flags on principle.
       - name: Install swag
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          export GOBIN="$GITHUB_WORKSPACE/bin"
-          go install github.com/swaggo/swag/cmd/swag@v1.16.6
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        with:
+          package: github.com/swaggo/swag/cmd/swag@v1.16.6
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -74,7 +97,12 @@ jobs:
           node-version: "24"
 
       - name: Install docs tooling (swagger2openapi)
-        run: npm ci
+        # --ignore-scripts: npm runs dependency preinstall/install/postinstall
+        # hooks by default, which is arbitrary code from the dependency tree
+        # executing in a job this file's own header calls out as installing
+        # untrusted third-party packages. Verified rather than assumed: nothing
+        # in the tree declares an install script, and swagger2openapi still runs.
+        run: npm ci --ignore-scripts
 
       - name: Swagger generation
         # Regenerates docs/swagger.json and docs/openapi3.json so drift against
@@ -225,6 +253,7 @@ jobs:
   postgres-tests:
     name: Postgres-backed tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     services:
@@ -245,6 +274,15 @@ jobs:
           --health-retries 10
 
     steps:
+      # hardening-exception: egress-audit — this job downloads Go modules and tools
+      #   from the module proxy and clones this repository; harden-runner has never
+      #   run in this repository, so no endpoint baseline exists and a block policy
+      #   written without one fails closed on its first run; audit is what produces
+      #   that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -289,6 +327,7 @@ jobs:
   swagger-docs-sync:
     name: Sync generated Swagger/OpenAPI docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: backend-test
     if: github.ref_type != 'tag'
     # Isolated from backend-test's build/lint/npm steps so the token needed
@@ -300,6 +339,14 @@ jobs:
       contents: write
       pull-requests: write # only used for the bot-PR path below (#657)
     steps:
+      # hardening-exception: egress-audit — this job transfers artifacts through the
+      #   Actions API and clones this repository; harden-runner has never run in this
+      #   repository, so no endpoint baseline exists and a block policy written
+      #   without one fails closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes regenerated swagger docs to the PR head branch
 
@@ -392,6 +439,7 @@ jobs:
   security-tooling-tests:
     name: Security tooling unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # backend/scripts/ holds the two programs that decide whether a security
     # finding blocks a merge: gosec_compare.py (new-vs-baseline) and
     # osv_triage.py (fixable-vs-unfixable). Both shipped with unit tests that
@@ -400,6 +448,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      # hardening-exception: egress-audit — this job clones this repository;
+      #   harden-runner has never run in this repository, so no endpoint baseline
+      #   exists and a block policy written without one fails closed on its first run;
+      #   audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -427,12 +483,22 @@ jobs:
   gosec:
     name: Security Scan (gosec)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Run in parallel with backend-test — no dependency needed.
     # Needs issues:write to open a GitHub issue when new findings are detected.
     permissions:
       contents: read
       issues: write
     steps:
+      # hardening-exception: egress-audit — this job transfers artifacts through the
+      #   Actions API, calls the GitHub API, and clones this repository; harden-runner
+      #   has never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -508,9 +574,19 @@ jobs:
   docker-build:
     name: Docker Build Smoke Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
+      # hardening-exception: egress-audit — this job pulls base images and pushes
+      #   layers to a container registry and clones this repository; harden-runner has
+      #   never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -555,9 +631,18 @@ jobs:
   deployment-validate:
     name: Deployment Config Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
+      # hardening-exception: egress-audit — this job fetches charts and schemas from
+      #   remote sources and clones this repository; harden-runner has never run in
+      #   this repository, so no endpoint baseline exists and a block policy written
+      #   without one fails closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -626,10 +711,20 @@ jobs:
   codeql:
     name: CodeQL Analysis (Go)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write
     steps:
+      # hardening-exception: egress-audit — this job downloads the CodeQL bundle and
+      #   its query packs, downloads Go modules and tools from the module proxy, and
+      #   clones this repository; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,6 +45,15 @@ jobs:
             fuzz_name: FuzzParseDelivery
 
     steps:
+      # hardening-exception: egress-audit — this job downloads Go modules and tools
+      #   from the module proxy, transfers artifacts through the Actions API, and
+      #   clones this repository; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -93,11 +102,21 @@ jobs:
   fuzz-failure-issue:
     name: Open issue on fuzz failure
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: fuzz
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write
     steps:
+      # hardening-exception: egress-audit — this job downloads Go modules and tools
+      #   from the module proxy and calls the GitHub API; harden-runner has never run
+      #   in this repository, so no endpoint baseline exists and a block policy
+      #   written without one fails closed on its first run; audit is what produces
+      #   that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Create issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,10 +13,19 @@ jobs:
   conventional-title:
     name: Conventional PR Title
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
     steps:
+      # hardening-exception: egress-audit — this job calls the GitHub API;
+      #   harden-runner has never run in this repository, so no endpoint baseline
+      #   exists and a block policy written without one fails closed on its first run;
+      #   audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Check PR title follows Conventional Commits
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
@@ -48,10 +57,19 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
     steps:
+      # hardening-exception: egress-audit — this job queries the GitHub advisory API
+      #   and clones this repository; harden-runner has never run in this repository,
+      #   so no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -85,10 +103,19 @@ jobs:
   breaking-change-footers:
     name: Breaking-change footers survive the squash
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
     steps:
+      # hardening-exception: egress-audit — this job calls the GitHub API;
+      #   harden-runner has never run in this repository, so no endpoint baseline
+      #   exists and a block policy written without one fails closed on its first run;
+      #   audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Count breaking-change declarations across this PR's commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -185,10 +212,20 @@ jobs:
   release-please-can-read-the-commit:
     name: release-please can read the merged commit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
     steps:
+      # hardening-exception: egress-audit — this job installs from the npm registry,
+      #   calls the GitHub API, and clones this repository; harden-runner has never
+      #   run in this repository, so no endpoint baseline exists and a block policy
+      #   written without one fails closed on its first run; audit is what produces
+      #   that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -196,7 +233,10 @@ jobs:
 
       - name: Install the parser release-please uses
         working-directory: .github/commit-message-check
-        run: npm ci
+        # --ignore-scripts: the only dependency is @conventional-commits/parser,
+        # which declares no install hooks, so nothing is lost by refusing to run
+        # dependency scripts.
+        run: npm ci --ignore-scripts
 
       - name: Parse the commit this PR would squash into main
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,18 @@ jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
+      # hardening-exception: egress-audit — this job clones this repository;
+      #   harden-runner has never run in this repository, so no endpoint baseline
+      #   exists and a block policy written without one fails closed on its first run;
+      #   audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need full history to walk ancestry
@@ -92,6 +101,7 @@ jobs:
   goreleaser:
     name: GoReleaser — binaries + GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: ci
     permissions:
       contents: write # required to create releases and upload assets
@@ -99,6 +109,16 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
+      # hardening-exception: egress-audit — this job resolves build dependencies and
+      #   uploads release artifacts, downloads Go modules and tools from the module
+      #   proxy, and transfers artifacts through the Actions API; harden-runner has
+      #   never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- goreleaser reads tags and publishes release artifacts
         with:
           fetch-depth: 0 # GoReleaser needs full history to resolve previous tag
@@ -176,6 +196,7 @@ jobs:
   docker:
     name: Publish Docker image
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment: release
     needs: ci
     permissions:
@@ -185,6 +206,15 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
+      # hardening-exception: egress-audit — this job pulls base images and pushes
+      #   layers to a container registry, transfers artifacts through the Actions API,
+      #   and calls the GitHub API; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -297,6 +327,7 @@ jobs:
   docker-fips:
     name: Publish FIPS Docker image
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment: release
     needs: ci
     permissions:
@@ -306,6 +337,15 @@ jobs:
       attestations: write # required for GitHub build provenance attestation
 
     steps:
+      # hardening-exception: egress-audit — this job pulls base images and pushes
+      #   layers to a container registry, transfers artifacts through the Actions API,
+      #   and calls the GitHub API; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -424,10 +464,20 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [goreleaser, docker, docker-fips]
     permissions:
       contents: write
     steps:
+      # hardening-exception: egress-audit — this job resolves build dependencies and
+      #   uploads release artifacts, transfers artifacts through the Actions API, and
+      #   calls the GitHub API; harden-runner has never run in this repository, so no
+      #   endpoint baseline exists and a block policy written without one fails closed
+      #   on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- publishes the GitHub Release
         with:
           sparse-checkout: CHANGELOG.md

--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -56,7 +56,17 @@ concurrency:
 jobs:
   replay:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
+      # hardening-exception: egress-audit — this job downloads Go modules and tools
+      #   from the module proxy, transfers artifacts through the Actions API, and
+      #   calls the GitHub API; harden-runner has never run in this repository, so no
+      #   endpoint baseline exists and a block policy written without one fails closed
+      #   on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       # ── THE FIRST STEP, AND IT HAS TO STAY THE FIRST STEP ────────────────
       #
       # WHAT THIS CLOSES. SUITE_READ_APP_KEY is in this repository's DEPENDABOT

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -60,10 +60,20 @@ jobs:
   osv-scan:
     name: OSV Vulnerability Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       issues: write
     steps:
+      # hardening-exception: egress-audit — this job queries the OSV vulnerability
+      #   database, calls the GitHub API, and clones this repository; harden-runner
+      #   has never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -180,10 +190,20 @@ jobs:
   govulncheck:
     name: govulncheck (reachability scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       issues: write
     steps:
+      # hardening-exception: egress-audit — this job downloads the Go vulnerability
+      #   database and the govulncheck tool, downloads Go modules and tools from the
+      #   module proxy, and calls the GitHub API; harden-runner has never run in this
+      #   repository, so no endpoint baseline exists and a block policy written
+      #   without one fails closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -193,7 +213,9 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        with:
+          package: golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         id: govulncheck
@@ -257,6 +279,7 @@ jobs:
   codeql:
     name: CodeQL Analysis (Go)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Schedule/dispatch only — ci.yml already runs CodeQL on every push/PR,
     # and GitHub code scanning rejects concurrent analyses for the same
     # ref/category, so this stays the weekly defense-in-depth backstop.
@@ -265,6 +288,15 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # hardening-exception: egress-audit — this job downloads the CodeQL bundle and
+      #   its query packs, downloads Go modules and tools from the module proxy, and
+      #   clones this repository; harden-runner has never run in this repository, so
+      #   no endpoint baseline exists and a block policy written without one fails
+      #   closed on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -290,12 +322,21 @@ jobs:
   stale-dependabot:
     name: Flag stale Dependabot PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Schedule/dispatch only — "stale" is a weekly-cadence concept, not
     # something to re-evaluate on every push/PR.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       pull-requests: write
     steps:
+      # hardening-exception: egress-audit — this job calls the GitHub API;
+      #   harden-runner has never run in this repository, so no endpoint baseline
+      #   exists and a block policy written without one fails closed on its first run;
+      #   audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Label PRs open > 14 days
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -313,11 +354,21 @@ jobs:
   notify-on-failure:
     name: Create issue on failure
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [ci, osv-scan, govulncheck, codeql, stale-dependabot]
     if: failure() && github.event_name == 'schedule'
     permissions:
       issues: write
     steps:
+      # hardening-exception: egress-audit — this job downloads the Go vulnerability
+      #   database and the govulncheck tool and calls the GitHub API; harden-runner
+      #   has never run in this repository, so no endpoint baseline exists and a block
+      #   policy written without one fails closed on its first run; audit is what
+      #   produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Create failure issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -43,9 +43,18 @@ jobs:
   sync:
     name: Mirror docs to wiki
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: true # never block the source repo on a wiki failure
 
     steps:
+      # hardening-exception: egress-audit — this job calls the GitHub API and clones
+      #   this repository; harden-runner has never run in this repository, so no
+      #   endpoint baseline exists and a block policy written without one fails closed
+      #   on its first run; audit is what produces that list
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
       - name: Checkout source repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked] -- pushes the generated wiki
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,3 +33,18 @@ concurrency:
 jobs:
   workflow-security:
     uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@2279e55c6318846f60f0c8ffcbadbeb9317e5fb5 # v1.0.0
+
+  # Second gate, same family: zizmor audits workflow SECURITY, this audits
+  # workflow HARDENING -- pins labelled, jobs bounded by a timeout,
+  # harden-runner first, npm installs refusing dependency scripts.
+  #
+  # It lived in exactly ONE of the fourteen repos until now, and caught a real
+  # defect the moment a shared-workflow pin reached it.
+  #
+  # script-ref MUST equal the pin above it: the checker is taken from
+  # shared-workflows at that commit, so this repo cannot weaken its own gate by
+  # editing a local copy -- there is no local copy.
+  workflow-hardening:
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+    with:
+      script-ref: bc0eaaec5d6f5cf632ef862ff7475da928e32466


### PR DESCRIPTION
## Workflow hardening: 54 findings → 0

Twenty-five jobs declared no `timeout-minutes`; twenty-seven never reached `harden-runner`, which this repository ran **zero** times anywhere.

**Timeouts from observed durations** across the last twenty runs — *Backend Tests & Quality* peaks at 9 min, gosec and CodeQL at 4, most guard jobs under 1. Each limit sits several times its job's real maximum, because a timeout that trips on ordinary variance teaches people to re-run.

Two are deliberately different: `fuzz` runs `-fuzztime=10m` per target so it gets 30, and `chaos-test` already carried `timeout-minutes: 1500` for soak runs and is **left alone**.

**`egress-policy: audit`, reason derived per job** — from what each job actually reaches for (module proxy, CodeQL bundle, container registry, OSV database) rather than one sentence pasted 27 times.

## `--ignore-scripts` on both npm sites

This matters more here than elsewhere. `ci.yml`'s own header calls `backend-test` out as a job that *"installs untrusted third-party packages"* — and npm was running those packages' install hooks by default.

Verified, not assumed: nothing in either tree declares an install script, and `swagger2openapi` still runs after the change.

## Go tool installs — all four sites

Now use the shared `go-install` action, which retries transient module-proxy failures and **still goes red if every attempt fails**. One of the four lives in `.github/actions/setup-backend`, a composite action a workflow-only search doesn't find.

**The swag site loses a bespoke `GOBIN` + `GITHUB_PATH` write.** The action installs to `$(go env GOPATH)/bin`, which `actions/setup-go` already puts on PATH — the `govulncheck` step in `weekly-security.yml` has relied on exactly that in this repo for as long as it has existed. Removing it also removes a write to an environment file, a code-execution vector.

## The gate itself

`zizmor.yml` now calls the shared `workflow-hardening` workflow, so this state is **enforced**, not merely reached.

Already proven: the same gate ran green in `terraform-state-manager-backend` and reported real enumerated counts there (23 jobs, 93 refs, 18 harden-runner steps) rather than a blind pass.
