### PR TITLE
fix(organizations): refuse a rename that would move another organization's artifacts

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -10056,7 +10056,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
+                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename. The rename is refused with 409 unless this organization owns both the old and the new namespace, so a rename can never move another organization's modules or providers. The organization row is renamed first, then the module and provider namespace columns are cascaded in a separate transaction on the registry's own connection; these are NOT one atomic transaction, and a failed cascade is compensated by renaming the organization back. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
                 "tags": [
                     "Organizations"
                 ],
@@ -10128,7 +10128,7 @@
                         }
                     },
                     "409": {
-                        "description": "Organization name already taken",
+                        "description": "Organization name already taken, or its namespace is owned by another organization",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -8126,7 +8126,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
+                "description": "Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename. The rename is refused with 409 unless this organization owns both the old and the new namespace, so a rename can never move another organization's modules or providers. The organization row is renamed first, then the module and provider namespace columns are cascaded in a separate transaction on the registry's own connection; these are NOT one atomic transaction, and a failed cascade is compensated by renaming the organization back. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to \"oidc\", \"saml\", or \"ldap\" to restrict login; set to empty string to clear.",
                 "consumes": [
                     "application/json"
                 ],
@@ -8184,7 +8184,7 @@
                         }
                     },
                     "409": {
-                        "description": "Organization name already taken",
+                        "description": "Organization name already taken, or its namespace is owned by another organization",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -4,6 +4,7 @@ package admin
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -642,7 +643,7 @@ type UpdateOrganizationRequest struct {
 }
 
 // @Summary      Update organization
-// @Description  Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename: the organization row, all module namespace columns, and all provider namespace columns are updated atomically in a single transaction. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to "oidc", "saml", or "ldap" to restrict login; set to empty string to clear.
+// @Description  Update an existing organization's name, display name, and optional IdP binding. Supplying a new `name` triggers a cascade rename. The rename is refused with 409 unless this organization owns both the old and the new namespace, so a rename can never move another organization's modules or providers. The organization row is renamed first, then the module and provider namespace columns are cascaded in a separate transaction on the registry's own connection; these are NOT one atomic transaction, and a failed cascade is compensated by renaming the organization back. User memberships reference the organization by UUID and are therefore unaffected. Set idp_type to "oidc", "saml", or "ldap" to restrict login; set to empty string to clear.
 // @Tags         Organizations
 // @Security     Bearer
 // @Accept       json
@@ -653,7 +654,7 @@ type UpdateOrganizationRequest struct {
 // @Failure      400  {object}  map[string]interface{}  "Invalid request body or name format"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized"
 // @Failure      404  {object}  map[string]interface{}  "Organization not found"
-// @Failure      409  {object}  map[string]interface{}  "Organization name already taken"
+// @Failure      409  {object}  map[string]interface{}  "Organization name already taken, or its namespace is owned by another organization"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /api/v1/organizations/{id} [put]
 // UpdateOrganizationHandler updates an organization
@@ -711,6 +712,28 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 				})
 				return
 			}
+			// Refuse a namespace-crossing rename BEFORE the identity-side write.
+			// That write commits on a different connection and the cascade below
+			// cannot roll it back, so discovering the conflict later would leave
+			// the organization renamed with its artifacts un-cascaded. The
+			// cascade re-runs this same rule under row locks.
+			if err := repositories.CheckOrganizationRenameConflicts(
+				c.Request.Context(), h.db, orgID, org.Name, newName,
+			); err != nil {
+				if errors.Is(err, repositories.ErrNamespaceRenameConflict) {
+					c.JSON(http.StatusConflict, gin.H{
+						"error": "Namespace is owned by another organization. Transfer or release the namespace before renaming.",
+					})
+					return
+				}
+				slog.Error("organization rename: namespace ownership pre-flight failed",
+					"organization_id", orgID, "old_name", org.Name, "new_name", newName, "error", err)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to check namespace ownership",
+				})
+				return
+			}
+
 			// ErrNotFound here means the organization was deleted between the
 			// GetByID above and this write. Answer 404 — the same status that
 			// pre-check gives for the same condition — rather than the 200 the
