### PR TITLE
fix(build): make swag and CI produce the same openapi3.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,42 +9,41 @@ swag:
 	cd backend && $(SWAG) init -g cmd/server/main.go --outputTypes json
 	@$(MAKE) openapi3
 
-# openapi3 converts the swag-generated Swagger 2.0 spec to OpenAPI 3.0 and
-# post-processes it so strict validators (oapi-codegen) accept the result:
-#   - Promotes operation-level path parameters to path level for every
-#     templated path (swag only emits per-operation params; OpenAPI 3 tools
-#     such as oapi-codegen require them at path level).
-# Downstream consumers (frontend codegen, terraform-provider-registry oapi-codegen)
-# require OpenAPI 3 — emitting it from this repo means each consumer doesn't
-# have to run its own conversion step.
+# openapi3 converts the swag-generated Swagger 2.0 spec to OpenAPI 3.0.
+#
+# This must stay byte-identical to CI's "Swagger generation" step, because the
+# swagger-docs-sync job regenerates the spec and commits ITS output to the PR
+# branch -- so any transformation here that CI does not also perform is
+# reverted, and a contributor who follows the documented workflow gets a large
+# diff that CI then throws away. That is what #947 was: they disagreed for
+# months and the artifact CI produced always won.
+#
+# NO PATH-PARAMETER HOISTING (#947). This target used to promote
+# operation-level path parameters to path level, on the stated grounds that
+# "OpenAPI 3 tools such as oapi-codegen require them at path level" and that
+# the downstream consumers needed it. Neither consumer did:
+#
+#   - terraform-provider-registry generates MODELS ONLY
+#     (internal/client/spec/oapi-codegen.yaml sets `client: false`), and
+#     oapi-codegen reads path parameters only when generating a client or a
+#     server. Its committed spec snapshot has 76 templated paths and ZERO
+#     path-level parameters, and its codegen has always worked.
+#   - terraform-registry-frontend has no typegen from openapi3.json at all.
+#     Its one spec consumer, frontend/scripts/contract-check.ts, reads
+#     swagger.json (OpenAPI 2) and parses the path templates itself.
+#
+# So the published spec never met a requirement that nothing had. The hoisting
+# was removed rather than adopted into CI because adding it would mean a large
+# one-time diff to satisfy no consumer.
+#
+# IF YOU ARE ADDING A CONSUMER THAT GENERATES A CLIENT OR SERVER from this
+# spec, it WILL need path-level parameters -- restore the hoisting here and add
+# it to CI's step in the same change, or the two will diverge again.
+# swagger_ci_parity_test.go fails if only one of them grows a post-process.
 openapi3:
 	@echo "Converting Swagger 2.0 -> OpenAPI 3.0..."
 	@test -x node_modules/.bin/swagger2openapi || (echo "swagger2openapi not installed — run 'npm install' first" && exit 1)
 	@node_modules/.bin/swagger2openapi backend/docs/swagger.json -o backend/docs/openapi3.json -p
-	@echo "Hoisting operation-level path parameters to path level..."
-	@node -e " \
-	  const fs = require('fs'); \
-	  const spec = JSON.parse(fs.readFileSync('backend/docs/openapi3.json', 'utf8')); \
-	  const methods = ['get','post','put','patch','delete','head','options','trace']; \
-	  for (const [path, item] of Object.entries(spec.paths || {})) { \
-	    if (!path.includes('{') || item.parameters) continue; \
-	    const byName = {}; \
-	    const names = [...path.matchAll(/\{([^}]+)\}/g)].map(m => m[1]); \
-	    for (const m of methods) { \
-	      const op = item[m]; \
-	      if (!op) continue; \
-	      for (const p of (op.parameters || [])) { \
-	        if (p.in === 'path' && names.includes(p.name)) byName[p.name] = p; \
-	      } \
-	    } \
-	    for (const n of names) { \
-	      if (!byName[n]) byName[n] = {name:n,in:'path',required:true,schema:{type:'string'}}; \
-	    } \
-	    item.parameters = Object.keys(byName).sort().map(n => byName[n]); \
-	  } \
-	  fs.writeFileSync('backend/docs/openapi3.json', JSON.stringify(spec, null, 2) + '\n'); \
-	  console.log('  done.'); \
-	"
 
 backend-test:
 	@echo "Running Go unit tests..."

