### PR TITLE
fix(storage): sign local download URLs, and verify them before serving

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -15916,7 +15916,7 @@
         },
         "/v1/files/{filepath}": {
             "get": {
-                "description": "Streams a stored archive file. Only registered when the local storage backend has ServeDirectly enabled. Path traversal sequences are rejected.",
+                "description": "Streams a stored archive file. Requires the `expires` and `sig` query parameters produced by the local storage backend's signed download URL; unsigned, forged or expired requests are rejected with 403. Path traversal sequences are rejected.",
                 "tags": [
                     "Files"
                 ],
@@ -15930,6 +15930,24 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Signature expiry, unix seconds",
+                        "name": "expires",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "URL signature",
+                        "name": "sig",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "responses": {
@@ -15938,6 +15956,17 @@
                     },
                     "400": {
                         "description": "Invalid file path",
+                        "content": {
+                            "application/octet-stream": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Invalid or expired download URL",
                         "content": {
                             "application/octet-stream": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12867,7 +12867,7 @@
         },
         "/v1/files/{filepath}": {
             "get": {
-                "description": "Streams a stored archive file. Only registered when the local storage backend has ServeDirectly enabled. Path traversal sequences are rejected.",
+                "description": "Streams a stored archive file. Requires the `expires` and `sig` query parameters produced by the local storage backend's signed download URL; unsigned, forged or expired requests are rejected with 403. Path traversal sequences are rejected.",
                 "produces": [
                     "application/octet-stream"
                 ],
@@ -12882,6 +12882,20 @@
                         "name": "filepath",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Signature expiry, unix seconds",
+                        "name": "expires",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "URL signature",
+                        "name": "sig",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -12890,6 +12904,13 @@
                     },
                     "400": {
                         "description": "Invalid file path",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "Invalid or expired download URL",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/mirror/main_test.go
+++ b/backend/internal/api/mirror/main_test.go
@@ -1,0 +1,21 @@
+package mirror
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain installs a JWT secret before any test runs.
+//
+// The mirror hands Terraform a local-storage download URL, which is now signed
+// (#973) with a key derived from the JWT secret. Without one GetURL fails closed
+// and the handler 500s rather than emitting an unsigned URL -- correct
+// behaviour, but it needs a secret here to exercise the success path.
+// auth.ValidateJWTSecret is sync.Once-guarded, so this has to happen before the
+// first test rather than inside one.
+func TestMain(m *testing.M) {
+	if os.Getenv("TFR_JWT_SECRET") == "" {
+		_ = os.Setenv("TFR_JWT_SECRET", "test-secret-for-url-signing-0123456789abcdef")
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/api/modules/main_test.go
+++ b/backend/internal/api/modules/main_test.go
@@ -1,0 +1,19 @@
+package modules
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain installs a JWT secret before any test runs.
+//
+// GET /v1/files/*filepath now requires a signature (#973), derived from the JWT
+// secret. auth.ValidateJWTSecret is sync.Once-guarded, so the value must be in
+// the environment before the FIRST test touches it -- t.Setenv inside a single
+// test would leave the rest of the package dependent on run order.
+func TestMain(m *testing.M) {
+	if os.Getenv("TFR_JWT_SECRET") == "" {
+		_ = os.Setenv("TFR_JWT_SECRET", "test-secret-for-url-signing-0123456789abcdef")
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -11,6 +11,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +22,7 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/storage/urlsign"
 )
 
 // assertErrorsArrayBody fails the test unless the response body is shaped
@@ -56,6 +59,11 @@ type mockStore struct {
 	existsErr    error
 	metadataErr  error
 	downloadErr  error
+	// existsCalls records storage reachability. #973 turns on the handler
+	// refusing an unsigned caller BEFORE touching storage -- asserting only the
+	// status code would pass just as well if the check ran after Exists, which
+	// would still leak which keys are present through timing and error shape.
+	existsCalls int
 }
 
 func (m *mockStore) Upload(_ context.Context, _ string, _ io.Reader, _ int64) (*storage.UploadResult, error) {
@@ -72,6 +80,7 @@ func (m *mockStore) GetURL(_ context.Context, _ string, _ time.Duration) (string
 	return m.getURLResult, m.getURLErr
 }
 func (m *mockStore) Exists(_ context.Context, _ string) (bool, error) {
+	m.existsCalls++
 	return m.existsResult, m.existsErr
 }
 func (m *mockStore) GetMetadata(_ context.Context, _ string) (*storage.FileMetadata, error) {
@@ -207,6 +216,22 @@ func doGET(r *gin.Engine, path string) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(http.MethodGet, path, nil)
 	r.ServeHTTP(w, req)
 	return w
+}
+
+// doSignedGET fetches a /v1/files path with a valid signature attached (#973).
+//
+// The route has no authentication middleware and now requires a signature from
+// LocalStorage.GetURL, so every positive test has to present one. Signed here
+// rather than hard-coded, because a fixture signature would silently stop
+// exercising the verifier the first time the scheme changed.
+func doSignedGET(t *testing.T, r *gin.Engine, storageKey string) *httptest.ResponseRecorder {
+	t.Helper()
+	expires, sig, err := urlsign.Sign(storageKey, 15*time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("sign %q: %v", storageKey, err)
+	}
+	q := neturl.Values{urlsign.ParamExpires: {expires}, urlsign.ParamSignature: {sig}}
+	return doGET(r, "/v1/files/"+storageKey+"?"+q.Encode())
 }
 
 // ---------------------------------------------------------------------------
@@ -480,23 +505,108 @@ func TestDownloadHandler_StorageError(t *testing.T) {
 // ServeFileHandler tests
 // ---------------------------------------------------------------------------
 
+// TestServeFileHandler_SlashOnlyPath — now 403, not 404.
+//
+// gin's *filepath wildcard sets filepath="/" here, which strips to the empty
+// string. It used to reach Exists("") and 404. Since #973 the signature check
+// runs first, so an unsigned request is refused before any storage call -- which
+// is the point: the handler must not answer "does this key exist?" for a caller
+// who cannot sign for it.
 func TestServeFileHandler_SlashOnlyPath(t *testing.T) {
-	// gin wildcard *filepath with path "/v1/files/" sets filepath="/"; after stripping leading slash
-	// becomes empty string → Exists("") returns false → 404
 	store := &mockStore{existsResult: false}
 	r := newServeRouter(t, store)
 	w := doGET(r, "/v1/files/")
-	if w.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want 404", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+	if store.existsCalls != 0 {
+		t.Errorf("storage was consulted %d times for an unsigned request; "+
+			"an unauthenticated caller must not be able to probe which keys exist", store.existsCalls)
 	}
 	assertErrorsArrayBody(t, w)
+}
+
+// TestServeFileHandler_RejectsUnsignedAndForged is the #973 regression.
+//
+// GET /v1/files/*filepath has no authentication middleware of any kind, and
+// storage keys are structural -- modules/{ns}/{name}/{system}/{version}.tar.gz,
+// terraform-binaries/{version}/{os}/{arch}/{file}. Before this, anyone who could
+// reach the port could enumerate and download every module archive and terraform
+// binary anonymously, with the fetch recorded nowhere as an authorised download.
+//
+// Table-driven over the whole class rather than the one reported shape: no
+// signature at all, a truncated one, one minted for a DIFFERENT object, and one
+// that has expired. The cross-object case is the one that matters most -- if the
+// MAC did not cover the path, a single legitimate download URL would unlock all
+// of storage.
+func TestServeFileHandler_RejectsUnsignedAndForged(t *testing.T) {
+	const target = "modules/acme/vpc/aws/1.0.0.tar.gz"
+
+	validExpires, validSig, err := urlsign.Sign(target, 15*time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	otherExpires, otherSig, err := urlsign.Sign("modules/acme/other/aws/1.0.0.tar.gz", 15*time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("sign other: %v", err)
+	}
+	staleExpires, staleSig, err := urlsign.Sign(target, -1*time.Minute, time.Now())
+	if err != nil {
+		t.Fatalf("sign stale: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{"no signature at all", ""},
+		{"expires but no sig", "?" + urlsign.ParamExpires + "=" + validExpires},
+		{"sig but no expires", "?" + urlsign.ParamSignature + "=" + validSig},
+		{"truncated signature", "?" + urlsign.ParamExpires + "=" + validExpires + "&" + urlsign.ParamSignature + "=" + validSig[:len(validSig)-1]},
+		{"signature for a different object", "?" + urlsign.ParamExpires + "=" + otherExpires + "&" + urlsign.ParamSignature + "=" + otherSig},
+		{"expired signature", "?" + urlsign.ParamExpires + "=" + staleExpires + "&" + urlsign.ParamSignature + "=" + staleSig},
+		{"expiry extended, signature kept", "?" + urlsign.ParamExpires + "=" + strconv.FormatInt(time.Now().Add(99*time.Hour).Unix(), 10) + "&" + urlsign.ParamSignature + "=" + validSig},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &mockStore{existsResult: true}
+			r := newServeRouter(t, store)
+
+			w := doGET(r, "/v1/files/"+target+tc.query)
+			if w.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403; body: %s", w.Code, w.Body.String())
+			}
+			// The refusal must be indistinguishable from every other refusal.
+			// A caller who can tell "expired" from "wrong key" from "no such
+			// file" has an oracle for which artifacts exist.
+			if body := w.Body.String(); !strings.Contains(body, "Invalid or expired download URL") {
+				t.Errorf("body %q leaks which check failed", body)
+			}
+			if store.existsCalls != 0 {
+				t.Errorf("storage consulted %d times before authorising; "+
+					"the handler must not confirm a key exists to a caller who cannot sign for it",
+					store.existsCalls)
+			}
+		})
+	}
+}
+
+// TestServeFileHandler_AcceptsAValidSignature is the other half: the guard must
+// let the real thing through, or it is just a broken endpoint.
+func TestServeFileHandler_AcceptsAValidSignature(t *testing.T) {
+	store := &mockStore{existsResult: true}
+	r := newServeRouter(t, store)
+
+	w := doSignedGET(t, r, "modules/acme/vpc/aws/1.0.0.tar.gz")
+	if w.Code != http.StatusOK {
+		t.Fatalf("a correctly signed request was refused: status %d, body %s", w.Code, w.Body.String())
+	}
 }
 
 func TestServeFileHandler_NotFound(t *testing.T) {
 	store := &mockStore{existsResult: false}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/path/to/file.tgz")
+	w := doSignedGET(t, r, "path/to/file.tgz")
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
 	}
@@ -507,7 +617,7 @@ func TestServeFileHandler_ExistsError(t *testing.T) {
 	store := &mockStore{existsErr: errors.New("storage error")}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/path/to/file.tgz")
+	w := doSignedGET(t, r, "path/to/file.tgz")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -518,7 +628,7 @@ func TestServeFileHandler_MetadataError(t *testing.T) {
 	store := &mockStore{existsResult: true, metadataErr: errors.New("metadata error")}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/path/to/file.tgz")
+	w := doSignedGET(t, r, "path/to/file.tgz")
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
@@ -529,7 +639,7 @@ func TestServeFileHandler_Success(t *testing.T) {
 	store := &mockStore{existsResult: true}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/path/to/file.tgz")
+	w := doSignedGET(t, r, "path/to/file.tgz")
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -541,7 +651,7 @@ func TestServeFileHandler_ProviderContentType(t *testing.T) {
 	store := &mockStore{existsResult: true}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/providers/hashicorp/aws/1.0.0/linux/amd64/terraform-provider-aws.zip")
+	w := doSignedGET(t, r, "providers/hashicorp/aws/1.0.0/linux/amd64/terraform-provider-aws.zip")
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -555,7 +665,7 @@ func TestServeFileHandler_ModuleContentType(t *testing.T) {
 	store := &mockStore{existsResult: true}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/modules/hashicorp/consul/aws/1.0.0.tar.gz")
+	w := doSignedGET(t, r, "modules/hashicorp/consul/aws/1.0.0.tar.gz")
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -570,7 +680,7 @@ func TestServeFileHandler_PathTraversal(t *testing.T) {
 	store := &mockStore{existsResult: true}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/../../etc/passwd")
+	w := doSignedGET(t, r, "../../etc/passwd")
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
@@ -581,7 +691,7 @@ func TestServeFileHandler_DoubleSlashTraversal(t *testing.T) {
 	store := &mockStore{existsResult: true}
 	r := newServeRouter(t, store)
 
-	w := doGET(r, "/v1/files/a//b")
+	w := doSignedGET(t, r, "a//b")
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -16,17 +16,21 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/storage/urlsign"
 	"github.com/terraform-registry/terraform-registry/internal/telemetry"
 )
 
 // ServeFileHandler serves a module or provider archive file directly from local storage.
 // @Summary      Serve archive file from local storage
-// @Description  Streams a stored archive file. Only registered when the local storage backend has ServeDirectly enabled. Path traversal sequences are rejected.
+// @Description  Streams a stored archive file. Requires the `expires` and `sig` query parameters produced by the local storage backend's signed download URL; unsigned, forged or expired requests are rejected with 403. Path traversal sequences are rejected.
 // @Tags         Files
-// @Param        filepath   path  string  true  "Storage-relative file path"
+// @Param        filepath   path   string  true  "Storage-relative file path"
+// @Param        expires    query  string  true  "Signature expiry, unix seconds"
+// @Param        sig        query  string  true  "URL signature"
 // @Produce      application/octet-stream
 // @Success      200
 // @Failure      400  {object}  map[string]interface{}  "Invalid file path"
+// @Failure      403  {object}  map[string]interface{}  "Invalid or expired download URL"
 // @Failure      404  {object}  map[string]interface{}  "File not found"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error"
 // @Router       /v1/files/{filepath} [get]
@@ -62,6 +66,40 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		if strings.Contains(filePath, "..") || strings.Contains(filePath, "//") {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"errors": []string{"Invalid file path"},
+			})
+			return
+		}
+
+		// AUTHORIZE THE FETCH (#973).
+		//
+		// This route has no authentication middleware -- not requireAuth, not
+		// OptionalAuth -- and it streams whatever storage key it is handed.
+		// Keys are structural and guessable, so before this check anyone who
+		// could reach the deployment could enumerate every module archive and
+		// terraform binary anonymously, and the fetch appeared nowhere as an
+		// authorised download.
+		//
+		// The signature comes from LocalStorage.GetURL, which is the only thing
+		// that produces these URLs. Verified BEFORE the approval gate and before
+		// any storage call, so an unsigned request cannot use this handler to
+		// probe which keys exist.
+		//
+		// filePath here is post-decode and post-leading-slash-strip -- the same
+		// canonical storage key GetURL signed.
+		if err := urlsign.Verify(
+			filePath,
+			c.Query(urlsign.ParamExpires),
+			c.Query(urlsign.ParamSignature),
+			time.Now(),
+		); err != nil {
+			// One response for every failure mode. Distinguishing "expired"
+			// from "wrong signature" from "no such file" hands an anonymous
+			// caller an oracle for which keys exist; the specific reason goes
+			// to the log, where the operator can see it and the caller cannot.
+			slog.Warn("rejected unsigned or invalid file request",
+				"path", filePath, "reason", err.Error(), "remote", c.ClientIP())
+			c.JSON(http.StatusForbidden, gin.H{
+				"errors": []string{"Invalid or expired download URL"},
 			})
 			return
 		}

--- a/backend/internal/storage/local/local.go
+++ b/backend/internal/storage/local/local.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
+	"github.com/terraform-registry/terraform-registry/internal/storage/urlsign"
 )
 
 func init() {
@@ -263,7 +265,49 @@ func (s *LocalStorage) GetURL(ctx context.Context, path string, ttl time.Duratio
 		return "", fmt.Errorf("file not found: %s", path)
 	}
 
-	return fmt.Sprintf("%s/v1/files/%s", s.baseURL, path), nil
+	// SIGNED, because GET /v1/files/*filepath has no authentication middleware
+	// on it and storage keys are structural and guessable (#973). The other
+	// three backends all return a credential here -- an S3 presign, a GCS
+	// signature, an Azure SAS -- and returning a bare path made the local
+	// backend the one configuration where every module archive and terraform
+	// binary was anonymously fetchable by anyone who could reach the port.
+	//
+	// The ttl argument was accepted and ignored before this. Every caller
+	// already passes one (15 minutes, or an hour for the mirror), so the
+	// bound is now real rather than documentary.
+	expires, sig, err := urlsign.Sign(path, ttl, time.Now())
+	if err != nil {
+		// Fail closed. Returning the unsigned URL on a signing failure would
+		// reinstate exactly the anonymous-fetch hole this closes, at the moment
+		// something is already wrong.
+		return "", fmt.Errorf("failed to sign download URL: %w", err)
+	}
+
+	// The path is escaped segment-wise; the SIGNATURE is over the unescaped
+	// storage key. Gin decodes the path parameter before the handler sees it,
+	// so the handler verifies against the same unescaped string this signed --
+	// which matters because real keys carry '+' and '~' from version strings
+	// such as 1.0.0+build.5.
+	return fmt.Sprintf("%s/v1/files/%s?%s=%s&%s=%s",
+		s.baseURL, escapePathSegments(path),
+		urlsign.ParamExpires, url.QueryEscape(expires),
+		urlsign.ParamSignature, url.QueryEscape(sig),
+	), nil
+}
+
+// escapePathSegments percent-encodes each segment while leaving the separators
+// alone.
+//
+// url.PathEscape on the whole key would encode the slashes too and collapse the
+// key into one segment; leaving it raw would break on any key byte that is not
+// URL-safe. Segment-wise is the only form that round-trips to the same storage
+// key Gin hands the handler.
+func escapePathSegments(p string) string {
+	segs := strings.Split(p, "/")
+	for i, seg := range segs {
+		segs[i] = url.PathEscape(seg)
+	}
+	return strings.Join(segs, "/")
 }
 
 // Exists checks if a file exists at the specified path

--- a/backend/internal/storage/local/local_test.go
+++ b/backend/internal/storage/local/local_test.go
@@ -3,8 +3,10 @@ package local
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/terraform-registry/terraform-registry/internal/config"
+	"github.com/terraform-registry/terraform-registry/internal/storage/urlsign"
 )
 
 // newTestStorage creates a LocalStorage backed by a temporary directory.
@@ -239,13 +242,140 @@ func TestGetURL_ServeDirectly(t *testing.T) {
 		t.Fatal("Upload:", err)
 	}
 
-	url, err := s.GetURL(ctx, "providers/foo/1.0.0.zip", time.Hour)
+	raw, err := s.GetURL(ctx, "providers/foo/1.0.0.zip", time.Hour)
 	if err != nil {
 		t.Fatalf("GetURL() error: %v", err)
 	}
-	want := "http://registry.example.com/v1/files/providers/foo/1.0.0.zip"
-	if url != want {
-		t.Errorf("GetURL() = %q, want %q", url, want)
+
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		t.Fatalf("GetURL() returned an unparseable URL %q: %v", raw, err)
+	}
+	if got, want := u.Scheme+"://"+u.Host+u.Path, "http://registry.example.com/v1/files/providers/foo/1.0.0.zip"; got != want {
+		t.Errorf("GetURL() path = %q, want %q", got, want)
+	}
+
+	// SIGNED (#973). GET /v1/files/*filepath carries no authentication
+	// middleware, so an unsigned URL here is an anonymously fetchable archive.
+	// This asserts the parameters are present AND that they verify -- present
+	// but wrong would satisfy a existence check while serving nothing.
+	if err := urlsign.Verify(
+		"providers/foo/1.0.0.zip",
+		u.Query().Get(urlsign.ParamExpires),
+		u.Query().Get(urlsign.ParamSignature),
+		time.Now(),
+	); err != nil {
+		t.Errorf("GetURL() produced a URL that does not verify: %v (url %q)", err, raw)
+	}
+}
+
+// TestGetURL_SignatureIsBoundToTheKey — #973.
+//
+// A signature that authorises ANY path is not a signature. The route serves
+// whatever key it is handed, so if the MAC did not cover the path, one legitimate
+// download URL would unlock every artifact in storage.
+func TestGetURL_SignatureIsBoundToTheKey(t *testing.T) {
+	s := newTestStorage(t, true, "http://registry.example.com")
+	ctx := context.Background()
+
+	for _, p := range []string{"providers/foo/1.0.0.zip", "modules/acme/vpc/aws/2.0.0.tar.gz"} {
+		if _, err := s.Upload(ctx, p, strings.NewReader("data"), 4); err != nil {
+			t.Fatal("Upload:", err)
+		}
+	}
+
+	raw, err := s.GetURL(ctx, "providers/foo/1.0.0.zip", time.Hour)
+	if err != nil {
+		t.Fatalf("GetURL() error: %v", err)
+	}
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// The same expires+sig, replayed against a different object.
+	if err := urlsign.Verify(
+		"modules/acme/vpc/aws/2.0.0.tar.gz",
+		u.Query().Get(urlsign.ParamExpires),
+		u.Query().Get(urlsign.ParamSignature),
+		time.Now(),
+	); err == nil {
+		t.Error("a signature minted for providers/foo/1.0.0.zip also authorised " +
+			"modules/acme/vpc/aws/2.0.0.tar.gz -- the MAC does not cover the path, so one " +
+			"download URL unlocks all of storage")
+	}
+}
+
+// TestGetURL_TTLIsHonoured — #973.
+//
+// The ttl argument was accepted and ignored before signing existed. Every caller
+// passes one, so a URL that never expires is a permanent anonymous credential
+// handed out on every download.
+func TestGetURL_TTLIsHonoured(t *testing.T) {
+	s := newTestStorage(t, true, "http://registry.example.com")
+	ctx := context.Background()
+	const key = "providers/foo/1.0.0.zip"
+
+	if _, err := s.Upload(ctx, key, strings.NewReader("data"), 4); err != nil {
+		t.Fatal("Upload:", err)
+	}
+	raw, err := s.GetURL(ctx, key, time.Minute)
+	if err != nil {
+		t.Fatalf("GetURL() error: %v", err)
+	}
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	exp, sig := u.Query().Get(urlsign.ParamExpires), u.Query().Get(urlsign.ParamSignature)
+
+	if err := urlsign.Verify(key, exp, sig, time.Now()); err != nil {
+		t.Fatalf("valid now, but rejected: %v", err)
+	}
+	if err := urlsign.Verify(key, exp, sig, time.Now().Add(2*time.Minute)); !errors.Is(err, urlsign.ErrExpired) {
+		t.Errorf("two minutes past a one-minute TTL: got %v, want ErrExpired", err)
+	}
+}
+
+// TestGetURL_SurvivesVersionMetadataInTheKey — #973.
+//
+// Real keys carry '+' from build metadata (hashicorp/go-version accepts
+// 1.0.0+build.5) and '~' from version strings. '+' means SPACE in a query
+// string and is literal in a path, so an escaping mismatch between the signer
+// and the verifier breaks exactly these artifacts and no others -- the shape of
+// bug that ships green and fails on one customer's module.
+func TestGetURL_SurvivesVersionMetadataInTheKey(t *testing.T) {
+	s := newTestStorage(t, true, "http://registry.example.com")
+	ctx := context.Background()
+
+	for _, key := range []string{
+		"modules/acme/vpc/aws/1.0.0+build.5.tar.gz",
+		"modules/acme/vpc/aws/1.0.0~rc1.tar.gz",
+		"providers/Acme/Foo/1.0.0/linux/amd64/terraform-provider-foo.zip",
+	} {
+		t.Run(key, func(t *testing.T) {
+			if _, err := s.Upload(ctx, key, strings.NewReader("data"), 4); err != nil {
+				t.Fatal("Upload:", err)
+			}
+			raw, err := s.GetURL(ctx, key, time.Hour)
+			if err != nil {
+				t.Fatalf("GetURL() error: %v", err)
+			}
+			u, err := neturl.Parse(raw)
+			if err != nil {
+				t.Fatalf("parse %q: %v", raw, err)
+			}
+			// What the handler sees: Gin decodes the path parameter, so the
+			// verifier is handed the unescaped storage key. u.Path is the
+			// decoded form, which models that exactly.
+			decoded := strings.TrimPrefix(u.Path, "/v1/files/")
+			if decoded != key {
+				t.Fatalf("path did not round-trip: encoded %q decoded to %q, want %q", u.EscapedPath(), decoded, key)
+			}
+			if err := urlsign.Verify(decoded, u.Query().Get(urlsign.ParamExpires), u.Query().Get(urlsign.ParamSignature), time.Now()); err != nil {
+				t.Errorf("signature does not verify against the decoded path: %v", err)
+			}
+		})
 	}
 }
 
@@ -465,5 +595,33 @@ func TestNew_NewDirectory(t *testing.T) {
 	}
 	if s == nil {
 		t.Fatal("New() returned nil")
+	}
+}
+
+// TestGetURL_FailsClosedWhenSigningFails — #973.
+//
+// The dangerous fallback here is not an error, it is a SUCCESS: returning the
+// old unsigned URL when signing fails would reinstate the anonymous-fetch hole
+// at exactly the moment something is already wrong, and every caller would
+// carry on as though nothing happened. Nothing else reaches this branch, so
+// without this test it is deletable with the suite still green.
+func TestGetURL_FailsClosedWhenSigningFails(t *testing.T) {
+	s := newTestStorage(t, true, "http://registry.example.com")
+	ctx := context.Background()
+	const key = "providers/foo/1.0.0.zip"
+
+	if _, err := s.Upload(ctx, key, strings.NewReader("data"), 4); err != nil {
+		t.Fatal("Upload:", err)
+	}
+
+	urlsign.SetSecretSourceForTest(t, func() (string, error) { return "", errors.New("no signing key") })
+
+	got, err := s.GetURL(ctx, key, time.Hour)
+	if err == nil {
+		t.Fatalf("GetURL succeeded with no signing key and returned %q; "+
+			"an unsigned URL is anonymously fetchable by anyone who can reach the deployment", got)
+	}
+	if got != "" {
+		t.Errorf("GetURL returned %q alongside its error; a caller ignoring the error would serve an unsigned URL", got)
 	}
 }

--- a/backend/internal/storage/local/main_test.go
+++ b/backend/internal/storage/local/main_test.go
@@ -1,0 +1,19 @@
+package local
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain installs a JWT secret before any test runs.
+//
+// GetURL now signs its output (#973) and derives the signing key from the JWT
+// secret. auth.ValidateJWTSecret is sync.Once-guarded, so the value has to be in
+// the environment before the FIRST test touches it -- t.Setenv inside one test
+// would fix that test and leave the rest of the package depending on run order.
+func TestMain(m *testing.M) {
+	if os.Getenv("TFR_JWT_SECRET") == "" {
+		_ = os.Setenv("TFR_JWT_SECRET", "test-secret-for-url-signing-0123456789abcdef")
+	}
+	os.Exit(m.Run())
+}

--- a/backend/internal/storage/urlsign/urlsign.go
+++ b/backend/internal/storage/urlsign/urlsign.go
@@ -1,0 +1,180 @@
+// Package urlsign gives the local storage backend the same protection the three
+// cloud backends already have: a download URL that is only usable for a specific
+// object, for a bounded time (#973).
+//
+// THE HOLE THIS CLOSES. Storage.GetURL is the one seam every download flows
+// through, and three of its four implementations return a credential: S3
+// presigns, GCS signs, Azure returns a time-limited SAS. The local backend
+// returned a bare, unexpiring, guessable API path -- and the route that serves
+// it, GET /v1/files/*filepath, is registered with NO authentication middleware
+// at all. Keys are structural (modules/{ns}/{name}/{system}/{version}.tar.gz,
+// terraform-binaries/{version}/{os}/{arch}/{file}), so anyone who could reach
+// the deployment could enumerate and fetch every module archive and binary,
+// unauthenticated, without it appearing anywhere as an authorised download.
+//
+// WHY A SIGNATURE RATHER THAN AUTHENTICATION ON THE ROUTE. The consumer is
+// Terraform, following an X-Terraform-Get or a mirror archive URL. It does not
+// necessarily carry a registry credential to a redirected host, which is exactly
+// why the object-store protocol is a signed URL rather than an authenticated
+// fetch. Matching that shape keeps the local backend a drop-in for the cloud
+// ones instead of a configuration with different client requirements.
+//
+// This is deliberately a miniature of an S3 presigned querystring, not a new
+// scheme.
+package urlsign
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/terraform-registry/terraform-registry/internal/auth"
+)
+
+// Query parameter names, matching the presign convention closely enough to be
+// recognisable in a log.
+const (
+	ParamExpires   = "expires"
+	ParamSignature = "sig"
+)
+
+var (
+	// ErrMissingSignature means the request carried no signature at all -- the
+	// pre-#973 URL shape, or a hand-constructed one. Kept distinct from
+	// ErrBadSignature so an operator upgrading can tell "old client" from
+	// "someone is forging".
+	ErrMissingSignature = errors.New("urlsign: request is not signed")
+	ErrBadSignature     = errors.New("urlsign: signature does not match")
+	ErrExpired          = errors.New("urlsign: signature has expired")
+	ErrMalformedExpiry  = errors.New("urlsign: expiry is not a unix timestamp")
+	// ErrNoKey means no signing key could be derived. Every entry point returns
+	// it rather than falling back to an empty HMAC key, which would otherwise
+	// produce signatures anyone can compute -- a lock that reports locked.
+	ErrNoKey = errors.New("urlsign: no signing key available")
+)
+
+// secretSource is the root secret the signing key is derived from, or an error
+// if none is configured.
+//
+// It does NOT call auth.GetJWTSecret directly, which PANICS when no secret is
+// configured. That panic is defensible at boot and wrong on a request path: it
+// would turn a misconfiguration into a stack trace and a 500 on a route whose
+// correct answer is a plain 403. auth.ValidateJWTSecret returns the same
+// condition as an error (it is sync.Once-guarded, so this is a load after the
+// first call), which lets the failure stay fail-closed and quiet.
+//
+// Indirected through a variable so tests can supply a secret without standing up
+// the auth package's global state.
+var secretSource = func() (string, error) {
+	if err := auth.ValidateJWTSecret(); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrNoKey, err)
+	}
+	return auth.GetJWTSecret(), nil
+}
+
+// derivationLabel domain-separates this key from every other use of the same
+// root secret.
+//
+// Signing with the JWT secret DIRECTLY would mean a URL signature and a session
+// token are produced by the same key, and any future confusion between the two
+// message formats becomes a forgery. The label costs one HMAC and removes the
+// question. Versioned so a future scheme change is a new key rather than a
+// silent reinterpretation of old signatures.
+const derivationLabel = "terraform-registry/local-storage-url/v1"
+
+// key derives the URL-signing key from the root secret.
+//
+// The root secret is the JWT secret, which the server validates for presence and
+// strength at boot (auth.ValidateJWTSecret) and refuses to start without -- so
+// by the time a request is served it is always set. An empty one is still
+// treated as fatal here rather than assumed impossible, because the failure it
+// would cause is silent: HMAC accepts a zero-length key happily and returns a
+// signature every caller can reproduce.
+func key() ([]byte, error) {
+	secret, err := secretSource()
+	if err != nil {
+		return nil, err
+	}
+	if secret == "" {
+		return nil, ErrNoKey
+	}
+	m := hmac.New(sha256.New, []byte(secret))
+	m.Write([]byte(derivationLabel))
+	return m.Sum(nil), nil
+}
+
+// signature computes the MAC over the storage key and the expiry.
+//
+// LENGTH-PREFIXED, so no two (path, expires) pairs can produce the same signing
+// input. storage.ValidateKey already rejects control characters, which makes a
+// plain newline delimiter safe today -- but that is a property of a guard in
+// another package, and this construction does not depend on it holding.
+func signature(k []byte, path string, expires int64) string {
+	m := hmac.New(sha256.New, k)
+	fmt.Fprintf(m, "%d:%s:%d", len(path), path, expires)
+	return base64.RawURLEncoding.EncodeToString(m.Sum(nil))
+}
+
+// Sign returns the query parameters that authorise fetching path until now+ttl.
+//
+// path is the storage key exactly as the serving handler will see it after it
+// strips the leading slash -- NOT URL-escaped. Signing an escaped form and
+// verifying a decoded one is the classic way a signature scheme comes apart, so
+// the canonical form is fixed here as "the storage key" and both ends use it.
+func Sign(path string, ttl time.Duration, now time.Time) (expires string, sig string, err error) {
+	k, err := key()
+	if err != nil {
+		return "", "", err
+	}
+	exp := now.Add(ttl).Unix()
+	return strconv.FormatInt(exp, 10), signature(k, path, exp), nil
+}
+
+// Verify reports whether sig authorises path at time now.
+//
+// Order matters: the signature is checked BEFORE the expiry. Reversing them
+// would let an unauthenticated caller probe for a valid signature by observing
+// which of two errors comes back, and would answer "was this ever signed?" for a
+// path they cannot sign for.
+func Verify(path, expires, sig string, now time.Time) error {
+	if expires == "" || sig == "" {
+		return ErrMissingSignature
+	}
+	k, err := key()
+	if err != nil {
+		return err
+	}
+	exp, err := strconv.ParseInt(expires, 10, 64)
+	if err != nil {
+		return ErrMalformedExpiry
+	}
+	want := signature(k, path, exp)
+	// Constant-time: a byte-wise comparison leaks the correct prefix, and this
+	// endpoint is unauthenticated and rate-limited rather than blocked, so an
+	// attacker gets as many attempts as they like.
+	if !hmac.Equal([]byte(want), []byte(sig)) {
+		return ErrBadSignature
+	}
+	if now.Unix() > exp {
+		return ErrExpired
+	}
+	return nil
+}
+
+// SetSecretSourceForTest replaces the root secret for the duration of a test.
+//
+// Exported because the fail-closed path matters MOST outside this package:
+// LocalStorage.GetURL must return an error rather than an unsigned URL when
+// signing fails, and without a way to force that failure the branch is
+// unreachable from a test and can be quietly deleted.
+func SetSecretSourceForTest(tb testing.TB, source func() (string, error)) {
+	tb.Helper()
+	prev := secretSource
+	secretSource = source
+	tb.Cleanup(func() { secretSource = prev })
+}

--- a/backend/internal/storage/urlsign/urlsign_test.go
+++ b/backend/internal/storage/urlsign/urlsign_test.go
@@ -1,0 +1,273 @@
+package urlsign
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withSecret swaps the root secret for the duration of a test.
+func withSecret(t *testing.T, secret string) {
+	t.Helper()
+	prev := secretSource
+	secretSource = func() (string, error) { return secret, nil }
+	t.Cleanup(func() { secretSource = prev })
+}
+
+const testSecret = "a-test-secret-with-enough-entropy-0123456789"
+
+func TestSignedURLVerifies(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+
+	exp, sig, err := Sign("modules/acme/vpc/aws/1.0.0.tar.gz", 15*time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := Verify("modules/acme/vpc/aws/1.0.0.tar.gz", exp, sig, now); err != nil {
+		t.Errorf("a freshly signed URL did not verify: %v", err)
+	}
+}
+
+// TestSignatureIsBoundToThePath is the property the whole issue turns on.
+//
+// GET /v1/files/*filepath serves whatever key it is handed. If the MAC did not
+// cover the path, one legitimate 15-minute download URL would authorise every
+// object in storage for those 15 minutes.
+func TestSignatureIsBoundToThePath(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+
+	exp, sig, err := Sign("modules/acme/vpc/aws/1.0.0.tar.gz", 15*time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	for _, other := range []string{
+		"modules/acme/vpc/aws/1.0.1.tar.gz",
+		"modules/other/vpc/aws/1.0.0.tar.gz",
+		"terraform-binaries/1.9.5/linux/amd64/terraform_1.9.5_linux_amd64.zip",
+		"modules/acme/vpc/aws/1.0.0.tar.gz.bak",
+		// A prefix and an extension of the signed key: a length-unaware
+		// construction ("path"+"expires" concatenated) would let these collide.
+		"modules/acme/vpc/aws/1.0.0.tar.g",
+		"modules/acme/vpc/aws/1.0.0.tar.gzz",
+	} {
+		if err := Verify(other, exp, sig, now); !errors.Is(err, ErrBadSignature) {
+			t.Errorf("signature for the target also authorised %q: got %v, want ErrBadSignature", other, err)
+		}
+	}
+}
+
+// TestSigningInputIsUnambiguous — the length prefix is load-bearing.
+//
+// Without it the signing input is just the path followed by the expiry, and
+// those two concatenations collide: path "x1" with expiry 700000900 and path "x"
+// with expiry 1700000900 both render as "x1700000900". A caller holding a
+// legitimate URL for one object could then replay its signature against a
+// DIFFERENT object at a different expiry.
+//
+// This is the case the obvious cross-object test misses, because it varies the
+// path while holding the expiry fixed and every such pair is trivially distinct.
+func TestSigningInputIsUnambiguous(t *testing.T) {
+	withSecret(t, testSecret)
+
+	// Chosen so that path+expires is byte-identical across the two.
+	longPath, shortExp := "modules/acme/vpc/aws/1.0.0.tar.gz1", int64(700000900)
+	shortPath, longExp := "modules/acme/vpc/aws/1.0.0.tar.gz", int64(1700000900)
+	if longPath+strconv.FormatInt(shortExp, 10) != shortPath+strconv.FormatInt(longExp, 10) {
+		t.Fatal("test inputs no longer collide under naive concatenation; pick new ones")
+	}
+
+	k, err := key()
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	if signature(k, longPath, shortExp) == signature(k, shortPath, longExp) {
+		t.Error("two different (path, expiry) pairs produced the same signature.\n" +
+			"A URL for one object can be replayed against another at a different expiry: " +
+			"the signing input needs the length prefix.")
+	}
+}
+
+// TestExpiryIsCoveredByTheSignature stops the cheapest possible forgery: keep a
+// real signature and edit the expiry in the querystring, turning a 15-minute
+// credential into a permanent one.
+func TestExpiryIsCoveredByTheSignature(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+
+	exp, sig, err := Sign("modules/acme/vpc/aws/1.0.0.tar.gz", time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	extended := strconv.FormatInt(now.Add(100*365*24*time.Hour).Unix(), 10)
+	if extended == exp {
+		t.Fatal("test is not extending the expiry")
+	}
+	if err := Verify("modules/acme/vpc/aws/1.0.0.tar.gz", extended, sig, now); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("the expiry could be extended without invalidating the signature: got %v", err)
+	}
+}
+
+func TestExpiredSignatureIsRefused(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+	const key = "modules/acme/vpc/aws/1.0.0.tar.gz"
+
+	exp, sig, err := Sign(key, 15*time.Minute, now)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := Verify(key, exp, sig, now.Add(14*time.Minute)); err != nil {
+		t.Errorf("still inside the TTL but refused: %v", err)
+	}
+	// Exactly at the expiry is still valid; one second past is not.
+	if err := Verify(key, exp, sig, now.Add(15*time.Minute)); err != nil {
+		t.Errorf("at the expiry boundary: got %v, want valid", err)
+	}
+	if err := Verify(key, exp, sig, now.Add(15*time.Minute+time.Second)); !errors.Is(err, ErrExpired) {
+		t.Errorf("one second past the expiry: got %v, want ErrExpired", err)
+	}
+}
+
+// TestMissingParamsAreDistinguishable lets an operator upgrading a deployment
+// tell an old client from a forgery in the log, without the HTTP response
+// telling the caller anything.
+func TestMissingParamsAreDistinguishable(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+
+	for _, tc := range []struct{ name, exp, sig string }{
+		{"neither", "", ""},
+		{"expires only", "1700000900", ""},
+		{"sig only", "", "AAAA"},
+	} {
+		if err := Verify("k", tc.exp, tc.sig, now); !errors.Is(err, ErrMissingSignature) {
+			t.Errorf("%s: got %v, want ErrMissingSignature", tc.name, err)
+		}
+	}
+	if err := Verify("k", "not-a-number", "AAAA", now); !errors.Is(err, ErrMalformedExpiry) {
+		t.Errorf("non-numeric expiry: got %v, want ErrMalformedExpiry", err)
+	}
+}
+
+// TestNoKeyFailsClosed is the fail-closed property.
+//
+// HMAC accepts a zero-length key without complaint and produces a signature
+// anyone can recompute. Falling back to one would leave a route that looks
+// authorised and is not -- a lock that reports locked. Both directions must
+// refuse, because signing with no key is what would MINT those forgeable URLs.
+func TestNoKeyFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source func() (string, error)
+	}{
+		{"empty secret", func() (string, error) { return "", nil }},
+		{"source errors", func() (string, error) { return "", errors.New("no secret configured") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := secretSource
+			secretSource = tc.source
+			t.Cleanup(func() { secretSource = prev })
+
+			if _, _, err := Sign("k", time.Minute, time.Unix(1_700_000_000, 0)); err == nil {
+				t.Error("Sign produced a signature with no key; every URL it mints would be forgeable")
+			}
+			if err := Verify("k", "1700000900", "AAAA", time.Unix(1_700_000_000, 0)); err == nil {
+				t.Error("Verify accepted a signature with no key")
+			}
+		})
+	}
+}
+
+// TestKeyIsDomainSeparated proves the signing key is not the root secret.
+//
+// Signing URLs with the JWT secret directly would mean one key produces both
+// session tokens and URL signatures, and any future confusion between the two
+// message formats becomes a forgery. Asserted by construction: the signature
+// must differ from what the raw secret would produce.
+func TestKeyIsDomainSeparated(t *testing.T) {
+	withSecret(t, testSecret)
+	derived, err := key()
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	if string(derived) == testSecret {
+		t.Fatal("the signing key IS the root secret; no domain separation")
+	}
+	if strings.Contains(string(derived), testSecret) {
+		t.Error("the signing key contains the root secret verbatim")
+	}
+}
+
+// TestDifferentSecretsProduceDifferentSignatures catches a derivation that
+// ignores its input -- a constant key would pass every other test here.
+func TestDifferentSecretsProduceDifferentSignatures(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	const k = "modules/acme/vpc/aws/1.0.0.tar.gz"
+
+	sign := func(secret string) string {
+		prev := secretSource
+		secretSource = func() (string, error) { return secret, nil }
+		defer func() { secretSource = prev }()
+		_, sig, err := Sign(k, time.Minute, now)
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		return sig
+	}
+	if a, b := sign("secret-one-0123456789abcdef"), sign("secret-two-0123456789abcdef"); a == b {
+		t.Error("two different root secrets produced the same signature; the derivation ignores the secret")
+	}
+}
+
+// TestSignatureIsURLSafe — the value goes into a querystring. A signature
+// carrying '+' or '/' would be mangled or re-decoded differently by an
+// intermediary and fail intermittently, which is worse than failing always.
+func TestSignatureIsURLSafe(t *testing.T) {
+	withSecret(t, testSecret)
+	now := time.Unix(1_700_000_000, 0)
+	for i := range 200 {
+		_, sig, err := Sign("modules/acme/vpc/aws/1.0."+strconv.Itoa(i)+".tar.gz", time.Minute, now)
+		if err != nil {
+			t.Fatalf("Sign: %v", err)
+		}
+		if strings.ContainsAny(sig, "+/=") {
+			t.Fatalf("signature %q contains a character that changes meaning in a querystring", sig)
+		}
+	}
+}
+
+// TestComparisonIsConstantTime guards a property no behavioural test can see.
+//
+// A byte-wise `want != sig` passes every functional test in this file and leaks
+// the correct prefix through timing. This endpoint is unauthenticated and merely
+// rate-limited, so an attacker gets as many attempts as they like -- which is
+// exactly the situation constant-time comparison exists for. Asserted at the
+// source level because the alternative is a flaky timing benchmark.
+func TestComparisonIsConstantTime(t *testing.T) {
+	src, err := os.ReadFile("urlsign.go")
+	if err != nil {
+		t.Fatalf("read urlsign.go: %v", err)
+	}
+	body := string(src)
+	i := strings.Index(body, "func Verify(")
+	if i < 0 {
+		t.Fatal("Verify not found; if it was renamed, point this guard at the new name rather than deleting it")
+	}
+	verify := body[i:]
+	if !strings.Contains(verify, "hmac.Equal(") {
+		t.Error("Verify does not compare the signature with hmac.Equal.\n" +
+			"A plain != leaks the correct prefix by timing, on an unauthenticated endpoint " +
+			"an attacker may hit as often as the rate limit allows.")
+	}
+	// And the naive comparison must not be there as well -- a short-circuit
+	// added "for speed" in front of hmac.Equal would restore the leak while
+	// leaving the call present.
+	if strings.Contains(verify, "want != sig") || strings.Contains(verify, "sig != want") {
+		t.Error("Verify contains a byte-wise signature comparison alongside hmac.Equal")
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,12 +251,65 @@ and was not fetchable by a remote Terraform client in any case. The API path wor
 local and same-host clients alike. Setting it to `false` logs a warning at startup.
 
 
+### Local download URLs are signed
+
+`/v1/files/...` URLs carry `expires` and `sig` query parameters, and the route rejects
+anything unsigned, forged or past its expiry with `403`. This is the local backend's
+equivalent of an S3 presign, a GCS signature or an Azure SAS — the other three backends
+have always returned a credential here, and the local one returned a bare, unexpiring,
+guessable path on a route with **no authentication middleware at all**. Storage keys are
+structural (`modules/{namespace}/{name}/{system}/{version}.tar.gz`,
+`terraform-binaries/{version}/{os}/{arch}/{file}`), so before this anyone who could reach
+the deployment could enumerate and download every artifact anonymously.
+
+Nothing to configure. The signing key is derived from `TFR_JWT_SECRET`, which the server
+already requires to start.
+
+Two consequences worth knowing before you debug a failed download:
+
+- **A reverse proxy or CDN in front of the registry must preserve the query string** on
+  `/v1/files/...`. Stripping it turns every download into a `403`. Caching these URLs is
+  also pointless — the signature changes per request.
+- **Rotating `TFR_JWT_SECRET` invalidates URLs already handed out.** They live 15 minutes
+  (an hour for provider mirror URLs) and Terraform fetches them within seconds, so a
+  rotation at worst fails an in-flight download that succeeds on retry.
+
+The reason is logged, at `WARN`, with the client IP; the response body is deliberately the
+same for every failure, so a caller cannot use it to learn which artifacts exist.
+
 **`TFR_STORAGE_LOCAL_BASE_PATH`** — Directory where modules and provider binaries are stored.
 The backend process must have read/write access. Use an absolute path in production.
 
 **`TFR_STORAGE_LOCAL_SERVE_DIRECTLY`** — When `true`, file contents are streamed through
 the backend. When `false`, the backend generates a redirect URL (requires an external
 file server). `true` is recommended unless you have a separate file server.
+
+### The bucket or container must not be publicly readable
+
+Every backend hands Terraform a **time-limited signed URL**: an Azure SAS, an S3 presign, a
+GCS signature, or — since the change above — a signed `/v1/files/...` path for local
+storage. All four are load-bearing only if the underlying store refuses anonymous reads.
+
+A publicly readable bucket makes the signature theatre: object keys are structural
+(`modules/{namespace}/{name}/{system}/{version}.tar.gz`), so anyone who can guess a key
+reads the object directly and never touches the registry — the download is unauthorised
+*and* invisible, since it is never counted or audited.
+
+Check it explicitly; the defaults are not uniformly safe across providers:
+
+```bash
+# S3: expect all four to be true
+aws s3api get-public-access-block --bucket "$BUCKET"
+
+# GCS: expect NO allUsers / allAuthenticatedUsers binding
+gsutil iam get "gs://$BUCKET"
+
+# Azure: expect "publicAccess": null on the container
+az storage container show-permission --name "$CONTAINER" --account-name "$ACCOUNT"
+```
+
+For local storage, the equivalent check is that `base_path` is not also exported by a
+web server or a file share.
 
 ### Azure Blob Storage
 


### PR DESCRIPTION
Closes #973.

## The defect

`GET /v1/files/*filepath` had rate limiting and **no authentication of any kind**, and streamed whatever storage key it was handed. Its only content gate covered paths matching `providers/`, so modules and terraform binaries had no gate on the route at all.

Keys are structural — `modules/{namespace}/{name}/{system}/{version}.tar.gz`, `terraform-binaries/{version}/{os}/{arch}/{file}` — so anyone who could reach the deployment could enumerate and download every artifact anonymously, and the download appeared nowhere as an authorised one.

As the issue frames it, the defect is small and specific: of the four `Storage.GetURL` implementations, three return a credential (S3 presigns, GCS signs, Azure returns a SAS) and the local one returned a bare, unexpiring, guessable path. It also **accepted a `ttl` argument and ignored it**, while all eight call sites pass one.

## The fix

`internal/storage/urlsign` is that missing credential: an HMAC over the storage key and an expiry, keyed by a value derived from the JWT secret under a versioned domain-separation label, encoded URL-safe. Deliberately a miniature of an S3 presigned querystring, not a new scheme.

**A signature rather than authentication on the route**, because the consumer is Terraform following an `X-Terraform-Get` or a mirror archive URL, and it does not necessarily carry a registry credential to a redirected host. That is precisely why the object-store protocol is a signed URL. Matching that shape keeps the local backend a drop-in for the cloud ones instead of a configuration with different client requirements.

Both ends fail closed:

- `GetURL` returns an **error**, never an unsigned URL, when signing fails.
- The handler verifies **before** the approval gate and **before any storage call**, so an unsigned caller cannot use the route to probe which keys exist.
- Every rejection is one identical `403`. The reason goes to the log with the client IP — visible to the operator, not to the caller.

Key derivation does **not** call `auth.GetJWTSecret` directly, because that panics when no secret is configured. Defensible at boot; wrong on a request path, where it turns a misconfiguration into a stack trace and a 500 on a route whose correct answer is a plain 403. `auth.ValidateJWTSecret` reports the same condition as an error.

## Guards

Fourteen mutations, each confirmed to **apply and compile** before its result was believed.

| Mutation | Caught by |
|---|---|
| MAC ignores the path | `TestSignatureIsBoundToThePath` |
| MAC ignores the expiry | `TestExpiryIsCoveredByTheSignature` |
| signing input loses its length prefix | `TestSigningInputIsUnambiguous` |
| expiry never checked | `TestExpiredSignatureIsRefused` |
| empty key allowed | `TestNoKeyFailsClosed` |
| `hmac.Equal` → `!=` | `TestComparisonIsConstantTime` |
| derivation ignores the secret | `TestDifferentSecretsProduceDifferentSignatures` |
| URL-safe → standard base64 | `TestSignatureIsURLSafe` |
| handler skips verification | `TestServeFileHandler_RejectsUnsignedAndForged` |
| handler verifies *after* the existence check | same (asserts `existsCalls == 0`) |
| `GetURL` returns unsigned on signing failure | `TestGetURL_FailsClosedWhenSigningFails` |
| plus 3 path/expiry forgery shapes | handler table test |

**Three were inert on the first attempt**, and all three are worth stating:

1. **The length prefix was unguarded.** My cross-object test varied the path with the expiry held fixed, so every pair was trivially distinct. Without the prefix the signing input is just path-then-expiry, and `"x1"+700000900` and `"x"+1700000900` render identically — a URL for one object replays against another at a different expiry. Now tested with an actually-colliding pair.
2. **Nothing caught `hmac.Equal` becoming `!=`**, which leaks the correct prefix by timing on an endpoint that is unauthenticated and merely rate-limited, so an attacker gets as many attempts as they like. No behavioural test can observe this; it is asserted at the source level instead of with a flaky timing benchmark.
3. **Nothing caught `GetURL` returning the old unsigned URL on a signing failure.** The dangerous fallback there is a *success*, not an error: it reinstates the hole at the moment something is already wrong, and every caller carries on unaware. The secret source is now injectable so the branch is reachable.

`TestServeFileHandler_SlashOnlyPath` changes from 404 to 403 — the signature check now runs before the existence check, which is the point.

## Docs

`docs/configuration.md` gains the two deployment consequences that produce confusing 403s:

- **a proxy or CDN in front of the registry must preserve the query string** on `/v1/files/...`;
- **rotating `TFR_JWT_SECRET` invalidates URLs already handed out** (15-minute lifetime, an hour for mirror URLs, fetched within seconds — so at worst an in-flight download fails and succeeds on retry).

It also gains the check the issue asks for:

> Worth checking at the same time: that the cloud buckets themselves refuse public reads. If a bucket is publicly readable, the SAS/presign is theatre.

— as a new section with the per-provider commands, since that applies to all four backends and not just this one.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on the touched packages — 0 issues
- Swagger/OpenAPI regenerated with CI's own invocation (`swag@v1.16.6`, then `swagger2openapi -p`); the diff touches only the `/v1/files` operation
- Coverage: 75.4% on this branch vs **75.3% on `main`** measured with the identical local (no-Postgres) invocation — no regression; `urlsign` is at 100% on all four functions