@@ -731,6 +754,21 @@ func (h *OrganizationHandlers) UpdateOrganizationHandler() gin.HandlerFunc {
 			// Cascade the new name to the registry's denormalized module/provider
 			// namespaces on the domain connection (identity rename is done above).
 			if err := repositories.CascadeOrganizationRename(c.Request.Context(), h.db, orgID, org.Name, newName); err != nil {
+				// The identity-side rename above already committed on another
+				// connection, so a failed cascade leaves the organization renamed
+				// with its artifacts still under the old namespace. Put it back.
+				// If the compensation ALSO fails the split is real and an operator
+				// has to repair it by hand, so log both outcomes with the names.
+				compErr := h.orgRepo.Rename(c.Request.Context(), orgID, org.Name, repositories.OrgScopeOrganizations(orgID))
+				slog.Error("organization rename: namespace cascade failed",
+					"organization_id", orgID, "old_name", org.Name, "new_name", newName,
+					"error", err, "compensated", compErr == nil, "compensation_error", compErr)
+				if errors.Is(err, repositories.ErrNamespaceRenameConflict) {
+					c.JSON(http.StatusConflict, gin.H{
+						"error": "Namespace is owned by another organization. Transfer or release the namespace before renaming.",
+					})
+					return
+				}
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error": "Failed to rename organization",
 				})