--- a/backend/internal/db/swagger_ci_parity_test.go
+++ b/backend/internal/db/swagger_ci_parity_test.go
@@ -1,0 +1,236 @@
+package db
+
+// swagger_ci_parity_test.go keeps `make swag` and CI producing the same
+// openapi3.json (#947).
+//
+// WHAT WENT WRONG. The Makefile's openapi3 target ran swagger2openapi and then
+// post-processed the result, promoting operation-level path parameters to path
+// level. CI's "Swagger generation" step ran the conversion alone. They
+// disagreed for months, and CI always won: the swagger-docs-sync job
+// regenerates the spec and commits ITS output to the PR branch, so a
+// contributor following the documented workflow produced a ~44,000-line diff
+// that CI then reverted.
+//
+// Neither output was wrong, exactly -- they were answers to different
+// questions, and nothing compared them. The hoisting has since been removed
+// (no consumer needed it: terraform-provider-registry generates models only,
+// and the frontend reads swagger.json rather than openapi3.json), which makes
+// them agree TODAY. This test is about tomorrow.
+//
+// THE PROPERTY, stated so it survives a rewrite of either side: neither the
+// Makefile recipe nor the CI step may transform openapi3.json beyond the
+// swagger2openapi invocation that produces it. The moment one of them grows a
+// post-process the other lacks, the two diverge again and the loser is
+// whichever a human ran.
+//
+// Deliberately NOT asserted: that the two command lines are textually
+// identical. They legitimately differ -- the Makefile runs from the repo root
+// with a node_modules/.bin path, CI runs from backend/ with ../node_modules.
+// A textual comparison would fail on that difference and teach whoever hits it
+// to delete the test.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// specArtifact is the file both sides produce.
+const specArtifact = "openapi3.json"
+
+// repoRoot walks up from this package to the directory holding the Makefile.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "Makefile")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("could not find the repository root (no Makefile found walking up)")
+	return ""
+}
+
+// makefileOpenAPIRecipe returns the lines of the `openapi3:` target's recipe,
+// comments and blank lines excluded.
+//
+// A make recipe is exactly the run of TAB-indented lines following the target,
+// which is what makes this parseable without a make parser.
+func makefileOpenAPIRecipe(t *testing.T, root string) []string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	lines := strings.Split(string(b), "\n")
+	var recipe []string
+	in := false
+	for _, ln := range lines {
+		if strings.HasPrefix(ln, "openapi3:") {
+			in = true
+			continue
+		}
+		if !in {
+			continue
+		}
+		if !strings.HasPrefix(ln, "\t") {
+			break // the recipe ends at the first non-tab line
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(ln, "\t"))
+		if body == "" || strings.HasPrefix(body, "#") {
+			continue
+		}
+		recipe = append(recipe, body)
+	}
+	if len(recipe) == 0 {
+		t.Fatal("the openapi3 target has no recipe, or it was renamed. If it moved, point this " +
+			"test at it -- do not delete it: it is what keeps `make swag` and CI from diverging (#947).")
+	}
+	return recipe
+}
+
+// ciSwaggerStep returns the shell body of ci.yml's "Swagger generation" step.
+func ciSwaggerStep(t *testing.T, root string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	s := string(b)
+	i := strings.Index(s, "- name: Swagger generation")
+	if i < 0 {
+		t.Fatal("ci.yml has no \"Swagger generation\" step. If it was renamed, point this test at " +
+			"the new name rather than deleting it (#947).")
+	}
+	rest := s[i:]
+	// The step ends at the next step at the same indentation.
+	if j := strings.Index(rest[1:], "\n      - name: "); j >= 0 {
+		rest = rest[:j+1]
+	}
+	return rest
+}
+
+// writesSpecOutsideConversion reports the lines in body that touch
+// openapi3.json for any reason OTHER than being swagger2openapi's -o argument.
+func writesSpecOutsideConversion(body string) []string {
+	conversion := regexp.MustCompile(`swagger2openapi\b`)
+	var offenders []string
+	for _, ln := range strings.Split(body, "\n") {
+		if !strings.Contains(ln, specArtifact) {
+			continue
+		}
+		if conversion.MatchString(ln) {
+			continue // the line that legitimately produces it
+		}
+		trimmed := strings.TrimSpace(ln)
+		// Comments explain; they do not transform.
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		offenders = append(offenders, trimmed)
+	}
+	return offenders
+}
+
+// TestMakefileDoesNotPostProcessTheSpec is one half of the parity property.
+func TestMakefileDoesNotPostProcessTheSpec(t *testing.T) {
+	root := repoRoot(t)
+	recipe := makefileOpenAPIRecipe(t, root)
+
+	if got := writesSpecOutsideConversion(strings.Join(recipe, "\n")); len(got) > 0 {
+		t.Errorf("the Makefile's openapi3 target touches %s outside the swagger2openapi call:\n  %s\n\n"+
+			"CI's \"Swagger generation\" step runs the conversion alone and its output is what gets "+
+			"committed, so a transformation here is reverted -- and a contributor who runs `make swag` "+
+			"gets a large diff CI throws away. That was #947.\n\n"+
+			"If the transformation is genuinely needed (a consumer that generates a CLIENT or SERVER "+
+			"from this spec does need path-level parameters), add it to BOTH sides in the same change.",
+			specArtifact, strings.Join(got, "\n  "))
+	}
+
+	// And the conversion itself must still be there -- a target that produces
+	// nothing would satisfy the check above trivially.
+	if !strings.Contains(strings.Join(recipe, "\n"), "swagger2openapi") {
+		t.Error("the openapi3 target no longer invokes swagger2openapi, so it produces no spec at all")
+	}
+}
+
+// TestCIDoesNotPostProcessTheSpec is the other half.
+//
+// Checked in both directions on purpose: the divergence is symmetric, and a
+// guard that only watched the Makefile would miss CI growing a step of its own.
+func TestCIDoesNotPostProcessTheSpec(t *testing.T) {
+	root := repoRoot(t)
+	step := ciSwaggerStep(t, root)
+
+	if got := writesSpecOutsideConversion(step); len(got) > 0 {
+		t.Errorf("ci.yml's \"Swagger generation\" step touches %s outside the swagger2openapi call:\n  %s\n\n"+
+			"`make openapi3` runs the conversion alone, so a transformation here means the committed "+
+			"spec can never be reproduced locally (#947). Add it to the Makefile in the same change.",
+			specArtifact, strings.Join(got, "\n  "))
+	}
+	if !strings.Contains(step, "swagger2openapi") {
+		t.Error("the CI step no longer invokes swagger2openapi")
+	}
+}
+
+// TestBothSidesPassTheSameConversionFlags catches the subtler divergence: the
+// same tool, invoked differently.
+//
+// -p is `--patch`, which repairs spec defects during conversion. One side
+// running with it and the other without produces two different valid specs,
+// which is exactly the shape of #947 one level down.
+func TestBothSidesPassTheSameConversionFlags(t *testing.T) {
+	root := repoRoot(t)
+	// The INVOCATION line, not merely a line mentioning the tool. The Makefile
+	// also has `test -x node_modules/.bin/swagger2openapi`, an existence guard
+	// whose -x is not a conversion flag -- the first draft of this test picked
+	// that line up and reported a difference that was entirely its own.
+	// Requiring the input file narrows it to the line that actually converts.
+	isInvocation := func(ln string) bool {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "#") || strings.HasPrefix(t, "//") {
+			return false
+		}
+		return strings.Contains(t, "swagger2openapi") &&
+			strings.Contains(t, "swagger.json") &&
+			strings.Contains(t, specArtifact) &&
+			!strings.HasPrefix(strings.TrimPrefix(t, "@"), "test ")
+	}
+	flags := func(body string) []string {
+		for _, ln := range strings.Split(body, "\n") {
+			if !isInvocation(ln) {
+				continue
+			}
+			var out []string
+			for _, tok := range strings.Fields(ln) {
+				if strings.HasPrefix(tok, "-") && tok != "-o" {
+					out = append(out, tok)
+				}
+			}
+			return out
+		}
+		return nil
+	}
+	mk := flags(strings.Join(makefileOpenAPIRecipe(t, root), "\n"))
+	ci := flags(ciSwaggerStep(t, root))
+
+	if strings.Join(mk, " ") != strings.Join(ci, " ") {
+		t.Errorf("swagger2openapi is invoked with different flags:\n  Makefile: %v\n  CI:       %v\n\n"+
+			"The same tool with different flags produces different specs, which is #947 one level down.",
+			mk, ci)
+	}
+	if len(mk) == 0 {
+		t.Error("no conversion flags were extracted from either side; this test is not reading the " +
+			"invocations it claims to compare")
+	}
+}


