### PR TITLE
fix(mtls): resolve certificate mappings through the platform-admin carrier (#876)

### DIFF
--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -218,11 +218,23 @@ security:
   mtls:
     enabled: false
     client_ca_file: /etc/certs/client-ca.crt
+    #
+    # A mapping's scopes are a claim, not a grant. `admin` is a grant-all
+    # wildcard held in the platform_admins carrier, which is keyed on a user —
+    # so a mapping carrying `admin` MUST name the user the certificate acts as,
+    # and the server refuses to start otherwise. That user's carrier row is
+    # then consulted on every request, so revoking it disarms the certificate
+    # immediately rather than at the next restart (issue #876).
+    #
+    # user_id is optional for ordinary machine credentials, which need no user.
     # mappings:
     #   - subject: "CN=terraform-ci"
     #     scopes: ["modules:read", "providers:read"]
     #   - subject: "CN=release-pipeline"
     #     scopes: ["modules:write", "providers:write"]
+    #   - subject: "CN=break-glass"
+    #     scopes: ["admin"]
+    #     user_id: "00000000-0000-0000-0000-000000000000"  # grant via POST /api/v1/admin/platform-admins
 
 logging:
   level: info  # Options: debug, info, warn, error

--- a/backend/internal/adminfloor/adminfloor.go
+++ b/backend/internal/adminfloor/adminfloor.go
@@ -20,11 +20,23 @@
 // # What "administrator" means, derived rather than invented
 //
 // PLATFORM administrator is what the middleware treats as platform-admin
-// authority today: the platform_admins carrier (migration 000051) OR an
-// admin-bearing role template held through any membership (the org-less scope
-// union, #652). Effective admin is `carrier OR union`, so the floor counts the
-// union of both — refusing a demotion because the carrier is empty when four
-// union administrators remain would be a refusal with no hazard behind it.
+// authority today: a row in the platform_admins carrier (migration 000051).
+// Nothing else, since migration 000054.
+//
+// It used to be `carrier OR union` — the carrier OR an admin-bearing role
+// template held through any membership (the org-less scope union, #652) — and
+// this paragraph went on saying so for a while after it stopped being true.
+// #874 made authority carrier-only and rewrote checkPlatformFloor to match; the
+// description here was not updated with it, so the package doc and the function
+// 280 lines below disagreed about who counts. Corrected while closing #876,
+// which was the other half of the same drift: mTLS was still publishing `admin`
+// from a config file, so the carrier was not in fact the only source the
+// sentence above claimed it was.
+//
+// The union half is gone deliberately, not by omission: the auth middleware
+// strips `admin` from the session union, so an admin-bearing membership
+// administers nothing, and counting one would report "an administrator remains"
+// while the deployment's last real one was being deleted.
 //
 // ORGANIZATION administrator is a member whose role template carries `admin`
 // or `organizations:write`. That is not a new definition: it is exactly what

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -582,7 +582,11 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		if mtlsErr != nil {
 			log.Fatalf("failed to initialize mTLS provider: %v", mtlsErr)
 		}
-		router.Use(mtls.AuthMiddleware(mtlsProvider))
+		// The carrier goes in so an mTLS mapping's `admin` is resolved per
+		// request against platform_admins rather than trusted from config
+		// (#876). Constructed above at the platformAdminCarrier assignment,
+		// which is why this registration sits after it.
+		router.Use(mtls.AuthMiddleware(mtlsProvider, platformAdminCarrier))
 	}
 
 	// Rate limiters are constructed HERE, ahead of route registration, because

