### PR TITLE
fix(config): remove multi_tenancy, which was wrong in both positions

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -661,7 +661,6 @@ func serve(cfg *config.Config) error {
 		log.Printf("Starting server on %s", cfg.Server.GetAddress())  // #nosec G706 -- config values from trusted config file/env, not user input
 		log.Printf("Base URL: %s", cfg.Server.BaseURL)                // #nosec G706 -- config values from trusted config file/env, not user input
 		log.Printf("Storage backend: %s", cfg.Storage.DefaultBackend) // #nosec G706 -- config values from trusted config file/env, not user input
-		log.Printf("Multi-tenancy: %v", cfg.MultiTenancy.Enabled)     // #nosec G706 -- config values from trusted config file/env, not user input
 		log.Println("Server is ready to accept connections")
 
 		var err error

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -142,10 +142,6 @@ auth:
     group_mappings: []
     default_role: ""
 
-multi_tenancy:
-  enabled: false  # Set to true for multi-organization support
-  default_organization: default
-  allow_public_signup: false  # Allow users to create organizations
 
 security:
   cors:

--- a/backend/internal/api/identity_db_wiring_test.go
+++ b/backend/internal/api/identity_db_wiring_test.go
@@ -86,16 +86,19 @@ var domainDBIsCorrect = map[string]string{
 	"admin.NewProviderAdminHandlers": "provider administration over domain tables",
 	"mirror.IndexHandler":            "mirror index over domain tables",
 	"mirror.PlatformIndexHandler":    "mirror index over domain tables",
-	"modules.SearchHandler":          "namespace -> org resolution joined to modules",
 	"modules.UploadHandler":          "namespace -> org resolution joined to modules",
 	"oci.NewHandler":                 "OCI blobs joined to modules",
+	// The two SearchHandlers used to be here too. They resolved the default
+	// organization only when multi_tenancy.enabled was set -- a flag whose
+	// every position was wrong and which #976 removed, so they now build no
+	// identity repository at all.
+	//
 	// modules.ServeFileHandler, providers.DownloadHandler and
 	// providers.ListVersionsHandler used to be here. Each resolved the default
 	// organization to filter a provider lookup, which made every provider owned
 	// by another organization a 404 -- and in ServeFileHandler's case silently
 	// skipped the mirrored-version approval gate entirely (#972). All three now
 	// resolve by namespace alone and build no identity repository at all.
-	"providers.SearchHandler": "namespace -> org resolution joined to providers",
 	"providers.UploadHandler": "namespace -> org resolution joined to providers",
 	"..NewRouter":             "the router itself; it receives both connections",
 }

--- a/backend/internal/api/modules/modules_test.go
+++ b/backend/internal/api/modules/modules_test.go
@@ -118,15 +118,6 @@ var moduleVersionGetCols2 = []string{
 	"commit_sha", "tag_name", "scm_repo_id",
 }
 
-// SearchModulesWithStats result: id, org_id, namespace, name, system, description, source,
-// created_by, created_by_name, created_at, updated_at, deprecated, deprecated_at, deprecation_message, successor_module_id, latest_version, total_downloads
-var moduleSearchCols = []string{
-	"id", "organization_id", "namespace", "name", "system", "description", "source",
-	"created_by", "created_by_name", "created_at", "updated_at",
-	"deprecated", "deprecated_at", "deprecation_message", "successor_module_id",
-	"latest_version", "total_downloads",
-}
-
 // moduleSearchColsFTS adds the rank column for FTS queries (searchQuery >= 3 chars).
 var moduleSearchColsFTS = []string{
 	"id", "organization_id", "namespace", "name", "system", "description", "source",
@@ -396,21 +387,6 @@ func TestSearchHandler_Success_SingleTenant(t *testing.T) {
 	}
 }
 
-func TestSearchHandler_Success_MultiTenant(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.MultiTenancy.Enabled = true
-	mock, r := newSearchRouter(t, cfg)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow2())
-	mock.ExpectQuery("SELECT COUNT.*FROM modules").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery("SELECT.*FROM modules.*ORDER BY").WillReturnRows(sqlmock.NewRows(moduleSearchCols))
-
-	w := doGET(r, "/v1/modules/search")
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
-	}
-}
-
 func TestSearchHandler_SearchError(t *testing.T) {
 	mock, r := newSearchRouter(t, &config.Config{})
 
@@ -421,23 +397,6 @@ func TestSearchHandler_SearchError(t *testing.T) {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
-
-func TestSearchHandler_MultiTenant_OrgError(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.MultiTenancy.Enabled = true
-	mock, r := newSearchRouter(t, cfg)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnError(errDB2)
-
-	w := doGET(r, "/v1/modules/search")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// DownloadHandler tests
-// ---------------------------------------------------------------------------
 
 func TestDownloadHandler_InvalidVersion(t *testing.T) {
 	_, r := newDownloadRouter(t, &mockStore{})

--- a/backend/internal/api/modules/search.go
+++ b/backend/internal/api/modules/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
-	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
@@ -42,7 +41,6 @@ var validModuleSortFields = map[string]bool{
 // Implements: GET /api/v1/modules/search?q=<query>&namespace=<namespace>&system=<system>&sort=<sort>&order=<order>&limit=<limit>&offset=<offset>
 func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 	moduleRepo := repositories.NewModuleRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
 
 	return func(c *gin.Context) {
 		// Get query parameters
@@ -74,24 +72,21 @@ func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			offset = 0
 		}
 
-		// Get organization context
+		// NO ORGANIZATION PREDICATE (#976). Search is public by decision -- see
+		// declaredPublicRoutes in internal/api/public_surface_class_test.go and
+		// the note above these routes in router_routes.go.
+		//
+		// This used to be conditional on multi_tenancy.enabled, a flag whose
+		// BOTH positions were wrong. False (the shipped default) applied no
+		// predicate, which is this behaviour. True resolved the organization
+		// literally named "default" -- never the caller's -- so every real
+		// tenant saw an EMPTY registry while the default organization's
+		// inventory stayed visible to everyone. It looked like the
+		// multi-tenancy switch and was the first thing anyone moving toward
+		// isolation would reach for; turning it on was an outage plus a
+		// continuing leak. Removed rather than repaired: isolation is carried
+		// by the host, not by a search filter.
 		var orgID string
-		if cfg.MultiTenancy.Enabled {
-			org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-			if identityerr.Missing(org, err) {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Default organization not found",
-				})
-				return
-			}
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Failed to get organization context",
-				})
-				return
-			}
-			orgID = org.ID
-		}
 
 		// Search modules with aggregated version stats in a single query
 		modules, total, err := moduleRepo.SearchModulesWithStats(

--- a/backend/internal/api/providers/providers_test.go
+++ b/backend/internal/api/providers/providers_test.go
@@ -138,14 +138,6 @@ var platformCols = []string{
 	"storage_path", "storage_backend", "size_bytes", "shasum", "h1_hash", "download_count",
 }
 
-// SearchProvidersWithStats result: id, org_id, namespace, type, description, source,
-// created_by, created_by_name, created_at, updated_at, latest_version, total_downloads
-var providerSearchCols = []string{
-	"id", "organization_id", "namespace", "type", "description", "source",
-	"created_by", "created_by_name", "created_at", "updated_at",
-	"latest_version", "total_downloads",
-}
-
 // providerSearchColsFTS adds the rank column for FTS queries (searchQuery >= 3 chars).
 var providerSearchColsFTS = []string{
 	"id", "organization_id", "namespace", "type", "description", "source",
@@ -318,21 +310,6 @@ func TestSearchHandler_Success_SingleTenant(t *testing.T) {
 	}
 }
 
-func TestSearchHandler_Success_MultiTenant(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.MultiTenancy.Enabled = true
-	mock, r := newSearchRouter(t, cfg)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sampleOrgRow())
-	mock.ExpectQuery("SELECT COUNT.*FROM providers").WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
-	mock.ExpectQuery("SELECT.*FROM providers.*ORDER BY").WillReturnRows(sqlmock.NewRows(providerSearchCols))
-
-	w := doGET(r, "/v1/providers/search")
-	if w.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200; body: %s", w.Code, w.Body.String())
-	}
-}
-
 func TestSearchHandler_SearchError(t *testing.T) {
 	mock, r := newSearchRouter(t, &config.Config{})
 
@@ -343,23 +320,6 @@ func TestSearchHandler_SearchError(t *testing.T) {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
 }
-
-func TestSearchHandler_MultiTenant_OrgNotFound(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.MultiTenancy.Enabled = true
-	mock, r := newSearchRouter(t, cfg)
-
-	mock.ExpectQuery("SELECT.*FROM organizations.*WHERE name").WillReturnRows(sqlmock.NewRows(orgCols))
-
-	w := doGET(r, "/v1/providers/search")
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500", w.Code)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// DownloadHandler tests
-// ---------------------------------------------------------------------------
 
 func TestDownloadHandler_InvalidVersion(t *testing.T) {
 	_, r := newDownloadRouter(t, &mockStore{})

--- a/backend/internal/api/providers/search.go
+++ b/backend/internal/api/providers/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/terraform-registry/terraform-registry/internal/config"
 	"github.com/terraform-registry/terraform-registry/internal/db/repositories"
-	"github.com/terraform-registry/terraform-registry/internal/identityerr"
 	"github.com/terraform-registry/terraform-registry/internal/pagination"
 )
 
@@ -41,7 +40,6 @@ var validProviderSortFields = map[string]bool{
 // Implements: GET /api/v1/providers/search?q=<query>&namespace=<namespace>&sort=<sort>&order=<order>&limit=<limit>&offset=<offset>
 func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 	providerRepo := repositories.NewProviderRepository(db)
-	orgRepo := repositories.NewOrganizationRepository(db)
 
 	return func(c *gin.Context) {
 		// Get query parameters
@@ -72,24 +70,21 @@ func SearchHandler(db *sql.DB, cfg *config.Config) gin.HandlerFunc {
 			offset = 0
 		}
 
-		// Get organization context
+		// NO ORGANIZATION PREDICATE (#976). Search is public by decision -- see
+		// declaredPublicRoutes in internal/api/public_surface_class_test.go and
+		// the note above these routes in router_routes.go.
+		//
+		// This used to be conditional on multi_tenancy.enabled, a flag whose
+		// BOTH positions were wrong. False (the shipped default) applied no
+		// predicate, which is this behaviour. True resolved the organization
+		// literally named "default" -- never the caller's -- so every real
+		// tenant saw an EMPTY registry while the default organization's
+		// inventory stayed visible to everyone. It looked like the
+		// multi-tenancy switch and was the first thing anyone moving toward
+		// isolation would reach for; turning it on was an outage plus a
+		// continuing leak. Removed rather than repaired: isolation is carried
+		// by the host, not by a search filter.
 		var orgID string
-		if cfg.MultiTenancy.Enabled {
-			org, err := orgRepo.GetDefaultOrganization(c.Request.Context())
-			if identityerr.Missing(org, err) {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Default organization not found",
-				})
-				return
-			}
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": "Failed to get organization context",
-				})
-				return
-			}
-			orgID = org.ID
-		}
 		// In single-tenant mode, orgID will be empty string which the repository will handle
 
 		// Search providers with aggregated version stats in a single query

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,8 +13,10 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -37,7 +39,6 @@ type Config struct {
 	Auth             AuthConfig     `mapstructure:"auth"`
 	// ApiDocs holds OpenAPI/Swagger metadata that can be overridden at deploy-time
 	ApiDocs         ApiDocsConfig         `mapstructure:"api_docs"`
-	MultiTenancy    MultiTenancyConfig    `mapstructure:"multi_tenancy"`
 	Security        SecurityConfig        `mapstructure:"security"`
 	Logging         LoggingConfig         `mapstructure:"logging"`
 	Telemetry       TelemetryConfig       `mapstructure:"telemetry"`
@@ -610,13 +611,6 @@ type LDAPConfig struct {
 	DefaultRole     string             `mapstructure:"default_role"`
 }
 
-// MultiTenancyConfig holds multi-tenancy configuration
-type MultiTenancyConfig struct {
-	Enabled             bool   `mapstructure:"enabled"`
-	DefaultOrganization string `mapstructure:"default_organization"`
-	AllowPublicSignup   bool   `mapstructure:"allow_public_signup"`
-}
-
 // SecurityConfig holds security-related configuration
 type SecurityConfig struct {
 	CORS         CORSConfig         `mapstructure:"cors"`
@@ -967,11 +961,6 @@ func bindEnvVars(v *viper.Viper) error {
 		"auth.azure_ad.client_secret",
 		"auth.azure_ad.redirect_url",
 
-		// Multi-tenancy
-		"multi_tenancy.enabled",
-		"multi_tenancy.default_organization",
-		"multi_tenancy.allow_public_signup",
-
 		// Security
 		"security.cors.allowed_origins",
 		"security.cors.allowed_methods",
@@ -1068,6 +1057,37 @@ func bindEnvVars(v *viper.Viper) error {
 }
 
 // Load loads configuration from file and environment variables
+// removedMultiTenancyKeys are the keys #976 deleted, with what each actually did.
+//
+// Kept as a list rather than one blanket "multi_tenancy is gone" message because
+// the three did different things and only one of them was dangerous.
+var removedMultiTenancyKeys = map[string]string{
+	"multi_tenancy.enabled": "had NO correct position. false applied no organization predicate to " +
+		"search; true filtered to the organization literally named \"default\" -- never the " +
+		"caller's -- so every real tenant saw an empty registry while the default organization's " +
+		"inventory stayed visible to everyone. Search is public by decision; isolation is carried " +
+		"by the host",
+	"multi_tenancy.default_organization": "was never read by anything. The organization name is " +
+		"hardcoded in the identity module",
+	"multi_tenancy.allow_public_signup": "was never read by anything",
+}
+
+// warnOnRemovedMultiTenancyKeys logs, once per supplied key, at WARN.
+func warnOnRemovedMultiTenancyKeys(v *viper.Viper) {
+	keys := make([]string, 0, len(removedMultiTenancyKeys))
+	for k := range removedMultiTenancyKeys {
+		if v.IsSet(k) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		slog.Warn("this configuration key has been removed and is being ignored",
+			"key", k, "removed_in", "#976", "why", removedMultiTenancyKeys[k],
+			"action", "delete it from your configuration")
+	}
+}
+
 func Load(configPath string) (*Config, error) {
 	v := viper.New()
 
@@ -1093,6 +1113,20 @@ func Load(configPath string) (*Config, error) {
 		}
 		// Config file not found; use defaults and environment variables
 	}
+
+	// Tell an operator who still sets multi_tenancy.* that it is gone (#976).
+	//
+	// Silently ignoring a removed key is the wrong treatment here, because the
+	// deployment most likely to carry it is the one that set enabled=true and
+	// has been serving an EMPTY REGISTRY to every real tenant. That
+	// deployment's behaviour changes the moment this version boots, and the
+	// operator needs to know why their content reappeared -- otherwise the
+	// change looks like a regression in isolation rather than the removal of a
+	// setting that never provided any.
+	//
+	// Read before defaults are consulted for these keys, which they no longer
+	// are: IsSet is therefore true only if the operator actually supplied it.
+	warnOnRemovedMultiTenancyKeys(v)
 
 	// Enable environment variable support
 	v.SetEnvPrefix("TFR")
@@ -1197,9 +1231,6 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("auth.azure_ad.enabled", false)
 
 	// Multi-tenancy defaults
-	v.SetDefault("multi_tenancy.enabled", false)
-	v.SetDefault("multi_tenancy.default_organization", "default")
-	v.SetDefault("multi_tenancy.allow_public_signup", false)
 
 	// Security defaults
 	// allowed_origins defaults to deny-by-default (no origins allowed) rather than a

--- a/backend/internal/config/removed_keys_test.go
+++ b/backend/internal/config/removed_keys_test.go
@@ -1,0 +1,153 @@
+package config
+
+// removed_keys_test.go keeps multi_tenancy.* deleted, and keeps the operator
+// warning honest (#976).
+//
+// WHY A GUARD FOR A DELETION. The flag looked exactly like the multi-tenancy
+// switch, which is why it existed and why someone will reach for that name
+// again. Both of its positions were wrong: false applied no organization
+// predicate to search, and true filtered to the organization literally named
+// "default" -- never the caller's -- so every real tenant saw an EMPTY REGISTRY
+// while the default organization's inventory stayed visible to everyone.
+// Re-adding a key by that name is far more likely than re-adding the specific
+// broken code behind it, and a name that implies isolation is the part that
+// misleads.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// minScannedGoFiles is the floor for the walk below. The tree held ~630 Go
+// files when this was written; the floor is set well under that so ordinary
+// growth and pruning do not trip it, and well over zero so a broken walk does.
+const minScannedGoFiles = 200
+
+func TestMultiTenancyKeysStayRemoved(t *testing.T) {
+	root := ".."
+	var offenders []string
+
+	scanned := 0
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// NEVER SKIP THE ROOT. filepath.Walk calls this with path == root
+			// first, and root here is "..", whose Name() is ".." -- which the
+			// hidden-directory test below matches. The first version of this
+			// guard skipped the root and walked ZERO files, passing while
+			// looking at nothing. It was caught by mutation: planting a
+			// reference in modules/search.go did not fail it, and neither did
+			// the real reference already sitting in that file's comment.
+			if path != root {
+				if info.Name() == "vendor" || info.Name() == "node_modules" || strings.HasPrefix(info.Name(), ".") {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// These two name the keys in code on purpose: config.go carries the
+		// warning list, and this file asserts against it.
+		if filepath.Base(path) == "removed_keys_test.go" || filepath.Base(path) == "config.go" {
+			return nil
+		}
+		scanned++
+		// PARSED, NOT GREPPED. A textual match also fires on the comments that
+		// explain the removal -- in search.go, in the identity-wiring list, and
+		// in this file -- and a guard that flags the documentation of a fix is
+		// one that gets deleted or blanket-suppressed. What must not come back
+		// is CODE that reads the flag: an identifier or a config key string.
+		// parser.ParseFile without ParseComments drops comments entirely, so
+		// prose is free and references are not.
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			// A file this package cannot parse is not evidence of anything;
+			// the compiler will object long before this test does.
+			return nil //nolint:nilerr // parse failures are the compiler's business
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch v := n.(type) {
+			case *ast.Ident:
+				if v.Name == "MultiTenancy" || v.Name == "MultiTenancyConfig" {
+					offenders = append(offenders, path)
+				}
+			case *ast.BasicLit:
+				if v.Kind == token.STRING && strings.Contains(v.Value, "multi_tenancy") {
+					offenders = append(offenders, path)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	// The empty-universe guard, and the reason this test is trustworthy at all:
+	// "no offenders" and "looked at nothing" are the same green.
+	if scanned < minScannedGoFiles {
+		t.Fatalf("scanned only %d Go files (floor %d): the walk is not reaching the tree, so this "+
+			"test passes without examining anything", scanned, minScannedGoFiles)
+	}
+
+	sort.Strings(offenders)
+	for _, p := range offenders {
+		t.Errorf("%s references multi_tenancy, which #976 removed.\n"+
+			"If you need per-tenant isolation, it is carried by the HOST -- see the estate tenancy "+
+			"model. A search filter named after multi-tenancy is what made the original flag "+
+			"dangerous: it looked like the isolation switch and was not one.", p)
+	}
+}
+
+// TestRemovedKeysAreOnlyDeclaredInConfig stops the warning list itself from
+// becoming the thing that reintroduces the keys.
+func TestRemovedKeysAreOnlyDeclaredInConfig(t *testing.T) {
+	if len(removedMultiTenancyKeys) == 0 {
+		t.Fatal("removedMultiTenancyKeys is empty, so an operator who still sets these keys is told " +
+			"nothing and their registry silently changes shape on upgrade")
+	}
+	for k, why := range removedMultiTenancyKeys {
+		if !strings.HasPrefix(k, "multi_tenancy.") {
+			t.Errorf("removedMultiTenancyKeys has %q, which is not a multi_tenancy key", k)
+		}
+		if why == "" {
+			t.Errorf("%q is warned about with no reason; a warning an operator cannot act on gets ignored", k)
+		}
+	}
+}
+
+// TestSuppliedRemovedKeyWarns is the behavioural half.
+//
+// The condition that matters is "the operator SUPPLIED it", not "it has a
+// value" -- which is why the defaults for these keys were deleted rather than
+// left in place. A SetDefault would make viper.IsSet true on every boot and
+// turn this warning into noise that everyone learns to skip.
+func TestSuppliedRemovedKeyWarns(t *testing.T) {
+	for key := range removedMultiTenancyKeys {
+		t.Run(key, func(t *testing.T) {
+			v := viper.New()
+			setDefaults(v)
+			if v.IsSet(key) {
+				t.Fatalf("%s still has a default, so IsSet is true for every deployment and the "+
+					"warning fires whether or not the operator set anything", key)
+			}
+			v.Set(key, "whatever")
+			if !v.IsSet(key) {
+				t.Errorf("%s was supplied but IsSet is false, so the operator would be told nothing", key)
+			}
+		})
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -109,10 +109,6 @@ auth:
     #    role: admin
     default_role: ""
 
-multi_tenancy:
-  enabled: false # Set to true for multi-organization support
-  default_organization: default
-  allow_public_signup: false # Allow users to create organizations
 
 security:
   cors:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -726,20 +726,35 @@ security:
 
 ## Multi-Tenancy
 
-```yaml
-multi_tenancy:
-  enabled: false                    # false = single-tenant (one organization)
-  default_organization: default     # slug of the default organization
-  allow_public_signup: false        # whether unauthenticated users can create orgs
-```
+**The `multi_tenancy` settings have been removed** (#976). If your configuration
+still has them, the server logs a `WARN` naming each one at startup and ignores
+it. Delete the block.
 
-**Single-tenant mode** (`enabled: false`): All modules and providers belong to one
-organization. Namespaces in Terraform addresses are not organization-isolated.
-Suitable for teams that don't need separate permission boundaries.
+They never did what their name said. This section used to promise that
+`enabled: true` gave each organization "isolated modules, providers, and member
+lists". It did not:
 
-**Multi-tenant mode** (`enabled: true`): Each organization has isolated modules,
-providers, and member lists. Users must be added to an organization to access its resources.
-Use this when hosting the registry for multiple independent teams or customers.
+| Setting | What it actually did |
+| --- | --- |
+| `enabled: false` (the shipped default) | applied no organization predicate to search — every module and provider in the deployment, to anyone |
+| `enabled: true` | filtered search to the organization literally named `default`, never the caller's — so **every real tenant saw an empty registry**, while the default organization's inventory stayed visible to everyone |
+| `default_organization` | never read by anything; the name is hardcoded in the identity module |
+| `allow_public_signup` | never read by anything |
+
+Neither position of `enabled` resolved the *caller's* organization, so neither
+was a tenancy control. It was the first thing anyone moving toward isolation
+would reach for, and turning it on was an outage plus a continuing leak.
+
+**Where isolation actually lives.** Per the
+[estate tenancy model](https://github.com/sethbacon/terraform-suite-identity/blob/main/docs/tenancy-model.md),
+the **host** is the content tenant: modules, providers and binaries belong to a
+host, and organizations divide editorial rights within one. Search being public
+is a separate, deliberate decision — see the note above the route registrations
+in `internal/api/router_routes.go`.
+
+Organizations, memberships and role templates are unaffected by this removal;
+they are configured through the identity settings above and the admin UI, and
+they were never governed by this flag.
 
 ---
 


### PR DESCRIPTION
Closes #976. Takes the issue's recommendation — **remove, don't repair**.

## Confirmed, and one addition

Everything in the issue re-derived against current `main`:

| Setting | What it actually did |
| --- | --- |
| `enabled: false` (shipped default) | no organization predicate on search — every module and provider, to anyone |
| `enabled: true` | filtered to the organization literally named `default`, never the caller's → **every real tenant sees an empty registry**, default org's inventory stays public |
| `default_organization` | declared, defaulted, bindable, **never read** |
| `allow_public_signup` | **never read** — the issue doesn't mention this one; it's the same story, so the whole block goes |

Two call sites (`modules/search.go:79`, `providers/search.go:77`), one log line (`main.go:664`), one struct, three defaults, three bindable entries.

## The documentation was making the promise directly

This is the part I'd flag hardest. `docs/configuration.md` said:

> **Multi-tenant mode** (`enabled: true`): Each organization has isolated modules, providers, and member lists. Users must be added to an organization to access its resources. Use this when hosting the registry for multiple independent teams or customers.

It does none of that. An operator following that paragraph gets an outage and keeps the leak. Replaced with what each key actually did and a pointer to where isolation really lives (the host). Both `config.example.yaml` files lose the block.

## A removed key warns rather than being silently ignored

The deployment most likely to still carry this is the one that set `enabled: true` and has been serving an empty registry to every tenant. **Its content reappears the moment this version boots.** Without a message that reads as a regression in isolation, rather than as the removal of a setting that never provided any.

```
WARN this configuration key has been removed and is being ignored
     key=multi_tenancy.enabled removed_in=#976
     why="had NO correct position. false applied no organization predicate to search; true filtered to
          the organization literally named \"default\" -- never the caller's -- so every real tenant saw
          an empty registry while the default organization's inventory stayed visible to everyone..."
     action="delete it from your configuration"
```

The defaults for these keys are **deleted rather than kept**, which is what makes `viper.IsSet` mean *the operator supplied it*. A retained `SetDefault` would fire the warning on every boot and train everyone to skip it — asserted by a test.

## Tests deleted, not adapted

Four tests asserted the removed branch. One of them — `TestSearchHandler_Success_MultiTenant` — asserted a **zero-result response**. It was encoding the bug as expected behaviour, which is how a defect survives a test suite.

Two `identity_db_wiring_test.go` entries came off too; that guard caught them itself.

## The guard, and how it was wrong first

`TestMultiTenancyKeysStayRemoved` walks the module and fails on any identifier or config-key string naming these settings. Re-adding a key by that name is far likelier than re-adding the specific broken code behind it, and the *name* is the misleading part.

**Its first version was blind.** It walked from root `".."` and skipped any directory whose name starts with `"."` — but `filepath.Walk` calls the callback with the **root first**, and that root is named `".."`, which matches. It `SkipDir`'d immediately and passed having read **zero files**.

Caught by mutation: a planted reference didn't fail it — and neither did the *real* reference already sitting in `search.go`'s own comment. It now refuses to pass under a floor of scanned files, which is the assertion that would have caught it on day one.

**It also parses rather than greps.** A textual match fires on the comments explaining the removal, and a guard that flags the documentation of its own fix gets suppressed. It matches identifiers and string literals in the AST, so prose is free and code is not — verified in both directions:

| Mutation | Result |
|---|---|
| config key string reappears in a handler | caught |
| the struct name reappears | caught |
| the walk skips the root again (blind) | caught |
| **only a comment mentions it** | **correctly does not fire** |

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on `./internal/config/...`, `./internal/api/...`, `./cmd/...` — 0 issues (two test fixtures orphaned by the deleted tests were removed; the `...ColsFTS` variants share their prefix, so that needed boundary matching rather than `contains`)
- Coverage 75.4%, unchanged from `main` under the same local invocation
- Swagger regenerated with CI's invocation — **no diff**, the removal touches no annotated route
