### PR TITLE
fix(ci): refuse a gosec scan that analysed nothing, and run the comparator's tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,21 @@ jobs:
         # gosec exits non-zero when findings exist; we capture that via the compare step.
         run: gosec -fmt json -out gosec-results.json ./... || true
 
+      # The comparator is the only thing standing between a gosec run and a green
+
+      # required check, and its own regression tests were committed but never
+
+      # executed by anything -- CI ran no python tests at all. A test nothing
+
+      # runs is indistinguishable from a test that passes.
+
+      - name: The gosec comparator's own tests
+
+        working-directory: backend
+
+        run: python3 scripts/gosec_compare_test.py
+
+
       - name: Compare against baseline
         id: compare
         working-directory: backend

--- a/backend/scripts/gosec-compare.py
+++ b/backend/scripts/gosec-compare.py
@@ -105,6 +105,46 @@ def load_findings(path: str, base_dir: Path) -> tuple[dict, dict]:
     return fps, data.get("Stats", {})
 
 
+def scan_integrity_problems(path: str) -> list[str]:
+    """Reasons this gosec run must not be read as a clean scan.
+
+    A run that analysed nothing writes `"Issues": []` — byte-identical to a run
+    that analysed everything and found nothing. Everything downstream then works
+    correctly on an empty universe: no fingerprints, so no new findings, so
+    exit 0, so a green required check certifying a scan that never happened.
+    `gosec ... || true` in CI discards the one signal that would have shown it.
+
+    Stats.files was already being read here, and printed. Printing a number into
+    the log of a run that passes is not a check — nobody opens it.
+    """
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    problems: list[str] = []
+
+    files = (data.get("Stats") or {}).get("files")
+    if not files:
+        problems.append(
+            f"gosec reports {files!r} files scanned. An empty result set from an "
+            "empty scan is indistinguishable from a clean one, so this cannot be "
+            "read as passing."
+        )
+
+    # gosec records per-package compile failures here and still exits reporting
+    # whatever it managed to parse. Findings from a package that did not build
+    # are absent rather than absent-because-clean.
+    errors = data.get("Golang errors") or {}
+    if errors:
+        where = ", ".join(sorted(errors)[:5])
+        problems.append(
+            f"gosec recorded Go compile errors in {len(errors)} package(s) "
+            f"({where}). Those packages were not analysed, so the finding set is "
+            "incomplete rather than clean."
+        )
+
+    return problems
+
+
 def _rel(issue: dict, base_dir: Path) -> str:
     return _normalize_path(issue.get("file", "?"), base_dir)
 
@@ -172,6 +212,27 @@ def main() -> None:
     args = parser.parse_args()
 
     base_dir = Path(args.base_dir).resolve()
+
+    # Before comparing anything: a comparison against an empty scan is arithmetic
+    # on nothing, and it produces the same exit 0 as a genuinely clean repo.
+    problems = scan_integrity_problems(args.results)
+    if problems:
+        print("\U0001f6a8 gosec did not produce a usable scan:")
+        for problem in problems:
+            print(f"  - {problem}")
+        body = "\n".join(
+            ["## gosec produced no usable scan", ""]
+            + [f"- {problem}" for problem in problems]
+            + [
+                "",
+                "This is not a report of new findings. The scan itself did not run "
+                "to completion, so the comparison against the baseline was skipped "
+                "rather than passed.",
+            ]
+        )
+        if args.output:
+            Path(args.output).write_text(body, encoding="utf-8")
+        sys.exit(1)
 
     current,  stats_cur  = load_findings(args.results,  base_dir)
     baseline, stats_base = load_findings(args.baseline, base_dir)