--- a/backend/internal/auth/mtls/carrier_test.go
+++ b/backend/internal/auth/mtls/carrier_test.go
@@ -1,0 +1,293 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/sethbacon/terraform-suite-identity/identity/platformadmin"
+	"github.com/terraform-registry/terraform-registry/internal/config"
+)
+
+// mTLS was the last credential class outside the platform-admin carrier (#876).
+// #874 brought sessions under Carrier.SessionScopes and stripped `admin` from
+// API keys with KeyScopes, but a subject→scope mapping still published whatever
+// the config file said — so `scopes: ["admin"]` produced a platform
+// administrator with no grant record, no audit entry, and no revocation short
+// of editing configuration and restarting.
+//
+// These tests hold the two halves of the fix shut: a mapping cannot reach
+// `admin` without naming a user, and a mapping that names one is only as
+// administrative as that user's carrier row says, RIGHT NOW.
+
+const (
+	testUserID  = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	otherUserID = "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+)
+
+func newTestCarrier(t *testing.T) (*platformadmin.Carrier, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	carrier, err := platformadmin.New(db, "platform_admins")
+	if err != nil {
+		t.Fatalf("platformadmin.New: %v", err)
+	}
+	return carrier, mock
+}
+
+func expectCarrierLookup(mock sqlmock.Sqlmock, userID string, granted bool) {
+	mock.ExpectQuery(`SELECT EXISTS.*FROM "platform_admins"`).
+		WithArgs(userID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(granted))
+}
+
+func certFor(cn string) *x509.Certificate {
+	return &x509.Certificate{Subject: pkix.Name{CommonName: cn}}
+}
+
+// runRequest drives the middleware with a verified client certificate and
+// returns the status and the scopes the RBAC layer would read.
+func runRequest(t *testing.T, p *Provider, carrier *platformadmin.Carrier, cn string) (int, []string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	var published []string
+	r := gin.New()
+	r.Use(AuthMiddleware(p, carrier))
+	r.GET("/x", func(c *gin.Context) {
+		if v, ok := c.Get("scopes"); ok {
+			published, _ = v.([]string)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.TLS = &tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{certFor(cn)}}}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code, published
+}
+
+func hasScope(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Startup refusal: `admin` needs a user to resolve against
+// ---------------------------------------------------------------------------
+
+func TestNewProvider_RefusesAdminWithoutAUser(t *testing.T) {
+	_, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"modules:read", "admin"}},
+		},
+	})
+	if err == nil {
+		t.Fatal("a mapping carrying `admin` with no user_id was accepted; the carrier is " +
+			"keyed on a user, so such a grant can never be audited or revoked")
+	}
+	if !strings.Contains(err.Error(), "user_id") {
+		t.Errorf("error should tell the operator what to add, got: %v", err)
+	}
+}
+
+func TestNewProvider_AcceptsAdminWithAUser(t *testing.T) {
+	p, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"admin"}, UserID: testUserID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("a mapping naming a user should build: %v", err)
+	}
+	_, _, userID, aerr := p.Authenticate(certFor("ci"))
+	if aerr != nil {
+		t.Fatalf("Authenticate: %v", aerr)
+	}
+	if userID != testUserID {
+		t.Errorf("user_id = %q, want %q — the binding must survive to the middleware", userID, testUserID)
+	}
+}
+
+func TestNewProvider_RefusesNonUUIDUser(t *testing.T) {
+	_, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"modules:read"}, UserID: "alice@example.com"},
+		},
+	})
+	if err == nil {
+		t.Fatal("a non-UUID user_id was accepted; it would never match a carrier row and " +
+			"would fail silently as 'not an administrator'")
+	}
+}
+
+func TestNewProvider_RefusesDuplicateSubjects(t *testing.T) {
+	_, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"modules:read"}, UserID: testUserID},
+			{Subject: "cn=CI", Scopes: []string{"modules:write"}, UserID: otherUserID},
+		},
+	})
+	if err == nil {
+		t.Fatal("a repeated subject was accepted; last-write-wins would bind the certificate " +
+			"to a different user than the line the operator is reading")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Runtime: the carrier, not the config file, decides
+// ---------------------------------------------------------------------------
+
+func TestAdminHoldsOnlyWhileTheCarrierRowDoes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		granted   bool
+		wantAdmin bool
+	}{
+		{"carrier row present — admin holds", true, true},
+		{"carrier row absent — admin does not hold", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewProvider(config.MTLSConfig{
+				Enabled:      true,
+				ClientCAFile: "/ca.crt",
+				Mappings: []config.MTLSSubjectMapping{
+					{Subject: "CN=ci", Scopes: []string{"modules:read", "admin"}, UserID: testUserID},
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewProvider: %v", err)
+			}
+			carrier, mock := newTestCarrier(t)
+			expectCarrierLookup(mock, testUserID, tc.granted)
+
+			status, scopes := runRequest(t, p, carrier, "ci")
+			if status != http.StatusOK {
+				t.Fatalf("status = %d, want 200", status)
+			}
+			if got := hasScope(scopes, "admin"); got != tc.wantAdmin {
+				t.Errorf("admin in published scopes = %v, want %v (scopes=%v)", got, tc.wantAdmin, scopes)
+			}
+			// The configured non-admin scope is untouched either way.
+			if !hasScope(scopes, "modules:read") {
+				t.Errorf("modules:read was lost; only `admin` is the carrier's business (scopes=%v)", scopes)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("the carrier was not consulted: %v", err)
+			}
+		})
+	}
+}
+
+func TestCarrierLookupFailureIsARefusalToAnswer(t *testing.T) {
+	p, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"admin"}, UserID: testUserID},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	carrier, mock := newTestCarrier(t)
+	mock.ExpectQuery(`SELECT EXISTS.*FROM "platform_admins"`).
+		WithArgs(testUserID).
+		WillReturnError(errBoom{})
+
+	status, _ := runRequest(t, p, carrier, "ci")
+	if status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 — an authority question that did not resolve must not "+
+			"be served as a completed 'no'", status)
+	}
+}
+
+type errBoom struct{}
+
+func (errBoom) Error() string { return "carrier unavailable" }
+
+// A mapping with no user cannot publish `admin` even if one reaches the publish
+// path — NewProvider refuses to build one, so this asserts the second lock.
+func TestPublishStripsAdminWhenNoUserIsNamed(t *testing.T) {
+	p := &Provider{mappings: map[string]subjectMapping{
+		"cn=ci": {scopes: []string{"modules:read", "admin"}},
+	}}
+	carrier, _ := newTestCarrier(t)
+
+	status, scopes := runRequest(t, p, carrier, "ci")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if hasScope(scopes, "admin") {
+		t.Errorf("admin published for a mapping naming no user (scopes=%v)", scopes)
+	}
+	if !hasScope(scopes, "modules:read") {
+		t.Errorf("modules:read was lost (scopes=%v)", scopes)
+	}
+}
+
+// A nil carrier is a deployment that never built one. It must degrade to
+// stripping, not to trusting the config file.
+func TestNilCarrierStripsRatherThanTrusts(t *testing.T) {
+	p := &Provider{mappings: map[string]subjectMapping{
+		"cn=ci": {scopes: []string{"modules:read", "admin"}, userID: testUserID},
+	}}
+
+	status, scopes := runRequest(t, p, nil, "ci")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if hasScope(scopes, "admin") {
+		t.Errorf("admin published with no carrier to confirm it (scopes=%v)", scopes)
+	}
+}
+
+// An ordinary machine credential needs no user and is not charged a carrier
+// lookup.
+func TestNonAdminMappingNeedsNoUserAndNoLookup(t *testing.T) {
+	p, err := NewProvider(config.MTLSConfig{
+		Enabled:      true,
+		ClientCAFile: "/ca.crt",
+		Mappings: []config.MTLSSubjectMapping{
+			{Subject: "CN=ci", Scopes: []string{"modules:read", "providers:read"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("an ordinary mapping should need no user_id: %v", err)
+	}
+	carrier, mock := newTestCarrier(t)
+
+	status, scopes := runRequest(t, p, carrier, "ci")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(scopes) != 2 || !hasScope(scopes, "modules:read") || !hasScope(scopes, "providers:read") {
+		t.Errorf("scopes = %v, want the two configured ones unchanged", scopes)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unexpected carrier traffic for a mapping with no user: %v", err)
+	}
+}

--- a/backend/internal/auth/mtls/middleware.go
+++ b/backend/internal/auth/mtls/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sethbacon/terraform-suite-identity/identity/platformadmin"
 )
 
 // AuthMiddleware creates Gin middleware that authenticates requests using
@@ -19,7 +20,23 @@ import (
 // treats auth_method=="mtls" as satisfying the "credentials present" check
 // even with no bearer token, so an mTLS-authenticated request reaches the
 // RBAC layer normally.
-func AuthMiddleware(p *Provider) gin.HandlerFunc {
+//
+// THE SCOPES PUBLISHED HERE ARE CARRIER-RESOLVED, NOT AS CONFIGURED (#876).
+//
+// A subject→scope mapping is a claim written in a config file. Before this,
+// that claim was published verbatim, so `scopes: ["admin"]` made the caller a
+// platform administrator with no grant record, no audit entry, and no
+// revocation short of editing configuration and restarting — while every other
+// credential class had been brought under the carrier by #874 (sessions through
+// SessionScopes, API keys stripped by KeyScopes). mTLS was the one that kept
+// its own answer to "who is a platform administrator?".
+//
+// Now a mapping that names a user is resolved through the carrier exactly as a
+// session is, so `admin` holds only while that user holds a carrier row and
+// stops holding the moment the row is revoked. A mapping that names no user
+// cannot reach `admin` at all: NewProvider refuses to build one at startup, and
+// the publish path below strips it anyway.
+func AuthMiddleware(p *Provider, carrier *platformadmin.Carrier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if p == nil {
 			c.Next()
@@ -40,21 +57,74 @@ func AuthMiddleware(p *Provider) gin.HandlerFunc {
 		}
 
 		cert := c.Request.TLS.VerifiedChains[0][0]
-		subject, scopes, err := p.Authenticate(cert)
+		subject, scopes, userID, err := p.Authenticate(cert)
 		if err != nil {
 			slog.Debug("mTLS auth: no mapping for client cert", "cn", cert.Subject.CommonName, "error", err)
 			c.Next()
 			return
 		}
 
+		effective, status, msg := resolveScopes(c, carrier, userID, scopes)
+		if status != 0 {
+			// An authority question that did not resolve is not a completed
+			// "no". Aborting with 500 rather than continuing unelevated matches
+			// middleware.AuthMiddleware's treatment of the same failure: a
+			// silent downgrade would take the admin surface away from an
+			// administrator during exactly the incident they need it in, with
+			// nothing in the response saying why.
+			c.AbortWithStatusJSON(status, gin.H{"error": msg})
+			return
+		}
+
 		// Set auth context for downstream middleware/handlers
 		c.Set("auth_method", "mtls")
 		c.Set("mtls_subject", subject)
-		c.Set("scopes", scopes)
+		c.Set("scopes", effective)
 
-		slog.Info("mTLS auth: client authenticated", "subject", subject, "scopes", scopes)
+		// Published under its OWN key rather than as "user_id" — deliberately.
+		//
+		// 36 non-test sites read "user_id", and some of them authorize with it
+		// (namespace_authz.go:487 among them). Setting it here would make an
+		// mTLS caller indistinguishable from a signed-in user across all of
+		// them, which is a second, wider change than binding a certificate to a
+		// carrier row, and is the kind of undesigned change #874 declined to
+		// carry. The binding is recorded so it can be audited and so this
+		// decision can be revisited on its own evidence.
+		if userID != "" {
+			c.Set("mtls_user_id", userID)
+		}
+
+		slog.Info("mTLS auth: client authenticated",
+			"subject", subject, "user_id", userID, "scopes", effective)
 		c.Next()
 	}
+}
+
+// resolveScopes turns a mapping's CONFIGURED scopes into the effective ones.
+//
+// Two paths, and neither can publish `admin` on the strength of the config
+// alone:
+//
+//   - the mapping NAMES A USER — the scopes go through the same
+//     Carrier.SessionScopes a JWT session uses, so `admin` survives only while
+//     that user holds a carrier row, and revoking the row disarms the
+//     certificate on the next request rather than at the next restart;
+//   - the mapping names NO user — KeyScopes, the API-key treatment: `admin`
+//     removed, always. NewProvider already refuses to build such a mapping with
+//     `admin` in it, so this is the second of two locks on the same door. It is
+//     here because the first one guards a construction path and this one guards
+//     the publish, and only the publish is what the RBAC layer reads.
+//
+// A nil carrier degrades to stripping rather than to trusting.
+func resolveScopes(c *gin.Context, carrier *platformadmin.Carrier, userID string, scopes []string) ([]string, int, string) {
+	if carrier == nil || userID == "" {
+		return platformadmin.KeyScopes(scopes), 0, ""
+	}
+	effective, err := carrier.SessionScopes(c.Request.Context(), userID, scopes)
+	if err != nil {
+		return effective, http.StatusInternalServerError, "Auth check failed"
+	}
+	return effective, 0, ""
 }
 
 // RequireMTLS creates middleware that rejects requests without a valid mTLS

--- a/backend/internal/auth/mtls/middleware_test.go
+++ b/backend/internal/auth/mtls/middleware_test.go
@@ -49,7 +49,7 @@ func requestWithVerifiedChains(leaf *x509.Certificate) *http.Request {
 
 func TestAuthMiddleware_NilProvider_PassesThrough(t *testing.T) {
 	r := gin.New()
-	r.Use(AuthMiddleware(nil))
+	r.Use(AuthMiddleware(nil, nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	w := httptest.NewRecorder()
@@ -63,7 +63,7 @@ func TestAuthMiddleware_NilProvider_PassesThrough(t *testing.T) {
 func TestAuthMiddleware_NoTLS_PassesThroughUnauthenticated(t *testing.T) {
 	p := newMTLSTestProvider(t)
 	r := gin.New()
-	r.Use(AuthMiddleware(p))
+	r.Use(AuthMiddleware(p, nil))
 	var authMethodSet bool
 	r.GET("/", func(c *gin.Context) {
 		_, authMethodSet = c.Get("auth_method")
@@ -84,7 +84,7 @@ func TestAuthMiddleware_NoTLS_PassesThroughUnauthenticated(t *testing.T) {
 func TestAuthMiddleware_NoVerifiedChains_PassesThroughUnauthenticated(t *testing.T) {
 	p := newMTLSTestProvider(t)
 	r := gin.New()
-	r.Use(AuthMiddleware(p))
+	r.Use(AuthMiddleware(p, nil))
 	var authMethodSet bool
 	r.GET("/", func(c *gin.Context) {
 		_, authMethodSet = c.Get("auth_method")
@@ -107,7 +107,7 @@ func TestAuthMiddleware_NoVerifiedChains_PassesThroughUnauthenticated(t *testing
 func TestAuthMiddleware_VerifiedCert_MatchedMapping_SetsContext(t *testing.T) {
 	p := newMTLSTestProvider(t)
 	r := gin.New()
-	r.Use(AuthMiddleware(p))
+	r.Use(AuthMiddleware(p, nil))
 
 	var gotAuthMethod, gotSubject string
 	var gotScopes []string
@@ -141,7 +141,7 @@ func TestAuthMiddleware_VerifiedCert_MatchedMapping_SetsContext(t *testing.T) {
 func TestAuthMiddleware_VerifiedCert_NoMapping_PassesThroughUnauthenticated(t *testing.T) {
 	p := newMTLSTestProvider(t)
 	r := gin.New()
-	r.Use(AuthMiddleware(p))
+	r.Use(AuthMiddleware(p, nil))
 	var authMethodSet bool
 	r.GET("/", func(c *gin.Context) {
 		_, authMethodSet = c.Get("auth_method")

--- a/backend/internal/auth/mtls/provider.go
+++ b/backend/internal/auth/mtls/provider.go
@@ -27,11 +27,22 @@ import (
 	"strings"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
+
+	"github.com/google/uuid"
+	"github.com/sethbacon/terraform-suite-identity/identity/auth"
 )
 
 // Provider verifies client certificates and maps subjects to scopes.
 type Provider struct {
-	mappings map[string][]string // subject → scopes
+	mappings map[string]subjectMapping // normalized subject → mapping
+}
+
+// subjectMapping is one configured certificate subject: the scopes it presents
+// and, when it carries `admin`, the user whose carrier row decides whether that
+// `admin` means anything on this request (issue #876).
+type subjectMapping struct {
+	scopes []string
+	userID string
 }
 
 // NewProvider creates an mTLS provider from configuration.
@@ -48,36 +59,83 @@ func NewProvider(cfg config.MTLSConfig) (*Provider, error) {
 		slog.Warn("mTLS enabled but no subject mappings configured")
 	}
 
-	m := make(map[string][]string, len(cfg.Mappings))
+	m := make(map[string]subjectMapping, len(cfg.Mappings))
 	for _, mapping := range cfg.Mappings {
 		subject := normalizeSubject(mapping.Subject)
-		m[subject] = mapping.Scopes
-		slog.Info("mTLS subject mapping registered", "subject", subject, "scopes", mapping.Scopes)
+
+		// A repeated subject used to overwrite silently. That was untidy when a
+		// mapping was only a scope list; now that one can name the user a
+		// certificate acts as, a silent overwrite would bind a certificate to a
+		// DIFFERENT PRINCIPAL than the line the operator is reading. Refuse.
+		if _, dup := m[subject]; dup {
+			return nil, fmt.Errorf("mtls.mappings: subject %q is configured more than once; "+
+				"remove the duplicate — a repeated subject would silently take the last "+
+				"scopes and user_id in the file", mapping.Subject)
+		}
+
+		// REFUSE `admin` WITHOUT A USER (issue #876).
+		//
+		// Platform-admin authority lives in the platform_admins carrier and the
+		// carrier is keyed on user_id, so an `admin` mapping with no user names
+		// no grant that can be audited, and none that revoking a carrier row
+		// can take away. Refusing at construction makes that unrepresentable
+		// rather than merely discouraged: router.go turns this error into a
+		// log.Fatalf, so a deployment configured this way does not start.
+		//
+		// This is the mTLS analogue of the write-time refusals #874 put on role
+		// templates and memberships. Those answer a request 400/403 because
+		// they intercept a write; a mapping is configuration, so the only
+		// moment there is to refuse is boot.
+		if err := auth.ValidateProvisionableScopes(mapping.Scopes); err != nil && mapping.UserID == "" {
+			return nil, fmt.Errorf("mtls.mappings: subject %q carries the `admin` scope with no user_id. "+
+				"Platform administration is held in the platform_admins carrier, which is keyed on a "+
+				"user; set user_id to the UUID of the user this certificate acts as (and grant them "+
+				"platform administration through POST /api/v1/admin/platform-admins), or remove `admin` "+
+				"from the mapping", mapping.Subject)
+		}
+
+		if mapping.UserID != "" {
+			if _, err := uuid.Parse(mapping.UserID); err != nil {
+				return nil, fmt.Errorf("mtls.mappings: subject %q has user_id %q, which is not a UUID: %w",
+					mapping.Subject, mapping.UserID, err)
+			}
+		}
+
+		m[subject] = subjectMapping{scopes: mapping.Scopes, userID: mapping.UserID}
+		slog.Info("mTLS subject mapping registered",
+			"subject", subject, "scopes", mapping.Scopes, "user_id", mapping.UserID)
 	}
 
 	return &Provider{mappings: m}, nil
 }
 
 // Authenticate extracts the subject from a verified client certificate and
-// returns the mapped scopes. Returns an error if no mapping matches.
-func (p *Provider) Authenticate(cert *x509.Certificate) (subject string, scopes []string, err error) {
+// returns the mapped scopes together with the user the mapping names, if any.
+// Returns an error if no mapping matches.
+//
+// The returned scopes are the CONFIGURED ones, not the effective ones. Anything
+// reaching for `admin` here is reading a claim from a config file; the carrier
+// decides whether it holds. AuthMiddleware performs that resolution — this
+// method deliberately does not, so there is one place where an mTLS request's
+// authority is settled rather than two.
+func (p *Provider) Authenticate(cert *x509.Certificate) (subject string, scopes []string, userID string, err error) {
 	if cert == nil {
-		return "", nil, fmt.Errorf("no client certificate provided")
+		return "", nil, "", fmt.Errorf("no client certificate provided")
 	}
 
 	// Try matching by CN first
 	cnSubject := "CN=" + cert.Subject.CommonName
-	if scopes, ok := p.mappings[normalizeSubject(cnSubject)]; ok {
-		return cnSubject, scopes, nil
+	if mapping, ok := p.mappings[normalizeSubject(cnSubject)]; ok {
+		return cnSubject, mapping.scopes, mapping.userID, nil
 	}
 
 	// Try matching by full DN
 	fullDN := cert.Subject.String()
-	if scopes, ok := p.mappings[normalizeSubject(fullDN)]; ok {
-		return fullDN, scopes, nil
+	if mapping, ok := p.mappings[normalizeSubject(fullDN)]; ok {
+		return fullDN, mapping.scopes, mapping.userID, nil
 	}
 
-	return "", nil, fmt.Errorf("no mTLS mapping for subject CN=%s (DN=%s)", cert.Subject.CommonName, fullDN)
+	return "", nil, "", fmt.Errorf("no mTLS mapping for subject CN=%s (DN=%s)", cert.Subject.CommonName, fullDN)
 }
 
 // normalizeSubject lower-cases and trims whitespace from a subject string

--- a/backend/internal/auth/mtls/provider_test.go
+++ b/backend/internal/auth/mtls/provider_test.go
@@ -52,7 +52,7 @@ func TestAuthenticate_ByCN(t *testing.T) {
 		Subject: pkix.Name{CommonName: "terraform-ci"},
 	}
 
-	subject, scopes, err := p.Authenticate(cert)
+	subject, scopes, _, err := p.Authenticate(cert)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestAuthenticate_CaseInsensitive(t *testing.T) {
 		Subject: pkix.Name{CommonName: "terraform-ci"},
 	}
 
-	_, scopes, err := p.Authenticate(cert)
+	_, scopes, _, err := p.Authenticate(cert)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestAuthenticate_NoMatch(t *testing.T) {
 		Subject: pkix.Name{CommonName: "unknown-client"},
 	}
 
-	_, _, err := p.Authenticate(cert)
+	_, _, _, err := p.Authenticate(cert)
 	if err == nil {
 		t.Error("expected error for unmatched subject")
 	}
@@ -112,7 +112,7 @@ func TestAuthenticate_NilCert(t *testing.T) {
 		Mappings:     []config.MTLSSubjectMapping{},
 	})
 
-	_, _, err := p.Authenticate(nil)
+	_, _, _, err := p.Authenticate(nil)
 	if err == nil {
 		t.Error("expected error for nil certificate")
 	}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -681,6 +681,22 @@ type MTLSConfig struct {
 type MTLSSubjectMapping struct {
 	Subject string   `mapstructure:"subject"`
 	Scopes  []string `mapstructure:"scopes"`
+
+	// UserID names the registry user this certificate acts as, and is what
+	// makes an `admin` mapping resolvable (issue #876).
+	//
+	// Optional for ordinary mappings: a certificate that only needs
+	// `modules:read` is a machine credential and needs no user behind it.
+	// REQUIRED when the mapping carries `admin`, because platform-admin
+	// authority is held in the platform_admins carrier, the carrier is keyed
+	// on user_id, and a subject with no user resolves to nothing to look up.
+	// mtls.NewProvider refuses such a mapping at startup.
+	//
+	// A UUID rather than an email or a username: it is what the carrier is
+	// keyed on and what POST /api/v1/admin/platform-admins already takes, and
+	// it does not change when a user is renamed. A mapping that named a mutable
+	// attribute could silently start pointing at a different person.
+	UserID string `mapstructure:"user_id"`
 }
 
 // RateLimitingConfig holds rate limiting configuration

--- a/backend/internal/middleware/scope_publisher_class_test.go
+++ b/backend/internal/middleware/scope_publisher_class_test.go
@@ -1,0 +1,221 @@
+package middleware_test
+
+// scope_publisher_class_test.go is the re-runnable signature for issue #876.
+//
+// The gin key "scopes" is what middleware.RequireScope reads, and the literal
+// element "admin" in it is an unconditional grant-all wildcard that
+// tenantscope.Resolve turns into cross-organization reach. So every place that
+// writes that key is deciding who is a platform administrator.
+//
+// #874 brought three of the four credential classes under the platform_admins
+// carrier: sessions resolve through Carrier.SessionScopes per request, API keys
+// are stripped by platformadmin.KeyScopes and can never be elevated. It did not
+// touch mTLS, which published a subject→scope mapping's slice verbatim — so an
+// `admin` written into a config file produced a platform administrator with no
+// grant record, no audit entry, and no revocation short of a restart, while the
+// carrier's own documentation said it was the only source. Five of six
+// publishers were governed and one was not, which is exactly the shape a
+// per-site fix leaves behind.
+//
+// This test is what stops a seventh publisher arriving ungoverned. It does not
+// check that the scopes are CORRECT — it checks that the value published was
+// produced by something whose job is to answer the authority question, rather
+// than read from a token, a config file, or a database row and forwarded.
+//
+// EMPTY IS NOT THE FINISH LINE HERE. Unlike a defect sweep, the expected state
+// is a NON-EMPTY set of publishers, all governed. A run that finds no
+// publishers at all means the matcher broke, not that the estate got tidy.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// governingFuncs answer "what authority does this principal actually have,
+// right now?". Each either consults the carrier or removes `admin` outright.
+//
+// Adding a name here is a claim that it cannot return an unearned `admin`, and
+// that claim has to survive review. It is deliberately a short list.
+var governingFuncs = map[string]string{
+	"SessionScopes":       "carrier lookup per request; strips `admin` on every return path, re-adds only on a live carrier row",
+	"KeyScopes":           "strips `admin` unconditionally — an API key is never elevated",
+	"platformAdminScopes": "middleware's wrapper over SessionScopes; returns stripped scopes even on error",
+	"currentKeyScopes":    "re-derives a key's authority at its binding; bottoms out in KeyScopes",
+	"resolveScopes":       "mTLS: carrier for a mapping that names a user, KeyScopes for one that does not (#876)",
+}
+
+// minimumPublishers is a floor, not a count. It exists so a broken matcher —
+// a renamed key, a rotted walk — reports a failure instead of a clean tree.
+const minimumPublishers = 5
+
+type publisher struct {
+	file string
+	line int
+	how  string
+}
+
+// governingCallIn reports the governing function called anywhere in n, if any.
+func governingCallIn(n ast.Node) (string, bool) {
+	found, why := "", false
+	ast.Inspect(n, func(node ast.Node) bool {
+		if why {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			name = fn.Name
+		case *ast.SelectorExpr:
+			name = fn.Sel.Name
+		}
+		if _, ok := governingFuncs[name]; ok {
+			found, why = name, true
+			return false
+		}
+		return true
+	})
+	return found, why
+}
+
+// assignedFrom finds where ident was last assigned within fn and reports the
+// governing call that produced it, if any.
+func assignedFrom(fn ast.Node, ident string) (string, bool) {
+	got, ok := "", false
+	ast.Inspect(fn, func(node ast.Node) bool {
+		assign, isAssign := node.(*ast.AssignStmt)
+		if !isAssign {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			id, isIdent := lhs.(*ast.Ident)
+			if !isIdent || id.Name != ident {
+				continue
+			}
+			for _, rhs := range assign.Rhs {
+				if name, isGov := governingCallIn(rhs); isGov {
+					got, ok = name, true
+				}
+			}
+		}
+		return true
+	})
+	return got, ok
+}
+
+func TestEveryScopePublisherIsGoverned(t *testing.T) {
+	root := repoRootForScopeSweep(t)
+	var governed, ungoverned []publisher
+
+	err := filepath.Walk(filepath.Join(root, "internal"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(node ast.Node) bool {
+				call, isCall := node.(*ast.CallExpr)
+				if !isCall || len(call.Args) != 2 {
+					return true
+				}
+				sel, isSel := call.Fun.(*ast.SelectorExpr)
+				if !isSel || sel.Sel.Name != "Set" {
+					return true
+				}
+				key, isLit := call.Args[0].(*ast.BasicLit)
+				if !isLit || key.Kind != token.STRING || strings.Trim(key.Value, `"`) != "scopes" {
+					return true
+				}
+
+				p := publisher{file: rel, line: fset.Position(call.Pos()).Line}
+
+				// The value is a governing call written inline.
+				if name, isGov := governingCallIn(call.Args[1]); isGov {
+					p.how = name
+					governed = append(governed, p)
+					return true
+				}
+				// Or an identifier this function assigned from one.
+				if id, isIdent := call.Args[1].(*ast.Ident); isIdent {
+					if name, isGov := assignedFrom(fn.Body, id.Name); isGov {
+						p.how = name + " (via " + id.Name + ")"
+						governed = append(governed, p)
+						return true
+					}
+				}
+				ungoverned = append(ungoverned, p)
+				return true
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	total := len(governed) + len(ungoverned)
+	if total < minimumPublishers {
+		t.Fatalf("found only %d publisher(s) of the \"scopes\" key, expected at least %d.\n"+
+			"That is not a tidy estate, it is a blind matcher: the key was renamed, or the walk "+
+			"stopped reaching the middleware. Fix this test before trusting its green.", total, minimumPublishers)
+	}
+
+	for _, p := range ungoverned {
+		t.Errorf("%s:%d publishes the \"scopes\" gin key with a value no governing function produced.\n"+
+			"That key is what RequireScope reads, and `admin` in it is a grant-all wildcard that "+
+			"tenantscope turns into cross-organization reach — so this line decides who is a platform "+
+			"administrator. Route the value through one of: %s.\n"+
+			"This is issue #876: mTLS published a config file's slice verbatim while every other "+
+			"credential class went through the carrier.", p.file, p.line, strings.Join(governingNames(), ", "))
+	}
+
+	for _, p := range governed {
+		t.Logf("governed: %s:%d via %s", p.file, p.line, p.how)
+	}
+}
+
+func governingNames() []string {
+	names := make([]string, 0, len(governingFuncs))
+	for n := range governingFuncs {
+		names = append(names, n)
+	}
+	return names
+}
+
+func repoRootForScopeSweep(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatal("could not locate the module root")
+	return ""
+}

--- a/docs/administrator-floor.md
+++ b/docs/administrator-floor.md
@@ -17,6 +17,16 @@ change that would break either one.
 **Platform administrator** — a principal holding a row in `platform_admins`
 (the carrier, migration `000051`). Nothing else, as of migration `000054`.
 
+That sentence was not true for mTLS until #876. A client-certificate subject
+mapping published its configured scopes verbatim, so `scopes: ["admin"]` in a
+config file produced a platform administrator holding no carrier row — with no
+`granted_by`, no audit entry, no revocation short of a restart, and invisible to
+everything on this page including the floor, which counts database rows and
+cannot see a YAML file. A mapping carrying `admin` must now name the user the
+certificate acts as, and that user's carrier row is resolved on every request.
+An mTLS caller is therefore counted like any other principal, because it *is*
+one of the rows being counted.
+
 An organization membership whose role template carries the `admin` scope used to
 count too, through the org-less scope union (#652). It does not any more: the
 auth middleware strips `admin` from the session union, so such a membership

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1236,7 +1236,33 @@ security:
     mappings:
       - subject: "CN=ci-runner"
         scopes: ["modules:read", "providers:read"]
+      - subject: "CN=break-glass"
+        scopes: ["admin"]
+        user_id: "3f1c9a02-6d4e-4a1b-9f77-2b8e5c0d1a44"
 ```
+
+### `admin` in a mapping needs a user, and the carrier still decides
+
+A subject mapping is configuration, so the scopes in it are a claim about
+authority rather than a grant of it. `admin` is a grant-all wildcard — it
+satisfies every scope check and lets the caller cross organization boundaries —
+and it is held in the `platform_admins` carrier, which is keyed on a user.
+
+So a mapping that carries `admin` must set `user_id` to the UUID of the user the
+certificate acts as. **The server refuses to start otherwise**, with an error
+naming the subject. `user_id` is optional for ordinary machine credentials,
+which need no user behind them.
+
+Naming a user does not by itself grant anything. On every request the carrier is
+consulted for that user, exactly as it is for a browser session: `admin` holds
+only while they hold a carrier row, and revoking it through
+`DELETE /api/v1/admin/platform-admins/{id}` disarms the certificate on the next
+request rather than at the next restart. The grant is recorded with
+`granted_by`, `granted_at` and a note, like every other one.
+
+A repeated `subject` is also refused: it used to take the last one silently,
+which would now bind a certificate to a different principal than the line you are
+reading.
 
 ---
 


### PR DESCRIPTION
## What was wrong

An mTLS subject mapping published its configured scopes **verbatim**. So `scopes: ["admin"]` in a config file produced a platform administrator with no grant record, no `granted_by`, no audit entry, and no revocation short of editing configuration and restarting.

Meanwhile #874 had brought every *other* credential class under the carrier — sessions via `Carrier.SessionScopes`, API keys stripped by `KeyScopes`, role templates refused at write time — and `docs/administrator-floor.md` stated the carrier was the only source. It wasn't.

The floor could not have caught it: it counts rows in `platform_admins`, and an mTLS administrator lived in a YAML file the process read at boot.

Blast radius, checked before choosing: mTLS is off by default, no shipped deployment enables it (all set `TFR_SECURITY_TLS_ENABLED=false`, which makes it inert anyway), no example maps `admin`, and **mappings can't be set by env var** — `bindEnvVars` never binds `security.mtls.*`. This was latent, not live.

## The fix (option 2)

A mapping names the user its certificate acts as, and that user's carrier row is resolved **per request**, exactly as a session's is. `admin` holds only while the row does — revoking it disarms the certificate on the next request rather than at the next restart, and the grant carries the same provenance as every other.

**Two locks, deliberately.** `NewProvider` refuses at startup to build an `admin` mapping with no user (`router.go` already turns that error into `log.Fatalf`, so such a deployment doesn't start). The publish path strips anyway — the first lock guards *construction*, and only the second guards what the RBAC layer actually reads.

`user_id` is a UUID, not an email: it's what the carrier is keyed on and what `POST /api/v1/admin/platform-admins` already takes, and it doesn't follow a rename. Duplicate subjects are now refused too — they used to take the last silently, which was untidy for a scope list and unacceptable once a mapping can name a principal.

## One thing I deliberately did not do

The binding publishes as **`mtls_user_id`, not `user_id`**. 36 non-test sites read `user_id` and some *authorize* with it (`namespace_authz.go:487`). Setting it would make an mTLS caller indistinguishable from a signed-in user across all of them — a second, wider change than binding a certificate to a carrier row, and the kind #874 declined to carry. Audit attribution for mTLS callers is worth its own decision.

## The class test is the point

Five of six publishers of the `scopes` gin key were already governed and **one was not** — which is exactly what a per-site fix leaves behind. `TestEveryScopePublisherIsGoverned` fails when a seventh arrives ungoverned, and **refuses to certify a run that finds no publishers at all**: a renamed key would otherwise look identical to a clean estate.

| Mutation | Result |
|---|---|
| mTLS republishes the config slice verbatim (the defect) | caught |
| a new publisher forwards a token's scopes | caught |
| the `scopes` key name rots (blind matcher) | caught |
| `admin` mapping with no user | caught |
| non-UUID user_id | caught |
| duplicate subject | caught |
| carrier row revoked → `admin` gone | caught |
| carrier lookup fails → 500, not a silent denial | caught |
| nil carrier → strips rather than trusts | caught |

68 packages pass, `go vet` clean.

## Drive-by, and worth calling out

`internal/adminfloor/adminfloor.go`'s package doc still described the invariant as `carrier OR union` — ended by #874, and contradicting `checkPlatformFloor` 280 lines below it. Corrected here because it describes the exact invariant this change turns on. `docs/administrator-floor.md` gains the history rather than silently reading as though it was always true.

## Sibling repo

`terraform-state-manager-backend` carries the same `MTLSConfig`/`MTLSSubjectMapping` and the same raw publish, and its `provider_test.go` uses `Scopes: ["admin"]` as a fixture and asserts it comes back. Following separately — the fix there differs depending on whether it has a carrier.

Closes #876