### PR TITLE
chore(ci): normalise the Dependabot updater conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,9 @@ updates:
     # Ignore major-version bumps for infrastructure libs that require manual review.
     ignore:
       - dependency-name: "github.com/gin-gonic/gin"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "github.com/golang-migrate/migrate/v4"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
 
@@ -84,7 +84,7 @@ updates:
     # their own. Taking a new Go minor stays a deliberate change.
     ignore:
       - dependency-name: "golang"
-        update-types: [ "version-update:semver-minor", "version-update:semver-major" ]
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     cooldown:
       default-days: 7
 
@@ -92,6 +92,10 @@ updates:
   # npm (repo root) — pinned doc-generation tooling only (swagger2openapi),
   # not a runtime/shipped dependency. See docs/development.md.
   # ---------------------------------------------------------------------------
+    groups:
+      docker-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -112,6 +116,10 @@ updates:
   # ---------------------------------------------------------------------------
   # GitHub Actions
   # ---------------------------------------------------------------------------
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -125,7 +133,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore(deps)"
     groups:
       github-actions-dependencies:
         patterns:
@@ -151,7 +159,7 @@ updates:
       - dependencies
       - github-actions
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore(deps)"
     groups:
       commit-message-check:
         patterns:


### PR DESCRIPTION
chore(ci): normalise the Dependabot updater conventions

`.github/dependabot.yml` cannot be shared -- it must live in each repository's
own `.github/`, there is no `uses:`-style include for it, and it is not one of
the files an org-level `.github` repository supplies defaults for. Every
convention in it is therefore duplicated 19 times by construction, and it had
drifted:

  commit-message.prefix     SIX variants (chore, chore(ci), chore(deps), deps,
                            ci(deps), build(deps)) plus two stanzas with none
  schedule                  a 36/36 split between bare `weekly` and
                            `weekly monday 09:00 UTC`
  open-pull-requests-limit  18 stanzas overriding the platform default
  groups                    11 stanzas with none, so one PR per dependency

Normalised to `chore(deps)`, `weekly monday 09:00 UTC`, no explicit
open-pull-requests-limit, and a group on every stanza.

NOT normalised, deliberately: the 16 groups that select by `dependency-type:
development` or `update-types: [minor, patch]` rather than `patterns`. Those are
NARROWER than `patterns: ["*"]`; rewriting them to a wildcard would widen what
they batch. The invariant is that a stanza groups its pull requests, not that it
groups them by pattern.

Also untouched: directories and `ignore` rules. 14 of 21 distinct directories
appear in exactly one repository and 33 of 72 stanzas carry repo-specific ignore
policy, so that half is irreducibly local -- centralising it would trade visible
duplication for the harder-to-see drift this estate already documents.

Changing the prefix is changelog-safe: no release-please config in the estate
declares changelog-sections for `ci`, `deps` or `chore`.

Rewritten with ruamel so comments survive; verified per repo that the file still
parses and the comment count is unchanged.