### PR TITLE
feat(suite): name the caller's organizations when proxying module consumers

### DIFF
--- a/backend/internal/api/orgscope_route_class_test.go
+++ b/backend/internal/api/orgscope_route_class_test.go
@@ -112,9 +112,6 @@ var tenantGuardExemptRoutes = map[string]string{
 	"POST /api/v1/organizations": "creates the organization; there is no membership to check against a row that does not exist yet. The auto-grant of org_owner it performs is the named bootstrapExemption in platform_admin_grant_class_test.go",
 	"POST /api/v1/users":         "the users table carries no organization_id; gated on users:write",
 
-	// --- Proxy, no local table --------------------------------------------
-	"GET /api/v1/suite/modules/:namespace/:name/:system/consumers": "server-side proxy to a sibling suite application (2s timeout, [] on any failure); reads no table in this database",
-
 	// --- SCIM: the IdP-driven platform provisioning surface ----------------
 	// SCIM is how an external identity provider administers the whole
 	// deployment's users and groups; it passes OrgScopeAllOrganizations

--- a/backend/internal/api/router_routes.go
+++ b/backend/internal/api/router_routes.go
@@ -635,7 +635,7 @@ func registerAPIV1Routes(router *gin.Engine, d *apiV1RouteDeps) {
 			// auth-required so internal state/source names aren't exposed anonymously.
 			// Namespaced under /suite to avoid the /modules/:version wildcard.
 			authenticatedGroup.GET("/suite/modules/:namespace/:name/:system/consumers",
-				moduleConsumersHandler(func() *suite.DiscoveryClient { return suiteClient }, cfg, egressGuard))
+				moduleConsumersHandler(func() *suite.DiscoveryClient { return suiteClient }, cfg, egressGuard, orgRepo))
 
 			// Stats endpoints (require auth)
 			authenticatedGroup.GET("/admin/stats/dashboard", statsHandlers.GetDashboardStats)

--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -14,9 +14,12 @@ import (
 	identityhttpsafe "github.com/sethbacon/terraform-suite-identity/identity/httpsafe"
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
 
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
+	"github.com/terraform-registry/terraform-registry/internal/tenantscope"
 )
 
 // maxConsumersResponseBytes bounds the sibling's "/consumers" JSON response
@@ -133,7 +136,7 @@ func startSuiteDiscovery(cfg *config.Config) *suite.DiscoveryClient {
 // @Success      200  {object}  map[string]interface{}  "Consuming states (rows forwarded opaquely from the sibling) and total count"
 // @Failure      401  {object}  map[string]interface{}  "Authentication required"
 // @Router       /api/v1/suite/modules/{namespace}/{name}/{system}/consumers [get]
-func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config, egressGuard *httpsafe.Guard) gin.HandlerFunc {
+func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config.Config, egressGuard *httpsafe.Guard, orgRepo *repositories.OrganizationRepository) gin.HandlerFunc {
 	// hosts is THIS registry's set of canonical host identities the sibling
 	// matches "consumed by" on: its public host, its base/discovery host, and any
 	// operator-configured aliases (TFR_SERVER_HOST_ALIASES) for vanity-CNAME or
@@ -178,6 +181,25 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 
 		moduleAddr := c.Param("namespace") + "/" + c.Param("name") + "/" + c.Param("system")
 
+		// Resolve which organizations this caller may read modules in. The
+		// route sits in the authenticated group with no RequireScope, so this
+		// is the only place the caller's tenancy is established.
+		scope, err := tenantscope.Resolve(c, orgRepo, auth.ScopeModulesRead)
+		if err != nil {
+			slog.Warn("suite consumers: could not resolve caller organization scope",
+				"error", err)
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+		// A caller who holds no organizations and is not a platform admin can
+		// legitimately see no consumers at all. Answer empty WITHOUT asking the
+		// sibling: doing so closes this half of the disclosure now, rather than
+		// waiting for the sibling to start enforcing the parameter below.
+		if !scope.PlatformAdmin && len(scope.OrgIDs) == 0 {
+			c.JSON(http.StatusOK, empty)
+			return
+		}
+
 		// Build the outbound URL structurally from the trusted sibling origin
 		// (siblingURL, parsed from the discovery-advertised PublicURL). The
 		// user-provided module address and the registry's own host set are
@@ -195,6 +217,23 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 		q.Set("module", moduleAddr)
 		for _, h := range hosts {
 			q.Add("host", h)
+		}
+		// NAME THE CALLER'S ORGANIZATIONS (#439).
+		//
+		// The sibling's /consumers has no principal of its own -- it is
+		// authenticated only by the shared suite service token -- so it cannot
+		// work out who is asking. Today it ignores this parameter and answers
+		// fleet-wide, which is why a registry user in one organization can see
+		// another's source names and state keys through this proxy. Sending the
+		// scope is what lets the sibling start enforcing it; until it does, this
+		// is inert on the wire and changes nothing.
+		//
+		// A platform admin deliberately sends none: that scope crosses
+		// organization boundaries here exactly as it does everywhere else, and
+		// the absence of the parameter is what the sibling will read as
+		// "fleet-wide", gated on its own operator opt-in.
+		for _, orgID := range scope.OrgIDs {
+			q.Add("organization", orgID)
 		}
 		target.RawQuery = q.Encode()
 

--- a/backend/internal/api/suite_consumers_test.go
+++ b/backend/internal/api/suite_consumers_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,9 @@ import (
 	identityhttpsafe "github.com/sethbacon/terraform-suite-identity/identity/httpsafe"
 	"github.com/sethbacon/terraform-suite-identity/identity/suite"
 
+	"github.com/terraform-registry/terraform-registry/internal/auth"
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/httpsafe"
 )
 
@@ -25,10 +28,26 @@ import (
 // internal target.
 var loopbackGuard = httpsafe.MustGuard("127.0.0.1", "::1")
 
+// mountConsumers mounts the proxy for a PLATFORM ADMIN caller.
+//
+// That scope crosses organization boundaries here as it does everywhere else,
+// so it is the caller for which this proxy's behaviour is unchanged by #439 --
+// which is what keeps every pre-existing test below meaningful. Callers with a
+// narrower scope are covered by the #439 tests at the end of this file.
 func mountConsumers(cfg *config.Config, dc *suite.DiscoveryClient, guard *httpsafe.Guard) *gin.Engine {
+	return mountConsumersAsCaller(cfg, dc, guard, func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+	})
+}
+
+// mountConsumersAsCaller mounts the proxy behind a middleware that establishes
+// whatever principal a test needs, standing in for the authenticated group the
+// route really sits in.
+func mountConsumersAsCaller(cfg *config.Config, dc *suite.DiscoveryClient, guard *httpsafe.Guard, principal gin.HandlerFunc) *gin.Engine {
 	r := gin.New()
 	r.GET("/api/v1/suite/modules/:namespace/:name/:system/consumers",
-		moduleConsumersHandler(func() *suite.DiscoveryClient { return dc }, cfg, guard))
+		principal,
+		moduleConsumersHandler(func() *suite.DiscoveryClient { return dc }, cfg, guard, nil))
 	return r
 }
 
@@ -299,5 +318,124 @@ func TestModuleConsumers_BlocksNonAllowlistedSiblingURL(t *testing.T) {
 	}
 	if consumersHit {
 		t.Error("the sibling's /consumers endpoint must never be reached when its advertised PublicURL is not egress-allowlisted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #439 — the sibling's /consumers has no principal, so this proxy must name the
+// caller's organizations on its behalf.
+//
+// The sibling is authenticated only by a shared suite service token and cannot
+// work out who is asking, so today it answers fleet-wide and a registry user in
+// one organization sees another's source names and state keys through here.
+// Sending the scope is what lets the sibling begin enforcing it.
+// ---------------------------------------------------------------------------
+
+// consumersSibling starts a sibling that records the /consumers query it was
+// asked, answers it, and serves discovery polls. onConsumers reports whether
+// the endpoint was reached at all.
+func consumersSibling(t *testing.T, body string, seen *url.Values, reached *bool) (*config.Config, *suite.DiscoveryClient) {
+	t.Helper()
+	manifest := suite.Manifest{SchemaVersion: suite.SchemaVersionV1, App: "terraform-state-manager"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/consumers") {
+			if reached != nil {
+				*reached = true
+			}
+			if seen != nil {
+				*seen = r.URL.Query()
+			}
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	t.Cleanup(srv.Close)
+	manifest.PublicURL = suite.UntrustedURL(srv.URL)
+
+	cfg := &config.Config{}
+	cfg.Server.PublicURL = "https://registry.example.com"
+	cfg.Suite.SiblingToken = "s3cr3t"
+	return cfg, activeClient(t, srv.URL)
+}
+
+// capturedQuery runs one request through the proxy and returns the query the
+// sibling was asked.
+func capturedQuery(t *testing.T, principal gin.HandlerFunc) url.Values {
+	t.Helper()
+	var got url.Values
+	cfg, dc := consumersSibling(t, `{"consumers":[],"total":0}`, &got, nil)
+	code, _ := getConsumers(mountConsumersAsCaller(cfg, dc, loopbackGuard, principal))
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	return got
+}
+
+func TestModuleConsumers_NamesTheCallersOrganizations(t *testing.T) {
+	q := capturedQuery(t, func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeModulesRead)})
+		c.Set("api_key", &models.APIKey{OrganizationID: "org-acme"})
+	})
+
+	orgs := q["organization"]
+	if len(orgs) != 1 || orgs[0] != "org-acme" {
+		t.Errorf("organization = %v, want [org-acme]", orgs)
+	}
+	// The pre-existing parameters must survive unchanged.
+	if q.Get("module") != "acme/vpc/aws" {
+		t.Errorf("module = %q, want acme/vpc/aws", q.Get("module"))
+	}
+	if len(q["host"]) == 0 {
+		t.Error("host set must still be sent")
+	}
+}
+
+// A platform admin deliberately sends NO organization parameter: that scope
+// crosses organization boundaries here exactly as it does elsewhere, and its
+// absence is what the sibling will read as fleet-wide, gated on its own
+// operator opt-in. Pinning this stops a later change from quietly narrowing an
+// admin's view, or from inventing a magic wildcard value.
+func TestModuleConsumers_PlatformAdminSendsNoOrganization(t *testing.T) {
+	q := capturedQuery(t, func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeAdmin)})
+	})
+	// Assert the sibling was ACTUALLY queried first. Without this, "sent no
+	// organization" and "never asked at all" are the same observation, and a
+	// short-circuit that wrongly caught platform admins would pass here.
+	if q.Get("module") != "acme/vpc/aws" {
+		t.Fatalf("the sibling was not queried for a platform admin (module=%q)", q.Get("module"))
+	}
+	if orgs := q["organization"]; len(orgs) != 0 {
+		t.Errorf("organization = %v, want none for a platform admin", orgs)
+	}
+}
+
+// A caller who holds no organizations can legitimately see no consumers, and
+// this is answered WITHOUT asking the sibling -- which closes this half of the
+// disclosure now rather than waiting for the sibling to enforce the parameter.
+//
+// The sibling here fails the test if it is contacted at all: that is the
+// assertion, not the empty body, because an un-enforcing sibling would answer
+// fleet-wide and the body alone could not tell the two apart.
+func TestModuleConsumers_CallerWithNoOrganizationsNeverReachesTheSibling(t *testing.T) {
+	var reached bool
+	cfg, dc := consumersSibling(t,
+		`{"consumers":[{"state_key":"other-org/prod"}],"total":1}`, nil, &reached)
+
+	r := mountConsumersAsCaller(cfg, dc, loopbackGuard, func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeModulesRead)})
+		// authenticated, but belongs to no organization
+	})
+	code, body := getConsumers(r)
+
+	if code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", code)
+	}
+	if reached {
+		t.Error("the sibling was queried for a caller with no organizations; it answers fleet-wide, so this leaks another organization's state keys")
+	}
+	if total, _ := body["total"].(float64); total != 0 {
+		t.Errorf("total = %v, want 0", total)
 	}
 }


