### PR TITLE
docs(approval): record the two #975 decisions as settled

### DIFF
--- a/backend/internal/db/repositories/version_approval_coverage_test.go
+++ b/backend/internal/db/repositories/version_approval_coverage_test.go
@@ -60,11 +60,14 @@ var unionBranch = map[string]string{
 // distinguished from an oversight. Naming them turns "modules are not gated"
 // into a statement someone decided rather than one nobody noticed.
 var ungatedArtifactTables = map[string]string{
-	"modules": "no approval concept exists for modules anywhere in the schema. A module published " +
-		"here came from a principal that already held publish rights under a claimed namespace, " +
-		"so the gate's question -- should this UPSTREAM artifact be trusted -- does not arise. " +
-		"Whether modules should have an approval concept at all is an open product question (#975).",
-	"module_versions": "as above; the approval concept, if one is ever added, would live here.",
+	"modules": "DECIDED 2026-08-27: modules stay ungated (#975). No approval concept exists for " +
+		"them anywhere in the schema, and that is the intended shape rather than a gap. This gate " +
+		"answers 'should this UPSTREAM artifact be trusted'; a module published here came from a " +
+		"principal that already held publish rights under a claimed namespace, enforced on every " +
+		"mutation by middleware.NamespaceAuthorizer, so the question does not arise. The gate is " +
+		"the control over what may be mirrored IN, not over what may be consumed.",
+	"module_versions": "as above, decided ungated (#975). If that is ever revisited, the approval " +
+		"concept would live here.",
 	"provider_versions": "locally UPLOADED provider versions are ungated by design: " +
 		"GetVersionApprovalStatus returns nil when no mirrored row exists, and callers treat nil " +
 		"as visible. Only the mirrored tracking row carries a verdict.",

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -185,9 +185,10 @@ Terraform modules and providers. It comprises:
 > reaches clients as soon as its scan completes, with no human decision in the
 > path.
 >
-> That is a defensible position — the gate exists to vet what arrives from
-> outside, and an upload came from a principal that already held publish rights
-> under a claimed namespace — but it is not the control this row was claiming.
+> That is the intended shape, confirmed as a decision on 2026-08-27 — the gate
+> exists to vet what arrives from outside, and an upload came from a principal
+> that already held publish rights under a claimed namespace — but it is not the
+> control this row was claiming.
 > A threat model that lists a mitigation which does not exist is worse than one
 > that leaves the risk unmitigated, because it stops anyone looking.
 >

--- a/docs/version-approval.md
+++ b/docs/version-approval.md
@@ -50,9 +50,14 @@ apply to:
 | Modules | No approval concept exists for modules anywhere in the schema. A module published here came from a principal that already held publish rights under a claimed namespace. |
 | Locally uploaded provider versions | Only the mirrored tracking row carries a verdict; a version with no mirrored row is treated as visible. |
 
-Whether modules should have an approval concept at all is an open question
-(#975). Until it is answered, do not describe this gate as the control over
-what may be consumed — it is the control over what may be **mirrored in**.
+**Modules are deliberately ungated** (decided 2026-08-27, #975). A module
+published here came from a principal that already held publish rights under a
+claimed namespace, enforced on every mutation by `NamespaceAuthorizer` — so this
+gate's question, *should this upstream artifact be trusted*, does not arise for
+it.
+
+Do not describe this gate as the control over what may be consumed. It is the
+control over what may be **mirrored in**.
 
 ### One verdict per artifact, shared by every organization
 
@@ -67,11 +72,14 @@ approve decides for everyone; the first to reject does too.** A second
 organization's administrator sees the artifact leave their queue without having
 acted on it.
 
-This is a known limitation, not a subtlety of the design. Under the
+This is a known and accepted limitation, not a subtlety of the design. Under the
 [estate tenancy model](https://github.com/sethbacon/terraform-suite-identity/blob/main/docs/tenancy-model.md),
 version approval and mirror configuration gate which providers a **host**
 offers, so the fix is a re-key of the verdict to per-(host, artifact) — which is
 part of the host work rather than a change that can be made independently of it.
+Re-keying it per-organization first was considered and rejected (2026-08-27):
+the host work would re-key the same column again, and running two migrations
+over one authorization verdict is how one of them ends up half-applied.
 
 Until then: if two organizations need independent verdicts on the same upstream
 provider, they need separate deployments.


### PR DESCRIPTION
Closes #975.

Follow-up to #984, which pinned the gate's reach but left both product questions open. You've now answered both, so the code and docs read as decisions rather than pending items — an "open question" comment nobody ever closes is indistinguishable from one nobody noticed.

**Modules stay ungated.** Not a gap — the intended shape. This gate answers *should this upstream artifact be trusted*; a module published here came from a principal that already held publish rights under a claimed namespace, enforced on every mutation by `NamespaceAuthorizer`. Stated in that form in `version_approval_coverage_test.go`, `docs/version-approval.md` and the RR-5 correction in `docs/threat-model.md`, rather than implied by the absence of a column.

**The deployment-wide verdict waits for the host key.** Re-keying per-organization first was considered and rejected: the host work re-keys the same column again, and two migrations over one authorization verdict is how one ends up half-applied. The limitation and its only current workaround (separate deployments) stay documented.

No behaviour change — comments and docs only. Guard tests still green.