### PR TITLE
fix(api): bound every page-size parameter, and see the ones that aren't (#900)

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -5183,7 +5183,7 @@
                 "summary": "List storage migrations",
                 "parameters": [
                     {
-                        "description": "Max results (default 20)",
+                        "description": "Max results (default 20, max 1000). A larger value is served as 1000.",
                         "name": "limit",
                         "in": "query",
                         "schema": {
@@ -5984,7 +5984,7 @@
                         }
                     },
                     {
-                        "description": "Maximum number of history rows to return (default: 50)",
+                        "description": "Maximum number of history rows to return (default 50, max 1000). A larger value is served as 1000.",
                         "name": "limit",
                         "in": "query",
                         "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4176,7 +4176,7 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Max results (default 20)",
+                        "description": "Max results (default 20, max 1000). A larger value is served as 1000.",
                         "name": "limit",
                         "in": "query"
                     },
@@ -4816,7 +4816,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Maximum number of history rows to return (default: 50)",
+                        "description": "Maximum number of history rows to return (default 50, max 1000). A larger value is served as 1000.",
                         "name": "limit",
                         "in": "query"
                     }

--- a/backend/internal/api/admin/scanning_admin.go
+++ b/backend/internal/api/admin/scanning_admin.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 	"github.com/terraform-registry/terraform-registry/internal/scanner"
 )
 
@@ -157,12 +159,12 @@ func GetScanningStatsHandler(db *sqlx.DB, orgRepo *repositories.OrganizationRepo
 			return
 		}
 
-		limit := 20
-		if l := c.Query("limit"); l != "" {
-			if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
-				limit = parsed
-			}
-		}
+		// GUARD per-page-clamps-to-max (issue #893). Written as an accept-guard
+		// rather than an if/reassign, so the sweep in internal/pagination could
+		// not see it: `?limit=200` failed the `<= 100` test and left limit at
+		// the DEFAULT of 20, so asking for more returned less.
+		limit, _ := strconv.Atoi(c.Query("limit"))
+		limit = pagination.ClampPerPage(limit, 20, 100)
 
 		offset := 0
 		if o := c.Query("offset"); o != "" {

--- a/backend/internal/api/admin/storage_migration.go
+++ b/backend/internal/api/admin/storage_migration.go
@@ -8,7 +8,9 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 	"github.com/terraform-registry/terraform-registry/internal/services"
 )
 
