### PR TITLE
fix(api): describe /auth/me's real response shape (#892)

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -17452,20 +17452,13 @@
                     "organization_name": {
                         "type": "string"
                     },
-                    "role_template_display_name": {
-                        "type": "string"
-                    },
-                    "role_template_id": {
-                        "type": "string"
-                    },
-                    "role_template_name": {
-                        "type": "string"
-                    },
-                    "role_template_scopes": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                    "role_template": {
+                        "description": "NO omitempty, deliberately: a membership with no role template emits\n`\"role_template\": null`. The key is always present.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/admin.MeRoleTemplate"
+                            }
+                        ]
                     }
                 }
             },
@@ -17484,12 +17477,50 @@
                             "$ref": "#/components/schemas/admin.MeMembershipEntry"
                         }
                     },
-                    "role_template": {},
+                    "role_template": {
+                        "description": "NO omitempty, matching the membership field above and matching the\nhandler, which has an else-branch setting this to nil rather than leaving\nthe key out. `omitempty` here would DROP `\"role_template\": null` from every\nresponse that currently carries it -- a silent wire-format change dressed\nup as a typing fix, which is the failure mode this whole issue is about.\n\nSessionExpiresAt is the one field that genuinely is omitted: the handler\nsets it only when JWT claims carry an expiry, and never for API-key auth.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/admin.MeRoleTemplateSummary"
+                            }
+                        ]
+                    },
                     "session_expires_at": {
                         "type": "string"
                     },
                     "user": {
                         "$ref": "#/components/schemas/User"
+                    }
+                }
+            },
+            "admin.MeRoleTemplate": {
+                "type": "object",
+                "properties": {
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "admin.MeRoleTemplateSummary": {
+                "type": "object",
+                "properties": {
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
                     }
                 }
             },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -14194,20 +14194,13 @@
                 "organization_name": {
                     "type": "string"
                 },
-                "role_template_display_name": {
-                    "type": "string"
-                },
-                "role_template_id": {
-                    "type": "string"
-                },
-                "role_template_name": {
-                    "type": "string"
-                },
-                "role_template_scopes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "role_template": {
+                    "description": "NO omitempty, deliberately: a membership with no role template emits\n`\"role_template\": null`. The key is always present.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/admin.MeRoleTemplate"
+                        }
+                    ]
                 }
             }
         },
@@ -14226,12 +14219,50 @@
                         "$ref": "#/definitions/admin.MeMembershipEntry"
                     }
                 },
-                "role_template": {},
+                "role_template": {
+                    "description": "NO omitempty, matching the membership field above and matching the\nhandler, which has an else-branch setting this to nil rather than leaving\nthe key out. `omitempty` here would DROP `\"role_template\": null` from every\nresponse that currently carries it -- a silent wire-format change dressed\nup as a typing fix, which is the failure mode this whole issue is about.\n\nSessionExpiresAt is the one field that genuinely is omitted: the handler\nsets it only when JWT claims carry an expiry, and never for API-key auth.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/admin.MeRoleTemplateSummary"
+                        }
+                    ]
+                },
                 "session_expires_at": {
                     "type": "string"
                 },
                 "user": {
                     "$ref": "#/definitions/User"
+                }
+            }
+        },
+        "admin.MeRoleTemplate": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "admin.MeRoleTemplateSummary": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -927,39 +927,6 @@ func (h *AuthHandlers) MeHandler() gin.HandlerFunc {
 			return
 		}
 
-		// Build response with user info and per-org role templates
-		response := gin.H{
-			"user": gin.H{
-				"id":         userWithRoles.ID,
-				"email":      userWithRoles.Email,
-				"name":       userWithRoles.Name,
-				"created_at": userWithRoles.CreatedAt,
-				"updated_at": userWithRoles.UpdatedAt,
-			},
-		}
-
-		// Build per-org memberships with role templates
-		memberships := make([]gin.H, 0, len(userWithRoles.Memberships))
-		for _, m := range userWithRoles.Memberships {
-			membership := gin.H{
-				"organization_id":   m.OrganizationID,
-				"organization_name": m.OrganizationName,
-				"created_at":        m.CreatedAt,
-			}
-			if m.RoleTemplateID != nil {
-				membership["role_template"] = gin.H{
-					"id":           m.RoleTemplateID,
-					"name":         m.RoleTemplateName,
-					"display_name": m.RoleTemplateDisplayName,
-					"scopes":       m.RoleTemplateScopes,
-				}
-			} else {
-				membership["role_template"] = nil
-			}
-			memberships = append(memberships, membership)
-		}
-		response["memberships"] = memberships
-
 		// Calculate combined allowed scopes across all organizations
 		// and provide a "primary" role template (highest privilege) for backward compatibility
 		allowedScopes := userWithRoles.GetAllowedScopes() //nolint:staticcheck // SA1019: deliberate suite-wide combined view for this admin display endpoint; narrow legitimate use per the deprecation notice
