### PR TITLE
fix(credlifecycle): record every API key the credential sweep destroys

### DIFF
--- a/backend/internal/api/admin/organizations.go
+++ b/backend/internal/api/admin/organizations.go
@@ -130,6 +130,14 @@ func NewOrganizationHandlers(cfg *config.Config, db *sql.DB, claimRepo *reposito
 	return h
 }
 
+// WithCredentialAudit gives the credential sweep somewhere to record the keys
+// it destroys (#961). Optional and nil-safe: a construction without a sweeper
+// stays without one. Returns the handler for chaining.
+func (h *OrganizationHandlers) WithCredentialAudit(audit *repositories.AuditRepository) *OrganizationHandlers {
+	h.creds = h.creds.WithAuditLog(audit)
+	return h
+}
+
 // revokeOrgCredentials invalidates every credential family carrying a snapshot
 // of the authority userID derived from orgID: the JWT revoke-all watermark and
 // the user's org-bound API keys.

--- a/backend/internal/api/admin/rbac.go
+++ b/backend/internal/api/admin/rbac.go
@@ -72,6 +72,15 @@ func NewRBACHandlers(rbacRepo *repositories.RBACRepository, userRevocations *rep
 	return &RBACHandlers{rbacRepo: rbacRepo, creds: credlifecycle.NewSweeper(userRevocations, apiKeys)}
 }
 
+// WithCredentialAudit gives the credential sweep somewhere to record the keys
+// it destroys (#961). Optional: without it the sweep still runs and still
+// deletes, it just leaves no audit row -- which is the behaviour this exists to
+// end, so production wiring must set it. Returns the handler for chaining.
+func (h *RBACHandlers) WithCredentialAudit(audit *repositories.AuditRepository) *RBACHandlers {
+	h.creds = h.creds.WithAuditLog(audit)
+	return h
+}
+
 // WithOrgRepo wires in the organization repository so the mirror-policy and
 // approval-request LIST routes can be scoped to the caller's organizations.
 // Returns the handler for chaining.

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -749,7 +749,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// apiKeyRepo on the identity connection, so the two halves cannot be
 	// constructed from a single handle -- it is built once here and injected
 	// wherever an authority-reducing handler lives (issues #732, #736).
-	credSweeper := credlifecycle.NewSweeper(userTokenRevocationRepo, apiKeyRepo)
+	credSweeper := credlifecycle.NewSweeper(userTokenRevocationRepo, apiKeyRepo).WithAuditLog(auditRepo)
 
 	var authHandlers *admin.AuthHandlers
 	authHandlers, err = admin.NewAuthHandlers(cfg, identityDB, oidcConfigRepo, tokenRepo, oidcStateStore,
@@ -775,6 +775,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 		// and scm_oauth_tokens stays in the registry's schema at cutover.
 		admin.WithUserSCMTokens(scmRepo))
 	orgHandlers := admin.NewOrganizationHandlers(cfg, identityDB, nsClaimRepo, userTokenRevocationRepo).
+		WithCredentialAudit(auditRepo).
 		WithAdminFloor(adminFloor).
 		// scmRepo and mirrorRepo, deliberately: both are built on the REGISTRY
 		// connection above, and scm_providers / mirror_configurations stay in