@@ -105,7 +107,7 @@ func (h *StorageMigrationHandler) StartMigration(c *gin.Context) {
 // @Tags         Storage Migration
 // @Security     Bearer
 // @Produce      json
-// @Param        limit   query  int  false  "Max results (default 20)"
+// @Param        limit   query  int  false  "Max results (default 20, max 1000). A larger value is served as 1000."
 // @Param        offset  query  int  false  "Offset for pagination (default 0)"
 // @Success      200  {object}  map[string]interface{}  "migrations array and pagination"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
@@ -114,13 +116,13 @@ func (h *StorageMigrationHandler) StartMigration(c *gin.Context) {
 // ListMigrations returns all migration jobs, newest first.
 // coverage:skip:requires-infrastructure
 func (h *StorageMigrationHandler) ListMigrations(c *gin.Context) {
-	limit := 20
+	// GUARD page-size-has-a-maximum (issue #900). This read had no upper
+	// bound at all: ?limit=1000000 was passed straight to the query, so one
+	// request could ask the database for every migration job ever recorded.
+	limit, _ := strconv.Atoi(c.Query("limit"))
+	limit = pagination.ClampPerPage(limit, 20, 1000)
+
 	offset := 0
-	if l := c.Query("limit"); l != "" {
-		if v, err := strconv.Atoi(l); err == nil && v > 0 {
-			limit = v
-		}
-	}
 	if o := c.Query("offset"); o != "" {
 		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
 			offset = v

--- a/backend/internal/api/admin/terraform_mirror.go
+++ b/backend/internal/api/admin/terraform_mirror.go
@@ -24,7 +24,9 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/storage"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
 // TerraformMirrorSyncJobInterface is the subset of TerraformMirrorSyncJob required by the handler.
@@ -742,7 +744,7 @@ func (h *TerraformMirrorHandler) UndeprecateVersion(c *gin.Context) {
 // @Security     Bearer
 // @Produce      json
 // @Param        id     path   string  true   "Mirror config UUID"
-// @Param        limit  query  int     false  "Maximum number of history rows to return (default: 50)"
+// @Param        limit  query  int     false  "Maximum number of history rows to return (default 50, max 1000). A larger value is served as 1000."
 // @Success      200  {object}  models.TerraformSyncHistoryListResponse
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Not found"
@@ -758,12 +760,11 @@ func (h *TerraformMirrorHandler) GetSyncHistory(c *gin.Context) {
 		return
 	}
 
-	limit := 50
-	if limitStr := c.Query("limit"); limitStr != "" {
-		if n, err := strconv.Atoi(limitStr); err == nil && n > 0 {
-			limit = n
-		}
-	}
+	// GUARD page-size-has-a-maximum (issue #900). Unbounded, exactly as in
+	// ListMigrations — the same defect, in a sibling handler the issue did
+	// not name.
+	limit, _ := strconv.Atoi(c.Query("limit"))
+	limit = pagination.ClampPerPage(limit, 50, 1000)
 
 	history, err := h.repo.ListSyncHistory(c.Request.Context(), id, limit)
 	if err != nil {

--- a/backend/internal/api/admin/version_approvals.go
+++ b/backend/internal/api/admin/version_approvals.go
@@ -15,7 +15,9 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/google/uuid"
+	"github.com/terraform-registry/terraform-registry/internal/pagination"
 
 	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
@@ -77,7 +79,11 @@ func (h *VersionApprovalHandler) tenantFilter(c *gin.Context) (repositories.Vers
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/admin/version-approvals [get]
 func (h *VersionApprovalHandler) List(c *gin.Context) {
+	// GUARD page-size-has-a-maximum (issue #900). Its siblings in
+	// endpoint's own @Param already promised "max 500, a larger value is
+	// served as 500" — the contract was written, never implemented.
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "100"))
+	limit = pagination.ClampPerPage(limit, 100, 500)
 	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
 
 	filter, ok := h.tenantFilter(c)

--- a/backend/internal/pagination/unclamped_sweep_test.go
+++ b/backend/internal/pagination/unclamped_sweep_test.go
@@ -1,0 +1,267 @@
+package pagination_test
+
+// unclamped_sweep_test.go is the re-runnable signature for issue #900.
+//
+// clamp_sweep_test.go, next to this file, catches a clamp that resolves to the
+// WRONG value. It cannot catch a page size that is never clamped AT ALL,
+// because there is no `if` for it to match — and that is a strictly worse
+// defect. `?limit=1000000` reached the database verbatim in three handlers.
+//
+// The two shapes it is blind to, both found in the estate while fixing #900:
+//
+//	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "100"))   // no ceiling at all
+//	// ...limit used directly
+//
+//	if parsed, err := strconv.Atoi(l); err == nil && parsed <= 100 {
+//		limit = parsed                                          // over-max keeps the
+//	}                                                           // default: #893 again,
+//	                                                            // as an accept-guard
+//
+// The second is issue #893's own defect wearing different syntax, which is the
+// more uncomfortable finding: the guard for #893 had been green over a live
+// instance of #893 since the day it was written. A signature that matches one
+// spelling of a defect certifies every other spelling.
+//
+// So this sweep does not match a shape. It asks a question that has the same
+// answer in every spelling: does this function read a page-size parameter and
+// then never pass anything through pagination.ClampPerPage? The helper has no
+// `if` to get wrong and no branch to omit, so "went through the helper" is the
+// property worth checking, and it is one grep from being re-run.
+//
+// Granularity is the enclosing top-level func: a read in one closure and a
+// clamp in a sibling closure of the same function would pass. No such pair
+// exists, and tightening it to per-closure scope would report the many
+// handlers that legitimately resolve their window in a helper. That is a known
+// edge, stated rather than papered over.
+//
+// EMPTY IS THE FINISH LINE for `unclamped`. readsAllowedUnclamped is not
+// expected to empty out — each entry claims an unbounded read is safe there,
+// and the claim has to survive review.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// pageSizeParams are the query parameters that decide how many rows a request
+// gets back. A new spelling is added here, not worked around at the call site.
+var pageSizeParams = map[string]bool{
+	"limit": true, "per_page": true, "perPage": true,
+	"page_size": true, "pageSize": true, "count": true,
+}
+
+// readsAllowedUnclamped maps a repo-relative file to the number of page-size
+// reads in it that are DELIBERATELY unbounded, with the reason.
+//
+// There are none. The entry set is empty because every read in the api tree
+// resolves through ClampPerPage — not because the sweep cannot see any.
+// TestPageSizeReadsAreClamped fails loudly if that ever becomes the reason.
+var readsAllowedUnclamped = map[string]int{}
+
+// paramsInUse are the page-size parameters the api tree is KNOWN to serve. Each
+// is a positive control on the matcher, not documentation.
+//
+// The whole-sweep check that `readsSeen > 0` only catches TOTAL blindness: drop
+// "limit" from pageSizeParams and the sweep still sees per_page and count, still
+// reports zero unclamped reads, and still passes — while eleven handlers go
+// unwatched. Verified: that mutation survived the first version of this test.
+// A per-parameter floor is what makes losing one spelling visible.
+var paramsInUse = []string{"limit", "per_page", "count"}
+
+// readsPageSizeParam reports whether the call reads one of pageSizeParams
+// FROM THE REQUEST. Matching the literal alone is not enough: `slog.Info(msg,
+// "count", n)` names one too, and an early draft of this sweep reported it.
+//
+// A read is either a context method — c.Query("limit"),
+// c.DefaultQuery("limit", "100") — or any call that takes both the gin context
+// and the parameter name, which is what every helper in this repo looks like
+// (queryInt(c, "per_page")). The second form is deliberately not a list of
+// helper names: a new helper is caught the day it is written, whereas a name
+// list would silently stop matching and look exactly like a clean tree.
+func readsPageSizeParam(call *ast.CallExpr) (string, bool) {
+	isPageSizeLit := func(e ast.Expr) (string, bool) {
+		lit, ok := e.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return "", false
+		}
+		name := strings.Trim(lit.Value, `"`)
+		return name, pageSizeParams[name]
+	}
+
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		switch sel.Sel.Name {
+		case "Query", "DefaultQuery", "GetQuery":
+			if len(call.Args) == 0 {
+				return "", false
+			}
+			return isPageSizeLit(call.Args[0])
+		}
+	}
+
+	takesContext, param := false, ""
+	for _, arg := range call.Args {
+		if ident, ok := arg.(*ast.Ident); ok && ident.Name == "c" {
+			takesContext = true
+		}
+		if name, ok := isPageSizeLit(arg); ok {
+			param = name
+		}
+	}
+	return param, takesContext && param != ""
+}
+
+// hasCeiling reports whether a function bounds its page size ABOVE, by either
+// of the two means this repo accepts.
+//
+// The second — a hand-written `if x > 1000 { x = 1000 }` — is accepted rather
+// than rewritten because it is already correct, and because the companion
+// sweep in clamp_sweep_test.go is what makes accepting it safe: that sweep
+// fails any `if x > LIT` whose body assigns something OTHER than LIT. So an
+// inline ceiling here has already been checked to resolve to the maximum.
+// Together the two sweeps say: every page-size read is bounded above, and
+// every bound resolves to the maximum rather than collapsing to the default.
+//
+// Converting those five to ClampPerPage would also change `?limit=0` from one
+// row to the default, which is a behaviour change that belongs in its own
+// change rather than smuggled into a fix for unbounded reads.
+func hasCeiling(n ast.Node) bool {
+	found := false
+	ast.Inspect(n, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		if sel, ok := node.(*ast.SelectorExpr); ok && sel.Sel.Name == "ClampPerPage" {
+			found = true
+			return false
+		}
+		stmt, ok := node.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		for _, cond := range disjuncts(stmt.Cond) {
+			bin, ok := cond.(*ast.BinaryExpr)
+			if !ok || bin.Op != token.GTR {
+				continue
+			}
+			lit, ok := bin.Y.(*ast.BasicLit)
+			if !ok || lit.Kind != token.INT {
+				continue
+			}
+			// The body must assign to the thing being compared, or the
+			// comparison is a test that reports rather than bounds.
+			for _, bodyStmt := range stmt.Body.List {
+				assign, ok := bodyStmt.(*ast.AssignStmt)
+				if !ok || len(assign.Lhs) != 1 {
+					continue
+				}
+				lhs, lok := assign.Lhs[0].(*ast.Ident)
+				cmp, cok := bin.X.(*ast.Ident)
+				if lok && cok && lhs.Name == cmp.Name {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func TestPageSizeReadsAreClamped(t *testing.T) {
+	root := moduleRoot(t)
+	unclamped := map[string]int{}
+	readsSeen := 0
+	seenByParam := map[string]int{}
+
+	err := filepath.Walk(filepath.Join(root, "internal", "api"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			reads := false
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				if call, ok := node.(*ast.CallExpr); ok {
+					if name, isRead := readsPageSizeParam(call); isRead {
+						reads = true
+						seenByParam[name]++
+						return false
+					}
+				}
+				return true
+			})
+			if !reads {
+				continue
+			}
+			readsSeen++
+			if !hasCeiling(fn.Body) {
+				unclamped[rel]++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// A sweep that can no longer find a single page-size read looks exactly
+	// like a fully-clamped tree. Refuse to certify one — this is the positive
+	// control, and it is the check that would have caught the #893 sweep's
+	// blindness years earlier than fixing #900 did.
+	if readsSeen == 0 {
+		t.Fatal("the sweep found NO page-size reads at all in internal/api. That is not a " +
+			"clamped tree, it is a blind matcher: readsPageSizeParam is no longer " +
+			"recognising a parameter read. Fix the matcher before trusting this green.")
+	}
+	for _, param := range paramsInUse {
+		if seenByParam[param] == 0 {
+			t.Errorf("the sweep no longer finds ANY read of %q, a parameter this api is "+
+				"known to serve. Either every handler using it was deleted — in which case "+
+				"remove it from paramsInUse — or the matcher stopped recognising it and is "+
+				"now certifying those handlers without looking at them.", param)
+		}
+	}
+
+	for file, n := range unclamped {
+		want, listed := readsAllowedUnclamped[file]
+		if !listed {
+			t.Errorf("%s has %d function(s) that read a page-size parameter without passing "+
+				"anything through pagination.ClampPerPage.\n"+
+				"That is issue #900: the caller's number reaches the query verbatim, so "+
+				"?limit=1000000 asks the database for a million rows. Use "+
+				"pagination.ClampPerPage(requested, default, max), or add the file to "+
+				"readsAllowedUnclamped with the reason an unbounded read is safe there.", file, n)
+			continue
+		}
+		if n != want {
+			t.Errorf("%s has %d unclamped page-size read(s), expected %d.", file, n, want)
+		}
+	}
+
+	for file, want := range readsAllowedUnclamped {
+		if _, ok := unclamped[file]; !ok {
+			t.Errorf("readsAllowedUnclamped lists %s (expecting %d) but every page-size read "+
+				"in it is clamped now. Remove the entry — a stale exemption is an exemption "+
+				"nobody re-justified.", file, want)
+		}
+	}
+}


### PR DESCRIPTION
## The reported defect

`ListMigrations` accepted any `limit` a caller sent — `?limit=1000000` reached the query verbatim.

## What enumerating the class found

Four sites, not one. The issue named the first; the second was its identical twin; the last two came from sweeping rather than reading.

| Site | State before |
|---|---|
| `storage/migrations` | unbounded — **the reported site** |
| mirror sync history | unbounded, same idiom, sibling handler |
| version approvals | unbounded — **and its `@Param` has promised "max 500, a larger value is served as 500" since it was written** |
| scanning admin | bounded, but `?limit=200` served **20** |

Two of these are worth dwelling on.

**Version approvals had a contract nobody implemented.** The documented maximum was already 500. I initially clamped it to 1000 to match its siblings, then found the annotation — so it clamps to the number the endpoint has been promising, not a fresh one I chose.

**Scanning admin is issue #893's defect, in a repo that has had a sweep for #893 since #896.** That sweep matches `if x > LIT { x = OTHER }`. This site is written as an accept-guard:

```go
if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 && parsed <= 100 {
    limit = parsed          // 200 fails the test, limit stays at the default 20
}
```

Same defect, different syntax, so it never matched — **the guard was green over a live instance of the exact defect it exists to catch.**

## The guard

Matching a second shape would just move the blind spot, so this sweep doesn't match a shape. It asks whether a function reads a page-size parameter and then never bounds it above — a question with the same answer in every spelling. A hand-written ceiling still counts, because the #893 sweep already verifies those resolve to the maximum; together the two say *every read is bounded, and every bound resolves upward*. That's why five correct inline clamps aren't rewritten here: converting them would change `?limit=0` from one row to the default, which isn't this change's business.

Both blindness controls were earned rather than assumed:

- The first draft flagged `slog.Info(msg, "count", n)` — a log key. A literal now only counts when read from the request, via the context method or any call taking both `c` and the name (so a *new* helper is caught the day it's written, rather than a name list that silently stops matching).
- The whole-sweep "found nothing" check caught only **total** blindness. Dropping `"limit"` from the vocabulary left `per_page` and `count` visible, reported zero unclamped reads, and **passed** — while eleven handlers went unwatched. Each parameter is now its own positive control.

## Mutation verification

| Mutation | Result |
|---|---|
| each of the four fixes reverted (4 runs) | caught |
| new unbounded handler via a helper name the sweep has never seen | caught |
| vocabulary loses `limit` / `per_page` / `count` | caught (all three) |

The exemption list is **empty** — no site was exempted to reach green.

Closes #900