@@ -999,28 +966,25 @@ func (h *AuthHandlers) MeHandler() gin.HandlerFunc {
 		if auth.HasScope(effective, auth.ScopeAdmin) {
 			allowedScopes = append(allowedScopes, string(auth.ScopeAdmin))
 		}
-		response["allowed_scopes"] = allowedScopes
 
-		// Include session expiry from JWT claims so the frontend can schedule the
-		// pre-expiry warning dialog for cookie-based sessions. Absent for API-key auth.
+		// Session expiry from JWT claims, so the frontend can schedule the
+		// pre-expiry warning for cookie sessions. Absent for API-key auth.
+		var sessionExpiresAt *time.Time
 		if claimsVal, ok := c.Get("jwt_claims"); ok {
 			if claims, ok := claimsVal.(*auth.Claims); ok && claims.ExpiresAt != nil {
 				t := claims.ExpiresAt.Time
-				response["session_expires_at"] = t
+				sessionExpiresAt = &t
 			}
 		}
 
-		// For backward compatibility, provide the first membership's role template as primary
-		// In a multi-org setup, the frontend should use per-org memberships
-		if len(userWithRoles.Memberships) > 0 && userWithRoles.Memberships[0].RoleTemplateID != nil {
-			m := userWithRoles.Memberships[0]
-			response["role_template"] = gin.H{
-				"name":         m.RoleTemplateName,
-				"display_name": m.RoleTemplateDisplayName,
-			}
-		} else {
-			response["role_template"] = nil
-		}
+		// Constructed, not assembled ad hoc: see buildMeResponse on why the
+		// swagger annotation below is only true because this is a MeResponse.
+		response := buildMeResponse(
+			&userWithRoles.User,
+			userWithRoles.Memberships,
+			allowedScopes,
+			sessionExpiresAt,
+		)
 
 		c.JSON(http.StatusOK, response)
 	}

--- a/backend/internal/api/admin/me_response.go
+++ b/backend/internal/api/admin/me_response.go
@@ -1,0 +1,75 @@
+package admin
+
+import (
+	"time"
+
+	"github.com/sethbacon/terraform-suite-identity/identity/models"
+)
+
+// buildMeResponse assembles the /auth/me body.
+//
+// # Why this is a function and not inline in the handler
+//
+// MeHandler used to build an ad-hoc gin.H while its swagger annotation claimed
+// `admin.MeResponse`. Neither MeResponse nor MeMembershipEntry was constructed
+// anywhere -- the only reference to either was the annotation itself -- so the
+// two drifted, and the published contract described a flat
+// `role_template_name` that no client has ever received (#892).
+//
+// Pulling the assembly out here makes the struct load-bearing: the handler now
+// returns a MeResponse, so the compiler keeps the emitted shape and the
+// documented shape in step. It also makes the shape testable without a database,
+// which is what actually pins the wire format.
+func buildMeResponse(
+	user *models.User,
+	memberships []models.UserMembership,
+	allowedScopes []string,
+	sessionExpiresAt *time.Time,
+) MeResponse {
+	resp := MeResponse{
+		User: MeUserInfo{
+			ID:        user.ID,
+			Email:     user.Email,
+			Name:      user.Name,
+			CreatedAt: user.CreatedAt,
+			UpdatedAt: user.UpdatedAt,
+		},
+		// Non-nil so an empty membership list marshals as [] rather than null.
+		Memberships:      make([]MeMembershipEntry, 0, len(memberships)),
+		AllowedScopes:    allowedScopes,
+		SessionExpiresAt: sessionExpiresAt,
+	}
+
+	for i := range memberships {
+		m := memberships[i]
+		entry := MeMembershipEntry{
+			OrganizationID:   m.OrganizationID,
+			OrganizationName: m.OrganizationName,
+			CreatedAt:        m.CreatedAt,
+		}
+		// Keyed on RoleTemplateID, matching the handler: a membership whose
+		// template id is nil emits `"role_template": null` even if some other
+		// template field happened to be set.
+		if m.RoleTemplateID != nil {
+			entry.RoleTemplate = &MeRoleTemplate{
+				ID:          m.RoleTemplateID,
+				Name:        m.RoleTemplateName,
+				DisplayName: m.RoleTemplateDisplayName,
+				Scopes:      m.RoleTemplateScopes,
+			}
+		}
+		resp.Memberships = append(resp.Memberships, entry)
+	}
+
+	// TOP-LEVEL role_template: the FIRST membership's, and only two of its
+	// fields. Retained for backward compatibility -- a multi-organization client
+	// should read the per-membership entries instead.
+	if len(memberships) > 0 && memberships[0].RoleTemplateID != nil {
+		resp.RoleTemplate = &MeRoleTemplateSummary{
+			Name:        memberships[0].RoleTemplateName,
+			DisplayName: memberships[0].RoleTemplateDisplayName,
+		}
+	}
+
+	return resp
+}

