### PR TITLE
chore(ci): move every shared-workflows pin to v1.13.0

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -19,6 +19,6 @@ runs:
 
     - name: Install gosec
       if: inputs.install-gosec == 'true'
-      uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+      uses: 4cloudguru/shared-workflows/.github/actions/go-install@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
       with:
         package: github.com/securego/gosec/v2/cmd/gosec@v2.26.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # repo's go.sum. One transient read took a required check red in
       # terraform-state-manager-backend on a PR with no Go changes.
       - name: Install golangci-lint
-        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
         with:
           package: github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
@@ -87,7 +87,7 @@ jobs:
       # it also removes a write to an environment file, which is a code-execution
       # vector zizmor flags on principle.
       - name: Install swag
-        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
         with:
           package: github.com/swaggo/swag/cmd/swag@v1.16.6
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -171,7 +171,7 @@ jobs:
       # as "Breaking-change footers survive the squash", so no branch protection
       # moves.
       - name: Count breaking-change declarations across this PR's commits
-        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@f38de4ea7ae1f75a35ad07604a6b7ce79625206b # v1.10.1
+        uses: 4cloudguru/shared-workflows/.github/actions/breaking-change-footers@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@2279e55c6318846f60f0c8ffcbadbeb9317e5fb5 # v1.0.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/release-please.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
     # Exactly one secret, named. NOT `secrets: inherit` -- that forwards EVERY
     # secret in this repository to a workflow in another owner's repository,
     # which zizmor flags (secrets-inherit) and which would have been an

--- a/.github/workflows/signature-replay.yml
+++ b/.github/workflows/signature-replay.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   replay:
-    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@0a0281d388c7f84057e2681bcf62bec217b94542 # v1.9.0
+    uses: 4cloudguru/shared-workflows/.github/workflows/signature-replay.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
     # Exactly one secret, named. NOT `secrets: inherit`.
     secrets:
       SUITE_READ_APP_KEY: ${{ secrets.SUITE_READ_APP_KEY }}

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -213,7 +213,7 @@ jobs:
         uses: ./.github/actions/setup-backend
 
       - name: Install govulncheck
-        uses: 4cloudguru/shared-workflows/.github/actions/go-install@bc0eaaec5d6f5cf632ef862ff7475da928e32466 # v1.2.0
+        uses: 4cloudguru/shared-workflows/.github/actions/go-install@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
         with:
           package: golang.org/x/vuln/cmd/govulncheck@v1.1.4
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   workflow-security:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-security.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
 
   # Second gate, same family: zizmor audits workflow SECURITY, this audits
   # workflow HARDENING -- pins labelled, jobs bounded by a timeout,
@@ -45,6 +45,6 @@ jobs:
   # shared-workflows at that commit, so this repo cannot weaken its own gate by
   # editing a local copy -- there is no local copy.
   workflow-hardening:
-    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@8b7215beac6420881d20d52f9b096edff4238ec9 # v1.6.1
+    uses: 4cloudguru/shared-workflows/.github/workflows/workflow-hardening.yml@9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b # v1.13.0
     with:
-      script-ref: 8b7215beac6420881d20d52f9b096edff4238ec9
+      script-ref: 9276df8e0bdb3152e2529ab98c8b99cfb9e22d4b


### PR DESCRIPTION
Moves every `4cloudguru/shared-workflows` pin in this repository to **v1.13.0** (`9276df8e`), as part of a single coordinated pass across all 19 consumers. Before this, the estate had **78 call sites at six different versions**; 71 were stale.

## Why all of them at once, and why now

Two Dependabot PRs (`hcp-terraform-pwsh#42`, `terraform-provider-registry#116`) were open to do part of this. **Both were unsafe to merge**, and merging them would have introduced a silent fault:

```
uses: ...workflow-hardening.yml@9276df8e…   # v1.13.0   ← Dependabot rewrote this
script-ref: 8b7215beac…                     # v1.6.1    ← and not this
```

`workflow-hardening.yml` declares `script-ref` as `required: true` with *"MUST equal the pin on the `uses:` line — the checker is taken from that commit."* Dependabot only rewrites `uses:` lines; it has no knowledge of the input. Both PRs were **green**, because nothing validates the coupling.

So this cannot be left to Dependabot at all. This PR updates the `uses:` pin, the version comment, and `script-ref` together, and asserts they agree.

## Risk: low, and verified rather than assumed

Diffed each artefact from the version this repo pinned to v1.13.0:

| artefact | change |
|---|---|
| `go-install` (v1.2.0) | **no change** |
| `breaking-change-footers` (v1.10.1) | **no change** |
| `signature-replay.yml` (v1.9.0) | **no change** |
| `release-please.yml` (v1.0.0) | +4 lines — `hardening-exception` comment only |
| `workflow-hardening.yml` (v1.6.1) | +4 lines — `hardening-exception` comment only |
| `workflow-security.yml` (v1.6.1) | +77/-1 — **the only substantive one** |

`workflow-security.yml` gains an optional `ref` input (`required: false`, backward compatible), `timeout-minutes`, harden-runner steps, an explicit `version: "1.29.0"` zizmor pin in place of the action's implicit default, and a self-test asserting actionlint still rejects a broken fixture.

Note it does **not** change `advanced-security`, which was already `false` at v1.6.1 — so no consumer's zizmor gate was previously running in the exit-0-regardless SARIF mode that file warns about.

## Verification

- no stale SHA (`8b7215be`, `0a0281d3`, `2279e55c`, `bc0eaaec`, `f38de4ea`) remains anywhere in the repo
- every `script-ref` equals the `workflow-hardening.yml` pin in the same file
- checked across the estate beforehand: **no repo's `main` currently has this skew** — it would have been introduced by the Dependabot route, not corrected by it

Tracked in sethbacon/security-orchestration#85.