--- a/backend/scripts/gosec_compare_test.py
+++ b/backend/scripts/gosec_compare_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
-Regression test for gosec-compare.py's fingerprinting (#655).
+Regression tests for gosec-compare.py: fingerprinting (#655) and the
+vacuous-scan guard.
 
 Run with:
     python3 backend/scripts/gosec_compare_test.py
@@ -9,7 +10,10 @@ Standard library only (unittest) — no extra dependencies required.
 """
 
 import importlib.util
+import json
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -85,6 +89,107 @@ class FingerprintCollisionTest(unittest.TestCase):
         self.assertEqual(
             gosec_compare.fingerprint(original, self.BASE_DIR),
             gosec_compare.fingerprint(shifted, self.BASE_DIR),
+        )
+
+
+class VacuousScanTest(unittest.TestCase):
+    """A scan that analysed nothing must not read as a scan that found nothing.
+
+    `gosec ... || true` discards gosec's exit code, so a run that failed to
+    analyse anything reaches the comparator looking exactly like a clean repo:
+    `"Issues": []`. Every step after that behaves correctly on an empty universe
+    and the required check goes green having verified nothing.
+    """
+
+    def _write(self, payload: dict) -> str:
+        path = Path(tempfile.mkdtemp()) / "gosec-results.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return str(path)
+
+    def test_zero_files_scanned_is_not_clean(self):
+        path = self._write({"Issues": [], "Stats": {"files": 0, "lines": 0}})
+        problems = gosec_compare.scan_integrity_problems(path)
+        self.assertTrue(problems, "a scan of 0 files must be reported as unusable")
+        self.assertIn("files scanned", problems[0])
+
+    def test_missing_stats_is_not_clean(self):
+        path = self._write({"Issues": []})
+        self.assertTrue(
+            gosec_compare.scan_integrity_problems(path),
+            "results with no Stats at all must be reported as unusable",
+        )
+
+    def test_go_compile_errors_make_the_finding_set_incomplete(self):
+        path = self._write(
+            {
+                "Issues": [],
+                "Stats": {"files": 248, "lines": 65750},
+                "Golang errors": {
+                    "internal/mirror": [{"error": "undefined: Foo"}],
+                },
+            }
+        )
+        problems = gosec_compare.scan_integrity_problems(path)
+        self.assertTrue(problems, "packages that did not compile were not analysed")
+        self.assertIn("internal/mirror", problems[0])
+
+    def test_a_real_scan_is_not_flagged(self):
+        path = self._write(
+            {
+                "Issues": [],
+                "Stats": {"files": 248, "lines": 65750, "nosec": 173},
+                "Golang errors": {},
+            }
+        )
+        self.assertEqual(
+            gosec_compare.scan_integrity_problems(path),
+            [],
+            "a genuine clean scan must still pass",
+        )
+
+
+class VacuousScanIsRejectedEndToEndTest(unittest.TestCase):
+    """Run the script the way CI runs it.
+
+    The unit tests above cover scan_integrity_problems() but not its CALL SITE:
+    deleting the call from main() leaves every one of them green while the guard
+    protects nothing. A tested function that nothing invokes is the same defect
+    as an untested one, so this drives the actual entry point and asserts on the
+    exit code CI branches on.
+    """
+
+    def _run(self, results: dict) -> subprocess.CompletedProcess:
+        tmp = Path(tempfile.mkdtemp())
+        (tmp / "results.json").write_text(json.dumps(results), encoding="utf-8")
+        (tmp / "baseline.json").write_text(
+            json.dumps({"Issues": [], "Stats": {"files": 248, "lines": 65750}}),
+            encoding="utf-8",
+        )
+        return subprocess.run(
+            [
+                sys.executable, str(_MODULE_PATH),
+                "--results", str(tmp / "results.json"),
+                "--baseline", str(tmp / "baseline.json"),
+                "--base-dir", str(tmp),
+            ],
+            capture_output=True, text=True,
+        )
+
+    def test_a_scan_of_nothing_exits_nonzero(self):
+        proc = self._run({"Issues": [], "Stats": {"files": 0, "lines": 0}})
+        self.assertNotEqual(
+            proc.returncode, 0,
+            "a gosec run that analysed 0 files must not exit 0:\n" + proc.stdout,
+        )
+        self.assertIn("did not produce a usable scan", proc.stdout)
+
+    def test_a_real_clean_scan_still_exits_zero(self):
+        proc = self._run(
+            {"Issues": [], "Stats": {"files": 248, "lines": 65750}, "Golang errors": {}}
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            "a genuine clean scan must still pass:\n" + proc.stdout + proc.stderr,
         )
 
 


### PR DESCRIPTION
Closes the vacuous-scan hole in the required `Security Scan (gosec)` check.

## The defect

A gosec run that analyses **zero files** writes `"Issues": []` — byte-identical to a run that analysed everything and found nothing. Everything downstream then behaves *correctly* on an empty universe: no fingerprints → no new findings → `exit 0` → a **green required context certifying a scan that never happened.**

Two things hid it:

- `gosec ... || true` discards the one signal that would have shown it
- `Stats.files` was already read — and only **printed**. A number in the log of a run that *passes* is not a check; nobody opens it.

## The fix

`scan_integrity_problems()` fails closed when:

| condition | why it is not "clean" |
|---|---|
| `Stats.files` is 0 | nothing was analysed |
| `Stats` absent entirely | the run did not get far enough to report |
| `Golang errors` non-empty | those packages did not build, so findings are **incomplete**, not absent |

It runs **before** the baseline comparison — comparing against an empty scan is arithmetic on nothing that produces the same `exit 0` as a genuinely clean repo. On failure it writes the issue body the existing CI wiring expects, worded so it cannot be misread as a report of new findings.

**Deliberately unchanged:** the `|| true` on the gosec step (gosec exits non-zero merely for *having* findings; the comparator decides pass/fail) and `continue-on-error: true` on the compare step (it exists so later steps can branch on `outcome`, which keeps the truth that `conclusion` discards).

## The tests now actually run

The comparator's tests were committed and **nothing executed them** — the only reference to `gosec_compare_test.py` anywhere in the repo was its own docstring, and CI ran no Python tests at all. The `#655` fingerprint regression test had therefore never guarded anything since it was written. It is now a step in the gosec job.

## Verified by mutation

Each of these turns the suite red:

| mutation | failures |
|---|---|
| drop the zero-files check | 3 |
| ignore `Golang errors` | 1 |
| remove the guard's call from `main()` | 1 |

That last one **initially passed**, which is why it exists. The first draft tested the function but not its *call site*, so deleting the call left every test green while the guard protected nothing. The end-to-end cases now drive the script exactly as CI drives it and assert on the exit code CI branches on.

## No false positive on real data

The committed baseline reports no problems, and comparing it against itself still exits 0 — 248 files, 14 findings.

Closes #939