### PR TITLE
fix(providers): resolve providers by namespace, not by the default organization

### DIFF
--- a/backend/internal/api/admin/providers.go
+++ b/backend/internal/api/admin/providers.go
@@ -48,27 +48,15 @@ func (h *ProviderAdminHandlers) GetProvider(c *gin.Context) {
 	namespace := c.Param("namespace")
 	providerType := c.Param("type")
 
-	// Get organization context (default org for single-tenant mode)
-	// A deployment with no default organization degrades to an EMPTY orgID
-	// here rather than failing the request — the `if org != nil` guard below is
-	// the original author's handling of the (nil, nil) miss, and identityerr
-	// .Missing preserves it now that the miss arrives as store.ErrNotFound.
-	// Letting the sentinel reach the 500 would turn every admin module/provider
-	// route into a hard failure on such a deployment, which is a behaviour
-	// change this change is not entitled to make.
-	org, err := h.orgRepo.GetDefaultOrganization(c.Request.Context())
-	if err != nil && !identityerr.Missing(org, err) {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get organization context"})
-		return
-	}
-
-	var orgID string
-	if org != nil {
-		orgID = org.ID
-	}
-
-	// Get provider
-	provider, err := h.providerRepo.GetProvider(c.Request.Context(), orgID, namespace, providerType)
+	// RESOLVED BY NAMESPACE, WITH NO ORGANIZATION (#972). This handler is
+	// mounted on the PUBLIC detail group and addressed by the same two protocol
+	// coordinates as the Terraform routes, so it had the same defect: a
+	// provider owned by any organization other than the one literally named
+	// "default" was a 404 here too.
+	//
+	// Its module counterpart, ModuleAdminHandlers.GetModule, already calls
+	// GetModuleByNamespace. This brings the provider half into line.
+	provider, _, err := h.providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get provider"})
 		return

--- a/backend/internal/api/admin/providers_test.go
+++ b/backend/internal/api/admin/providers_test.go
@@ -161,25 +161,9 @@ func expectOrgFound(mock sqlmock.Sqlmock) {
 // GetProvider tests
 // ---------------------------------------------------------------------------
 
-func TestGetProvider_OrgDBError(t *testing.T) {
-	mock, r := newProviderRouter(t)
-
-	mock.ExpectQuery("SELECT.*FROM organizations").
-		WithArgs("default").
-		WillReturnError(errDB)
-
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest("GET", "/providers/hashicorp/aws", nil))
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-}
-
 func TestGetProvider_ProviderNotFound(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectNoDefaultOrg(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(emptyProviderRow())
 
@@ -194,7 +178,6 @@ func TestGetProvider_ProviderNotFound(t *testing.T) {
 func TestGetProvider_Success_NoVersions(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectNoDefaultOrg(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(sampleProviderRow())
 	// ListVersions returns empty
@@ -216,7 +199,6 @@ func TestGetProvider_Success_NoVersions(t *testing.T) {
 func TestGetProvider_ProviderDBError(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectNoDefaultOrg(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnError(errDB)
 
@@ -231,7 +213,6 @@ func TestGetProvider_ProviderDBError(t *testing.T) {
 func TestGetProvider_ListVersionsDBError(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectNoDefaultOrg(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions").
@@ -684,13 +665,18 @@ func TestUndeprecateVersion_UndeprecateDBError(t *testing.T) {
 
 // ---------------------------------------------------------------------------
 // GetProvider — additional uncovered branches
+//
+// The "OrgFound" in these names is historical. GetProvider used to resolve the
+// default organization and filter the lookup by it, which made a provider owned
+// by any other organization a 404 (#972); the org-found and no-default-org
+// cases were therefore different code paths worth separating. The handler now
+// resolves by namespace alone and queries organizations not at all, so the
+// distinction no longer exists and these are simply more GetProvider cases.
 // ---------------------------------------------------------------------------
 
 func TestGetProvider_OrgFound_Success_WithVersionsAndPlatforms(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	// Org found (non-nil org)
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(sampleProviderRow())
 	// ListVersions returns one version with deprecated fields set
@@ -734,7 +720,6 @@ func TestGetProvider_OrgFound_Success_WithVersionsAndPlatforms(t *testing.T) {
 func TestGetProvider_OrgFound_Success_SurfacesSignedVersion(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(sampleProviderRow())
 	protocols := []byte(`["6.0"]`)
@@ -762,7 +747,6 @@ func TestGetProvider_OrgFound_Success_SurfacesSignedVersion(t *testing.T) {
 func TestGetProvider_OrgFound_ProviderNotFound(t *testing.T) {
 	mock, r := newProviderRouter(t)
 
-	expectOrgFound(mock)
 	mock.ExpectQuery("SELECT.*FROM providers").
 		WillReturnRows(emptyProviderRow())
 

--- a/backend/internal/api/identity_db_wiring_test.go
+++ b/backend/internal/api/identity_db_wiring_test.go
@@ -87,14 +87,17 @@ var domainDBIsCorrect = map[string]string{
 	"mirror.IndexHandler":            "mirror index over domain tables",
 	"mirror.PlatformIndexHandler":    "mirror index over domain tables",
 	"modules.SearchHandler":          "namespace -> org resolution joined to modules",
-	"modules.ServeFileHandler":       "namespace -> org resolution joined to modules",
 	"modules.UploadHandler":          "namespace -> org resolution joined to modules",
 	"oci.NewHandler":                 "OCI blobs joined to modules",
-	"providers.DownloadHandler":      "namespace -> org resolution joined to providers",
-	"providers.ListVersionsHandler":  "namespace -> org resolution joined to providers",
-	"providers.SearchHandler":        "namespace -> org resolution joined to providers",
-	"providers.UploadHandler":        "namespace -> org resolution joined to providers",
-	"..NewRouter":                    "the router itself; it receives both connections",
+	// modules.ServeFileHandler, providers.DownloadHandler and
+	// providers.ListVersionsHandler used to be here. Each resolved the default
+	// organization to filter a provider lookup, which made every provider owned
+	// by another organization a 404 -- and in ServeFileHandler's case silently
+	// skipped the mirrored-version approval gate entirely (#972). All three now
+	// resolve by namespace alone and build no identity repository at all.
+	"providers.SearchHandler": "namespace -> org resolution joined to providers",
+	"providers.UploadHandler": "namespace -> org resolution joined to providers",
+	"..NewRouter":             "the router itself; it receives both connections",
 }
 
 func parseGoFile(t *testing.T, path string) (*token.FileSet, *ast.File) {

--- a/backend/internal/api/mirror/index.go
+++ b/backend/internal/api/mirror/index.go
@@ -62,8 +62,24 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 			return
 		}
 
-		// Get provider
-		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+		// RESOLVED BY NAMESPACE, WITH NO ORGANIZATION (#972). A provider source
+		// is host/namespace/type: two identifier segments and no slot for an
+		// organization, so a Terraform client cannot supply one. Filtering by
+		// one here was never a narrowing of what the caller asked for -- it
+		// guessed the organization literally named "default", and every
+		// provider owned by any other organization was a permanent 404 to every
+		// client, with no error to say why.
+		//
+		// This is what the module half of the same protocol already does; the
+		// provider half was never brought along, so a deployment that renamed
+		// or deleted its default organization served its modules correctly and
+		// its providers to nobody.
+		//
+		// The organization resolved above is still used, for the PULL-THROUGH
+		// mirror configuration below -- that really is owned by an
+		// organization. Only the lookup of an already-published provider is
+		// org-blind.
+		provider, _, err := providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"errors": []string{"Failed to query provider"},
@@ -86,7 +102,7 @@ func IndexHandler(db *sql.DB, _ *config.Config, pullThrough *services.PullThroug
 					return
 				}
 				// Re-query provider now that metadata has been populated
-				provider, err = providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+				provider, _, err = providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 				if err != nil || provider == nil {
 					c.Data(http.StatusNotFound, "application/json", []byte(`{"errors":["provider not found after pull-through"]}`))
 					return

--- a/backend/internal/api/mirror/mirror_test.go
+++ b/backend/internal/api/mirror/mirror_test.go
@@ -134,7 +134,7 @@ func TestIndex_ProviderDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnError(mirrorErrDB)
 
 	w := httptest.NewRecorder()
@@ -150,7 +150,7 @@ func TestIndex_ProviderNotFound(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sqlmock.NewRows(mirrorProvCols))
 
 	w := httptest.NewRecorder()
@@ -165,7 +165,7 @@ func TestIndex_ListVersionsDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	// ListVersions fails
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE pv.provider_id").
@@ -184,7 +184,7 @@ func TestIndex_Success_NoVersions(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	// ListVersions returns empty
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE pv.provider_id").
@@ -245,7 +245,7 @@ func TestPlatformIndex_ProviderNotFound(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sqlmock.NewRows(mirrorProvCols))
 
 	w := httptest.NewRecorder()
@@ -260,7 +260,7 @@ func TestPlatformIndex_VersionNotFound(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	// GetVersion returns no rows
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
@@ -340,7 +340,7 @@ func TestPlatformIndex_ProviderDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnError(mirrorErrDB)
 
 	w := httptest.NewRecorder()
@@ -356,7 +356,7 @@ func TestPlatformIndex_GetVersionDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnError(mirrorErrDB)
@@ -377,7 +377,7 @@ func TestPlatformIndex_ApprovalStatusDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
@@ -397,7 +397,7 @@ func TestPlatformIndex_ListPlatformsDBError(t *testing.T) {
 	mock, r := newMirrorAPIRouter(t)
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
@@ -431,7 +431,7 @@ func TestPlatformIndex_StorageInitError(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
@@ -467,7 +467,7 @@ func TestPlatformIndex_Success_EmptyPlatforms(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())
@@ -520,7 +520,7 @@ func TestPlatformIndex_Success_WithPlatforms(t *testing.T) {
 
 	mock.ExpectQuery("SELECT.*FROM organizations WHERE name").
 		WillReturnRows(sampleMirrorAPIOrg())
-	mock.ExpectQuery("SELECT.*FROM providers.*WHERE.*organization_id").
+	mock.ExpectQuery("SELECT.*FROM providers.*WHERE p.namespace").
 		WillReturnRows(sampleMirrorAPIProvider())
 	mock.ExpectQuery("SELECT.*FROM provider_versions WHERE provider_id").
 		WillReturnRows(sampleMirrorVersionGetRow())

--- a/backend/internal/api/mirror/platform_index.go
+++ b/backend/internal/api/mirror/platform_index.go
@@ -97,8 +97,24 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 			return
 		}
 
-		// Get provider
-		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+		// RESOLVED BY NAMESPACE, WITH NO ORGANIZATION (#972). A provider source
+		// is host/namespace/type: two identifier segments and no slot for an
+		// organization, so a Terraform client cannot supply one. Filtering by
+		// one here was never a narrowing of what the caller asked for -- it
+		// guessed the organization literally named "default", and every
+		// provider owned by any other organization was a permanent 404 to every
+		// client, with no error to say why.
+		//
+		// This is what the module half of the same protocol already does; the
+		// provider half was never brought along, so a deployment that renamed
+		// or deleted its default organization served its modules correctly and
+		// its providers to nobody.
+		//
+		// The organization resolved above is still used, for the PULL-THROUGH
+		// mirror configuration below -- that really is owned by an
+		// organization. Only the lookup of an already-published provider is
+		// org-blind.
+		provider, _, err := providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"errors": []string{"Failed to query provider"},
@@ -119,7 +135,7 @@ func PlatformIndexHandler(db *sql.DB, cfg *config.Config, auditRepo *repositorie
 					c.Data(http.StatusBadGateway, "application/json", []byte(`{"errors":["upstream fetch failed"]}`))
 					return
 				}
-				provider, err = providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+				provider, _, err = providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 				if err != nil || provider == nil {
 					c.Data(http.StatusNotFound, "application/json", []byte(`{"errors":["provider not found after pull-through"]}`))
 					return

--- a/backend/internal/api/modules/download_track_timeout_test.go
+++ b/backend/internal/api/modules/download_track_timeout_test.go
@@ -37,17 +37,20 @@ func TestTrackProviderDownload_ReturnsWhenTheDatabaseStalls(t *testing.T) {
 	// The first query the function makes stalls far longer than the deadline.
 	// WillDelayFor honours the context, so a bounded context aborts the wait and
 	// an unbounded one blocks for the full delay.
-	mock.ExpectQuery("(?s)SELECT.*organizations").
+	//
+	// That first query is the PROVIDER lookup. It used to be an organizations
+	// lookup, resolving the default org to filter the provider by -- which made
+	// a provider owned by any other organization uncountable (#972).
+	mock.ExpectQuery("(?s)SELECT.*FROM providers").
 		WillDelayFor(60 * time.Second).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("org-1"))
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("prov-1"))
 
 	providerRepo := repositories.NewProviderRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
 
 	done := make(chan time.Duration, 1)
 	go func() {
 		start := time.Now()
-		trackProviderDownload(providerRepo, orgRepo, "hashicorp", "aws", "5.31.0", "linux", "amd64")
+		trackProviderDownload(providerRepo, "hashicorp", "aws", "5.31.0", "linux", "amd64")
 		done <- time.Since(start)
 	}()
 

--- a/backend/internal/api/modules/serve.go
+++ b/backend/internal/api/modules/serve.go
@@ -39,10 +39,8 @@ import (
 // Only used when local storage has ServeDirectly: true
 func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sql.DB, auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 	var providerRepo *repositories.ProviderRepository
-	var orgRepo *repositories.OrganizationRepository
 	if db != nil {
 		providerRepo = repositories.NewProviderRepository(db)
-		orgRepo = repositories.NewOrganizationRepository(db)
 	}
 
 	return func(c *gin.Context) {
@@ -113,18 +111,24 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		// workflow entirely. Return the same "File not found" response as a
 		// genuinely missing file so the gate does not reveal that a hidden version
 		// exists.
+		//
+		// RESOLVED BY NAMESPACE (#972). This lookup used to resolve the default
+		// organization first and filter by it, which meant the gate SILENTLY
+		// DID NOT RUN for a provider owned by any other organization: the
+		// lookup missed, the nested conditions fell through, and the archive
+		// was served. An approval gate that skips itself on the deployments it
+		// was least tested against is worse than none, because it reports
+		// coverage it does not have.
 		if providerRepo != nil {
 			if ns, pt, ver, _, _, ok := parseProviderFilePath(filePath); ok {
-				if org, err := orgRepo.GetDefaultOrganization(c.Request.Context()); err == nil && org != nil {
-					if provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, ns, pt); err == nil && provider != nil {
-						if pv, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, ver); err == nil && pv != nil {
-							status, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), pv.ID)
-							if err == nil && status != nil && *status != models.VersionApprovalStatusApproved {
-								c.JSON(http.StatusNotFound, gin.H{
-									"errors": []string{"File not found"},
-								})
-								return
-							}
+				if provider, _, err := providerRepo.GetProviderByNamespace(c.Request.Context(), ns, pt); err == nil && provider != nil {
+					if pv, err := providerRepo.GetVersion(c.Request.Context(), provider.ID, ver); err == nil && pv != nil {
+						status, err := providerRepo.GetVersionApprovalStatus(c.Request.Context(), pv.ID)
+						if err == nil && status != nil && *status != models.VersionApprovalStatusApproved {
+							c.JSON(http.StatusNotFound, gin.H{
+								"errors": []string{"File not found"},
+							})
+							return
 						}
 					}
 				}
@@ -168,7 +172,7 @@ func ServeFileHandler(storageBackend storage.Storage, cfg *config.Config, db *sq
 		// Track provider downloads: path is providers/{namespace}/{type}/{version}/{os}/{arch}/{file}
 		if providerRepo != nil {
 			if ns, pt, ver, osName, arch, ok := parseProviderFilePath(filePath); ok {
-				safego.Go(func() { trackProviderDownload(providerRepo, orgRepo, ns, pt, ver, osName, arch) })
+				safego.Go(func() { trackProviderDownload(providerRepo, ns, pt, ver, osName, arch) })
 				telemetry.ProviderDownloadsTotal.WithLabelValues(ns, pt, osName, arch).Inc()
 			}
 		}
@@ -229,7 +233,7 @@ func parseProviderFilePath(path string) (namespace, providerType, version, os, a
 }
 
 // trackProviderDownload looks up the provider platform and increments its download count.
-func trackProviderDownload(providerRepo *repositories.ProviderRepository, orgRepo *repositories.OrganizationRepository, namespace, providerType, version, osName, arch string) {
+func trackProviderDownload(providerRepo *repositories.ProviderRepository, namespace, providerType, version, osName, arch string) {
 	// One budget for the whole operation, matching the audit goroutine 30 lines
 	// above (issue #758). This runs fire-and-forget after the response is
 	// served and makes FOUR sequential queries; with a bare context.Background()
@@ -241,11 +245,11 @@ func trackProviderDownload(providerRepo *repositories.ProviderRepository, orgRep
 	// is precisely when these pile up.
 	ctx, cancel := context.WithTimeout(context.Background(), downloadTrackTimeout)
 	defer cancel()
-	org, err := orgRepo.GetDefaultOrganization(ctx)
-	if err != nil || org == nil {
-		return
-	}
-	provider, err := providerRepo.GetProvider(ctx, org.ID, namespace, providerType)
+	// RESOLVED BY NAMESPACE (#972). Same defect as the approval gate above: a
+	// provider owned by any organization other than "default" resolved to
+	// nothing here, so its downloads were never counted -- silently, since this
+	// runs detached and returns on every miss.
+	provider, _, err := providerRepo.GetProviderByNamespace(ctx, namespace, providerType)
 	if err != nil || provider == nil {
 		return
 	}

--- a/backend/internal/api/provider_protocol_orgblind_class_test.go
+++ b/backend/internal/api/provider_protocol_orgblind_class_test.go
@@ -1,0 +1,213 @@
+package api
+
+// provider_protocol_orgblind_class_test.go pins the fix for #972 as a CLASS
+// property rather than as five separate patched call sites.
+//
+// THE DEFECT. A provider source is host/namespace/type: two identifier segments
+// and no slot for an organization, so a Terraform client cannot supply one.
+// Every public provider route nevertheless resolved the organization literally
+// named "default" and passed it as a filter, which made a provider owned by any
+// OTHER organization a permanent 404 -- with no error, so it read as "that
+// provider does not exist" rather than as a misconfiguration. Modules were
+// unaffected, which is what made it hard to notice: the same deployment served
+// its modules correctly and its providers not at all.
+//
+// WHY A GUARD AND NOT JUST THE FIX. There were seven call sites across five
+// files, all written the same way, and the idiom (resolve the default org, pass
+// its ID to a lookup) is the obvious thing to write again. One of the seven was
+// not a lookup at all but the mirrored-version APPROVAL GATE, which did not
+// return a wrong answer -- it silently DID NOT RUN, fell through its nested
+// conditions, and served the archive. A guard that only checks the routes that
+// 404 would have missed exactly the one that mattered most.
+//
+// WHAT IS DELIBERATELY NOT COVERED. The admin write surface
+// (create/update/delete, upload) still resolves an organization and still
+// should: those routes decide who may PUBLISH under a namespace, which IS an
+// organization question. Only READ resolution is org-blind.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// orgScopedProviderLookup is the repository method that takes an organization
+// and filters by it. Reaching it from a protocol read path is the defect.
+const orgScopedProviderLookup = "GetProvider"
+
+// providerProtocolReadFuncs are the functions that answer, or gate, a request
+// addressed by protocol coordinates alone. None of them may filter a provider
+// lookup by organization.
+//
+// Listed by name rather than by file so a function moving between files does not
+// silently leave the guard. Each entry must be found, which is asserted.
+var providerProtocolReadFuncs = map[string]string{
+	"ListVersionsHandler":   "GET /v1/providers/:namespace/:type/versions — the Terraform protocol listing",
+	"DownloadHandler":       "GET /v1/providers/:namespace/:type/:version/download/:os/:arch — the protocol download",
+	"IndexHandler":          "the provider network mirror index",
+	"PlatformIndexHandler":  "the provider network mirror platform index",
+	"GetProvider":           "GET /api/v1/providers/:namespace/:type — the public detail route",
+	"ServeFileHandler":      "GET /v1/files/*filepath — carries the mirrored-version APPROVAL GATE",
+	"trackProviderDownload": "the detached download counter for a protocol download",
+}
+
+// defaultOrgExemptForPullThrough are the functions that may still resolve the
+// default organization, with the reason.
+//
+// A named exemption rather than a narrower guard, because "this function is
+// allowed to do the dangerous thing" is a claim that should be written down and
+// re-read, not encoded as an absence.
+//
+// The two mirror handlers resolve an organization for the PULL-THROUGH mirror
+// configuration -- which upstream to fetch from, and with which credentials.
+// That genuinely is owned by an organization, unlike the lookup of an
+// already-published provider, which is why only the lookup was changed in #972.
+//
+// It is not obviously RIGHT, either: a provider published under organization B
+// whose pull-through config lives under the organization named "default" will
+// use A's upstream. That is a separate question from the 404 this issue is
+// about, and it belongs to the host-scoping work rather than being decided here
+// by a guard that happened to notice it.
+var defaultOrgExemptForPullThrough = map[string]string{
+	"IndexHandler":         "resolves the org for pull-through mirror config, not for the provider lookup",
+	"PlatformIndexHandler": "resolves the org for pull-through mirror config, not for the provider lookup",
+}
+
+// minWatchedProviderReads is the shrink-the-universe guard.
+//
+// Every assertion in this file runs only for a function named in
+// providerProtocolReadFuncs, so DELETING an entry silently stops checking that
+// call site while the whole file still reports green -- the same failure the
+// map exists to prevent, one level up. Raise this when adding entries; a
+// reduction has to be deliberate.
+const minWatchedProviderReads = 7
+
+// approvalGateFunc must always be watched, by name.
+//
+// A floor alone would let someone drop this entry and add a trivial one. This
+// is the site whose failure is silent: it does not return a wrong answer, it
+// skips the mirrored-version approval gate and serves the archive.
+const approvalGateFunc = "ServeFileHandler"
+
+// providerProtocolPackages are the directories searched for those functions.
+var providerProtocolPackages = []string{
+	"internal/api/providers",
+	"internal/api/mirror",
+	"internal/api/modules",
+	"internal/api/admin",
+}
+
+func TestProviderProtocolReadsAreOrganizationBlind(t *testing.T) {
+	if len(providerProtocolReadFuncs) < minWatchedProviderReads {
+		t.Fatalf("only %d provider read functions are watched (floor %d): entries have been removed, "+
+			"so those call sites are no longer checked and this file passes without looking at them",
+			len(providerProtocolReadFuncs), minWatchedProviderReads)
+	}
+	if _, ok := providerProtocolReadFuncs[approvalGateFunc]; !ok {
+		t.Fatalf("%s is not watched. It carries the mirrored-version approval gate, whose failure "+
+			"mode is silence: an org-scoped lookup there does not 404, it skips the gate and serves "+
+			"the archive (#972).", approvalGateFunc)
+	}
+
+	root := moduleRoot(t)
+	found := map[string]bool{}
+
+	for _, pkg := range providerProtocolPackages {
+		dir := filepath.Join(root, pkg)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", pkg, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, e.Name())
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+			ast.Inspect(file, func(n ast.Node) bool {
+				fn, ok := n.(*ast.FuncDecl)
+				if !ok {
+					return true
+				}
+				why, watched := providerProtocolReadFuncs[fn.Name.Name]
+				if !watched {
+					return true
+				}
+				found[fn.Name.Name] = true
+
+				// Two signatures, because the defect had two shapes: calling
+				// the org-taking lookup, and resolving the default org at all.
+				// The second matters on its own -- in ServeFileHandler the
+				// resolution WAS the gate's outer condition, and a failed
+				// resolve skipped the gate rather than refusing the request.
+				ast.Inspect(fn, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					pos := fset.Position(call.Pos())
+					switch sel.Sel.Name {
+					case orgScopedProviderLookup:
+						// Distinguish the repository method from same-named
+						// handlers: the repository call carries a context plus
+						// an org id plus the two coordinates.
+						if len(call.Args) == 4 {
+							t.Errorf("%s:%d: %s calls the organization-scoped %s.\n"+
+								"%s\nUse GetProviderByNamespace: the protocol has no slot for an "+
+								"organization, so filtering by one makes every provider owned by "+
+								"another organization a 404 (#972).",
+								pos.Filename, pos.Line, fn.Name.Name, orgScopedProviderLookup, why)
+						}
+					case "GetDefaultOrganization":
+						if _, exempt := defaultOrgExemptForPullThrough[fn.Name.Name]; exempt {
+							return true
+						}
+						t.Errorf("%s:%d: %s resolves the default organization.\n"+
+							"%s\nA provider read addressed by protocol coordinates must not depend "+
+							"on which organization is named \"default\" -- and where the resolution "+
+							"gates something, a failed resolve skips the gate rather than refusing "+
+							"the request (#972).",
+							pos.Filename, pos.Line, fn.Name.Name, why)
+					}
+					return true
+				})
+				return true
+			})
+		}
+	}
+
+	// Empty-universe guard. Every assertion above runs inside a walk; if the
+	// walk found none of these functions they all pass while checking nothing.
+	var missing []string
+	for name := range providerProtocolReadFuncs {
+		if !found[name] {
+			missing = append(missing, name)
+		}
+	}
+	for name := range defaultOrgExemptForPullThrough {
+		if _, watched := providerProtocolReadFuncs[name]; !watched {
+			t.Errorf("defaultOrgExemptForPullThrough exempts %q, which is not a watched function. "+
+				"An exemption for something nobody checks is not an exemption.", name)
+		}
+	}
+
+	sort.Strings(missing)
+	for _, name := range missing {
+		t.Errorf("%s was not found in any of %v, so it is not being checked.\n"+
+			"If it was renamed or moved, update providerProtocolReadFuncs -- do not drop the entry.",
+			name, providerProtocolPackages)
+	}
+}

--- a/backend/internal/api/providers/download.go
+++ b/backend/internal/api/providers/download.go
@@ -16,7 +16,6 @@ import (
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/models"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
-	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 	"github.com/terraform-registry/terraform-registry/internal/middleware"
 	"github.com/terraform-registry/terraform-registry/internal/safego"
 	"github.com/terraform-registry/terraform-registry/internal/storage"
@@ -43,7 +42,6 @@ import (
 // Returns JSON with download URL, checksums, and signing keys
 func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Config, auditRepo *repositories.AuditRepository) gin.HandlerFunc {
 	providerRepo := repositories.NewProviderRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
 
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
@@ -68,23 +66,19 @@ func DownloadHandler(db *sql.DB, storageBackend storage.Storage, cfg *config.Con
 			return
 		}
 
-		// Get organization context
-		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-		if identityerr.Missing(org, err) {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"errors": []string{"Default organization not found - please run migrations"},
-			})
-			return
-		}
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"errors": []string{"Failed to get organization context"},
-			})
-			return
-		}
-
-		// Get provider
-		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+		// RESOLVED BY NAMESPACE, WITH NO ORGANIZATION (#972). A provider source
+		// is host/namespace/type: two identifier segments and no slot for an
+		// organization, so a Terraform client cannot supply one. Filtering by
+		// one here was never a narrowing of what the caller asked for -- it
+		// guessed the organization literally named "default", and every
+		// provider owned by any other organization was a permanent 404 to every
+		// client, with no error to say why.
+		//
+		// This is what the module half of the same protocol already does; the
+		// provider half was never brought along, so a deployment that renamed
+		// or deleted its default organization served its modules correctly and
+		// its providers to nobody.
+		provider, _, err := providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"errors": []string{"Failed to query provider"},

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -250,7 +250,6 @@ func doGET(r *gin.Engine, path string) *httptest.ResponseRecorder {
 func TestListVersionsHandler_Success(t *testing.T) {
 	mock, r := newVersionsRouter(t)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	// ListVersionsPaginated — COUNT query
 	mock.ExpectQuery("SELECT COUNT.*FROM provider_versions").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
@@ -265,34 +264,9 @@ func TestListVersionsHandler_Success(t *testing.T) {
 	}
 }
 
-func TestListVersionsHandler_OrgError(t *testing.T) {
-	mock, r := newVersionsRouter(t)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnError(errDB2)
-
-	w := doGET(r, "/v1/providers/hashicorp/aws/versions")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-	assertErrorsArrayBody(t, w)
-}
-
-func TestListVersionsHandler_OrgNotFound(t *testing.T) {
-	mock, r := newVersionsRouter(t)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sqlmock.NewRows(orgCols))
-
-	w := doGET(r, "/v1/providers/hashicorp/aws/versions")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-	assertErrorsArrayBody(t, w)
-}
-
 func TestListVersionsHandler_ProviderError(t *testing.T) {
 	mock, r := newVersionsRouter(t)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnError(errDB2)
 
 	w := doGET(r, "/v1/providers/hashicorp/aws/versions")
@@ -305,7 +279,6 @@ func TestListVersionsHandler_ProviderError(t *testing.T) {
 func TestListVersionsHandler_ProviderNotFound(t *testing.T) {
 	mock, r := newVersionsRouter(t)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sqlmock.NewRows(providerCols))
 
 	w := doGET(r, "/v1/providers/hashicorp/aws/versions")
@@ -317,7 +290,6 @@ func TestListVersionsHandler_ProviderNotFound(t *testing.T) {
 func TestListVersionsHandler_VersionsError(t *testing.T) {
 	mock, r := newVersionsRouter(t)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE pv.provider_id").WillReturnError(errDB2)
 
@@ -407,22 +379,9 @@ func TestDownloadHandler_InvalidPlatform(t *testing.T) {
 	}
 }
 
-func TestDownloadHandler_OrgError(t *testing.T) {
-	mock, r := newDownloadRouter(t, &mockStore{})
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnError(errDB2)
-
-	w := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-	assertErrorsArrayBody(t, w)
-}
-
 func TestDownloadHandler_ProviderNotFound(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sqlmock.NewRows(providerCols))
 
 	w := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
@@ -434,7 +393,6 @@ func TestDownloadHandler_ProviderNotFound(t *testing.T) {
 func TestDownloadHandler_VersionNotFound(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sqlmock.NewRows(providerVersionGetCols))
 
@@ -447,7 +405,6 @@ func TestDownloadHandler_VersionNotFound(t *testing.T) {
 func TestDownloadHandler_PlatformNotFound(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").WillReturnRows(sqlmock.NewRows([]string{"approval_status"}).AddRow(nil))
@@ -463,7 +420,6 @@ func TestDownloadHandler_Success(t *testing.T) {
 	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").WillReturnRows(sqlmock.NewRows([]string{"approval_status"}).AddRow(nil))
@@ -482,7 +438,6 @@ func TestDownloadHandler_Success(t *testing.T) {
 func TestDownloadHandler_PendingApprovalHidden(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").
@@ -499,7 +454,6 @@ func TestDownloadHandler_PendingApprovalHidden(t *testing.T) {
 func TestDownloadHandler_RejectedHidden(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").
@@ -515,7 +469,6 @@ func TestDownloadHandler_StorageError(t *testing.T) {
 	store := &mockStore{getURLErr: errors.New("storage error")}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").WillReturnRows(sqlmock.NewRows([]string{"approval_status"}).AddRow(nil))
@@ -1789,23 +1742,9 @@ func TestUploadHandler_CreatePlatformError(t *testing.T) {
 // DownloadHandler — additional error paths
 // ---------------------------------------------------------------------------
 
-func TestDownloadHandler_OrgNotFound(t *testing.T) {
-	mock, r := newDownloadRouter(t, &mockStore{})
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").
-		WillReturnRows(sqlmock.NewRows(orgCols))
-
-	w := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500 (org not found): body=%s", w.Code, w.Body.String())
-	}
-	assertErrorsArrayBody(t, w)
-}
-
 func TestDownloadHandler_ProviderQueryError(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnError(errDB2)
 
 	w := doGET(r, "/v1/providers/hashicorp/aws/4.0.0/download/linux/amd64")
@@ -1818,7 +1757,6 @@ func TestDownloadHandler_ProviderQueryError(t *testing.T) {
 func TestDownloadHandler_VersionQueryError(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
 		WillReturnError(errDB2)
@@ -1833,7 +1771,6 @@ func TestDownloadHandler_VersionQueryError(t *testing.T) {
 func TestDownloadHandler_PlatformQueryError(t *testing.T) {
 	mock, r := newDownloadRouter(t, &mockStore{})
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").
 		WillReturnRows(sampleProviderVersionGetRow())
@@ -1852,7 +1789,6 @@ func TestDownloadHandler_SuccessWithGPGKey(t *testing.T) {
 	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(
 		sqlmock.NewRows(providerVersionGetCols).
@@ -1897,7 +1833,6 @@ func TestDownloadHandler_SuccessWithGPGKey_PopulatesKeyID(t *testing.T) {
 	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(
 		sqlmock.NewRows(providerVersionGetCols).
@@ -1924,7 +1859,6 @@ func TestDownloadHandler_SuccessWithShasumURLs(t *testing.T) {
 	store := &mockStore{getURLResult: "https://example.com/provider.zip"}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(
 		sqlmock.NewRows(providerVersionGetCols).
@@ -1958,7 +1892,6 @@ func TestDownloadHandler_SuccessWithStorageKeys(t *testing.T) {
 	store := &mockStore{getURLResult: presignedURL}
 	mock, r := newDownloadRouter(t, store)
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(
 		sqlmock.NewRows(providerVersionGetCols).
@@ -2001,7 +1934,6 @@ func TestDownloadHandler_SuccessWithAuditContext(t *testing.T) {
 	r.GET("/v1/providers/:namespace/:type/:version/download/:os/:arch",
 		DownloadHandler(db, store, &config.Config{}, auditRepo))
 
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
 	mock.ExpectQuery("SELECT.*FROM providers.*WHERE").WillReturnRows(sampleProviderRow())
 	mock.ExpectQuery("SELECT.*FROM provider_versions.*WHERE provider_id.*AND version").WillReturnRows(sampleProviderVersionGetRow())
 	mock.ExpectQuery("SELECT approval_status FROM mirrored_provider_versions").WillReturnRows(sqlmock.NewRows([]string{"approval_status"}).AddRow(nil))

--- a/backend/internal/api/providers/versions.go
+++ b/backend/internal/api/providers/versions.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
-	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 )
 
 // @Summary      List provider versions
@@ -29,7 +28,6 @@ import (
 // Implements: GET /v1/providers/:namespace/:type/versions
 func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 	providerRepo := repositories.NewProviderRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
 
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
@@ -47,23 +45,19 @@ func ListVersionsHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			offset = 0
 		}
 
-		// Get organization context (default org for single-tenant mode)
-		org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-		if identityerr.Missing(org, err) {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"errors": []string{"Default organization not found - please run migrations"},
-			})
-			return
-		}
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"errors": []string{"Failed to get organization context"},
-			})
-			return
-		}
-
-		// Get provider
-		provider, err := providerRepo.GetProvider(c.Request.Context(), org.ID, namespace, providerType)
+		// RESOLVED BY NAMESPACE, WITH NO ORGANIZATION (#972). A provider source
+		// is host/namespace/type: two identifier segments and no slot for an
+		// organization, so a Terraform client cannot supply one. Filtering by
+		// one here was never a narrowing of what the caller asked for -- it
+		// guessed the organization literally named "default", and every
+		// provider owned by any other organization was a permanent 404 to every
+		// client, with no error to say why.
+		//
+		// This is what the module half of the same protocol already does; the
+		// provider half was never brought along, so a deployment that renamed
+		// or deleted its default organization served its modules correctly and
+		// its providers to nobody.
+		provider, _, err := providerRepo.GetProviderByNamespace(c.Request.Context(), namespace, providerType)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"errors": []string{"Failed to query provider"},

--- a/backend/internal/db/repositories/provider_namespace_resolution_test.go
+++ b/backend/internal/db/repositories/provider_namespace_resolution_test.go
@@ -1,0 +1,151 @@
+package repositories
+
+// provider_namespace_resolution_test.go is the #972 regression.
+//
+// A provider owned by any organization other than the one literally named
+// "default" was a permanent 404 to every Terraform client. The module half of
+// the protocol resolved globally by namespace; the provider half resolved to
+// the default organization, so the two halves of one protocol disagreed -- and
+// a deployment that renamed or deleted its default organization served its
+// modules correctly and its providers to nobody, with no error to say why.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func providerRowCols() []string {
+	return []string{"id", "organization_id", "namespace", "type", "description",
+		"source", "created_by", "created_at", "updated_at", "created_by_name"}
+}
+
+func newProviderRepoMock(t *testing.T) (*ProviderRepository, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	return NewProviderRepository(db), mock, func() { _ = db.Close() }
+}
+
+// TestGetProviderByNamespace_TakesOnlyProtocolCoordinates pins the property.
+//
+// WithArgs is the assertion that matters: an organization predicate cannot be
+// reintroduced without a third argument, and sqlmock refuses a call whose
+// arguments do not match. The query regex pins the WHERE clause as well, so a
+// filter smuggled in as a literal rather than a placeholder also fails.
+func TestGetProviderByNamespace_TakesOnlyProtocolCoordinates(t *testing.T) {
+	repo, mock, closeDB := newProviderRepoMock(t)
+	defer closeDB()
+
+	mock.ExpectQuery(`WHERE p\.namespace = \$1 AND p\.type = \$2 ORDER BY`).
+		WithArgs("acme", "widget").
+		WillReturnRows(sqlmock.NewRows(providerRowCols()))
+
+	if _, _, err := repo.GetProviderByNamespace(context.Background(), "acme", "widget"); err != nil {
+		t.Fatalf("GetProviderByNamespace: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("the query was not the two-coordinate lookup: %v", err)
+	}
+}
+
+// TestGetProviderByNamespace_ServesProvidersOwnedByAnyOrganization is the
+// user-visible bug.
+//
+// The NULL case is called out separately because the old query's
+// `OR p.organization_id IS NULL` was what kept mirrored and single-tenant
+// providers working, and the issue explicitly cautions against "fixing" this by
+// deleting that clause. Dropping the predicate entirely subsumes it -- but only
+// if that is actually true, which is what this asserts.
+func TestGetProviderByNamespace_ServesProvidersOwnedByAnyOrganization(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		orgID   any
+		wantOrg string
+	}{
+		{"owned by a non-default organization", "11111111-1111-1111-1111-111111111111", "11111111-1111-1111-1111-111111111111"},
+		{"mirrored or single-tenant (NULL organization)", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, mock, closeDB := newProviderRepoMock(t)
+			defer closeDB()
+
+			mock.ExpectQuery(`FROM providers`).
+				WillReturnRows(sqlmock.NewRows(providerRowCols()).
+					AddRow("prov-1", tc.orgID, "acme", "widget", nil, "acme/terraform-provider-widget",
+						nil, time.Now(), time.Now(), nil))
+
+			provider, others, err := repo.GetProviderByNamespace(context.Background(), "acme", "widget")
+			if err != nil {
+				t.Fatalf("GetProviderByNamespace: %v", err)
+			}
+			if provider == nil {
+				t.Fatal("provider not found. Before #972 this was a permanent 404 to every " +
+					"Terraform client for any provider not owned by the organization named \"default\".")
+			}
+			if provider.OrganizationID != tc.wantOrg {
+				t.Errorf("OrganizationID = %q, want %q", provider.OrganizationID, tc.wantOrg)
+			}
+			if others != 0 {
+				t.Errorf("others = %d, want 0", others)
+			}
+		})
+	}
+}
+
+// TestGetProviderByNamespace_MissIsNotAnError keeps a 404 a 404.
+//
+// Returning an error for "no such provider" would turn every miss into a 500,
+// which is a different wrong answer rather than a fix.
+func TestGetProviderByNamespace_MissIsNotAnError(t *testing.T) {
+	repo, mock, closeDB := newProviderRepoMock(t)
+	defer closeDB()
+
+	mock.ExpectQuery(`FROM providers`).WillReturnRows(sqlmock.NewRows(providerRowCols()))
+
+	provider, others, err := repo.GetProviderByNamespace(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("a miss returned an error: %v", err)
+	}
+	if provider != nil || others != 0 {
+		t.Errorf("got (%v, %d), want (nil, 0)", provider, others)
+	}
+}
+
+// TestGetProviderByNamespace_ReportsCollisions covers what removing the
+// organization predicate makes possible: two organizations publishing the same
+// namespace/type.
+//
+// Provider storage keys carry no organization segment, so those two rows may
+// already have overwritten each other's archives. The count is returned rather
+// than swallowed so a caller that wants to refuse can, and it is deterministic
+// -- ordered by created_at then id -- because a resolution that varies per
+// request is worse than one that is consistently wrong.
+func TestGetProviderByNamespace_ReportsCollisions(t *testing.T) {
+	repo, mock, closeDB := newProviderRepoMock(t)
+	defer closeDB()
+
+	older := time.Now().Add(-time.Hour)
+	mock.ExpectQuery(`ORDER BY p\.created_at ASC, p\.id ASC`).
+		WillReturnRows(sqlmock.NewRows(providerRowCols()).
+			AddRow("prov-older", "org-a", "acme", "widget", nil, "", nil, older, older, nil).
+			AddRow("prov-newer", "org-b", "acme", "widget", nil, "", nil, time.Now(), time.Now(), nil))
+
+	provider, others, err := repo.GetProviderByNamespace(context.Background(), "acme", "widget")
+	if err != nil {
+		t.Fatalf("GetProviderByNamespace: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("a collision returned nothing; it must still serve one row deterministically")
+	}
+	if provider.ID != "prov-older" {
+		t.Errorf("served %q, want the oldest row %q -- resolution must not depend on row order", provider.ID, "prov-older")
+	}
+	if others != 1 {
+		t.Errorf("others = %d, want 1; the collision would go unreported", others)
+	}
+}

--- a/backend/internal/db/repositories/provider_repository.go
+++ b/backend/internal/db/repositories/provider_repository.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strconv"
 	"strings"
@@ -136,6 +137,84 @@ func (r *ProviderRepository) GetProvider(ctx context.Context, orgID, namespace, 
 	}
 
 	return provider, nil
+}
+
+// providerSelectColumns is the projection GetProvider and GetProviderByNamespace
+// share, so the two cannot drift into scanning different shapes.
+const providerSelectColumns = `p.id, p.organization_id, p.namespace, p.type, p.description, p.source,
+	       p.created_by, p.created_at, p.updated_at, u.name as created_by_name`
+
+// GetProviderByNamespace resolves a provider from the protocol coordinates
+// alone, with NO organization predicate (#972).
+//
+// WHY THERE IS NO ORGANIZATION ARGUMENT. A provider source is
+// host/namespace/type: two identifier segments and no slot for an organization,
+// so a Terraform client cannot supply one. Every public provider route
+// previously resolved the organization literally named "default" and passed it
+// as a filter, which made a provider owned by any OTHER organization a
+// permanent 404 to every client -- with no error, so it read as "that provider
+// does not exist" rather than as a misconfiguration.
+//
+// This is the same treatment GetModuleByNamespace already gives modules, and
+// bringing the provider half along is the whole point: the two halves of one
+// protocol disagreed, and a deployment that renamed or deleted its default
+// organization served its modules correctly and its providers to nobody.
+//
+// The organization still governs who may PUBLISH under a namespace. It never
+// governed who may read, because the protocol has nowhere to put it.
+//
+// Returns (nil, 0, nil) when nothing matches. `others` is the number of
+// ADDITIONAL rows sharing these coordinates.
+func (r *ProviderRepository) GetProviderByNamespace(ctx context.Context, namespace, providerType string) (provider *models.Provider, others int, err error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT `+providerSelectColumns+`
+		FROM providers p
+		LEFT JOIN users u ON p.created_by = u.id
+		WHERE p.namespace = $1 AND p.type = $2
+		ORDER BY p.created_at ASC, p.id ASC`, namespace, providerType)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get provider by namespace: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		p := &models.Provider{}
+		var scannedOrgID sql.NullString
+		if scanErr := rows.Scan(
+			&p.ID, &scannedOrgID, &p.Namespace, &p.Type, &p.Description,
+			&p.Source, &p.CreatedBy, &p.CreatedAt, &p.UpdatedAt, &p.CreatedByName,
+		); scanErr != nil {
+			return nil, 0, fmt.Errorf("failed to scan provider: %w", scanErr)
+		}
+		// organization_id is nullable: mirrored and single-tenant providers
+		// carry NULL, and this query includes them because it filters on
+		// nothing else. Scanned through a NullString so a NULL is an empty
+		// string rather than a scan error.
+		if scannedOrgID.Valid {
+			p.OrganizationID = scannedOrgID.String
+		}
+		if provider == nil {
+			provider = p
+			continue
+		}
+		others++
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("failed to read providers: %w", err)
+	}
+	if others > 0 {
+		// Logged HERE rather than left to each caller, for the same reason
+		// GetModuleByNamespace does it: this is a fact about the data, not
+		// about the request, so every reader of these coordinates is affected
+		// and a signal that depends on somebody checking a return value goes
+		// quiet exactly when a new call site is added.
+		slog.Error("provider namespace collision: these coordinates resolve to more than one row, "+
+			"and provider storage keys carry no organization segment — the archives may already "+
+			"have overwritten one another",
+			"namespace", namespace, "type", providerType,
+			"rows", others+1, "serving_provider_id", provider.ID, "serving_organization_id", provider.OrganizationID)
+	}
+	return provider, others, nil
 }
 
 // GetProviderByNamespaceType retrieves a provider by namespace and type only (for single-tenant mode)


### PR DESCRIPTION
Closes #972.

## The fix

A provider source is `host/namespace/type` — two identifier segments and no slot for an organization — so a Terraform client cannot supply one. Filtering by one was therefore never a narrowing of what the caller asked for: it guessed the organization literally named `default`, and every provider owned by any other organization was a permanent 404, with no error to say why.

`GetProviderByNamespace` is the counterpart to the module half's `GetModuleByNamespace`, which already resolves this way with this exact reasoning written above it. It carries the same collision reporting, because dropping the organization predicate makes two organizations publishing the same `namespace/type` resolvable — and provider storage keys carry no organization segment, so those archives may already have overwritten one another. Resolution is ordered by `created_at, id`: a resolution that varies per request is worse than one that is consistently wrong.

Per the issue's caution, `GetProvider` keeps its `OR p.organization_id IS NULL` clause untouched for its remaining callers. Dropping the predicate entirely subsumes that case, and there is a test asserting it rather than an assumption that it does.

## Seven call sites, not five

The issue names five. Two more had the same defect, and they are the ones worth reporting.

**`modules.ServeFileHandler` carries the mirrored-version approval gate**, nested inside the default-org resolution:

```go
if org, err := orgRepo.GetDefaultOrganization(...); err == nil && org != nil {
    if provider, err := providerRepo.GetProvider(..., org.ID, ns, pt); err == nil && provider != nil {
        // ... approval check ...
```

For a provider owned by another organization this did not return a wrong answer — it **silently did not run**. The lookup missed, the nested conditions fell through, and the archive was served. That is precisely the approval bypass the gate exists to prevent, and it was invisible.

**`trackProviderDownload`** never counted a download for such a provider, silently, since it runs detached and returns on every miss.

## What is deliberately not changed

**The two mirror handlers keep their org resolution.** It feeds the *pull-through* configuration — which upstream to fetch from, with which credentials — and that genuinely is owned by an organization, unlike the lookup of an already-published provider. Only the lookups within them changed.

It is recorded as a **named exemption with the reason**, not as an absence, and the note says why it is not obviously right either: a provider published under organization B whose pull-through config lives under `default` will use the wrong upstream. That is a different question from this 404 and belongs with the host work.

**The admin write surface still resolves an organization.** Create, update, delete and upload decide who may *publish* under a namespace, which **is** an organization question. Only read resolution is org-blind.

## Why a class guard is the actual change

Seven call sites across five files, all written the same way, and the idiom — resolve the default org, pass its ID to a lookup — is the obvious thing to write again. `TestProviderProtocolReadsAreOrganizationBlind` walks the AST of the provider-read functions and fails on either shape: calling the org-taking `GetProvider`, or resolving the default organization at all. Both matter, because in `ServeFileHandler` the *resolution itself* was the gate's outer condition.

A guard that only checked the routes which 404 would have missed exactly the one that mattered most.

Seven mutations, each confirmed to **apply and compile**:

| Mutation | Caught |
|---|---|
| protocol listing filters by default org again | ✓ |
| approval gate filters by default org again | ✓ |
| public detail route filters by default org again | ✓ |
| repository reintroduces the org predicate | ✓ |
| collision reporting silenced | ✓ |
| drop the approval-gate watch entry | ✓ (after the fix below) |
| drop any watch entry (floor) | ✓ (after the fix below) |

**One was inert first time.** Deleting an entry from the watch map silently stopped checking that call site while the file still reported green — the same failure the map exists to prevent, one level up. There is now a floor on the map's size *and* a by-name assertion for the approval gate specifically, since a floor alone would let someone drop that entry and add a trivial one.

## Tests deleted rather than adapted

`TestListVersionsHandler_OrgError`, `TestListVersionsHandler_OrgNotFound`, `TestDownloadHandler_OrgError`, `TestDownloadHandler_OrgNotFound` and `TestGetProvider_OrgDBError` assert a "default organization not found" branch these handlers can no longer reach. A test that keeps asserting a branch the code cannot take is a claim about behaviour that does not exist.

The `OrgFound` prefix on three surviving admin tests is now historical, and a comment at that section says so rather than leaving the names reading as live assertions.

Two entries also came off `domainDBIsCorrect` in `identity_db_wiring_test.go` — that guard caught them itself, which is what it is for.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on `./internal/api/...` and `./internal/db/repositories/...` — 0 issues
- Coverage 75.4%, identical to `main` under the same local (no-Postgres) invocation