### PR DESCRIPTION
Half one of two for `sethbacon/terraform-state-manager-backend#439`. **This side lands and deploys first** — the ordering is not a preference, see below.

## The disclosure

TSM's `/api/v1/consumers` has **no principal of its own**. It is authenticated only by a shared suite service token, so it cannot work out who is asking and answers **fleet-wide**. This proxy sits in the authenticated group with **no `RequireScope`** and forwards the sibling's rows opaquely, so a registry user in one organization sees another organization's **source names and state keys** — which is exactly what `ConsumedByPanel.tsx` renders.

The registry is the only side that knows the caller, so it is the side that has to say.

## What this does

Resolves the caller with `tenantscope.Resolve` and emits one `organization=` parameter per organization the caller holds `modules:read` in.

**Today this is inert on the wire, deliberately.** TSM reads only `module=` and `host=` and ignores unknown parameters, so nothing changes for any caller until TSM begins enforcing it.

## Why the order is forced

TSM converts **any non-200 into an empty 200**. Enforcing there before this ships would silently empty every "Consumed by" panel in the estate — no error, no log, nothing to notice. So: this merges, this **deploys**, then TSM enforces. Per the estate's own lesson, that means checking the *running* registry build, not `main`.

## One thing does change now

A caller who holds **no** organizations and is not a platform admin is answered empty **without contacting the sibling at all**. That closes this half of the disclosure immediately rather than waiting for TSM, and it is the correct answer for such a caller regardless.