--- a/backend/internal/api/admin/organizations_test.go
+++ b/backend/internal/api/admin/organizations_test.go
@@ -483,6 +483,21 @@ func TestUpdateOrganization_Success(t *testing.T) {
 // Rename tests
 // ---------------------------------------------------------------------------
 
+// expectOrgRenamePreflight stages the #934 namespace-ownership proof for a
+// rename where neither namespace is owned by another organization. It is run
+// twice per rename: once in the handler before the identity write, and again
+// inside the cascade transaction under row locks.
+func expectOrgRenamePreflight(mock sqlmock.Sqlmock, oldName, newName string) {
+	for _, ns := range []string{oldName, newName} {
+		mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+			WithArgs(ns).
+			WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+		mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+			WithArgs(ns).
+			WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	}
+}
+
 func TestUpdateOrganization_RenameSuccess(t *testing.T) {
 	mock, r := newOrgRouter(t)
 
@@ -492,18 +507,30 @@ func TestUpdateOrganization_RenameSuccess(t *testing.T) {
 	// 2. GetByName uniqueness check — new name is available
 	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
 		WillReturnRows(emptyOrgRow())
-	// 3. Rename (identity) — single UPDATE, no transaction
+	// 3. Namespace-ownership pre-flight (#934), OUTSIDE any transaction and
+	//    BEFORE the identity rename: neither namespace is owned by anyone else.
+	expectOrgRenamePreflight(mock, "default", "new-org-name")
+	// 4. Rename (identity) — single UPDATE, no transaction
 	mock.ExpectExec("UPDATE organizations SET name").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// 4. Cascade to denormalized module/provider namespaces and namespace
-	//    ownership claims (domain) — own transaction
+	// 5. Cascade to denormalized module/provider namespaces and namespace
+	//    ownership claims (domain) — own transaction, which re-runs the same
+	//    ownership rule under row locks before rewriting anything.
 	mock.ExpectBegin()
+	expectOrgRenamePreflight(mock, "default", "new-org-name")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("UPDATE providers SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("UPDATE namespace_claims SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	// pre-commit re-read of the target claim
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("new-org-name").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs("new-org-name").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
 	mock.ExpectCommit()
 	// 5. Regular Update for remaining fields (display_name / idp_type)
 	mock.ExpectExec("UPDATE organizations SET display_name").
@@ -1692,5 +1719,44 @@ func TestUpdateMemberHandler_SweepFails_ReportsRevocationIncomplete(t *testing.T
 	}
 	if !body.RevocationIncomplete {
 		t.Errorf("expected revocation_incomplete=true after a failed sweep, got body=%s", w.Body.String())
+	}
+}
+
+// #934: a rename into a namespace another organization owns must be refused
+// with 409, and it must be refused BEFORE the identity-side rename runs. That
+// write commits on a different connection and the cascade cannot roll it back,
+// so a late refusal would leave the organization renamed but un-cascaded.
+//
+// Staging no UPDATE expectations is the assertion: sqlmock fails the test if the
+// handler reaches the identity rename at all.
+func TestUpdateOrganization_RenameRefusedWhenNamespaceOwnedByAnotherOrg(t *testing.T) {
+	mock, r := newOrgRouter(t)
+
+	mock.ExpectQuery("SELECT.*FROM organizations WHERE id").
+		WillReturnRows(sampleOrgRow())
+	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
+		WillReturnRows(emptyOrgRow())
+	// Source namespace is ours...
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("default").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs("default").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	// ...but the target namespace belongs to someone else.
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("new-org-name").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-2"))
+
+	newName := "new-org-name"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("PUT", "/organizations/org-1",
+		jsonBody(map[string]interface{}{"name": &newName})))
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: body=%s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations (the identity rename must not have run): %v", err)
 	}
 }

--- a/backend/internal/db/repositories/organization_repository.go
+++ b/backend/internal/db/repositories/organization_repository.go
@@ -442,6 +442,127 @@ func (r *OrganizationRepository) RemoveAllMembershipsForUser(ctx context.Context
 	return removed, nil
 }
 
+// ErrNamespaceRenameConflict reports that an organization rename would move a
+// namespace that another organization owns, in either direction: renaming AWAY
+// from a namespace whose content belongs to someone else, or renaming INTO a
+// namespace someone else already owns. The second direction is a takeover, and
+// it is the more dangerous of the two.
+var ErrNamespaceRenameConflict = errors.New("namespace is owned by another organization")
+
+// namespaceQuerier is the read surface the ownership pre-flight needs. Both
+// *sql.DB and *sql.Tx satisfy it, so the SAME rule runs standalone in the
+// handler (to refuse before the identity-side rename commits) and again inside
+// the cascade transaction (where it can hold row locks).
+type namespaceQuerier interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// resolveNamespaceOwner mirrors middleware.NamespaceAuthorizer.resolveOwnerOrg
+// exactly, deliberately: a claim wins; without one, the single organization
+// owning artifact rows in the namespace is authoritative; a namespace with
+// neither is unowned and returns "". Two or more artifact organizations and no
+// claim is ambiguous, and ambiguous ownership must never authorize a bulk move.
+//
+// Kept as raw SQL here rather than reusing NamespaceClaimRepository because
+// those methods are bound to their own *sql.DB and cannot participate in the
+// cascade's transaction.
+//
+// lockClaim takes FOR UPDATE on the claim row so a concurrent transfer cannot
+// land between this check and the UPDATEs it authorizes. It is only applied to
+// the claims read: Postgres rejects FOR UPDATE on the UNION/DISTINCT fallback.
+func resolveNamespaceOwner(ctx context.Context, q namespaceQuerier, namespace string, lockClaim bool) (string, error) {
+	claimQuery := `SELECT organization_id FROM namespace_claims WHERE namespace = $1`
+	if lockClaim {
+		claimQuery += ` FOR UPDATE`
+	}
+	var owner string
+	switch err := q.QueryRowContext(ctx, claimQuery, namespace).Scan(&owner); {
+	case err == nil:
+		return owner, nil
+	case !errors.Is(err, sql.ErrNoRows):
+		return "", fmt.Errorf("read namespace claim %q: %w", namespace, err)
+	}
+
+	rows, err := q.QueryContext(ctx, `
+		SELECT DISTINCT organization_id FROM (
+			SELECT organization_id FROM modules   WHERE namespace = $1 AND organization_id IS NOT NULL
+			UNION
+			SELECT organization_id FROM providers WHERE namespace = $1 AND organization_id IS NOT NULL
+		) artifact_orgs`, namespace)
+	if err != nil {
+		return "", fmt.Errorf("read namespace artifact organizations %q: %w", namespace, err)
+	}
+	defer rows.Close()
+
+	var owners []string
+	for rows.Next() {
+		var orgID string
+		if err := rows.Scan(&orgID); err != nil {
+			return "", fmt.Errorf("scan namespace artifact organization %q: %w", namespace, err)
+		}
+		owners = append(owners, orgID)
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterate namespace artifact organizations %q: %w", namespace, err)
+	}
+
+	switch len(owners) {
+	case 0:
+		return "", nil
+	case 1:
+		return owners[0], nil
+	default:
+		// Ambiguous. Refuse rather than guess: a wrong guess here rewrites
+		// another tenant's rows, which is the whole defect this check exists for.
+		return "", fmt.Errorf("%w: namespace %q has artifacts owned by %d organizations and no claim",
+			ErrNamespaceRenameConflict, namespace, len(owners))
+	}
+}
+
+// checkRenameNamespaceConflicts proves that renaming orgID from oldName to
+// newName moves only namespaces this organization owns.
+//
+// BOTH directions are checked, and the target side is the one the issue title
+// understated. Source side: the cascade rewrites every row in the old namespace,
+// so this organization must own it. Target side: the cascade rewrites those rows
+// INTO the new namespace, so if another organization owns that namespace the
+// rename is a cross-tenant takeover -- the renaming organization's content lands
+// under a namespace someone else holds the claim to, and the protocol read path
+// (which resolves by namespace alone) then serves whichever row is older.
+//
+// An unowned namespace on either side is fine: nothing to move, or nothing to
+// collide with. This is the common case for an organization that never published.
+func checkRenameNamespaceConflicts(ctx context.Context, q namespaceQuerier, orgID, oldName, newName string) error {
+	for _, side := range []struct {
+		namespace string
+		direction string
+	}{
+		{oldName, "rename would move artifacts out of"},
+		{newName, "rename would move artifacts into"},
+	} {
+		owner, err := resolveNamespaceOwner(ctx, q, side.namespace, true)
+		if err != nil {
+			return err
+		}
+		if owner != "" && owner != orgID {
+			return fmt.Errorf("%w: %s namespace %q, which belongs to organization %s",
+				ErrNamespaceRenameConflict, side.direction, side.namespace, owner)
+		}
+	}
+	return nil
+}
+
+// CheckOrganizationRenameConflicts runs the namespace-ownership pre-flight
+// outside a transaction so a caller can refuse a rename BEFORE any write
+// happens. The cascade re-runs the same rule under row locks; this exists so the
+// identity-side rename -- which commits on a different connection and cannot be
+// rolled back by the cascade -- is never performed for a rename that the cascade
+// will then refuse.
+func CheckOrganizationRenameConflicts(ctx context.Context, db *sql.DB, orgID, oldName, newName string) error {
+	return checkRenameNamespaceConflicts(ctx, db, orgID, oldName, newName)
+}
+
 // CascadeOrganizationRename propagates a renamed organization's new name to the
 // registry's denormalized module and provider namespace columns and to the
 // organization's namespace-ownership claims, in a single transaction on the
@@ -458,19 +579,34 @@ func CascadeOrganizationRename(ctx context.Context, db *sql.DB, orgID, oldName, 
 		}
 	}()
 