### PR DESCRIPTION
Closes #947. Takes **fork option 2** — the hoisting is dead code — on evidence, not preference.

## Why option 2

The issue says to confirm against the consumers before choosing. I did, and neither named consumer needs path-level parameters. Full evidence is in [my earlier comment](https://github.com/sethbacon/terraform-registry-backend/issues/947#issuecomment-5439654996); in short:

| consumer | verdict |
|---|---|
| `terraform-provider-registry` | generates **models only** (`client: false`). oapi-codegen reads path parameters only for client/server generation. Its committed spec has **76 templated paths, 0 path-level parameters**, and its codegen works — with CI failing on drift, so this is a live pipeline, not a latent break. |
| `terraform-registry-frontend` | **no typegen from `openapi3.json` at all.** Its one spec consumer, `contract-check.ts`, reads `swagger.json` (OpenAPI 2) and parses path templates itself. |

So the published artifact never met a requirement that nothing had. Adopting the hoisting into CI instead would have meant a large one-time diff to satisfy no consumer.

## Verified, not asserted

`make openapi3` and CI's exact invocation now produce **byte-identical** output — and both match the currently committed spec, so this lands with **no regeneration diff at all**:

```
=== byte-identical? ===
  YES — make and CI now agree
=== does either differ from what is committed? ===
  committed spec already matches (no regeneration diff)
```

## The guard is the durable part

The fork is a one-time decision; the *divergence* is the recurring risk, and it went unnoticed for months. `swagger_ci_parity_test.go` asserts the property rather than the current spelling:

- neither side may transform `openapi3.json` beyond the `swagger2openapi` call that produces it
- both must pass the same conversion flags (`-p` is `--patch` — one side with it and one without yields two different *valid* specs, which is #947 one level down)
- checked in **both directions**, since a guard watching only the Makefile would miss CI growing a step of its own

It deliberately does **not** compare the command lines textually. They legitimately differ — repo root with `node_modules/.bin` versus `backend/` with `../node_modules` — and a test that failed on that would teach whoever hit it to delete the test.

### Mutations

| Mutation | Caught |
|---|---|
| Makefile regrows a post-process | ✓ |
| CI grows a post-process | ✓ |
| CI drops the `-p` flag | ✓ |
| Makefile stops converting at all | ✓ |
| the `openapi3:` target is renamed | ✓ |
| the CI step is renamed | ✓ |

**One mutation caught a bug in the test itself.** The flag extractor matched the Makefile's `test -x node_modules/.bin/swagger2openapi` existence guard and reported its `-x` as a conversion flag — a difference that was entirely the test's own invention. It now requires the input file to be on the line before treating it as the invocation.

## On the "CI should fail on drift" suggestion

I didn't change `swagger-docs-sync`'s commit-to-PR-branch behaviour. It's deliberate and its reasoning is documented in `ci.yml` (including why it carries no `[skip ci]` marker, and the convergence check that stops a commit loop). The property the issue actually wants — *the two can't diverge again unnoticed* — is what the parity test gives, without trading away a working sync design.

## One thing left open

If a future consumer generates a **client or server** from this spec, it *will* need the hoisting. That's recorded in the Makefile where whoever adds it will read it, with the instruction to add it to both sides in the same change — and the parity test fails if only one side grows it.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on `./internal/db/...` — 0 issues