@@ -809,6 +810,7 @@ func NewRouter(cfg *config.Config, db, identityDB *sql.DB) (*gin.Engine, *Backgr
 	// Role-template CRUD follows the identity schema; mirror methods stay public.
 	rbacRepo := repositories.NewRBACRepositoryWithIdentity(sqlxDB, identitySqlxDB)
 	rbacHandlers := admin.NewRBACHandlers(rbacRepo, userTokenRevocationRepo, apiKeyRepo).
+		WithCredentialAudit(auditRepo).
 		WithNotifications(&cfg.Notifications, &cfg.CVE).
 		WithOrgRepo(orgRepo).
 		WithMirrorRepo(mirrorRepo)

--- a/backend/internal/credlifecycle/audit_wiring_class_test.go
+++ b/backend/internal/credlifecycle/audit_wiring_class_test.go
@@ -1,0 +1,142 @@
+package credlifecycle_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every production Sweeper must reach an audit sink (#961).
+//
+// WHY THIS IS A CLASS TEST AND NOT A UNIT TEST. The audit repository is an
+// OPTIONAL dependency: with it nil the Sweeper still deletes and simply writes
+// no audit row. That is deliberate -- it keeps every existing construction and
+// its tests valid -- but it means a construction that was never given the sink
+// behaves EXACTLY like one that was, right up until somebody needs the trail
+// and finds it empty. There is no runtime signal, no error, and no failing
+// unit test. The only way to notice is to ask, structurally, whether every
+// construction was wired.
+//
+// There are three of them and they are easy to miss because two are built
+// inside handler constructors rather than at the composition root:
+//
+//	internal/api/router.go              credSweeper, wired directly
+//	internal/api/admin/organizations.go inside NewOrganizationHandlers
+//	internal/api/admin/rbac.go          inside NewRBACHandlers
+//
+// The last is the highest-volume destruction path in the codebase.
+//
+// The test asks a QUESTION rather than matching a known list: "does the file
+// that constructs a Sweeper also attach an audit sink?" A new construction in a
+// new file fails this until it is wired, which is the point -- a hardcoded list
+// of three files would pass forever while a fourth went unaudited.
+func TestEveryProductionSweeperReachesAnAuditSink(t *testing.T) {
+	root := repoRoot(t)
+
+	// A file may attach the sink itself (WithAuditLog) or expose a chainable
+	// that the composition root calls (WithCredentialAudit). Both count: what
+	// matters is that the constructed Sweeper can receive one.
+	const (
+		construct = "NewSweeper"
+		attachA   = "WithAuditLog"
+		attachB   = "WithCredentialAudit"
+	)
+
+	constructors := map[string]bool{}
+	attachers := map[string]bool{}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// vendor and testdata are not our wiring.
+			if name := info.Name(); name == "vendor" || name == "testdata" || name == "docs" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // unparseable non-test file is a build problem, not this test's
+		}
+		rel, _ := filepath.Rel(root, path)
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			switch fn := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				switch fn.Sel.Name {
+				case construct:
+					constructors[rel] = true
+				case attachA, attachB:
+					attachers[rel] = true
+				}
+			case *ast.Ident:
+				switch fn.Name {
+				case construct:
+					constructors[rel] = true
+				case attachA, attachB:
+					attachers[rel] = true
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// Positive control. If the sweep is ever renamed or moved and this test
+	// stops finding ANY construction, an empty universe would pass silently --
+	// the failure mode this whole file exists to prevent.
+	if len(constructors) == 0 {
+		t.Fatal("found no NewSweeper construction anywhere: this test has gone blind, fix its search before trusting a green run")
+	}
+	if len(attachers) == 0 {
+		t.Fatal("found no audit-sink attachment anywhere: this test has gone blind")
+	}
+
+	var unwired []string
+	for file := range constructors {
+		if !attachers[file] {
+			unwired = append(unwired, file)
+		}
+	}
+	if len(unwired) > 0 {
+		t.Errorf("these files construct a credential Sweeper but never attach an audit sink, so the keys they destroy leave no record:\n  %s\n\nAttach it with .WithAuditLog(auditRepo), or expose a WithCredentialAudit chainable and call it from the composition root.",
+			strings.Join(unwired, "\n  "))
+	}
+}
+
+// repoRoot walks up from the test's working directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "internal")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("could not locate module root (no go.mod found walking up)")
+	return ""
+}

--- a/backend/internal/credlifecycle/sweeper.go
+++ b/backend/internal/credlifecycle/sweeper.go
@@ -38,6 +38,7 @@ import (
 	"log/slog"
 
 	"github.com/terraform-registry/terraform-registry/internal/auth"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 )
@@ -81,6 +82,10 @@ type Sweeper struct {
 	userRevocations *repositories.UserTokenRevocationRepository
 	// apiKeys deletes API-key rows. Lives on the identity connection.
 	apiKeys *repositories.APIKeyRepository
+	// audit records what was destroyed. Optional: nil means no audit rows are
+	// written and behaviour is byte-identical to before #961, which is what
+	// keeps every existing construction and its tests valid.
+	audit *repositories.AuditRepository
 }
 
 // NewSweeper builds a Sweeper. Either repository may be nil, in which case
@@ -91,6 +96,22 @@ func NewSweeper(userRevocations *repositories.UserTokenRevocationRepository, api
 		return nil
 	}
 	return &Sweeper{userRevocations: userRevocations, apiKeys: apiKeys}
+}
+
+// WithAuditLog attaches the audit repository that records each destroyed key.
+// Chainable and nil-safe on both sides so a construction that has no audit
+// repository -- or no Sweeper at all -- keeps working unchanged.
+//
+// This is deliberately NOT a NewSweeper parameter: every existing call site
+// would have to be edited, and the ones that were missed would be silently
+// un-audited rather than failing to compile. Making it an explicit opt-in keeps
+// the wiring greppable.
+func (s *Sweeper) WithAuditLog(audit *repositories.AuditRepository) *Sweeper {
+	if s == nil {
+		return nil
+	}
+	s.audit = audit
+	return s
 }
 
 // Outcome reports what a sweep actually managed to invalidate. Every sweep is
