### PR TITLE
fix(maintenance): rekey-secrets reports the columns it does not certify

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -1121,5 +1121,32 @@ func runRekeySecrets(cfg *config.Config, verify bool) error {
 	for name, res := range results {
 		slog.Info("rekey-secrets column complete", "mode", mode, "column", name, "result", res.String())
 	}
+
+	// SAY WHAT THIS GATE DOES NOT CERTIFY (#878).
+	//
+	// verify answers one question -- may ENCRYPTION_KEY_PREVIOUS be dropped? --
+	// and used to answer it while silent about the columns no sweep touches. An
+	// operator could follow the runbook exactly, see it exit zero, drop the
+	// previous key, and leave unrefreshed user SCM links unreadable.
+	//
+	// Printed in BOTH modes, deliberately. The re-encrypt run is where an
+	// operator forms the belief that everything has been converted, so that is
+	// exactly where the exclusion needs saying.
+	for _, u := range maintenance.ReportUncovered(context.Background(), database) {
+		if u.CountFailed != nil {
+			slog.Warn("rekey-secrets: could not count an uncovered column",
+				"column", u.Column, "error", u.CountFailed,
+				"impact", "this column is NOT covered by the gate and its population is unknown")
+			continue
+		}
+		if u.Rows == 0 {
+			slog.Info("rekey-secrets: uncovered column is empty",
+				"column", u.Column, "rows", 0)
+			continue
+		}
+		slog.Warn("rekey-secrets: rows NOT covered by this gate",
+			"column", u.Column, "rows", u.Rows, "reason", u.Reason,
+			"impact", "a green verify does not certify these rows; dropping ENCRYPTION_KEY_PREVIOUS may make them unreadable")
+	}
 	return err
 }

