### PR TITLE
chore(release): restore conventional versioning; hold breaking changes at a minor with Release-As

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,13 +1,11 @@
 {
   "draft": true,
   "force-tag-creation": true,
-  "versioning": "always-bump-minor",
   "packages": {
     ".": {
       "release-type": "go",
       "package-name": "terraform-registry",
       "include-component-in-tag": false,
-      "versioning": "always-bump-minor",
       "extra-files": [
         {
           "type": "yaml",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,36 @@ PR titles (and commit messages) must follow [Conventional Commits](https://www.c
 > `deps` are **not** valid — use `fix:` for security fixes and `build:` or `chore:` for
 > dependency updates.
 
-Breaking changes: append `!` to the type (`feat!:`) **or** add a `BREAKING CHANGE:` footer in the commit body. These trigger a major version bump.
+Breaking changes: append `!` to the type (`feat!:`) **or** add a `BREAKING CHANGE:`
+footer in the commit body. Keep doing this — the footer is what warns an operator,
+and CI's `Breaking-change footers survive the squash` check enforces exactly one
+declaration per merged commit.
+
+**A breaking change defaults to a MAJOR bump, and usually should not take one.**
+This is an application: nothing imports it, so there is no Go `/vN` import-path
+requirement and the major number is pure signalling. A release carrying one
+behaviour change does not warrant announcing a redesign — that is what took the
+repository from `3.5.2` to `4.0.0` in a single afternoon (#792).
+
+So when a PR carries a breaking change, add a `Release-As:` footer naming the next
+MINOR, and release-please cuts that instead of the major:
+
+```text
+fix(mtls)!: refuse an `admin` mapping with no user_id
+
+BREAKING CHANGE: a mapping carrying `admin` must now set user_id, or the
+server refuses to start.
+
+Release-As: 4.11.0
+```
+
+Two footers, doing two different jobs: `BREAKING CHANGE` tells the operator, and
+`Release-As` decides the number. Neither substitutes for the other, and dropping
+the first to avoid the second is how a break ships unannounced.
+
+Read the current version off the latest tag (`gh release list --limit 1`) and add
+one to the minor. **A genuine major redesign takes the major** — just leave
+`Release-As` off and let the default happen.
 
 Keep the subject line under **72 characters**. Reference issues in the commit body with `Closes #123`.
 


### PR DESCRIPTION
## The side effect nobody wrote down

#792 set `always-bump-minor` to stop a breaking change cutting a major, and **that reasoning still holds**: this is an application, nothing imports it, there is no Go `/vN` requirement, and `4.0.0` announced a redesign that didn't happen.

But `always-bump-minor` is **symmetric**. It doesn't only cap majors — it lifts everything *below* minor up to it. So a release of nothing but `fix:` commits became a minor too.

That half was never the intent and was never recorded. `CONTRIBUTING.md` has said *"fix — patch bump"* and *"feat — minor bump"* the whole time, so **the documentation and the configuration have disagreed since #792 landed**. Removing the strategy makes the docs true again.

## The cap moves from the config to the commit

A PR carrying a breaking change adds a `Release-As:` footer naming the next minor:

```text
fix(mtls)!: refuse an `admin` mapping with no user_id

BREAKING CHANGE: a mapping carrying `admin` must now set user_id, or the
server refuses to start.

Release-As: 4.11.0
```

**Two footers, two jobs.** `BREAKING CHANGE` warns the operator and is what the required `Breaking-change footers survive the squash` check counts. `Release-As` decides the number. Dropping the first to avoid the second is how a break ships unannounced — which is the failure #792 was itself fixing.

This is per-release rather than per-repository, which is the point: **a genuine major redesign leaves `Release-As` off and takes the major.**

## Why it's safe here

The repository squash-merges with `squash_merge_commit_message=COMMIT_MESSAGES`, so a footer in any commit body reaches the squashed commit release-please reads. That's the same property the existing footer check already depends on — I verified it rather than assuming.

## Known gap, stated rather than hidden

**Nothing enforces the pairing.** A PR with a `BREAKING CHANGE` footer and no `Release-As` cuts a major silently. That's recoverable and cosmetic — you can retag — so it's documented rather than gated.

If you'd rather it were enforced, the natural home is the existing `breaking-change-footers` shared action: it already parses every commit body for the footer, so failing when it finds one without a `Release-As` beside it is a small addition. That would touch all seven repos, so I've left it as your call.

The diff is exactly two removed lines plus the CONTRIBUTING section. TSM has the matching PR — #345 set the same flag there for the same reason.