A platform admin deliberately sends **no** `organization` parameter — that scope crosses organization boundaries here as it does everywhere else, and its absence is what TSM will read as fleet-wide, gated on its own operator opt-in rather than on a missing value.

## The route-class guard is bidirectional, and it caught me

Dropping the route's `tenantGuardExemptRoutes` entry is part of this change. The guard failed until it was removed:

```
GET …/consumers resolves a tenant scope in its handler (via tenantscope.Resolve)
AND has a tenantGuardExemptRoutes entry — drop the exemption
```

That failure is what *proved* the route now resolves a tenant, rather than my asserting it.

## Verification

| Mutation | Result |
|---|---|
| stop emitting `organization=` | `NamesTheCallersOrganizations` fails |
| remove the empty-scope short-circuit | `CallerWithNoOrganizationsNeverReachesTheSibling` fails |
| widen the short-circuit to catch platform admins | `PlatformAdminSendsNoOrganization` fails |

The third only works because I strengthened that test first. As originally written it asserted "no `organization` parameter was sent" — but **"sent none" and "never asked the sibling" are the same observation**, so it passed against a short-circuit that wrongly swallowed admins. It now asserts the sibling was actually queried before checking what it was asked.

The empty-scope test likewise asserts the sibling was **not reached**, rather than checking the response body — an un-enforcing sibling answers fleet-wide, so the body alone cannot tell the two cases apart.

Refs #439
