### PR TITLE
fix(suite): say platform-admin explicitly when proxying module consumers

### DIFF
--- a/backend/internal/api/suite.go
+++ b/backend/internal/api/suite.go
@@ -228,12 +228,22 @@ func moduleConsumersHandler(getClient func() *suite.DiscoveryClient, cfg *config
 		// scope is what lets the sibling start enforcing it; until it does, this
 		// is inert on the wire and changes nothing.
 		//
-		// A platform admin deliberately sends none: that scope crosses
-		// organization boundaries here exactly as it does everywhere else, and
-		// the absence of the parameter is what the sibling will read as
-		// "fleet-wide", gated on its own operator opt-in.
+		// A platform admin sends fleet=1 INSTEAD of an organization list: that
+		// scope crosses organization boundaries here exactly as it does
+		// everywhere else.
+		//
+		// It is an EXPLICIT signal rather than the absence of a parameter, and
+		// that distinction is the whole point. Absence cannot be told apart from
+		// a client that simply did not send one -- an older registry, a
+		// misconfiguration, a future caller -- so a sibling reading absence as
+		// "fleet-wide" would hand every organization's state topology to anyone
+		// who omitted the parameter. With an explicit signal the sibling can
+		// require one of the two and refuse anything else.
 		for _, orgID := range scope.OrgIDs {
 			q.Add("organization", orgID)
+		}
+		if scope.PlatformAdmin {
+			q.Set("fleet", "1")
 		}
 		target.RawQuery = q.Encode()
 

--- a/backend/internal/api/suite_consumers_test.go
+++ b/backend/internal/api/suite_consumers_test.go
@@ -409,6 +409,29 @@ func TestModuleConsumers_PlatformAdminSendsNoOrganization(t *testing.T) {
 	if orgs := q["organization"]; len(orgs) != 0 {
 		t.Errorf("organization = %v, want none for a platform admin", orgs)
 	}
+	// The EXPLICIT signal, which is what lets the sibling refuse a request
+	// carrying neither. Absence would be indistinguishable from a caller that
+	// simply did not send one.
+	if q.Get("fleet") != "1" {
+		t.Errorf("fleet = %q, want \"1\": a platform admin must say so explicitly, not by omission", q.Get("fleet"))
+	}
+}
+
+// The converse, and the one that keeps the signal meaningful: a caller scoped
+// to organizations must NOT carry the fleet marker. If it leaked onto scoped
+// requests the sibling would serve them the whole estate.
+func TestModuleConsumers_ScopedCallerDoesNotClaimFleetWide(t *testing.T) {
+	q := capturedQuery(t, func(c *gin.Context) {
+		c.Set("scopes", []string{string(auth.ScopeModulesRead)})
+		c.Set("api_key", &models.APIKey{OrganizationID: "org-acme"})
+	})
+
+	if q.Get("fleet") != "" {
+		t.Errorf("fleet = %q, want empty for an organization-scoped caller", q.Get("fleet"))
+	}
+	if orgs := q["organization"]; len(orgs) != 1 || orgs[0] != "org-acme" {
+		t.Errorf("organization = %v, want [org-acme]", orgs)
+	}
 }
 
 // A caller who holds no organizations can legitimately see no consumers, and


### PR DESCRIPTION
Follow-up to #968, and it must **deploy** before the TSM side of `sethbacon/terraform-state-manager-backend#439` enforces.

## What #968 got wrong

It gave the proxy the caller's organization list, and made a platform admin send **no** `organization` parameter — intending the sibling to read that absence as "fleet-wide".

**Absence is the wrong signal.** A sibling that reads a *missing* parameter as fleet-wide hands every organization's state topology to anything that simply doesn't send one — an older registry build, a misconfiguration, any future caller. That is the disclosure #439 exists to close, reintroduced through the mechanism meant to close it.

The hole is invisible from the sibling's side: it cannot tell "new registry saying platform-admin" from "client that didn't send it", because those are the same request.

## The fix

A platform admin now sends `fleet=1` **instead of** an organization list:

```
scoped caller:  ?module=…&host=…&organization=A&organization=B
platform admin: ?module=…&host=…&fleet=1
```

The sibling can then require one of the two and refuse anything carrying neither, so a fleet-wide answer is only ever given to a caller that explicitly asked for it and was entitled to.

## Still inert, still ordered

TSM reads only `module=` and `host=` today and ignores the rest, so this changes nothing on the wire until the sibling enforces. The ordering is unchanged and still forced: **this deploys, then TSM enforces.** Enforcing first empties every "Consumed by" panel silently, because the proxy converts any non-200 into an empty 200.

## Verification

| Mutation | Result |
|---|---|
| stop sending the signal | `PlatformAdminSendsNoOrganization` fails |
| send it for **every** caller | `ScopedCallerDoesNotClaimFleetWide` fails |

The second is the one that matters. A signal leaking onto organization-scoped requests would serve them the whole estate — the exact failure this parameter exists to prevent — and without that test the change would look correct.

Refs #439
