### PR TITLE
fix(auth): skip the group-mapping reassignment when the role is unchanged

### DIFF
--- a/backend/internal/api/admin/auth.go
+++ b/backend/internal/api/admin/auth.go
@@ -1134,7 +1134,11 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		}
 		managedOrgIDs[org.ID] = struct{}{}
 
-		isMember, _, err := h.orgRepo.CheckMembership(ctx, org.ID, userID, repositories.OrgScopeAllOrganizations())
+		// currentRoleID is REGISTRY's organization_member_roles.role_template_id
+		// for this membership (CheckMembership -> GetMember -> MirroredRole.id()).
+		// It is nil when there is no mirrored row, or when the mirrored row holds
+		// no role -- migration 000055 keeps those two states distinct.
+		isMember, currentRoleID, err := h.orgRepo.CheckMembership(ctx, org.ID, userID, repositories.OrgScopeAllOrganizations())
 		if err != nil {
 			return fmt.Errorf("check membership org=%s user=%s: %w", org.ID, userID, err)
 		}
@@ -1151,20 +1155,60 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 		// On acceptance it also yields the mapped template's scopes, which are
 		// what the member will hold in this org once the write commits — the
 		// retention filter the reassignment branch's sweep needs, obtained from
-		// the lookup the guard was already making.
-		resolveProvisionableRole := func() ([]string, bool) {
-			scopes, guardErr := h.guardProvisionableRole(ctx, role)
+		// the lookup the guard was already making — and that template's ID,
+		// which is how the reassignment branch tells a real role change from a
+		// re-application of the role already held (#962).
+		resolveProvisionableRole := func() (string, []string, bool) {
+			roleID, scopes, guardErr := h.guardProvisionableRole(ctx, role)
 			if guardErr != nil {
 				slog.Warn(provider+" group mapping rejected: resolved role is not automatically provisionable by an IdP-driven mapping; a human admin must grant it explicitly",
 					"user_id", userID, "org", orgName, "role", role, "error", guardErr)
-				return nil, false
+				return "", nil, false
 			}
-			return scopes, true
+			return roleID, scopes, true
 		}
 		switch {
 		case wanted && isMember:
-			retained, ok := resolveProvisionableRole()
+			mappedRoleID, retained, ok := resolveProvisionableRole()
 			if !ok {
+				continue
+			}
+			// A reassignment to the role already held changes nothing, so do
+			// nothing (#962). Reached on every login once a mapping matches, for
+			// every managed organization.
+			//
+			// WHAT THIS SKIPS, per login per managed org, for a change that
+			// changes nothing: idpReduce -> adminfloor.Guard.Protect ->
+			// Guard.Serialize, which takes a DEPLOYMENT-WIDE
+			// pg_advisory_xact_lock, plus the carrier read, the per-org member
+			// and admin enumeration, the UPDATE, the mirror read-back-and-upsert,
+			// and the sweep's api_keys SELECT. That lock sits on the login path,
+			// so the cost is paid by every concurrent sign-in.
+			//
+			// WHY THE COMPARISON IS SOUND: currentRoleID is registry's
+			// organization_member_roles.role_template_id and mappedRoleID is
+			// registry_role_templates.id, which migration 000055 declares that
+			// column REFERENCES. Same table, same connection, same driver.
+			//
+			// BOTH ids must be KNOWN. A nil currentRoleID means the member holds
+			// no mirrored role and the write must still run to establish one --
+			// that one is load-bearing and pinned by
+			// TestReconcile_MemberHoldsNoRole_IsNotANoOp.
+			//
+			// The `mappedRoleID != ""` clause is DEFENCE IN DEPTH, not a live
+			// path: guardProvisionableRole yields "" for a name that does not
+			// resolve, and today an unresolved name simply fails the equality
+			// against a real held id anyway (pinned by
+			// TestReconcile_UnknownRoleTemplate_ForExistingMember_IsNotANoOp).
+			// It would only bite if a held id were ever a non-nil EMPTY string,
+			// which organization_member_roles.role_template_id being a UUID
+			// forbids. Kept because an id comparison that can silently skip a
+			// privilege write should not rely on a column type to be safe --
+			// but it is deliberately not claimed as mutation-verified, because
+			// no reachable state exercises it.
+			if currentRoleID != nil && mappedRoleID != "" && *currentRoleID == mappedRoleID {
+				slog.Debug(provider+" group mapping unchanged, skipping reassignment",
+					"user_id", userID, "org", orgName, "role", role)
 				continue
 			}
 			// isMember was read earlier in this reconciliation; the membership
@@ -1221,7 +1265,10 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			// The scopes are not needed on this branch: adding a membership is
 			// an authority INCREASE, and no credential of this user in this org
 			// can be a snapshot of an authority they did not have.
-			if _, ok := resolveProvisionableRole(); !ok {
+			// The id is not needed either: there is no held role to compare
+			// against on an ADD, which is why the no-op skip lives only on the
+			// reassignment branch above.
+			if _, _, ok := resolveProvisionableRole(); !ok {
 				continue
 			}
 			if err := h.orgRepo.AddMemberWithParams(ctx, org.ID, userID, role, repositories.OrgScopeAllOrganizations()); err != nil {
@@ -1311,7 +1358,7 @@ func (h *AuthHandlers) reconcileGroupMemberships(ctx context.Context, userID str
 			// The scopes are not needed here: adding a membership is an
 			// authority increase, so no existing credential of this user in
 			// this org can be a snapshot of an authority they did not have.
-			if _, guardErr := h.guardProvisionableRole(ctx, defaultRole); guardErr != nil {
+			if _, _, guardErr := h.guardProvisionableRole(ctx, defaultRole); guardErr != nil {
 				slog.Warn(provider+" default_role rejected: it is not automatically provisionable by an IdP-driven mapping; a human admin must grant it explicitly",
 					"user_id", userID, "role", defaultRole, "error", guardErr)
 				return nil

--- a/backend/internal/api/admin/auth_test.go
+++ b/backend/internal/api/admin/auth_test.go
@@ -906,11 +906,26 @@ var authMemberCols = []string{"organization_id", "user_id", "role_template_id", 
 // expectRoleScopesLookup queues the guardProvisionableRole scopes lookup that
 // now runs before every "wanted" (add/update) branch of reconcileGroupMemberships.
 // scopes is marshaled to the JSON array the real `scopes` column holds.
+// roleTemplateIDFor mirrors the `rt-<name>` convention the membership fixtures
+// in this package already use, so a test staging a member holding `rt-editor`
+// and a mapping resolving to `editor` describes a member whose role is
+// UNCHANGED -- which is exactly the no-op the reassignment branch must skip
+// (#962). Tests needing the held and mapped ids to DIFFER call
+// expectRoleScopesLookupWithID directly.
+func roleTemplateIDFor(roleName string) string { return "rt-" + roleName }
+
 func expectRoleScopesLookup(mock sqlmock.Sqlmock, roleName string, scopes []string) {
+	expectRoleScopesLookupWithID(mock, roleName, roleTemplateIDFor(roleName), scopes)
+}
+
+// expectRoleScopesLookupWithID stages the guard's lookup, which since #962 returns
+// the template's id alongside its scopes: the scopes are the credential sweep's
+// retention filter, the id is the no-op comparator.
+func expectRoleScopesLookupWithID(mock sqlmock.Sqlmock, roleName, roleID string, scopes []string) {
 	scopesJSON, _ := json.Marshal(scopes)
-	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE name").
+	mock.ExpectQuery("SELECT id, scopes FROM registry_role_templates WHERE name").
 		WithArgs(roleName).
-		WillReturnRows(sqlmock.NewRows([]string{"scopes"}).AddRow(scopesJSON))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "scopes"}).AddRow(roleID, scopesJSON))
 }
 
 func TestApplyGroupMappings_MatchingGroup_AddMember(t *testing.T) {
@@ -1795,21 +1810,127 @@ func TestReconcile_GroupChanges_UpdatesRole(t *testing.T) {
 	}
 }
 
-// User keeps the group → membership preserved with the correct role (UPDATE to same role).
-func TestReconcile_KeepsGroup_PreservesMembership(t *testing.T) {
+// User keeps the group and the role they already hold → NOTHING happens (#962).
+//
+// This test previously staged an UPDATE to the same role and asserted it was
+// issued, which is the defect written down as intended behaviour. Reaching that
+// branch on an unchanged role is not free: it takes a DEPLOYMENT-WIDE
+// pg_advisory_xact_lock through the admin floor, on the login path, plus the
+// carrier read, the member/admin enumeration, the UPDATE, the mirror
+// read-back-and-upsert, and the sweep's api_keys SELECT -- once per login per
+// managed organization, for a change that changes nothing.
+//
+// Staging nothing after the guard lookup IS the assertion: sqlmock rejects any
+// statement it was not told to expect, so a re-introduced write fails here.
+func TestReconcile_KeepsGroup_SameRole_IsANoOp(t *testing.T) {
 	db, mock, _ := sqlmock.New()
 	defer db.Close()
 
 	cfg := &config.Config{}
-	// Role is a non-admin role template deliberately: this test is about
-	// preserving membership across logins, not the ScopeAdmin guard.
+	// Role is a non-admin role template deliberately: this test is about the
+	// unchanged-role skip, not the ScopeAdmin guard.
 	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
 		{Group: "admins", Organization: "acme", Role: "editor"},
 	}
 	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
 
 	expectOrgByName(mock, "acme", "org-acme")
+	// The member already holds rt-editor...
 	expectIsMember(mock, "org-acme", "user-1", "rt-editor")
+	// ...and the mapping resolves to the very same template. The guard lookup
+	// still runs -- it is what supplies the id being compared -- and everything
+	// after it must not.
+	expectRoleScopesLookup(mock, "editor", []string{"modules:read", "modules:write"})
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// The same branch, with the role ACTUALLY changing, must still write and sweep.
+// Without this, making the skip unconditional would pass every other test here.
+func TestReconcile_KeepsGroup_DifferentRole_StillUpdates(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "editor"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	// Holds rt-viewer, mapping resolves to editor -> a genuine reassignment.
+	expectIsMember(mock, "org-acme", "user-1", "rt-viewer")
+	expectUpdateMember(mock, "editor", "rt-editor")
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err != nil {
+		t.Fatalf("applyGroupMappings: unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A mapping naming a role template that does NOT resolve is not a no-op either.
+// guardProvisionableRole returns an EMPTY id for an unknown name, and an empty
+// id must never be read as "matches the held role" -- doing so would silently
+// skip a write for every mapping pointing at a typo'd or deleted template,
+// leaving the member on their old role with no signal at all.
+func TestReconcile_UnknownRoleTemplate_ForExistingMember_IsNotANoOp(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "ghost-role"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	expectIsMember(mock, "org-acme", "user-1", "rt-editor")
+	// Unknown template: no id, no scopes.
+	mock.ExpectQuery("SELECT id, scopes FROM registry_role_templates WHERE name").
+		WithArgs("ghost-role").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "scopes"}))
+	// The write must still be attempted, and reach the real role_templates
+	// lookup that reports the unknown name properly.
+	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
+		WithArgs("ghost-role").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
+	if err == nil {
+		t.Fatal("expected the unresolvable role template to surface an error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// A member holding NO mirrored role is not a no-op: currentRoleID is nil, the
+// write must still run to establish one. Skipping here would leave a membership
+// permanently without a role.
+func TestReconcile_MemberHoldsNoRole_IsNotANoOp(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	cfg := &config.Config{}
+	cfg.Auth.OIDC.GroupMappings = []config.OIDCGroupMapping{
+		{Group: "admins", Organization: "acme", Role: "editor"},
+	}
+	h, _ := NewAuthHandlers(cfg, db, nil, nil, auth.NewMemoryStateStore(time.Hour))
+
+	expectOrgByName(mock, "acme", "org-acme")
+	mock.ExpectQuery("SELECT.*FROM organization_members.*WHERE organization_id.*AND user_id").
+		WillReturnRows(sqlmock.NewRows(authMemberCols).
+			AddRow("org-acme", "user-1", nil, time.Now()))
+	expectRegistryRoleFor(mock, registryRole{})
 	expectUpdateMember(mock, "editor", "rt-editor")
 
 	err := h.applyGroupMappings(context.Background(), "user-1", []string{"admins"})
@@ -2144,10 +2265,12 @@ func TestReconcile_GuardProvisionableRole_UnknownRoleTemplate_DefersToRealLookup
 
 	expectOrgByName(mock, "acme", "org-acme")
 	expectNotMember(mock)
-	// guardProvisionableRole's own scopes lookup finds no such role template.
-	mock.ExpectQuery("SELECT scopes FROM registry_role_templates WHERE name").
+	// guardProvisionableRole's own lookup finds no such role template, so it
+	// yields neither an id nor scopes -- and an EMPTY id must not be read as
+	// matching an absent held role (#962).
+	mock.ExpectQuery("SELECT id, scopes FROM registry_role_templates WHERE name").
 		WithArgs("ghost-role").
-		WillReturnRows(sqlmock.NewRows([]string{"scopes"}))
+		WillReturnRows(sqlmock.NewRows([]string{"id", "scopes"}))
 	// AddMemberWithParams's lookup is reached and fails with its own clear error.
 	mock.ExpectQuery("SELECT id FROM role_templates WHERE name").
 		WithArgs("ghost-role").

--- a/backend/internal/api/admin/group_mapping_guard.go
+++ b/backend/internal/api/admin/group_mapping_guard.go
@@ -45,28 +45,40 @@ import (
 // set this returns. Any other lookup/parse failure is returned (fails closed)
 // — a transient DB error here should not silently let an unverified role's
 // scopes through.
-func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) ([]string, error) {
+// Returns the template's ID as well as its scopes. Both come from the one row
+// this already fetches: the scopes are the sweep's retention filter, and the id
+// is what lets the caller tell a genuine reassignment from a re-application of
+// the role the member already holds (#962). The id is registry's own
+// `registry_role_templates.id`, which is exactly what
+// `organization_member_roles.role_template_id` references (migration 000055), so
+// the two are directly comparable.
+func (h *AuthHandlers) guardProvisionableRole(ctx context.Context, roleTemplateName string) (string, []string, error) {
 	// REGISTRY's own table (terraform-suite-identity#206, phase 3b), for the same
 	// reason as role_ceiling.go: the returned scopes are what the member WILL
 	// hold once the write commits, and since the read cutover that is decided by
 	// `registry_role_templates`. They are also the retention filter for the
 	// credential sweep, so reading the shared table would retain credentials
 	// against an authority the product no longer confers.
+	var roleTemplateID string
 	var scopesJSON []byte
 	err := h.db.QueryRowContext(ctx,
-		`SELECT scopes FROM registry_role_templates WHERE name = $1`, roleTemplateName).Scan(&scopesJSON)
+		`SELECT id, scopes FROM registry_role_templates WHERE name = $1`, roleTemplateName).Scan(&roleTemplateID, &scopesJSON)
 	if err == sql.ErrNoRows {
-		return nil, nil
+		// Unchanged semantics: an unresolvable name is not an error, it simply
+		// yields no scopes. It now also yields no id, which the caller must
+		// treat as "unknown" rather than as a match -- an empty id equal to an
+		// empty held id would skip a write that should happen.
+		return "", nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("look up role template %q scopes: %w", roleTemplateName, err)
+		return "", nil, fmt.Errorf("look up role template %q scopes: %w", roleTemplateName, err)
 	}
 	var scopes []string
 	if err := json.Unmarshal(scopesJSON, &scopes); err != nil {
-		return nil, fmt.Errorf("parse role template %q scopes: %w", roleTemplateName, err)
+		return "", nil, fmt.Errorf("parse role template %q scopes: %w", roleTemplateName, err)
 	}
 	if err := auth.ValidateProvisionableScopes(scopes); err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	return scopes, nil
+	return roleTemplateID, scopes, nil
 }


### PR DESCRIPTION
`reconcileGroupMemberships` called `UpdateMemberRole` unconditionally on the `wanted && isMember` branch, never comparing the mapped role against the role the member already held. **The information needed to skip was already fetched and discarded** — `CheckMembership` returns `(bool, *string, error)` whose second value is the current role-template id, thrown away as `_`.

The guard's own lookup now returns that template's id alongside its scopes — from the row it was already fetching, so no extra round trip — and the branch skips when the two ids match.

The comparison is apples-to-apples: `currentRoleID` is registry's `organization_member_roles.role_template_id`, `mappedRoleID` is `registry_role_templates.id`, and migration `000055` declares that column `REFERENCES` it. Same table, same connection, same driver.

## The issue has been reworded to match the code

**A no-op does not normally delete API keys.** `revokeOrgKeys` already filters per key with `AuthorityRetained`, and on this branch `retained` is the *same* template's scopes — so a key minted clamped to that template is kept. The deletion you observed was a key that **already over-asked** relative to `admin` (it held `scanning:read`/`audit:read`, which registry's `admin` template does not carry).

This fix does prevent that destruction. Closing on the original wording would have credited the change with preventing routine key deletion it never caused, so **#962 has been rewritten** — new title, corrected impact section, and a visible note recording what the original said and why it was wrong. The observed evidence in the issue is unchanged.

**The recurring cost is the write path, and it isn't mentioned.** Every no-op ran `idpReduce` → `adminfloor.Guard.Protect` → `Guard.Serialize`, which takes a **deployment-wide `pg_advisory_xact_lock`** — plus the carrier read, the per-org member and admin enumeration, the UPDATE, the mirror read-back-and-upsert, and the sweep's `api_keys` SELECT. Once per login, per managed organization, for a change that changes nothing. That lock sits **on the login path**, so every concurrent sign-in pays for it.

## The skip is deliberately narrow

Only a positive match on two **known** ids. A nil held id means the member holds no mirrored role and the write must still run to establish one — otherwise a membership would sit permanently without a role.

## Two existing tests failed, and both were right to

Widening the shared helper to stage `SELECT id, scopes` (deriving the id from the role name, matching the `rt-<name>` convention the fixtures here already use) broke exactly two tests:

- **`TestReconcile_KeepsGroup_PreservesMembership`** staged an UPDATE to the same role and asserted it was issued — the defect written down as intended behaviour. Rewritten as `TestReconcile_KeepsGroup_SameRole_IsANoOp`, which stages **nothing** after the guard lookup, so any re-introduced write fails.
- **`TestReconcile_GuardProvisionableRole_UnknownRoleTemplate_DefersToRealLookup`** hand-staged the old single-column query.

## Verification

| Mutation | Result |
|---|---|
| disable the skip | `SameRole_IsANoOp` fails |
| widen it to ignore equality | `DifferentRole_StillUpdates` fails |
| treat a nil held role as a match | `MemberHoldsNoRole_IsNotANoOp` fails |
| drop the `mappedRoleID != ""` clause | **no test fails — see below** |

My first mutation run reported three of four as "still passes". They hadn't: `if false {` left the bound variables unused, so the package **failed to build**, and my harness read a build failure as a pass. Rewritten as mutations that compile and keep both variables live.

The fourth is an honest negative. That clause guards against a non-nil **empty** held id, which `role_template_id` being a `UUID` column forbids — an unresolved template already fails the equality against a real id. I kept it as defence in depth, and the code comment says plainly that it is *not* mutation-verified rather than implying it is.

Class guards confirmed green, unchanged: `TestIdPMembershipWrites_AreAllBehindTheProvisionableGuard`, `TestMembershipWriteVocabulary_MatchesTheRepository`, the `TestAdminFloorClass_*` family, `TestCredentialLifecycleClass_*`.

Closes #962