@@ -106,6 +127,14 @@ type Outcome struct {
 	// scope they carry is still granted by the principal's remaining authority.
 	KeysRetained int
 	Incomplete   bool
+	// AuditIncomplete reports that the sweep destroyed credentials it could not
+	// fully record. Kept SEPARATE from Incomplete on purpose: callers such as
+	// users.go and user_service.go treat Incomplete as "the enclosing
+	// destructive operation did not fully land" and surface it to the client,
+	// whereas a missing audit row means the destruction DID land and the trail
+	// is short. Folding the two together would either hide a real sweep failure
+	// or make a logging problem look like a failed deletion.
+	AuditIncomplete bool
 }
 
 // OrgAuthorityReduced invalidates the credentials a user derives from ONE
@@ -204,6 +233,25 @@ func (s *Sweeper) UserDeprovisioned(ctx context.Context, userID string, scope re
 	// race that must not read as an incomplete sweep — and that whole branch is
 	// gone with the second round trip: a set-based delete reports how many rows
 	// it removed, and removing zero is an ordinary answer, not a miss.
+	// Snapshot BEFORE the delete. The set-based DELETE reports only a count, and
+	// once it runs the names and scopes exist nowhere -- so the pre-image is the
+	// only chance to record what was destroyed. Read only when an audit sink is
+	// attached, so an un-audited deployment issues no extra query.
+	var snapshot []*models.APIKey
+	if s.audit != nil {
+		var listErr error
+		snapshot, listErr = s.apiKeys.ListAPIKeysByUser(ctx, userID, scope)
+		if listErr != nil {
+			// Do NOT abort. The authority reduction has already committed, and
+			// refusing to delete here would strand exactly the credentials this
+			// sweep exists to remove (#732/#736). Proceed and report the gap.
+			slog.Error("credlifecycle: could not snapshot API keys before revoking them",
+				"user_id", userID, "reason", reason, "error", listErr,
+				"impact", "the keys are still deleted below, but the audit trail will not name them")
+			out.AuditIncomplete = true
+			snapshot = nil
+		}
+	}
 	n, err := s.apiKeys.RevokeAPIKeysForUser(ctx, userID, scope)
 	if err != nil {
 		slog.Error("credlifecycle: failed to revoke user API keys",
@@ -214,7 +262,88 @@ func (s *Sweeper) UserDeprovisioned(ctx context.Context, userID string, scope re
 	out.KeysRevoked = int(n)
 	slog.Info("credlifecycle: API keys revoked", "user_id", userID,
 		"api_keys_revoked", n, "scope", scope.String(), "reason", reason)
+	for _, k := range snapshot {
+		if !s.recordKeyDestroyed(ctx, k, reason) {
+			out.AuditIncomplete = true
+		}
+	}
+	// A snapshot that disagrees with the delete count means rows arrived or
+	// vanished between the two statements, so the trail is not a faithful
+	// account of what this sweep destroyed. Say so rather than letting the
+	// mismatch pass silently.
+	if s.audit != nil && len(snapshot) != int(n) {
+		slog.Warn("credlifecycle: audit snapshot does not match the number of keys deleted",
+			"user_id", userID, "snapshotted", len(snapshot), "deleted", n, "reason", reason)
+		out.AuditIncomplete = true
+	}
 	return out
+}
+
+// SweepActor is the actor_email recorded for a sweep-initiated destruction.
+//
+// These writes have no HTTP actor reachable from here. Four of the five call
+// sites DO run inside an authenticated request, but the Sweeper receives only a
+// context and never the caller's identity, so attributing the row to a person
+// would require threading a principal through every path -- and guessing wrong
+// is worse than being explicit that the system did it. audit_logs.actor_email
+// (migration 000058) is NOT NULL-safe but a null actor is unreadable in the
+// admin surface, so a sentinel is used instead.
+const SweepActor = "system:credlifecycle"
+
+// recordKeyDestroyed writes the audit row for one destroyed key. It reports
+// whether the record was written.
+//
+// The row must make the destruction RECONSTRUCTABLE: the api_keys row is
+// hard-deleted (identity models revocation as deletion and deliberately dropped
+// is_active in its migration 000004), so name, scopes and prefix exist nowhere
+// else once this returns. Scopes matter most -- they are what tells the owner
+// what the key could do and therefore what to recreate.
+func (s *Sweeper) recordKeyDestroyed(ctx context.Context, k *models.APIKey, reason string) bool {
+	if s == nil || s.audit == nil || k == nil {
+		return true
+	}
+	resourceType := "api_key"
+	resourceID := k.ID
+	orgID := k.OrganizationID
+	actor := SweepActor
+
+	metadata := map[string]interface{}{
+		"name":       k.Name,
+		"scopes":     k.Scopes,
+		"key_prefix": k.KeyPrefix,
+		"reason":     reason,
+		"created_at": k.CreatedAt,
+	}
+	if k.UserID != nil {
+		metadata["owner_user_id"] = *k.UserID
+	}
+	if k.Description != nil {
+		metadata["description"] = *k.Description
+	}
+	if k.ExpiresAt != nil {
+		metadata["expires_at"] = *k.ExpiresAt
+	}
+	if k.LastUsedAt != nil {
+		metadata["last_used_at"] = *k.LastUsedAt
+	}
+
+	entry := &models.AuditLog{
+		// UserID stays nil: the row records a SYSTEM action, and the audit
+		// repository resolves actor_email from user_id when ActorEmail is unset.
+		OrganizationID: &orgID,
+		Action:         "api_key.revoked_by_sweep",
+		ResourceType:   &resourceType,
+		ResourceID:     &resourceID,
+		Metadata:       metadata,
+		ActorEmail:     &actor,
+	}
+	if err := s.audit.CreateAuditLog(ctx, entry); err != nil {
+		slog.Error("credlifecycle: destroyed an API key but could not record it in the audit log",
+			"api_key_id", k.ID, "organization_id", k.OrganizationID, "reason", reason, "error", err,
+			"impact", "the key is gone and its name and scopes are not recoverable from the audit trail")
+		return false
+	}
+	return true
 }
 
 func (s *Sweeper) revokeTokens(ctx context.Context, userID, reason string) Outcome {
@@ -280,6 +409,13 @@ func (s *Sweeper) revokeOrgKeys(ctx context.Context, userID, orgID string, retai
 		out.KeysRevoked++
 		slog.Info("credlifecycle: API key revoked",
 			"api_key_id", k.ID, "user_id", userID, "organization_id", orgID, "reason", reason)
+		// Recorded AFTER the delete, deliberately. Auditing first would
+		// manufacture a record of a destruction that might then not happen, and
+		// a phantom entry corrupts the trail in a way a missing one does not --
+		// a miss is loud in the error log and sets AuditIncomplete.
+		if !s.recordKeyDestroyed(ctx, k, reason) {
+			out.AuditIncomplete = true
+		}
 	}
 	return out
 }

--- a/backend/internal/credlifecycle/sweeper_test.go
+++ b/backend/internal/credlifecycle/sweeper_test.go
@@ -3,6 +3,8 @@ package credlifecycle
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -547,6 +549,205 @@ func TestUserDeprovisioned_NoKeyRepository_StillMovesWatermark(t *testing.T) {
 		repositories.OrgScopeAllOrganizations(), "test")
 	if !out.TokensRevoked || out.Incomplete {
 		t.Errorf("Outcome = %+v, want TokensRevoked=true Incomplete=false", out)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #961 — a destroyed credential must leave a reconstructable record.
+//
+// api_keys is HARD-deleted (identity models revocation as deletion and dropped
+// is_active in its migration 000004), so once a sweep runs the key's name and
+// scopes exist nowhere else. An audit row that merely says "a key was revoked"
+// is not enough to tell the owner what to recreate, which is precisely what
+// happened on the deployment that produced this issue.
+// ---------------------------------------------------------------------------
+
+// auditMetadataNaming matches the metadata JSONB argument of an audit INSERT and
+// asserts the destroyed key is RECONSTRUCTABLE from it.
+//
+// This is the assertion that makes the test non-vacuous. Expecting only that an
+// INSERT happened would pass against an audit row with empty metadata -- which
+// records that something was destroyed while still losing the one thing worth
+// keeping. Verified by mutation: hollowing out the metadata map must turn this
+// red, and with a statement-only expectation it does not.
+type auditMetadataNaming struct {
+	name   string
+	scopes []string
+}
+
+func (a auditMetadataNaming) Match(v driver.Value) bool {
+	raw, ok := v.([]byte)
+	if !ok {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	if m["name"] != a.name {
+		return false
+	}
+	got, ok := m["scopes"].([]interface{})
+	if !ok || len(got) != len(a.scopes) {
+		return false
+	}
+	for i, want := range a.scopes {
+		if got[i] != want {
+			return false
+		}
+	}
+	return true
+}
+
+func expectKeyDestroyedAudit(mock sqlmock.Sqlmock, keyID, name string, scopes []string) {
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			sqlmock.AnyArg(), // id
+			nil,              // user_id — a SYSTEM action has no acting user
+			sqlmock.AnyArg(), // organization_id
+			"api_key.revoked_by_sweep",
+			"api_key",
+			keyID,
+			auditMetadataNaming{name: name, scopes: scopes},
+			nil,              // ip_address
+			sqlmock.AnyArg(), // created_at
+			SweepActor,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"actor_email"}).AddRow(SweepActor))
+}
+
+func TestOrgKeysOnly_WritesAnAuditRowNamingTheDestroyedKey(t *testing.T) {
+	s, mock, db := newSweeperWithMock(t)
+	s = s.WithAuditLog(repositories.NewAuditRepository(db))
+
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1", sqlmock.AnyArg()).
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write","scanning:read"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectKeyDestroyedAudit(mock, "key-1", "CI Key", []string{"modules:write", "scanning:read"})
+
+	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", nil, "idp group mapping role reassigned")
+
+	if out.KeysRevoked != 1 {
+		t.Fatalf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if out.AuditIncomplete {
+		t.Error("AuditIncomplete set although the audit write succeeded")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A key the sweep RETAINS must not be audited as destroyed: a phantom entry
+// corrupts the trail worse than a missing one.
+func TestOrgKeysOnly_RetainedKeyIsNotAudited(t *testing.T) {
+	s, mock, db := newSweeperWithMock(t)
+	s = s.WithAuditLog(repositories.NewAuditRepository(db))
+
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1", sqlmock.AnyArg()).
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:read"]`))
+	// No DELETE and no INSERT staged: the key is still covered by the retained
+	// authority, so nothing may be destroyed and nothing may be recorded.
+
+	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", []string{"modules:read"}, "no-op")
+
+	if out.KeysRevoked != 0 || out.KeysRetained != 1 {
+		t.Fatalf("KeysRevoked=%d KeysRetained=%d, want 0 and 1", out.KeysRevoked, out.KeysRetained)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The bulk path deletes with ONE statement that reports only a count, so the
+// pre-image is the only chance to learn what was destroyed.
+func TestUserDeprovisioned_SnapshotsKeysBeforeTheBulkDelete(t *testing.T) {
+	s, mock, db := newSweeperWithMock(t)
+	s = s.WithAuditLog(repositories.NewAuditRepository(db))
+
+	expectWatermark(mock, "user-1")
+	// The snapshot read must come BEFORE the delete; sqlmock is ordered, so
+	// staging it first is itself the assertion.
+	// OrgScopeAllOrganizations renders as `AND TRUE` and binds no parameter, so
+	// both statements take exactly one argument.
+	mock.ExpectQuery("(?s)FROM api_keys").
+		WithArgs("user-1").
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE user_id").
+		WithArgs("user-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectKeyDestroyedAudit(mock, "key-1", "CI Key", []string{"modules:write"})
+
+	out := s.UserDeprovisioned(context.Background(), "user-1", repositories.OrgScopeAllOrganizations(), "user deleted")
+
+	if out.KeysRevoked != 1 {
+		t.Fatalf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if out.AuditIncomplete {
+		t.Error("AuditIncomplete set although the snapshot and audit write both succeeded")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A failed audit write must NOT abort the sweep: the authority reduction has
+// already committed, and refusing to delete would strand the credentials the
+// sweep exists to remove. It must be reported instead -- and reported through
+// AuditIncomplete, not Incomplete, because callers treat Incomplete as "the
+// destructive operation did not land".
+func TestOrgKeysOnly_AuditFailureIsReportedButDoesNotStopTheSweep(t *testing.T) {
+	s, mock, db := newSweeperWithMock(t)
+	s = s.WithAuditLog(repositories.NewAuditRepository(db))
+
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1", sqlmock.AnyArg()).
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WillReturnError(errors.New("audit_logs unavailable"))
+
+	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", nil, "idp deprovision")
+
+	if out.KeysRevoked != 1 {
+		t.Fatalf("KeysRevoked = %d, want 1 (the deletion must still happen)", out.KeysRevoked)
+	}
+	if !out.AuditIncomplete {
+		t.Error("AuditIncomplete must be set when the audit write fails")
+	}
+	if out.Incomplete {
+		t.Error("Incomplete must NOT be set: the sweep itself succeeded, only its record did not")
+	}
+}
+
+// With no audit sink attached the sweeper must issue no extra statement at all,
+// so every existing construction and its tests stay valid.
+func TestSweeperWithoutAuditSinkIssuesNoAuditStatement(t *testing.T) {
+	s, mock, _ := newSweeperWithMock(t)
+
+	mock.ExpectQuery("(?s)FROM api_keys ak.*ak.organization_id").
+		WithArgs("user-1", "org-1", sqlmock.AnyArg()).
+		WillReturnRows(keyRow("key-1", "user-1", "org-1", `["modules:write"]`))
+	mock.ExpectExec("DELETE FROM api_keys WHERE id").
+		WithArgs("key-1", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	out := s.OrgKeysOnly(context.Background(), "user-1", "org-1", nil, "idp deprovision")
+
+	if out.KeysRevoked != 1 {
+		t.Fatalf("KeysRevoked = %d, want 1", out.KeysRevoked)
+	}
+	if out.AuditIncomplete {
+		t.Error("AuditIncomplete must stay false when no audit sink is attached")
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)


### PR DESCRIPTION
The sweeper hard-deletes `api_keys` rows and wrote nothing but a `slog` line. The row is **deleted, not flagged** — identity models revocation as deletion and deliberately dropped `is_active` in its migration `000004` — so the moment a sweep runs, the key's **name, scopes and prefix exist nowhere**.

On the deployment that produced this issue, an operator could see that *"a key"* was destroyed and could not tell the owner what it had been able to do, or what to recreate.

For a product that ships a dedicated audit surface behind an `audit:read` scope, destroying a secret is exactly the class of event that surface exists for. Application logs are retained differently and are less tamper-evident, so *"it's in the logs"* is not an equivalent control.

## The optional dependency is also the hazard

`Sweeper` gains an **optional** audit repository. With it nil, behaviour is byte-identical to before — which is what keeps every existing construction and its tests valid, and is also the trap: **an unwired sweeper behaves exactly like a wired one** until somebody needs the trail and finds it empty. No error, no runtime signal, no failing unit test.

There are three production constructions and two hide inside handler constructors rather than at the composition root:

| Site | Note |
|---|---|
| `internal/api/router.go` | wired directly |
| `internal/api/admin/organizations.go` | inside `NewOrganizationHandlers` |
| `internal/api/admin/rbac.go` | inside `NewRBACHandlers` — **highest-volume destruction path** |

All three are wired here, and a **class test** asserts structurally that every file constructing a `Sweeper` also attaches a sink. It asks that as a *question* rather than checking a list of three, so a fourth construction fails until it is wired — and it fails loudly if it ever stops finding any construction at all, rather than passing on an empty universe.

## Two orderings, both deliberate

**Per-key path — audit AFTER the delete.** Auditing first would manufacture a record of a destruction that might then not happen. A phantom entry corrupts the trail in a way a missing one does not; a miss is loud in the error log and sets `AuditIncomplete`.

**Bulk path — snapshot BEFORE the delete.** `RevokeAPIKeysForUser` is one set-based statement reporting only a count, so the pre-image is the only chance to learn what was destroyed. A snapshot that disagrees with the delete count is warned about rather than passed over.

## A failed audit never aborts a sweep

By then the authority reduction has committed, and refusing to delete would strand exactly the credentials the sweep exists to remove (#732/#736). It is reported through a **new `AuditIncomplete`** flag rather than the existing `Incomplete`, which callers treat as *"the destructive operation did not land"* and surface to clients. Conflating them would either hide a real sweep failure or make a logging problem look like a failed deletion.

## Corrections to the issue

**The issue says these sweeps have "no HTTP actor". Four of the five call sites do** — they run inside authenticated requests. The real constraint is that the actor is unreachable from the context the `Sweeper` receives. Rather than thread a principal through every path or guess, the row carries an explicit **system sentinel** in `actor_email` (the column from migration `000058`), so the entry is attributable and readable in the admin surface.

**The issue's option (b), soft-deleting `api_keys`, is not viable** — not merely bigger. The table is owned by `terraform-suite-identity`, whose migration `000004` dropped `is_active` on the stated grounds that revocation is modeled entirely by hard delete. A `revoked_at` would be a library migration, release and version bump. Recording this so (b) isn't re-proposed.

## Verification

Four mutations, each turning a specific test red:

| Mutation | Result |
|---|---|
| remove the per-key audit call | `OrgKeysOnly` audit test fails |
| remove the bulk snapshot loop | `UserDeprovisioned` test fails |
| drop any one wiring | class test fails, **naming the file** |
| **keep the INSERT, empty the metadata** | **still fails** |

The last is the one that matters. An expectation asserting only that *an INSERT happened* would pass against an audit row with empty metadata — recording that something was destroyed while losing the only thing worth keeping. The test uses a custom `sqlmock.Argument` that unmarshals the metadata and asserts the key's name and full scope list are present.

Existing `internal/api/admin` class tests pass **unchanged** — the audit repo is nil in those constructions, so no new statement is issued.

Closes #961