--- a/backend/internal/api/admin/me_response_test.go
+++ b/backend/internal/api/admin/me_response_test.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sethbacon/terraform-suite-identity/identity/models"
+)
+
+// The /auth/me wire format, pinned as JSON.
+//
+// Asserted as exact JSON rather than by poking at struct fields, because the
+// defect this closes was a struct that did not match the bytes on the wire
+// (#892). A test that checked the struct would have agreed with the struct and
+// missed it entirely -- the swagger annotation already "agreed" with the struct
+// for months while describing a shape no client ever received.
+//
+// The two null-vs-absent distinctions below are the substance:
+//   - role_template, at both levels, is PRESENT and null when there is none
+//   - session_expires_at is ABSENT when there is none
+// Getting either backwards is a silent contract change, which is why they are
+// separate cases rather than one happy path.
+
+func strPtr(s string) *string { return &s }
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+var meFixedTime = time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+func meUser() *models.User {
+	return &models.User{
+		ID: "u1", Email: "a@b.c", Name: "Alice",
+		CreatedAt: meFixedTime, UpdatedAt: meFixedTime,
+	}
+}
+
+func TestBuildMeResponse_WireFormat(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		memberships []models.UserMembership
+		expires     *time.Time
+		want        string
+	}{
+		{
+			name: "membership with a role template",
+			memberships: []models.UserMembership{{
+				OrganizationID: "o1", OrganizationName: "Org One",
+				RoleTemplateID: strPtr("rt1"), RoleTemplateName: strPtr("owner"),
+				RoleTemplateDisplayName: strPtr("Owner"),
+				RoleTemplateScopes:      []string{"admin"},
+				CreatedAt:               meFixedTime,
+			}},
+			want: `{"user":{"id":"u1","email":"a@b.c","name":"Alice","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"},` +
+				`"memberships":[{"organization_id":"o1","organization_name":"Org One","created_at":"2026-08-24T12:00:00Z",` +
+				`"role_template":{"id":"rt1","name":"owner","display_name":"Owner","scopes":["admin"]}}],` +
+				`"allowed_scopes":["admin"],"role_template":{"name":"owner","display_name":"Owner"}}`,
+		},
+		{
+			// role_template is PRESENT and null, at both levels.
+			name: "membership with no role template",
+			memberships: []models.UserMembership{{
+				OrganizationID: "o1", OrganizationName: "Org One", CreatedAt: meFixedTime,
+			}},
+			want: `{"user":{"id":"u1","email":"a@b.c","name":"Alice","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"},` +
+				`"memberships":[{"organization_id":"o1","organization_name":"Org One","created_at":"2026-08-24T12:00:00Z","role_template":null}],` +
+				`"allowed_scopes":["admin"],"role_template":null}`,
+		},
+		{
+			// memberships is [] and not null.
+			name:        "no memberships at all",
+			memberships: nil,
+			want: `{"user":{"id":"u1","email":"a@b.c","name":"Alice","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"},` +
+				`"memberships":[],"allowed_scopes":["admin"],"role_template":null}`,
+		},
+		{
+			// session_expires_at is the one field that IS omitted when absent —
+			// contrast every role_template above.
+			name:        "with a session expiry",
+			memberships: nil,
+			expires:     &meFixedTime,
+			want: `{"user":{"id":"u1","email":"a@b.c","name":"Alice","created_at":"2026-08-24T12:00:00Z","updated_at":"2026-08-24T12:00:00Z"},` +
+				`"memberships":[],"allowed_scopes":["admin"],"role_template":null,"session_expires_at":"2026-08-24T12:00:00Z"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustJSON(t, buildMeResponse(meUser(), tc.memberships, []string{"admin"}, tc.expires))
+			if got != tc.want {
+				t.Errorf("wire format changed.\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMeResponse_RoundTripsIntoItsOwnStruct is the check the issue asked for as
+// the minimum: whatever the handler emits must unmarshal back into the type the
+// swagger annotation names. If the two ever diverge again, this fails.
+func TestMeResponse_RoundTripsIntoItsOwnStruct(t *testing.T) {
+	built := buildMeResponse(meUser(), []models.UserMembership{{
+		OrganizationID: "o1", OrganizationName: "Org One",
+		RoleTemplateID: strPtr("rt1"), RoleTemplateName: strPtr("owner"),
+		RoleTemplateDisplayName: strPtr("Owner"), RoleTemplateScopes: []string{"admin"},
+		CreatedAt: meFixedTime,
+	}}, []string{"admin"}, nil)
+
+	var back MeResponse
+	if err := json.Unmarshal([]byte(mustJSON(t, built)), &back); err != nil {
+		t.Fatalf("the emitted body does not unmarshal into MeResponse: %v", err)
+	}
+	if mustJSON(t, back) != mustJSON(t, built) {
+		t.Errorf("MeResponse does not round-trip.\n once: %s\ntwice: %s", mustJSON(t, built), mustJSON(t, back))
+	}
+	if back.Memberships[0].RoleTemplate == nil || back.Memberships[0].RoleTemplate.Name == nil {
+		t.Fatal("the nested role_template was lost in the round trip")
+	}
+	if *back.Memberships[0].RoleTemplate.Name != "owner" {
+		t.Errorf("role_template.name = %q, want \"owner\"", *back.Memberships[0].RoleTemplate.Name)
+	}
+}

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -23,24 +23,52 @@ type MeUserInfo struct {
 	UpdatedAt time.Time `json:"updated_at"`
 } // @name User
 
+// MeRoleTemplate is a membership's role template, nested. The four fields used
+// to be spliced FLAT into MeMembershipEntry as role_template_id, _name,
+// _display_name and _scopes -- which is not what the handler has ever emitted
+// (#892). The wire format is the nested object; the struct was the thing that
+// was wrong.
+type MeRoleTemplate struct {
+	ID          *string  `json:"id"`
+	Name        *string  `json:"name"`
+	DisplayName *string  `json:"display_name"`
+	Scopes      []string `json:"scopes"`
+}
+
+// MeRoleTemplateSummary is the TOP-LEVEL role_template, kept for backward
+// compatibility: the first membership's template, with only two of its fields.
+// Deliberately a different type from MeRoleTemplate -- they carry different
+// fields, and one struct with omitempty everywhere would let either shape pass.
+type MeRoleTemplateSummary struct {
+	Name        *string `json:"name"`
+	DisplayName *string `json:"display_name"`
+}
+
 // MeMembershipEntry describes one organisation membership in the /me response.
 type MeMembershipEntry struct {
-	OrganizationID          string    `json:"organization_id"`
-	OrganizationName        string    `json:"organization_name"`
-	RoleTemplateID          *string   `json:"role_template_id"`
-	RoleTemplateName        *string   `json:"role_template_name"`
-	RoleTemplateDisplayName *string   `json:"role_template_display_name"`
-	RoleTemplateScopes      []string  `json:"role_template_scopes"`
-	CreatedAt               time.Time `json:"created_at"`
+	OrganizationID   string    `json:"organization_id"`
+	OrganizationName string    `json:"organization_name"`
+	CreatedAt        time.Time `json:"created_at"`
+	// NO omitempty, deliberately: a membership with no role template emits
+	// `"role_template": null`. The key is always present.
+	RoleTemplate *MeRoleTemplate `json:"role_template"`
 }
 
 // MeResponse is returned by GET /api/v1/auth/me.
 type MeResponse struct {
-	User             MeUserInfo          `json:"user"`
-	Memberships      []MeMembershipEntry `json:"memberships"`
-	AllowedScopes    []string            `json:"allowed_scopes"`
-	RoleTemplate     interface{}         `json:"role_template"`
-	SessionExpiresAt *time.Time          `json:"session_expires_at,omitempty"`
+	User          MeUserInfo          `json:"user"`
+	Memberships   []MeMembershipEntry `json:"memberships"`
+	AllowedScopes []string            `json:"allowed_scopes"`
+	// NO omitempty, matching the membership field above and matching the
+	// handler, which has an else-branch setting this to nil rather than leaving
+	// the key out. `omitempty` here would DROP `"role_template": null` from every
+	// response that currently carries it -- a silent wire-format change dressed
+	// up as a typing fix, which is the failure mode this whole issue is about.
+	//
+	// SessionExpiresAt is the one field that genuinely is omitted: the handler
+	// sets it only when JWT claims carry an expiry, and never for API-key auth.
+	RoleTemplate     *MeRoleTemplateSummary `json:"role_template"`
+	SessionExpiresAt *time.Time             `json:"session_expires_at,omitempty"`
 }
 
 // APIKeyItem represents a single API key in list/get responses.
@@ -132,8 +160,8 @@ type ListBranchesResponse struct {
 // `int64,omitempty` an uncounted list and an empty one were byte-identical,
 // which is the same class of silence this struct exists to end.
 type PaginationMeta struct {
-	Page    int  `json:"page"`
-	PerPage int  `json:"per_page"`
+	Page    int `json:"page"`
+	PerPage int `json:"per_page"`
 	// HasMore reports whether any rows follow this page.
 	HasMore bool `json:"has_more"`
 	// Total is the number of matching rows across all pages, or null when the


### PR DESCRIPTION
## The defect

`admin.MeMembershipEntry` declared four flat fields — `role_template_id`, `role_template_name`, `role_template_display_name`, `role_template_scopes` — and `MeResponse.RoleTemplate` was `interface{}`. `MeHandler` returned neither. It assembled a `gin.H` by hand which nests the role template as an **object**:

```json
"memberships": [{ "organization_id": "…", "role_template": { "id": …, "name": …, "display_name": …, "scopes": […] } }],
"role_template": { "name": …, "display_name": … }
```

Both structs were dead — nothing in the tree referenced them — so the generated spec described a response that has never been sent, and `interface{}` documented the top-level field as an untyped object.

## Which side moved, and why

Reshaping the structs, not the handler. The frontend types against the handler's output deliberately — `authApi.ts` documents the nested shape — so the handler is the contract in use. Changing it would break a live consumer to satisfy a spec nobody generated from; changing the structs breaks nothing and makes the spec true.

## Verification

The response is unchanged, and that is the claim worth checking rather than asserting. I reconstructed the previous `gin.H` assembly verbatim alongside the new builder and compared marshalled output across a membership **with** a role template, one **without**, and **no memberships at all** — identical in all three. (Key *order* differs: a map marshals sorted, a struct in field order. JSON objects are unordered and no correct client can observe it.)

The tests assert **exact JSON strings**, not field equality — the defect was a wrong shape, not a wrong value, and only marshalled bytes distinguish a nested object from four flat keys. Each was mutation-verified; all four planted defects were caught:

| Mutation | Result |
|---|---|
| `omitempty` on top-level `role_template` (drops a key clients receive) | caught |
| `omitempty` on membership `role_template` | caught |
| `memberships` marshals as `null` instead of `[]` | caught |
| top-level `role_template` stops being populated | caught |

That first one is not hypothetical: I added `omitempty` while writing this, then found the `else` branch sets the key to `nil` explicitly, so it is *always* present. The test now pins that.

`make swag && make openapi3` regenerated both specs. The diff is exactly 2 definitions added, 2 modified, **0 paths changed** — which also confirms the committed spec had no unrelated drift.

Full `./internal/api/...` suite green, `go vet` clean.

Closes #892