+	// Prove this organization owns BOTH namespaces before rewriting either.
+	// Holds FOR UPDATE on the claim rows for the rest of the transaction, so a
+	// concurrent transfer cannot land between the check and the UPDATEs it
+	// authorizes.
+	if err = checkRenameNamespaceConflicts(ctx, tx, orgID, oldName, newName); err != nil {
+		return err
+	}
+
 	// Match module/provider rows by namespace alone, NOT by organization_id.
-	// Artifact rows are stamped with the DEFAULT organization at publish time,
-	// not the namespace's true owner (issue #555), so an `organization_id = orgID`
-	// predicate matches nothing whenever a NON-default organization is renamed --
-	// silently leaving that organization's artifacts pinned to the old namespace
-	// while the organization row and its namespace_claims move to the new name,
-	// orphaning them from the unauthenticated protocol read path (which resolves
-	// modules/providers by namespace). A namespace is a globally-unique ownership
-	// identity (namespace_claims.namespace is the PRIMARY KEY) and this cascade is
-	// triggered precisely by renaming the organization that owns it, so matching
-	// on the old namespace string alone is both correct and complete. The
-	// namespace_claims row below is matched by organization_id because claims —
-	// unlike artifact rows — do carry the true owning organization.
+	// The organization_id predicate is deliberately ABSENT, and that is now safe
+	// because checkRenameNamespaceConflicts above has PROVEN this organization
+	// owns the namespace. Do not add `AND organization_id = $orgID` here.
+	//
+	// Why the predicate must stay absent (issue #555): rows published before
+	// #778 can still carry the DEFAULT organization rather than the namespace's
+	// true owner, so an organization_id predicate would match nothing whenever a
+	// NON-default organization is renamed -- silently leaving that organization's
+	// artifacts pinned to the old namespace while the organization row and its
+	// namespace_claims move, orphaning them from the unauthenticated protocol
+	// read path (which resolves modules/providers by namespace alone).
+	//
+	// #778 made new uploads stamp the true owning organization, which makes the
+	// ORIGINAL justification for this comment stale -- but not its conclusion.
+	// Legacy rows still exist, so namespace-wide matching stays. What changed is
+	// that the authority to rewrite a whole namespace now comes from the proven
+	// ownership check, not from an assumption that the namespace must be ours.
+	// The namespace_claims row below is matched by organization_id because
+	// claims -- unlike artifact rows -- always carry the true owning organization.
 	if _, err = tx.ExecContext(ctx,
 		`UPDATE modules SET namespace = $1, updated_at = NOW() WHERE namespace = $2`,
 		newName, oldName,
@@ -490,6 +626,18 @@ func CascadeOrganizationRename(ctx context.Context, db *sql.DB, orgID, oldName, 
 		newName, orgID, oldName,
 	); err != nil {
 		return fmt.Errorf("cascade rename to namespace claims: %w", err)
+	}
+
+	// Re-read the target claim before committing. FOR UPDATE cannot lock a row
+	// that does not exist yet, so under READ COMMITTED a concurrent first-publish
+	// can claim the target namespace after the pre-flight passed. A committed
+	// insert IS visible to this re-read, so it converts that race into a clean
+	// refusal instead of a silent takeover.
+	if owner, err := resolveNamespaceOwner(ctx, tx, newName, false); err != nil {
+		return err
+	} else if owner != "" && owner != orgID {
+		return fmt.Errorf("%w: namespace %q was claimed by organization %s during the rename",
+			ErrNamespaceRenameConflict, newName, owner)
 	}
 
 	return tx.Commit()

--- a/backend/internal/db/repositories/organization_repository_test.go
+++ b/backend/internal/db/repositories/organization_repository_test.go
@@ -114,6 +114,34 @@ func newOrgRepo(t *testing.T) (*OrganizationRepository, sqlmock.Sqlmock) {
 	return NewOrganizationRepository(db), mock
 }
 
+// expectRenameOwnershipPreflight stages the namespace-ownership proof that
+// CascadeOrganizationRename now runs BEFORE it rewrites anything (#934): this
+// organization must own both the namespace it is renaming out of and the one it
+// is renaming into. The default shape here is the ordinary case -- the old
+// namespace is claimed by the renaming organization, the new one is unowned.
+func expectRenameOwnershipPreflight(mock sqlmock.Sqlmock, orgID, oldName, newName string) {
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs(oldName).
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow(orgID))
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs(newName).
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs(newName).
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+}
+
+// expectRenameTargetRecheck stages the pre-commit re-read of the target claim,
+// which catches a namespace claimed concurrently after the pre-flight passed.
+func expectRenameTargetRecheck(mock sqlmock.Sqlmock, newName string) {
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs(newName).
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs(newName).
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+}
+
 func TestCascadeOrganizationRename_Success(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -122,12 +150,14 @@ func TestCascadeOrganizationRename_Success(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 2))
 	mock.ExpectExec("UPDATE providers SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec("UPDATE namespace_claims SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectRenameTargetRecheck(mock, "new")
 	mock.ExpectCommit()
 
 	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err != nil {
@@ -155,6 +185,7 @@ func TestCascadeOrganizationRename_MatchesArtifactsByNamespaceOnly(t *testing.T)
 	defer db.Close()
 
 	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WithArgs("new", "old").
 		WillReturnResult(sqlmock.NewResult(0, 3))
@@ -164,6 +195,7 @@ func TestCascadeOrganizationRename_MatchesArtifactsByNamespaceOnly(t *testing.T)
 	mock.ExpectExec("UPDATE namespace_claims SET namespace").
 		WithArgs("new", "org-1", "old").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectRenameTargetRecheck(mock, "new")
 	mock.ExpectCommit()
 
 	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err != nil {
@@ -182,6 +214,7 @@ func TestCascadeOrganizationRename_ModulesError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnError(context.DeadlineExceeded)
 	mock.ExpectRollback()
@@ -202,6 +235,7 @@ func TestCascadeOrganizationRename_ProvidersError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("UPDATE providers SET namespace").
@@ -224,6 +258,7 @@ func TestCascadeOrganizationRename_ClaimsError(t *testing.T) {
 	defer db.Close()
 
 	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
 	mock.ExpectExec("UPDATE modules SET namespace").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("UPDATE providers SET namespace").
@@ -931,5 +966,155 @@ func TestGetDefaultOrganization_CacheHit(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations (extra DB query occurred): %v", err)
+	}
+}
+
+// --- #934: an organization rename must not move another organization's artifacts ---
+//
+// The cascade rewrites module and provider rows by namespace alone, which is
+// correct ONLY once ownership has been proven. These tests pin both directions.
+// The target-side case is the more severe one and is the direction the issue
+// title understated: renaming INTO a namespace another organization holds is a
+// cross-tenant takeover, not merely an eviction.
+
+func TestCascadeOrganizationRename_RefusesWhenSourceNamespaceBelongsToAnotherOrg(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	// "old" is claimed by org-2, not by the renaming org-1.
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("old").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-2"))
+	mock.ExpectRollback()
+
+	err = CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new")
+	if !errors.Is(err, ErrNamespaceRenameConflict) {
+		t.Fatalf("want ErrNamespaceRenameConflict, got %v", err)
+	}
+	// The UPDATEs must never run: staging none above means sqlmock fails the
+	// test if the cascade reached them.
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestCascadeOrganizationRename_RefusesTakeoverOfClaimedTargetNamespace(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("old").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-1"))
+	// "new" is already owned by org-2: renaming into it would move org-1's rows
+	// under org-2's namespace and shadow org-2's artifacts on the read path.
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("new").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-2"))
+	mock.ExpectRollback()
+
+	err = CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new")
+	if !errors.Is(err, ErrNamespaceRenameConflict) {
+		t.Fatalf("want ErrNamespaceRenameConflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestCascadeOrganizationRename_RefusesAmbiguousUnclaimedNamespace(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	// No claim on "old", and artifacts there belong to two organizations. There
+	// is no answer that is safe to guess, so the rename must refuse.
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("old").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+		WithArgs("old").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-2").AddRow("org-3"))
+	mock.ExpectRollback()
+
+	err = CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new")
+	if !errors.Is(err, ErrNamespaceRenameConflict) {
+		t.Fatalf("want ErrNamespaceRenameConflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// An organization that never published owns no namespace. There is nothing to
+// move and nothing to collide with, so the rename must still succeed -- a check
+// that refused this would break the ordinary case.
+func TestCascadeOrganizationRename_AllowsUnownedNamespaces(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	for _, ns := range []string{"old", "new"} {
+		mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+			WithArgs(ns).
+			WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+		mock.ExpectQuery("SELECT DISTINCT organization_id FROM").
+			WithArgs(ns).
+			WillReturnRows(sqlmock.NewRows([]string{"organization_id"}))
+	}
+	mock.ExpectExec("UPDATE modules SET namespace").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE providers SET namespace").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").WillReturnResult(sqlmock.NewResult(0, 0))
+	expectRenameTargetRecheck(mock, "new")
+	mock.ExpectCommit()
+
+	if err := CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new"); err != nil {
+		t.Fatalf("CascadeOrganizationRename: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// FOR UPDATE cannot lock a claim row that does not exist yet, so a concurrent
+// first-publish can claim the target namespace after the pre-flight passed. The
+// pre-commit re-read must catch it and refuse rather than commit a takeover.
+func TestCascadeOrganizationRename_RefusesTargetClaimedConcurrently(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	expectRenameOwnershipPreflight(mock, "org-1", "old", "new")
+	mock.ExpectExec("UPDATE modules SET namespace").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("UPDATE providers SET namespace").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("UPDATE namespace_claims SET namespace").WillReturnResult(sqlmock.NewResult(0, 1))
+	// Between the pre-flight and here, org-2 claimed "new".
+	mock.ExpectQuery("SELECT organization_id FROM namespace_claims").
+		WithArgs("new").
+		WillReturnRows(sqlmock.NewRows([]string{"organization_id"}).AddRow("org-2"))
+	mock.ExpectRollback()
+
+	err = CascadeOrganizationRename(context.Background(), db, "org-1", "old", "new")
+	if !errors.Is(err, ErrNamespaceRenameConflict) {
+		t.Fatalf("want ErrNamespaceRenameConflict, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
 	}
 }


### PR DESCRIPTION
`CascadeOrganizationRename` rewrote module and provider rows **by namespace alone**, with no organization predicate — while the `namespace_claims` UPDATE sitting beside them *is* org-scoped. That asymmetry is the defect: **content** moved namespace-wide for every tenant, **ownership** moved only for the renaming tenant.

## Both directions were reachable, and the worse one isn't in the title

| | What happens |
|---|---|
| **Eviction** | Org A is named `acme`; org B holds the claim on namespace `acme`. A renames to `acme-corp` and B's modules and providers are dragged along, while the claims UPDATE matches nothing — the claim is B's. |
| **Takeover** | A renames **into** a namespace B owns. A's rows land under B's namespace; the unauthenticated protocol read path resolves by namespace alone and serves whichever row is older, so B's artifacts are shadowed. The storage path has no organization segment to keep the archives apart. |

**Reachable by an ordinary org admin, not a platform admin.** The route is `RequireScope(organizations:write)` + `RequireOrgScopeForPathOrg`, and the `org_owner` template carries `organizations:write` (migration `000049`), auto-granted to whoever creates the organization. That makes it a tenant-boundary crossing rather than an operator footgun.

## The fix

A namespace-ownership pre-flight that **mirrors `NamespaceAuthorizer.resolveOwnerOrg` exactly** rather than inventing new semantics: a claim wins; without one, the single organization owning artifact rows is authoritative; an unowned namespace is free; two owners and no claim is ambiguous and refuses — a wrong guess there rewrites another tenant's rows, which is the whole defect.

Both the old and the new namespace must resolve to the renaming organization.

**The check runs twice, deliberately.** In the handler it refuses *before* the identity-side rename, which commits on a different connection and cannot be rolled back by the cascade. Inside the cascade it re-runs under `FOR UPDATE` so a concurrent transfer cannot land between check and write — and the target claim is re-read before `COMMIT`, because `FOR UPDATE` cannot lock a row that does not exist yet and a concurrent first-publish would otherwise slip through.

## What deliberately did NOT change

The modules/providers UPDATEs **still match by namespace alone**, and that must stay. Rows published before #778 can carry the default organization rather than the true owner, so an `organization_id` predicate would silently leave them behind under the old namespace — the #555 regression that `TestCascadeOrganizationRename_MatchesArtifactsByNamespaceOnly` exists to prevent.

That test is **amended, not replaced**. What changed is where the authority comes from: proven ownership, rather than an assumption that the namespace must be ours. The stale comment that justified the unscoped UPDATE on the old premise is rewritten to say so, so the next reader doesn't "fix" it and re-open #555.

## Also corrected: the docs were lying

The Swagger description claimed the row and every namespace column were updated *"atomically in a single transaction"*. They are not, and were not before this change — the identity rename commits first, then the cascade runs in its own transaction on another connection. A failed cascade is now compensated by renaming the organization back, with both outcomes logged so an operator can repair by hand if the compensation also fails.

## Verification

Every new guard was **mutation-tested** — broken, watched fail, restored:

| Mutation | Result |
|---|---|
| cascade pre-flight removed | all 10 cascade tests fail |
| pre-commit target re-check removed | concurrent-claim test fails |
| handler pre-flight removed | 409 test fails |

The handler test stages **no** UPDATE expectations, so sqlmock fails it if the identity rename is reached at all — that is the assertion that the refusal happens before the un-rollbackable write.

Docs regenerated with CI's exact pin (`swag@v1.16.6`); the diff is exactly the two changed lines in each file, no generator drift.

Closes #934