--- a/backend/internal/maintenance/rekey_coverage_test.go
+++ b/backend/internal/maintenance/rekey_coverage_test.go
@@ -56,17 +56,35 @@ var sweptAADContexts = map[string]string{
 // re-enter — but it is not "nothing", and docs/secrets-rotation.md says so
 // rather than letting the gate imply a coverage it does not have.
 //
-// They are also not reachable from the registry as it stands: column.context
-// takes one row-id string, and both scm_oauth_tokens contexts are derived from
-// a user id AND a provider id (see internal/scm/aad.go). Widening the registry
-// to carry composite keys is a change to the binding sweep as much as to this
-// one, and belongs to its own issue rather than being smuggled in behind a
-// rotation fix.
+// WHY THEY ARE NOT SWEPT -- and it is NOT that the registry cannot address them.
+// An earlier revision of this comment said the single-row-id registry "cannot
+// express" a key derived from a user id AND a provider id. That is mechanically
+// false: sealedRow.id is an opaque string the column's own rows() supplies, and
+// systemSettingsID already passes a non-row-id through it. Anyone who read that
+// and set out to "just widen the registry" would find nothing in the way, which
+// is the dangerous shape for a wrong reason to have.
+//
+// The real obstacle is that a wrong AAD derivation here is NOT fail-closed.
+// TokenCipher's OpenWithContextOrLegacy discards the supplied AAD on its legacy
+// fallback, so a sweep that derives the AAD wrongly still opens every unbound
+// row, re-seals it under the wrong AAD, satisfies its own round-trip proof, and
+// reports green -- on this run and on every verify afterwards. The gate cannot
+// catch it, because the gate and the sweep derive the AAD from the same
+// col.context. The damage is silent, permanent, and indistinguishable from
+// success.
+//
+// So the exemption stands, and #878 closed the harm the other way: verify now
+// COUNTS these rows and says out loud that it does not certify them (see
+// uncovered.go). An operator gets a number instead of silence before they drop
+// ENCRYPTION_KEY_PREVIOUS. Sweeping them needs a differential probe that reads
+// under the bound AAD and the legacy path separately -- design it before
+// writing it.
 var unsweptAADContexts = map[string]string{
 	"ProviderTokenContext": "scm_provider_tokens.access_token_encrypted is a cache with an expiry; " +
 		"entries are re-minted from the identity provider, so the table converts itself",
-	"UserTokenContext": "scm_oauth_tokens.access_token_encrypted is keyed by user AND provider, " +
-		"which the single-row-id registry cannot express; a lost token is restored by the user re-linking",
+	"UserTokenContext": "scm_oauth_tokens.access_token_encrypted is keyed by user AND provider, and a " +
+		"wrong AAD derivation would convert it silently rather than failing; a lost token is restored " +
+		"by the user re-linking",
 	"UserRefreshTokenContext": "scm_oauth_tokens.refresh_token_encrypted, as above",
 }
 

--- a/backend/internal/maintenance/uncovered.go
+++ b/backend/internal/maintenance/uncovered.go
@@ -1,0 +1,132 @@
+// Package maintenance - uncovered.go makes the rekey gate say what it does NOT
+// certify (#878).
+//
+// THE DEFECT THIS CLOSES IS A REPORTING ONE, NOT A COVERAGE ONE. `rekey-secrets
+// verify` exists to answer exactly one question: is it safe to drop
+// ENCRYPTION_KEY_PREVIOUS? It answers that for the columns it sweeps, and says
+// NOTHING about the columns it does not. An operator can follow the runbook
+// exactly, see verify exit zero, drop the previous key, and leave unrefreshed
+// user SCM links unreadable until those users re-link.
+//
+// A gate that reports success over a set narrower than the operator believes it
+// covers converts an unknown into a wrong answer. That is worse than no gate,
+// and it is fixed by printing a number rather than by re-encrypting anything.
+//
+// WHY THIS COUNTS ROWS AND DOES NOT TOUCH CIPHERTEXT. The obvious next step --
+// sweep the columns too -- is not safe to take blind, and the reason is
+// specific. The AAD for these two columns derives from the row's user and
+// provider ids, and a sweep that derives it WRONGLY is not fail-closed on the
+// rows that matter: TokenCipher's legacy fallback discards the supplied AAD, so
+// an unbound row opens anyway, gets re-sealed under the wrong AAD, passes the
+// sweep's own round-trip proof, and reports green on every later verify. The
+// gate cannot catch that, because the gate and the sweep derive the AAD the same
+// way.
+//
+// A read-only count cannot do any of that. Its worst failure is an inaccurate
+// number, which is loud and free to correct.
+package maintenance
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// UncoveredColumn is an encrypted column the rekey sweep does not convert.
+//
+// ContextFunc names the AAD derivation, and is the join key with the coverage
+// guard's exemption list -- so an exemption cannot be added without the operator
+// being told about the rows behind it, and this list cannot name a column the
+// guard does not know about.
+//
+// Name IS THE QUERY, not a label for it. The COUNT is built by splitting this
+// one string, so the identifier a test checks against the migrations and the
+// identifier the statement actually selects on cannot be different. An earlier
+// draft carried the table and column a second time inside the count and was
+// provably inert: misspelling them there left Name correct, the typo-catcher
+// green, and the query erroring at runtime into "population unknown" -- a
+// softer, more ignorable version of the silence this whole file replaces.
+type UncoveredColumn struct {
+	Name        string
+	ContextFunc string
+	Reason      string
+}
+
+// count returns how many rows currently hold a non-empty secret in this column.
+func (c UncoveredColumn) count(ctx context.Context, db *sql.DB) (int, error) {
+	table, column, ok := strings.Cut(c.Name, ".")
+	if !ok {
+		return 0, fmt.Errorf("uncovered column %q is not in table.column form", c.Name)
+	}
+	// Identifiers come from the constant registry below, never caller input.
+	q := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s IS NOT NULL AND %s <> ''`, table, column, column) // #nosec G201
+	var n int
+	if err := db.QueryRowContext(ctx, q).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// UncoveredReport is one column's population at verify time.
+type UncoveredReport struct {
+	Column      string
+	Reason      string
+	Rows        int
+	CountFailed error
+}
+
+// uncoveredColumns is the registry. Every entry must have a matching exemption
+// in the coverage guard, and vice versa -- asserted bidirectionally in
+// uncovered_test.go, so neither list can drift from the other.
+var uncoveredColumns = []UncoveredColumn{
+	{
+		Name:        "scm_oauth_tokens.access_token_encrypted",
+		ContextFunc: "UserTokenContext",
+		Reason: "not swept: the AAD derives from the row's user and provider ids. " +
+			"A lost token is restored by that user re-linking their account.",
+	},
+	{
+		Name:        "scm_oauth_tokens.refresh_token_encrypted",
+		ContextFunc: "UserRefreshTokenContext",
+		Reason:      "not swept, as above. Without it a link cannot refresh and the user must re-link.",
+	},
+	{
+		Name:        "scm_provider_tokens.access_token_encrypted",
+		ContextFunc: "ProviderTokenContext",
+		Reason: "not swept, and does not need to be: a cache with an expiry whose entries are " +
+			"re-minted from the provider, so the table converts itself.",
+	},
+}
+
+// ReportUncovered counts the rows in every column the rekey sweep does not
+// convert.
+//
+// A failing count is reported per column rather than aborting: the point is to
+// tell the operator what the gate does not cover, and losing that message
+// because one table was unreadable would reinstate exactly the silence this
+// exists to end.
+func ReportUncovered(ctx context.Context, db *sql.DB) []UncoveredReport {
+	out := make([]UncoveredReport, 0, len(uncoveredColumns))
+	for _, c := range uncoveredColumns {
+		r := UncoveredReport{Column: c.Name, Reason: c.Reason}
+		n, err := c.count(ctx, db)
+		if err != nil {
+			r.CountFailed = err
+		} else {
+			r.Rows = n
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// UncoveredContextFuncs returns the AAD derivations this registry declares
+// uncovered, for the coverage guard to check itself against.
+func UncoveredContextFuncs() []string {
+	out := make([]string, 0, len(uncoveredColumns))
+	for _, c := range uncoveredColumns {
+		out = append(out, c.ContextFunc)
+	}
+	return out
+}

--- a/backend/internal/maintenance/uncovered_test.go
+++ b/backend/internal/maintenance/uncovered_test.go
@@ -1,0 +1,255 @@
+package maintenance
+
+// uncovered_test.go holds the registry of uncovered columns to the same standard
+// as the coverage guard next to it: checked in BOTH directions, because a
+// one-way check rots.
+//
+// The two lists describe the same set from opposite ends -- the guard says
+// "these AAD derivations are deliberately not swept", this registry says "these
+// columns therefore need counting so the operator hears about them". If they can
+// drift, the failure is silent and lands in exactly the place #878 is about: an
+// exemption gets added, the operator is told nothing about the rows behind it,
+// and verify keeps exiting zero over a set narrower than they believe.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUncoveredRegistryMatchesCoverageExemptions(t *testing.T) {
+	declared := map[string]int{}
+	for _, f := range UncoveredContextFuncs() {
+		declared[f]++
+	}
+
+	// Every exemption must produce a report. This is the direction that
+	// matters most: an exemption without one is a column the gate excludes
+	// and never mentions, which is the defect itself.
+	for fn := range unsweptAADContexts {
+		if declared[fn] == 0 {
+			t.Errorf("AAD context %q is exempted from the rekey sweep but no uncovered column reports it.\n"+
+				"An operator running `rekey-secrets verify` would be told nothing about those rows and could "+
+				"drop ENCRYPTION_KEY_PREVIOUS believing they were covered.\n"+
+				"Add an entry to uncoveredColumns in uncovered.go naming the column and a COUNT for it.", fn)
+		}
+	}
+
+	// And no report may name an exemption that no longer exists -- that is a
+	// column being counted and warned about after it started being swept,
+	// which teaches operators to ignore the warning.
+	for fn := range declared {
+		if _, ok := unsweptAADContexts[fn]; !ok {
+			t.Errorf("uncoveredColumns reports AAD context %q, but it is not exempted in unsweptAADContexts.\n"+
+				"Either it is swept now (drop the uncovered entry) or the guard has lost the exemption.", fn)
+		}
+	}
+}
+
+func TestUncoveredRegistryIsWellFormed(t *testing.T) {
+	if len(uncoveredColumns) == 0 {
+		t.Fatal("uncoveredColumns is empty; the bidirectional check above would then pass vacuously")
+	}
+	seen := map[string]bool{}
+	for _, c := range uncoveredColumns {
+		switch {
+		case c.Name == "":
+			t.Error("an uncovered column has no name; the operator warning would not say which column")
+		case c.ContextFunc == "":
+			t.Errorf("uncovered column %q has no ContextFunc, so it cannot be joined to the coverage guard", c.Name)
+		case c.Reason == "":
+			t.Errorf("uncovered column %q has no reason; a warning without one reads as noise and gets ignored", c.Name)
+		case !strings.Contains(c.Name, "."):
+			t.Errorf("uncovered column %q is not in table.column form, so its COUNT cannot be built from it", c.Name)
+		}
+		if seen[c.Name] {
+			t.Errorf("uncovered column %q is listed twice; it would be counted and warned about twice", c.Name)
+		}
+		seen[c.Name] = true
+	}
+}
+
+// TestReportUncoveredCountsOnlyNonEmptyAndNeverWrites is the safety property.
+//
+// This whole feature exists BECAUSE re-encrypting these columns is unsafe to do
+// blind: the AAD derives from the row's user and provider ids, and TokenCipher's
+// legacy fallback discards a supplied AAD -- so a wrong derivation opens an
+// unbound row anyway, re-seals it wrongly, and passes its own round-trip proof.
+// The count is the safe half. sqlmock fails the test on any statement that was
+// not expected, so an UPDATE or a ciphertext read introduced here is caught.
+func TestReportUncoveredCountsOnlyNonEmptyAndNeverWrites(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for i := range uncoveredColumns {
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)`)).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(i + 1))
+	}
+
+	got := ReportUncovered(context.Background(), db)
+	if len(got) != len(uncoveredColumns) {
+		t.Fatalf("reported %d columns, registry has %d", len(got), len(uncoveredColumns))
+	}
+	for i, r := range got {
+		if r.CountFailed != nil {
+			t.Errorf("%s: unexpected count failure: %v", r.Column, r.CountFailed)
+		}
+		if r.Rows != i+1 {
+			t.Errorf("%s: rows = %d, want %d", r.Column, r.Rows, i+1)
+		}
+		if r.Reason == "" {
+			t.Errorf("%s: reason did not survive into the report", r.Column)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestReportUncoveredKeepsGoingWhenOneCountFails guards the reason the report
+// does not abort on error.
+//
+// Losing every column's message because one table was unreadable would reinstate
+// precisely the silence this exists to end -- and it would do it on the runs
+// most likely to be unusual, which are the runs where the operator most needs
+// the list.
+func TestReportUncoveredKeepsGoingWhenOneCountFails(t *testing.T) {
+	if len(uncoveredColumns) < 2 {
+		t.Skip("needs at least two columns to show the second still reports")
+	}
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	boom := errors.New("relation does not exist")
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)`)).WillReturnError(boom)
+	for range uncoveredColumns[1:] {
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)`)).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
+	}
+
+	got := ReportUncovered(context.Background(), db)
+	if len(got) != len(uncoveredColumns) {
+		t.Fatalf("a failing count truncated the report: got %d of %d columns", len(got), len(uncoveredColumns))
+	}
+	if !errors.Is(got[0].CountFailed, boom) {
+		t.Errorf("first column: CountFailed = %v, want the query error surfaced", got[0].CountFailed)
+	}
+	if got[0].Rows != 0 {
+		t.Errorf("a failed count reported %d rows; it must not look like a real zero", got[0].Rows)
+	}
+	for _, r := range got[1:] {
+		if r.CountFailed != nil {
+			t.Errorf("%s: reporting stopped after the failure: %v", r.Column, r.CountFailed)
+		}
+		if r.Rows != 7 {
+			t.Errorf("%s: rows = %d, want 7", r.Column, r.Rows)
+		}
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// TestUncoveredCountsTargetRealColumns keeps the COUNT statements honest.
+//
+// A count against a misspelled column errors at runtime and shows up as
+// "population unknown" -- which is a softer, more ignorable version of the
+// silence this replaces. The names are checked against the migrations rather
+// than trusted.
+//
+// This assertion is only worth anything because Name IS the query: when the
+// registry carried the identifiers a second time inside the count, misspelling
+// them there left this test green. Do not reintroduce a second copy.
+func TestUncoveredCountsTargetRealColumns(t *testing.T) {
+	sorted := make([]string, 0, len(uncoveredColumns))
+	for _, c := range uncoveredColumns {
+		sorted = append(sorted, c.Name)
+	}
+	sort.Strings(sorted)
+	for _, name := range sorted {
+		if !migrationsDefineColumn(t, name) {
+			t.Errorf("uncovered column %q is not defined by any migration; its COUNT would error "+
+				"and report the population as unknown", name)
+		}
+	}
+}
+
+// migrationsDefineColumn reports whether "table.column" appears as a column of
+// that table anywhere in the migration set.
+//
+// Deliberately textual and loose: it must tolerate a column arriving in one
+// migration and its table in another, so it looks for the table being named and
+// the column being named in the same file. It is a typo catcher, not a schema
+// model -- the assertion it supports is only "this identifier exists".
+//
+// MATCHED ON WORD BOUNDARIES, not substrings. A plain strings.Contains was inert
+// against the likeliest typo of all -- a dropped trailing letter -- because
+// "scm_oauth_token" is a substring of "scm_oauth_tokens" and matched happily.
+func identifierRe(name string) *regexp.Regexp {
+	// \b is not enough on its own: SQL identifiers contain underscores, which
+	// are word characters, so \bscm_oauth_token\b happily matches inside
+	// scm_oauth_tokens. Assert the neighbours are not identifier characters.
+	return regexp.MustCompile(`(^|[^A-Za-z0-9_])` + regexp.QuoteMeta(name) + `($|[^A-Za-z0-9_])`)
+}
+
+func migrationsDefineColumn(t *testing.T, qualified string) bool {
+	t.Helper()
+	table, column, ok := strings.Cut(qualified, ".")
+	if !ok {
+		t.Fatalf("uncovered column %q is not in table.column form", qualified)
+	}
+	dir := filepath.Join("..", "db", "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".up.sql") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name())) // #nosec G304 -- test-only, directory listing
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		sql := string(b)
+		if identifierRe(table).MatchString(sql) && identifierRe(column).MatchString(sql) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestUncoveredCountRejectsMalformedName covers the branch the registry guard
+// makes unreachable, so that if someone relaxes that guard the failure is an
+// error rather than a SQL statement built from a half-parsed identifier.
+func TestUncoveredCountRejectsMalformedName(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, err = UncoveredColumn{Name: "no_dot_here"}.count(context.Background(), db)
+	if err == nil {
+		t.Fatal("a name with no table.column split produced no error; a malformed identifier must not reach a statement")
+	}
+	if !strings.Contains(err.Error(), "table.column") {
+		t.Errorf("error does not say what is wrong with the name: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("a query was issued for a malformed name: %v", err)
+	}
+}

--- a/backend/internal/maintenance/uncovered_wiring_class_test.go
+++ b/backend/internal/maintenance/uncovered_wiring_class_test.go
@@ -1,0 +1,139 @@
+package maintenance
+
+// uncovered_wiring_class_test.go guards the WIRING, not the report.
+//
+// uncovered_test.go proves ReportUncovered counts the right rows. It says
+// nothing about whether anyone calls it -- and an uncalled report is exactly the
+// silence #878 is about, restored, while every other test stays green. That is
+// the shape of an inert guard: correct machinery nothing invokes.
+//
+// Checked at the source level because the thing being asserted is a wiring fact
+// about a command, and the alternative (execute the command against a real
+// database) tests the report a second time rather than the wiring once.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestEveryRekeySecretsRunReportsUncoveredColumns asserts the operator-facing
+// rekey command still tells the operator what it does not certify.
+//
+// BOTH MODES, deliberately. A re-encrypt run is where an operator forms the
+// belief that everything has been converted, so restricting the report to
+// `verify` would leave the more dangerous half silent.
+func TestEveryRekeySecretsRunReportsUncoveredColumns(t *testing.T) {
+	const cmd = "../../cmd/server/main.go"
+	b, err := os.ReadFile(cmd)
+	if err != nil {
+		t.Fatalf("read %s: %v", cmd, err)
+	}
+	body, ok := funcBody(string(b), "runRekeySecrets")
+	if !ok {
+		t.Fatalf("runRekeySecrets not found in %s.\n"+
+			"If it was renamed or moved, point this guard at the new one -- do not delete it: "+
+			"it is the only thing keeping `rekey-secrets` from going silent about its uncovered columns again.",
+			filepath.Base(cmd))
+	}
+	if !strings.Contains(body, "maintenance.ReportUncovered(") {
+		t.Errorf("runRekeySecrets does not call maintenance.ReportUncovered.\n" +
+			"Both `rekey-secrets` and `rekey-secrets verify` must print the population of every column " +
+			"the sweep does not convert (#878). Without it an operator sees a zero exit, drops " +
+			"ENCRYPTION_KEY_PREVIOUS, and leaves unrefreshed user SCM links unreadable.")
+	}
+	// The count is only useful if it is loud. slog.Info scrolls past in a
+	// deploy log; the whole point is that a non-zero count interrupts someone.
+	if !regexp.MustCompile(`slog\.Warn\(\s*"rekey-secrets: rows NOT covered`).MatchString(body) {
+		t.Errorf("the non-zero uncovered-row count is not reported at WARN.\n" +
+			"An operator about to delete a key reads warnings; they scroll past info lines.")
+	}
+
+	// AND THE REPORT MUST NOT BE GATED ON THE MODE.
+	//
+	// Asserting the call merely EXISTS was provably inert: wrapping the loop in
+	// `if verify` kept it present, kept the WARN literal present, kept this test
+	// green, and silenced the re-encrypt run -- the run where an operator forms
+	// the belief that everything has been converted. docs/secrets-rotation.md
+	// tells operators both runs print the counts, so that is the property.
+	//
+	// Checked as "the mode flag is not referenced from the report onward",
+	// which is exactly what "unconditional" means here and does not depend on
+	// how the branch is spelled.
+	if i := strings.Index(body, "maintenance.ReportUncovered("); i >= 0 {
+		// Strip string literals first. The log lines legitimately contain the
+		// word "verify" ("a green verify does not certify these rows"), and
+		// matching inside them made this fire on correct code -- a guard that
+		// cries wolf gets deleted, which is how the property would be lost.
+		tail := stripGoStrings(body[i:])
+		if regexp.MustCompile(`\bverify\b`).MatchString(tail) {
+			t.Errorf("the uncovered-column report is gated on the `verify` flag.\n"+
+				"It must run in BOTH modes: docs/secrets-rotation.md promises the counts on the "+
+				"re-encrypt run too, and that is the run that convinces an operator the sweep was "+
+				"total. Offending code:\n%s", strings.TrimSpace(tail))
+		}
+	}
+}
+
+// stripGoStrings blanks the contents of interpreted and raw string literals,
+// preserving offsets so an excerpt still reads sensibly.
+func stripGoStrings(src string) string {
+	out := []byte(src)
+	for i := 0; i < len(out); i++ {
+		var closer byte
+		switch out[i] {
+		case '"':
+			closer = '"'
+		case '`':
+			closer = '`'
+		default:
+			continue
+		}
+		j := i + 1
+		for j < len(out) {
+			if closer == '"' && out[j] == '\\' {
+				j += 2
+				continue
+			}
+			if out[j] == closer {
+				break
+			}
+			out[j] = ' '
+			j++
+		}
+		i = j
+	}
+	return string(out)
+}
+
+// funcBody returns the body of the named top-level func, matched by brace depth.
+//
+// Brace counting rather than a regex to the closing brace: the body contains
+// braces, and a lazy match would stop at the first one and let the assertions
+// pass against a fragment.
+func funcBody(src, name string) (string, bool) {
+	i := strings.Index(src, "\nfunc "+name+"(")
+	if i < 0 {
+		return "", false
+	}
+	open := strings.Index(src[i:], "{")
+	if open < 0 {
+		return "", false
+	}
+	start := i + open
+	depth := 0
+	for j := start; j < len(src); j++ {
+		switch src[j] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : j+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/backend/internal/scm/aad.go
+++ b/backend/internal/scm/aad.go
@@ -41,6 +41,15 @@ func ProviderTokenContext(scmProviderID uuid.UUID) []byte {
 // UserTokenContext binds a user's OAuth access token to its row in
 // scm_user_tokens.
 //
+// DO NOT "FIX" THE TABLE NAME IN THESE LITERALS. There is no scm_user_tokens
+// table and there never has been -- the rows live in scm_oauth_tokens. The
+// string is not a reference to a table, it is an opaque domain separator that is
+// already baked into every ciphertext in production. Changing it to the real
+// table name changes the AAD, and every existing token then fails to open: not
+// at deploy time where it would be noticed, but the next time each individual
+// user's SCM link is used. Every affected user must re-link. The misleading name
+// is cheaper than the migration to correct it.
+//
 // The row is keyed by BOTH the user and the provider, so both are in the
 // context: binding to one axis alone would let a token be replayed across the
 // other. Every SCMUserTokenRecord carries both fields, so read sites derive this

--- a/docs/secrets-rotation.md
+++ b/docs/secrets-rotation.md
@@ -187,6 +187,30 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
    A non-zero exit means at least one row still requires the previous key, or could not be
    read at all. Both hold the gate shut, and both are logged per column with a row id.
 
+   **The gate is narrower than "every secret", and it now tells you so.** Two tables are
+   deliberately not swept, so a zero exit says nothing about them:
+
+   | Column | Rows not covered |
+   |---|---|
+   | `scm_oauth_tokens.access_token_encrypted` | each user's SCM link |
+   | `scm_oauth_tokens.refresh_token_encrypted` | each user's SCM link |
+   | `scm_provider_tokens.access_token_encrypted` | cached app tokens (re-minted automatically) |
+
+   Both `verify` and the re-encrypt run print a count for each of these before exiting, at
+   `WARN` when the count is non-zero:
+
+   ```
+   WARN rekey-secrets: rows NOT covered by this gate column=scm_oauth_tokens.access_token_encrypted rows=214
+   ```
+
+   That number is what to weigh. These rows are sealed under whichever key was current when
+   each user last linked, so some may still need `ENCRYPTION_KEY_PREVIOUS` even when the
+   gate is green. Dropping it does not corrupt them and no administrator has to re-enter
+   anything — but every affected user's SCM link stops working until they **re-link**, and
+   they find out by hitting a failure, not at deploy time. With a non-zero count, either
+   accept that or have those users re-link first; the count going to zero on its own is
+   also fine to wait for on the `scm_provider_tokens` row, which re-mints itself.
+
    Removing `ENCRYPTION_KEY_PREVIOUS` while any row is still encrypted under it makes that
    secret **permanently unreadable**, by the service and by these commands alike, and it
    has to be re-entered by an administrator. There is no undo. When the gate is red, keep
@@ -208,6 +232,7 @@ The encryption key protects SCM OAuth tokens stored in the database. The backend
 | Rolling restart                                  | Day 0                               |
 | `rekey-secrets` (re-encrypt everything)         | Day 0 - Day 7                       |
 | `rekey-secrets verify` returns zero             | Before removing the previous key    |
+| Weigh the uncovered-row counts it prints        | Before removing the previous key    |
 | Remove previous key                             | Day 7+ (only after the gate is green) |
 
 ### Completing a Rotation: `rekey-secrets`


### PR DESCRIPTION
Closes #878.

## What the issue asked, and what this does

The issue's harm is a reporting one:

> An operator can follow the runbook exactly, see `verify` exit zero, drop the previous key, and leave **unrefreshed user SCM links unreadable** until those users re-link. The gate reports success over a set narrower than the operator believes it covers — which converts an unknown into a wrong answer.

Both `rekey-secrets` and `rekey-secrets verify` now count the rows in every column the sweep does not convert, and log the non-zero ones at `WARN`:

```
WARN rekey-secrets: rows NOT covered by this gate column=scm_oauth_tokens.access_token_encrypted rows=214 impact="a green verify does not certify these rows; dropping ENCRYPTION_KEY_PREVIOUS may make them unreadable"
```

`docs/secrets-rotation.md` states the exclusion at step 7 — the step where the key actually gets deleted — with the three columns, what "not covered" costs (users re-link; no administrator re-entry, no corruption), and a checklist row.

## Why counts and not a sweep

The larger fix the issue gestures at — sweep these columns too — **is not safe to take blind**, and this PR deliberately does not attempt it.

`OpenWithContextOrLegacy` (suite-identity v0.36.0, `tokencipher.go:246-262`) discards the supplied AAD on its legacy fallback. So a sweep that derives the AAD *wrongly* still opens every unbound row, re-seals it under the wrong AAD, satisfies its own round-trip proof at `rekeysecrets.go:134`, and reports green — on that run and on every `verify` afterwards. The gate cannot detect the one error class that matters, because the gate and the sweep both derive from `col.context`.

A read-only count cannot do any of that. Its worst failure is an inaccurate number, which is loud and free to correct. Sweeping these columns needs a differential probe that reads under the bound AAD and the legacy path *separately*; that wants designing before it is written, and it is not this PR.

## Two false premises corrected

**1. The registry can address these columns.** The exemption comment said they were unreachable because `column.context` takes one row id and these keys are composite:

> which the single-row-id registry cannot express

That is mechanically false. `sealedRow.id` is an opaque string the column's own `rows()` supplies, and `systemSettingsID = "1"` already passes a non-row-id through it. Anyone who read that comment and set out to "just widen the registry" would find nothing in the way — the dangerous shape for a wrong reason to have. The comment now records the real obstacle (the non-fail-closed AAD above).

**2. `scm_user_tokens` is not a table and never has been.** `internal/scm/aad.go` binds these tokens with the literal `"scm_user_tokens:"`; the rows live in `scm_oauth_tokens`. `grep -rn "scm_user_tokens" internal/db/migrations/` returns nothing.

It is not a table reference — it is an opaque domain separator already baked into every production ciphertext. "Correcting" it to the real table name changes the AAD and makes every existing token fail to open: not at deploy time where it would be noticed, but the next time each individual user's SCM link is used. Marked do-not-fix in place.

## Guards

Ten mutations, each confirmed to **apply and compile** before its test result was believed.

| Mutation | Caught by |
|---|---|
| drop an exemption's report | `MatchesCoverageExemptions` |
| report a context nobody exempted | `MatchesCoverageExemptions` |
| typo a column / table / prefix / suffix (×4) | `CountsTargetRealColumns` |
| abort the report on first count error | `KeepsGoingWhenOneCountFails` |
| let a failed count report as a real zero | `KeepsGoingWhenOneCountFails` |
| delete the report loop | wiring guard |
| downgrade the non-zero count to `Info` | wiring guard |
| gate the report on `verify` (two spellings) | wiring guard |

**Two were inert on the first attempt**, and both are the same shape — a check that looked at a copy rather than at the thing that runs:

- The registry carried the table and column a *second time* inside its count closure. Misspelling them there left `Name` correct, the migration typo-catcher green, and the query erroring at runtime into "population unknown" — a softer, more ignorable version of the silence being fixed. `Name` is now the query, not a label for it, so they cannot disagree.
- The wiring guard asserted the report call merely *existed*. Wrapping the loop in `if verify` kept it present, kept the `WARN` literal present, kept the guard green, and silenced the re-encrypt run — the run where an operator forms the belief that everything has been converted. It now asserts the mode flag is unreferenced from the report onward.

The typo-catcher additionally matched on substrings, so the likeliest typo of all — a dropped trailing letter — passed, because `scm_oauth_token` is contained in `scm_oauth_tokens`. It matches on identifier boundaries now (`\b` alone is insufficient: `_` is a word character), verified against four typo shapes.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on the touched packages — 0 issues
- `internal/maintenance` coverage 88.3%
