### PR TITLE
feat(schemaguard): fail when a foreign key's target schema is chosen by the topology

### DIFF
--- a/backend/internal/schemaguard/schema_constraint_test.go
+++ b/backend/internal/schemaguard/schema_constraint_test.go
@@ -1,0 +1,439 @@
+package schemaguard
+
+// schema_constraint_test.go widens schemaguard past column existence, to the
+// class of defect where every column exists and the write still fails (#898).
+//
+// WHAT #883 WAS. Migrations 000038 and 000045 chose each foreign key's target
+// SCHEMA at migration time:
+//
+//	IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+//	  ... REFERENCES identity.organizations(id)
+//	ELSE
+//	  ... REFERENCES public.organizations(id)
+//
+// Where the identity schema exists but the application still reads and writes
+// public -- a documented rollout step, not an exotic configuration -- the
+// constraint resolved at identity while every row carried a public id. POST
+// /api/v1/modules returned 500 on every attempt.
+//
+// The existing guard could not have caught it and said so in its own
+// boundaries: every column involved EXISTED. Its answer, "this write can land",
+// was correct about columns and wrong about the write.
+//
+// WHAT THIS GUARD DOES INSTEAD. It records each foreign key's target as the SET
+// of values the migration stream could have given it, and never evaluates the
+// branch predicate. A constraint whose possible targets span more than one
+// schema is chosen by the deployment's topology rather than by the migration,
+// and that is reportable without modelling any topology at all.
+//
+// That formulation is deliberately blind to spelling. It never reads the
+// condition, so `to_regclass`, `'identity'::regnamespace`, a
+// `has_schema_privilege` call, an EXCEPTION handler and a CASE all land in the
+// same place. The text-level lint in internal/db/migrations_test.go catches one
+// spelling of the mistake; this catches the mistake.
+//
+// WHAT IT DOES NOT COVER, stated rather than left to be discovered:
+//
+//   - .down.sql files. The replay is forward-only.
+//   - DML that branches on schema existence. Several migrations do this to
+//     decide where to COPY rows from; it is reported below as a fact, never
+//     failed on, because a data move is not a constraint.
+//   - Anything about which topology is CORRECT. The guard's claim is only that
+//     no single arm can be right in every topology -- converge the artifact,
+//     do not pick an arm.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// minLedgerEntries is the empty-universe floor.
+//
+// Every assertion here iterates m.fks. If the ledger were empty they would all
+// pass while checking nothing -- and an empty ledger is exactly what a broken
+// parser produces, which is how this guard would fail silently rather than
+// loudly. The tree carried 47 entries when this was written.
+const minLedgerEntries = 30
+
+// checkLedgerNotVacuous is the empty-universe guard, factored out as a pure
+// function so it can be falsified DIRECTLY -- the same treatment
+// checkNotVacuous gets in schema_demand_guard_test.go, and for the same reason.
+//
+// A floor cannot be falsified by lowering it: the tree is healthy, so nothing
+// else fails and the mutation looks harmless. Handing the checker an empty
+// ledger is the only way to prove it would object.
+func checkLedgerNotVacuous(m *schemaModel) error {
+	if len(m.fks) < minLedgerEntries {
+		return fmt.Errorf("the foreign-key ledger holds only %d entries (floor %d): the migration "+
+			"replay is not extracting constraints, so every assertion over it is vacuous",
+			len(m.fks), minLedgerEntries)
+	}
+	return nil
+}
+
+func TestNoForeignKeyTargetDependsOnTheEnvironment(t *testing.T) {
+	a := buildAnalysis(t)
+	m := a.Model
+
+	if err := checkLedgerNotVacuous(m); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	keys := make([]fkKey, 0, len(m.fks))
+	for k := range m.fks {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+
+	// --- the fact report, on every run -------------------------------------
+	//
+	// #898 observes that merely REPORTING each constraint's target schema would
+	// have made #883 visible in the test log even without a rule that fails on
+	// it. This is that report, and it is what makes the assertions below
+	// auditable rather than oracular.
+	var report []string
+	for _, k := range keys {
+		report = append(report, "  "+k.String()+" -> "+describeTargets(m.fks[k]))
+	}
+	t.Logf("foreign-key ledger (%d constraints):\n%s", len(keys), strings.Join(report, "\n"))
+
+	for _, k := range keys {
+		targets := m.fks[k]
+
+		// --- V3: a target this analyzer could not read ----------------------
+		//
+		// Checked before V1, because a migration that computes its FK target at
+		// runtime is the same defect wearing a different hat, and reporting it
+		// as "only one schema seen" would be actively misleading.
+		for _, tgt := range targets {
+			if tgt.Unresolved {
+				t.Errorf("%s has a foreign-key target this analyzer cannot resolve statically (%s).\n"+
+					"A migration that computes its FOREIGN KEY target -- with format('%%I', …), string "+
+					"concatenation, or a variable -- decides at run time what the schema should have "+
+					"decided, which is the defect this file exists for. Write the target literally.",
+					k, tgt.Origin)
+			}
+		}
+
+		// --- V1: the #883 catcher ------------------------------------------
+		schemas := map[string]bool{}
+		for _, tgt := range targets {
+			if !tgt.Unresolved {
+				schemas[tgt.Schema] = true
+			}
+		}
+		if len(schemas) > 1 {
+			names := make([]string, 0, len(schemas))
+			for s := range schemas {
+				names = append(names, s)
+			}
+			sort.Strings(names)
+			t.Errorf("the target SCHEMA of %s is chosen by the deployment's topology, not by the "+
+				"migration: it can resolve at %s (%s).\n\n"+
+				"Under one topology this constraint points at one schema and under another at a "+
+				"different one, while the application writes ids from whichever schema its own "+
+				"search_path selects -- so every column exists and the write still fails. That was "+
+				"#883.\n\n"+
+				"NO ARM IS CORRECT IN EVERY TOPOLOGY, so do not pick an arm: converge the artifact. "+
+				"Migration 000056 converged the previous 24 of these by dropping them and holding "+
+				"the invariant in the application instead. See #883 and #898.",
+				k, strings.Join(names, " or "), describeTargets(targets))
+			continue
+		}
+
+		// --- V2: reported, never failed ------------------------------------
+		//
+		// A singleton target this replay does not model is usually a table in a
+		// stream the default configuration does not apply -- which is a fact
+		// about the configuration, not a defect in the migration. Failing here
+		// would make the guard configuration-relative, and V1's whole value is
+		// that it is not.
+		for s := range schemas {
+			if len(targets) > 0 && !m.has(tableKey{Schema: s, Table: targets[0].Table}) {
+				t.Logf("note: %s targets %s.%s, which the default configuration's replay does not "+
+					"model (reported, not failed -- see V2 in this file)", k, s, targets[0].Table)
+			}
+		}
+	}
+}
+
+// describeTargets renders a possibility set for a message.
+func describeTargets(targets []fkTarget) string {
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range targets {
+		var d string
+		switch {
+		case t.Unresolved:
+			d = fmt.Sprintf("<unresolved> from %s", t.Origin)
+		case t.Certain:
+			d = fmt.Sprintf("%s.%s from %s", t.Schema, t.Table, t.Origin)
+		default:
+			d = fmt.Sprintf("%s.%s possible, from %s", t.Schema, t.Table, t.Origin)
+		}
+		if !seen[d] {
+			seen[d] = true
+			out = append(out, d)
+		}
+	}
+	sort.Strings(out)
+	return strings.Join(out, "; ")
+}
+
+// ---------------------------------------------------------------------------
+// Hermetic ledger tests
+//
+// The guard above runs against the real migration stream, which is CLEAN --
+// migration 000056 converged the 24 constraints that made #883. That is a
+// problem for falsification: breaking the extractor on a clean tree makes the
+// ledger find nothing, and finding nothing is the correct answer there, so the
+// guard still passes.
+//
+// Four separate mutations proved exactly that, and were inert until these
+// tests existed: treating a possible DROP as certain, not descending into DO
+// blocks at all, removing the PL/pgSQL re-anchor, and removing the
+// empty-universe floor. Each is invisible against clean input and fatal against
+// dirty input.
+//
+// So these feed the analyzer SQL that CONTAINS the defect and require it to be
+// reported.
+// ---------------------------------------------------------------------------
+
+// ledgerFor replays sql and returns the resulting model.
+func ledgerFor(t *testing.T, sql string) *schemaModel {
+	t.Helper()
+	m := newSchemaModel()
+	m.applyStatements(splitStatements(stripComments(sql)), "public", true, "test.sql")
+	return m
+}
+
+// schemasFor returns the distinct target schemas recorded for one constraint.
+func schemasFor(t *testing.T, m *schemaModel, table, cols string) []string {
+	t.Helper()
+	k := fkKey{Table: tableKey{Schema: "public", Table: table}, Columns: cols}
+	targets, ok := m.fks[k]
+	if !ok {
+		t.Fatalf("no ledger entry for %s(%s). Recorded: %v", table, cols, ledgerKeys(m))
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, tg := range targets {
+		if tg.Unresolved {
+			out = append(out, "<unresolved>")
+			continue
+		}
+		if !seen[tg.Schema] {
+			seen[tg.Schema] = true
+			out = append(out, tg.Schema)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func ledgerKeys(m *schemaModel) []string {
+	var out []string
+	for k := range m.fks {
+		out = append(out, k.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestLedgerSeesBothArmsOfASchemaBranch is the #883 shape, reduced.
+func TestLedgerSeesBothArmsOfASchemaBranch(t *testing.T) {
+	m := ledgerFor(t, `
+CREATE TABLE claims (namespace TEXT, organization_id UUID);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.claims ADD CONSTRAINT claims_org_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id);
+  ELSE
+    ALTER TABLE public.claims ADD CONSTRAINT claims_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+  END IF;
+END $$;`)
+
+	got := schemasFor(t, m, "claims", "organization_id")
+	if len(got) != 2 {
+		t.Fatalf("target schemas = %v, want both identity and public. A constraint whose schema is "+
+			"chosen by a branch must record BOTH arms, or the guard cannot see the choice.", got)
+	}
+}
+
+// TestLedgerSeesTheFirstStatementInEachArm is the subtle one, and the reason
+// this test exists as its own case.
+//
+// splitStatements splits on ";", and PL/pgSQL control flow carries no semicolon
+// -- so the first statement after THEN and after ELSE arrives glued to its
+// prefix ("BEGIN IF EXISTS (...) THEN ALTER TABLE ..."). Without re-anchoring
+// past that prefix, the FIRST constraint in each arm is invisible while every
+// later one is seen.
+//
+// Against the real stream that lost exactly namespace_claims(organization_id) --
+// the constraint #883 is about -- while still reporting 23 others. A guard that
+// looks like it works is worse than one that obviously does not.
+func TestLedgerSeesTheFirstStatementInEachArm(t *testing.T) {
+	m := ledgerFor(t, `
+CREATE TABLE claims (organization_id UUID, claimed_by UUID);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.claims ADD CONSTRAINT claims_org_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id);
+    ALTER TABLE public.claims ADD CONSTRAINT claims_by_fkey FOREIGN KEY (claimed_by) REFERENCES identity.users(id);
+  ELSE
+    ALTER TABLE public.claims ADD CONSTRAINT claims_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+    ALTER TABLE public.claims ADD CONSTRAINT claims_by_fkey FOREIGN KEY (claimed_by) REFERENCES public.users(id);
+  END IF;
+END $$;`)
+
+	// The SECOND constraint in each arm is the easy one; it is the FIRST that
+	// used to vanish.
+	if got := schemasFor(t, m, "claims", "organization_id"); len(got) != 2 {
+		t.Errorf("the FIRST constraint in each arm recorded %v, want two schemas. It arrives glued "+
+			"to its BEGIN/IF/ELSE prefix and needs re-anchoring past it.", got)
+	}
+	if got := schemasFor(t, m, "claims", "claimed_by"); len(got) != 2 {
+		t.Errorf("the second constraint in each arm recorded %v, want two schemas", got)
+	}
+}
+
+// TestPossibleDropDoesNotHideAConditionalRepoint pins the load-bearing rule.
+//
+// 000038 repoints constraints created earlier against public, and has no ELSE.
+// Treating its conditional DROP as a real one would leave a single target and
+// make the repoint look like a plain move -- which is precisely the defect.
+func TestPossibleDropDoesNotHideAConditionalRepoint(t *testing.T) {
+	m := ledgerFor(t, `
+CREATE TABLE modules (organization_id UUID);
+ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.modules DROP CONSTRAINT modules_org_fkey;
+    ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id);
+  END IF;
+END $$;`)
+
+	got := schemasFor(t, m, "modules", "organization_id")
+	if len(got) != 2 {
+		t.Fatalf("target schemas = %v, want both. A DROP inside a conditional removes the "+
+			"constraint in ONE world only; the original target is still live in the other, so a "+
+			"possible drop must be a no-op.", got)
+	}
+}
+
+// TestCertainDropRemovesTheEntry is the other half, and it is what makes the
+// real tree green: 000056's 24 drops are unconditional and top-level.
+func TestCertainDropRemovesTheEntry(t *testing.T) {
+	m := ledgerFor(t, `
+CREATE TABLE modules (organization_id UUID);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id);
+  ELSE
+    ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+  END IF;
+END $$;
+ALTER TABLE IF EXISTS public.modules DROP CONSTRAINT IF EXISTS modules_org_fkey;`)
+
+	k := fkKey{Table: tableKey{Schema: "public", Table: "modules"}, Columns: "organization_id"}
+	if _, ok := m.fks[k]; ok {
+		t.Errorf("an unconditional DROP left the entry in the ledger: %v.\nConverging a constraint "+
+			"by dropping it is how 000056 fixed #883, and a guard that still reported it afterwards "+
+			"would be permanently red for a defect that had been fixed.", m.fks[k])
+	}
+}
+
+// TestRuntimeComputedTargetIsUnresolved. A migration that builds its FK target
+// with format('%I', …) decides at run time what the schema should decide, and
+// reporting it as "one schema seen" would be actively misleading.
+func TestRuntimeComputedTargetIsUnresolved(t *testing.T) {
+	// The realistic shape: the DDL lives inside a string handed to EXECUTE, and
+	// the schema arrives through a format placeholder. An earlier draft of this
+	// test used `REFERENCES quote_ident(sch).organizations(id)` inline, which is
+	// not valid SQL and which the parser happily resolved to `public.quote_ident`
+	// -- a reminder that a hermetic fixture has to be something the database
+	// would actually accept, or it tests the parser against a language nobody
+	// writes.
+	m := ledgerFor(t, `
+CREATE TABLE modules (organization_id UUID);
+DO $$
+DECLARE sch text := 'identity';
+BEGIN
+  EXECUTE format('ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES %I.organizations(id)', sch);
+END $$;`)
+
+	got := schemasFor(t, m, "modules", "organization_id")
+	if len(got) != 1 || got[0] != "<unresolved>" {
+		t.Errorf("target = %v, want <unresolved>. A computed target must be reported as unreadable, "+
+			"not silently resolved or dropped.", got)
+	}
+}
+
+// TestInlineColumnReferencesIsRecorded covers the CREATE TABLE path: an inline
+// REFERENCES is a single-column FK, and 000056 drops several of them by the
+// implicit name PostgreSQL would have generated.
+func TestInlineColumnReferencesIsRecorded(t *testing.T) {
+	m := ledgerFor(t, `CREATE TABLE download_events (id UUID, user_id UUID REFERENCES users(id));`)
+
+	got := schemasFor(t, m, "download_events", "user_id")
+	if len(got) != 1 || got[0] != "public" {
+		t.Fatalf("inline REFERENCES recorded %v, want [public] (unqualified names in a migration "+
+			"resolve at public)", got)
+	}
+	k := fkKey{Table: tableKey{Schema: "public", Table: "download_events"}, Columns: "user_id"}
+	if !m.fkNames[k]["download_events_user_id_fkey"] {
+		t.Errorf("the implicit constraint name was not synthesized (names: %v). A later "+
+			"DROP CONSTRAINT names it that way, and without it the drop cannot find the entry.",
+			m.fkNames[k])
+	}
+}
+
+// TestLedgerFloorRefusesAnEmptyUniverse falsifies the floor directly.
+func TestLedgerFloorRefusesAnEmptyUniverse(t *testing.T) {
+	if err := checkLedgerNotVacuous(newSchemaModel()); err == nil {
+		t.Error("an empty ledger was accepted. Every assertion in this file iterates m.fks, so an " +
+			"empty one passes them all while checking nothing -- which is exactly what a broken " +
+			"extractor produces.")
+	}
+	// And a healthy one must be accepted, or the floor is simply always red.
+	m := newSchemaModel()
+	for i := 0; i < minLedgerEntries; i++ {
+		k := fkKey{Table: tableKey{Schema: "public", Table: fmt.Sprintf("t%d", i)}, Columns: "c"}
+		m.fks[k] = []fkTarget{{Schema: "public", Table: "u", Certain: true}}
+	}
+	if err := checkLedgerNotVacuous(m); err != nil {
+		t.Errorf("a ledger at the floor was rejected: %v", err)
+	}
+}
+
+// TestCertainAddReplacesThePossibilitySet.
+//
+// A migration that states, unconditionally, what a constraint now points at has
+// SETTLED the question -- the earlier conditional arms are no longer possible.
+// Appending instead would leave a stale target in the set forever, so a
+// constraint converged by a later migration would keep failing the guard and
+// the only way to quiet it would be to delete the guard.
+func TestCertainAddReplacesThePossibilitySet(t *testing.T) {
+	m := ledgerFor(t, `
+CREATE TABLE modules (organization_id UUID);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'identity') THEN
+    ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES identity.organizations(id);
+  ELSE
+    ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+  END IF;
+END $$;
+ALTER TABLE public.modules ADD CONSTRAINT modules_org_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);`)
+
+	got := schemasFor(t, m, "modules", "organization_id")
+	if len(got) != 1 || got[0] != "public" {
+		t.Errorf("after an unconditional re-add the possibility set is %v, want [public] only.\n"+
+			"A certain ADD settles the question; keeping the earlier arms would leave a converged "+
+			"constraint failing forever.", got)
+	}
+}

--- a/backend/internal/schemaguard/schema_demand_analyzer_test.go
+++ b/backend/internal/schemaguard/schema_demand_analyzer_test.go
@@ -59,10 +59,58 @@ type tableKey struct {
 
 func (k tableKey) String() string { return k.Schema + "." + k.Table }
 
+// fkKey identifies a foreign key by the table and columns it constrains.
+//
+// Keyed on the CONSTRAINED side rather than on the constraint name, because the
+// defect this exists to catch is one constraint being pointed at two different
+// schemas in two topologies -- and in the migration that does it, the arms
+// carry different names.
+type fkKey struct {
+	Table   tableKey
+	Columns string // unquoted, sorted, comma-joined
+}
+
+func (k fkKey) String() string { return k.Table.String() + "(" + k.Columns + ")" }
+
+// fkTarget is one possible referent of a foreign key.
+//
+// POSSIBLE, not actual. A migration that chooses its target inside a DO block
+// contributes one target per arm, and this analyzer deliberately does not
+// evaluate the branch -- see the fifth arm of applySQL. Unresolved marks a
+// target this analyzer could not parse at all, which is a stronger signal than
+// a competing pair: a migration computing its target at runtime cannot be
+// checked by anything static.
+type fkTarget struct {
+	Schema     string
+	Table      string
+	Unresolved bool
+	Certain    bool
+	Origin     string // migration file, for the report
+}
+
+// migrationSearchPath is the schema an unqualified name in a MIGRATION resolves
+// to, and it is "public" in every topology.
+//
+// Migrations always run on GetMigrationDSN(), which emits no search_path
+// option, while the APPLICATION may resolve identity names at "identity". That
+// split is the mechanical root of this whole defect class: a constraint written
+// by a migration and a row written by the application can disagree about which
+// schema they mean, and every column involved still exists.
+const migrationSearchPath = "public"
+
 // schemaModel is the state of the world after replaying a set of migrations.
 type schemaModel struct {
 	// columns holds the column set of every table whose shape is known.
 	columns map[tableKey]map[string]bool
+	// fks records, per constrained (table, columns), every target the
+	// migration stream could have pointed it at. A singleton is the healthy
+	// case; more than one distinct target SCHEMA is the #883 defect.
+	fks map[fkKey][]fkTarget
+	// fkNames maps a key to every constraint name it has been created under,
+	// so a later DROP CONSTRAINT can find it. A key can carry several names
+	// because the conditional arms of one DO block name their constraints
+	// differently.
+	fkNames map[fkKey]map[string]bool
 	// opaque holds relations that exist but whose column set this analyzer
 	// declines to model — views, CREATE TABLE AS SELECT. Writes to these are
 	// checked for existence only. Modelling a view's columns would mean
@@ -75,6 +123,8 @@ func newSchemaModel() *schemaModel {
 	return &schemaModel{
 		columns: map[tableKey]map[string]bool{},
 		opaque:  map[tableKey]bool{},
+		fks:     map[fkKey][]fkTarget{},
+		fkNames: map[fkKey]map[string]bool{},
 	}
 }
 
@@ -266,7 +316,39 @@ var (
 	reCreateTableAnywhere = regexp.MustCompile(`(?i)\bCREATE\s+(?:UNLOGGED\s+|TEMP\s+|TEMPORARY\s+)?TABLE\b`)
 	reCreateView          = regexp.MustCompile(`(?i)^CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w".]+)`)
 	reDropTable           = regexp.MustCompile(`(?i)^DROP\s+(?:MATERIALIZED\s+)?(?:TABLE|VIEW)\s+(?:IF\s+EXISTS\s+)?(.+?)(?:\s+CASCADE|\s+RESTRICT)?$`)
-	reAlterTable          = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?([\w".]+)\s+(.*)$`)
+	// reDoOpen matches the opening of a dollar-quoted DO block.
+	//
+	// Only the OPENING. Go's regexp is RE2 and has NO BACKREFERENCES, so the
+	// natural `(\$[A-Za-z_]*\$)(.*)\1` does not compile -- it panics at
+	// MustCompile. The closing tag is found by string search instead, which is
+	// what a dollar-quote is anyway.
+	reDoOpen = regexp.MustCompile(`(?is)^DO\s+(\$[A-Za-z_]*\$)`)
+	// reAddConstraintFK matches ADD CONSTRAINT <name> FOREIGN KEY (<cols>)
+	// TARGET-AGNOSTICALLY: the REFERENCES clause is parsed separately so a
+	// target this analyzer cannot read becomes Unresolved rather than being
+	// dropped on the floor. A migration that computes its FK target is the same
+	// defect wearing a different hat, and silently skipping it would hide
+	// exactly that.
+	reAddConstraintFK = regexp.MustCompile(`(?is)^ADD\s+CONSTRAINT\s+([\w".]+)\s+FOREIGN\s+KEY\s*\(([^)]*)\)\s*(.*)$`)
+	reReferences      = regexp.MustCompile(`(?is)\bREFERENCES\s+([\w".]+)\s*(?:\(|$|\s)`)
+	reDropConstraint  = regexp.MustCompile(`(?is)^DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?([\w".]+)`)
+	// reDDLLeader finds where the DDL actually starts inside a PL/pgSQL
+	// statement.
+	//
+	// WHY THIS IS NEEDED, and it is not cosmetic. splitStatements splits on
+	// ";", and PL/pgSQL control flow carries no semicolon of its own -- so the
+	// FIRST statement after THEN or ELSE arrives glued to its prefix:
+	//
+	//	"BEGIN IF EXISTS (...) THEN ALTER TABLE ... ADD CONSTRAINT ..."
+	//	"ELSE ALTER TABLE ... ADD CONSTRAINT ..."
+	//
+	// Neither matches ^ALTER TABLE, so the first constraint in each arm was
+	// invisible while every subsequent one was seen. Against the real migration
+	// stream that lost exactly namespace_claims(organization_id) -- the
+	// constraint issue #883 is ABOUT -- while still reporting 23 others, which
+	// is the most dangerous possible failure: a guard that looks like it works.
+	reDDLLeader  = regexp.MustCompile(`(?is)\b(ALTER\s+TABLE|CREATE\s+TABLE|DROP\s+TABLE)\b`)
+	reAlterTable = regexp.MustCompile(`(?i)^ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?([\w".]+)\s+(.*)$`)
 
 	reRenameColumn = regexp.MustCompile(`(?i)^RENAME\s+COLUMN\s+([\w"]+)\s+TO\s+([\w"]+)`)
 	reRenameTable  = regexp.MustCompile(`(?i)^RENAME\s+TO\s+([\w"]+)`)
@@ -316,21 +398,63 @@ func (m *schemaModel) replay(stream migrationStream) error {
 		if rErr != nil {
 			return fmt.Errorf("schemaguard: read %s: %w", name, rErr)
 		}
-		m.applySQL(string(b), stream.DefaultSchema)
+		m.applyStatements(splitStatements(stripComments(string(b))), stream.DefaultSchema, true, name)
 	}
 	return nil
 }
 
 // applySQL replays the DDL in one SQL blob.
 func (m *schemaModel) applySQL(sql, defaultSchema string) {
-	for _, raw := range splitStatements(stripComments(sql)) {
+	m.applyStatements(splitStatements(stripComments(sql)), defaultSchema, true, "")
+}
+
+// applyStatements replays statements, tracking whether their effects are
+// CERTAIN (top level) or merely POSSIBLE (inside a conditional DO block).
+//
+// THE EXISTENCE MODEL ONLY ACCEPTS CERTAIN EFFECTS. Crediting a conditional
+// CREATE TABLE into m.columns could only ever HIDE a write violation -- the
+// same reasoning as creditRuntimeDDL's creations-only rule. The FK ledger is
+// the opposite: it wants every possible target, because a target that exists in
+// only one topology is precisely what it is looking for.
+func (m *schemaModel) applyStatements(stmts []string, defaultSchema string, certain bool, origin string) {
+	for _, raw := range stmts {
 		stmt := normalize(raw)
 		if stmt == "" {
 			continue
 		}
+		// A DO block: descend, marking everything inside as possible.
+		//
+		// NO ARM TRACKING, deliberately. Every statement in the body is
+		// "possible", which over-approximates -- and that is both cheaper and
+		// strictly more robust than splitting IF/ELSIF/ELSE: it covers the
+		// EXCEPTION-handler shape and the CASE shape for free, and it produces
+		// no false positives, because a block that points one constraint at one
+		// schema still yields a singleton set.
+		if mm := reDoOpen.FindStringSubmatch(stmt); mm != nil {
+			tag := mm[1]
+			rest := stmt[len(mm[0]):]
+			if end := strings.LastIndex(rest, tag); end >= 0 {
+				m.applyStatements(splitStatements(rest[:end]), defaultSchema, false, origin)
+			}
+			continue
+		}
+		if !certain {
+			// Inside a conditional: the ledger still wants ALTER TABLE effects,
+			// but nothing may touch the existence model.
+			//
+			// Re-anchored past the PL/pgSQL control-flow prefix first -- see
+			// reDDLLeader for why the first statement in each arm arrives
+			// carrying its BEGIN/IF/ELSE.
+			body := reAnchorDDL(stmt)
+			if reAlterTable.MatchString(body) {
+				am := reAlterTable.FindStringSubmatch(body)
+				m.applyAlterTableFKs(parseName(am[1], defaultSchema), am[2], false, origin)
+			}
+			continue
+		}
 		switch {
 		case reCreateTable.MatchString(stmt):
-			m.applyCreateTable(stmt, defaultSchema)
+			m.applyCreateTable(stmt, defaultSchema, origin)
 		case reCreateView.MatchString(stmt):
 			key := parseName(reCreateView.FindStringSubmatch(stmt)[1], defaultSchema)
 			delete(m.columns, key)
@@ -343,12 +467,14 @@ func (m *schemaModel) applySQL(sql, defaultSchema string) {
 			}
 		case reAlterTable.MatchString(stmt):
 			mm := reAlterTable.FindStringSubmatch(stmt)
-			m.applyAlterTable(parseName(mm[1], defaultSchema), mm[2])
+			key := parseName(mm[1], defaultSchema)
+			m.applyAlterTable(key, mm[2])
+			m.applyAlterTableFKs(key, mm[2], true, origin)
 		}
 	}
 }
 
-func (m *schemaModel) applyCreateTable(stmt, defaultSchema string) {
+func (m *schemaModel) applyCreateTable(stmt, defaultSchema, origin string) {
 	key := parseName(reCreateTable.FindStringSubmatch(stmt)[1], defaultSchema)
 	body, ok := parenBody(stmt)
 	if !ok {
@@ -364,12 +490,164 @@ func (m *schemaModel) applyCreateTable(stmt, defaultSchema string) {
 		}
 		first := strings.ToLower(strings.Trim(strings.Fields(item)[0], `"`))
 		if tableConstraintLeaders[first] {
+			// A table-level constraint. Not a column -- but it may be a
+			// FOREIGN KEY, which the ledger wants. This arm used to discard
+			// the item entirely.
+			m.recordCreateTableFK(key, item, origin)
 			continue
 		}
-		cols[unquoteIdent(strings.Fields(item)[0])] = true
+		name := unquoteIdent(strings.Fields(item)[0])
+		cols[name] = true
+		// An inline column REFERENCES is a single-column foreign key. It
+		// carries no explicit name, so the implicit one PostgreSQL would
+		// generate is synthesized -- that is what a later DROP CONSTRAINT
+		// names, and 000056 drops several of these.
+		if reReferences.MatchString(item) {
+			fk := fkKey{Table: key, Columns: name}
+			m.recordFK(fk, key.Table+"_"+name+"_fkey", parseFKTarget(item, origin, true), true)
+		}
 	}
 	delete(m.opaque, key)
 	m.columns[key] = cols
+}
+
+// applyAlterTableFKs records foreign-key effects into the ledger.
+//
+// Separate from applyAlterTable because the two answer different questions and
+// obey opposite rules about certainty: the existence model takes only certain
+// effects, the ledger wants every possible one.
+// reAnchorDDL returns stmt from its first DDL leader onward, or stmt unchanged
+// when it contains none.
+//
+// Only used on statements from inside a DO body: at top level a statement
+// already starts with its own verb, and re-anchoring there would let a stray
+// "ALTER TABLE" in some other construct be read as one.
+func reAnchorDDL(stmt string) string {
+	if loc := reDDLLeader.FindStringIndex(stmt); loc != nil {
+		return stmt[loc[0]:]
+	}
+	return stmt
+}
+
+// recordCreateTableFK captures a table-level FOREIGN KEY inside CREATE TABLE.
+//
+// Named constraints ("CONSTRAINT x FOREIGN KEY (...)") and unnamed ones
+// ("FOREIGN KEY (...)") both land here; the unnamed form gets the implicit name
+// PostgreSQL would generate, so a later DROP CONSTRAINT can find it.
+func (m *schemaModel) recordCreateTableFK(key tableKey, item, origin string) {
+	fields := strings.Fields(item)
+	lower := strings.ToLower(item)
+	if !strings.Contains(lower, "foreign key") {
+		return
+	}
+	name := ""
+	if strings.EqualFold(fields[0], "constraint") && len(fields) > 1 {
+		name = unquoteIdent(fields[1])
+	}
+	cols, ok := parenBody(item)
+	if !ok {
+		return
+	}
+	fk := fkKey{Table: key, Columns: normalizeFKColumns(cols)}
+	if name == "" {
+		name = key.Table + "_" + strings.ReplaceAll(fk.Columns, ",", "_") + "_fkey"
+	}
+	// The REFERENCES clause is whatever follows the constrained column list.
+	rest := item
+	if i := strings.Index(lower, "references"); i >= 0 {
+		rest = item[i:]
+	}
+	m.recordFK(fk, name, parseFKTarget(rest, origin, true), true)
+}
+
+func (m *schemaModel) applyAlterTableFKs(key tableKey, actions string, certain bool, origin string) {
+	for _, action := range splitTopLevel(actions) {
+		action = strings.TrimSpace(action)
+		switch {
+		case reAddConstraintFK.MatchString(action):
+			mm := reAddConstraintFK.FindStringSubmatch(action)
+			name := unquoteIdent(mm[1])
+			fk := fkKey{Table: key, Columns: normalizeFKColumns(mm[2])}
+			m.recordFK(fk, name, parseFKTarget(mm[3], origin, certain), certain)
+
+		case reDropConstraint.MatchString(action):
+			// A POSSIBLE drop is a NO-OP, and this is the rule that makes the
+			// whole ledger work.
+			//
+			// Dropping a constraint in one arm of a conditional leaves it alive
+			// in the complementary arm, so the target it pointed at is still
+			// possible. Treating a possible drop as a real one would let a
+			// migration that repoints a constraint under a condition look like
+			// a migration that simply moved it -- which is exactly the shape of
+			// 000038, and exactly the defect being hunted.
+			if !certain {
+				continue
+			}
+			m.dropFKByName(unquoteIdent(reDropConstraint.FindStringSubmatch(action)[1]))
+		}
+	}
+}
+
+// recordFK adds a target. A CERTAIN add replaces the possibility set: the
+// migration has stated, unconditionally, what this constraint now points at. A
+// POSSIBLE add appends, because it is one of several worlds.
+func (m *schemaModel) recordFK(fk fkKey, name string, tgt fkTarget, certain bool) {
+	if certain {
+		m.fks[fk] = []fkTarget{tgt}
+	} else {
+		m.fks[fk] = append(m.fks[fk], tgt)
+	}
+	if m.fkNames[fk] == nil {
+		m.fkNames[fk] = map[string]bool{}
+	}
+	if name != "" {
+		m.fkNames[fk][name] = true
+	}
+}
+
+// dropFKByName removes every ledger entry created under this constraint name.
+func (m *schemaModel) dropFKByName(name string) {
+	for fk, names := range m.fkNames {
+		if names[name] {
+			delete(m.fks, fk)
+			delete(m.fkNames, fk)
+		}
+	}
+}
+
+// normalizeFKColumns folds a column list to a canonical form so the same
+// constraint written two ways lands on one key.
+func normalizeFKColumns(list string) string {
+	var out []string
+	for _, c := range splitTopLevel(list) {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		out = append(out, unquoteIdent(strings.Fields(c)[0]))
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
+}
+
+// parseFKTarget reads the REFERENCES clause.
+//
+// A clause this cannot parse yields Unresolved rather than nothing. A migration
+// that builds its FK target with format('%I', …) or string concatenation is
+// making the same runtime decision the ledger exists to catch, and dropping the
+// statement would make the loudest case the silent one.
+func parseFKTarget(clause, origin string, certain bool) fkTarget {
+	mm := reReferences.FindStringSubmatch(clause)
+	if mm == nil {
+		return fkTarget{Unresolved: true, Certain: certain, Origin: origin}
+	}
+	name := strings.TrimSpace(mm[1])
+	// A target assembled at runtime does not look like an identifier.
+	if strings.ContainsAny(name, "|'()") {
+		return fkTarget{Unresolved: true, Certain: certain, Origin: origin}
+	}
+	k := parseName(name, migrationSearchPath)
+	return fkTarget{Schema: k.Schema, Table: k.Table, Certain: certain, Origin: origin}
 }
 
 func (m *schemaModel) applyAlterTable(key tableKey, actions string) {

--- a/backend/internal/schemaguard/schema_demand_guard_test.go
+++ b/backend/internal/schemaguard/schema_demand_guard_test.go
@@ -84,9 +84,16 @@ import (
 //     projections means resolving aliases, joins, subqueries and CTEs. Out of
 //     scope. #864's write happened to also RETURNING the same column.
 //
-//  2. TYPES, NULLABILITY, CONSTRAINTS AND DEFAULTS. Presence of a column is
-//     all that is checked. A write of the wrong type, or omitting a NOT NULL
-//     column with no default, passes here and fails at runtime.
+//  2. TYPES, NULLABILITY AND DEFAULTS. For the guards in THIS file, presence of
+//     a column is all that is checked: a write of the wrong type, or omitting a
+//     NOT NULL column with no default, passes here and fails at runtime.
+//
+//     CONSTRAINTS ARE NO LONGER ENTIRELY OUTSIDE THE MODEL. schema_constraint_test.go
+//     records each foreign key's possible target schemas and fails when they
+//     span more than one, because that is a constraint chosen by the
+//     deployment's topology rather than by the migration (#883, #898). It is a
+//     narrow widening -- foreign-key TARGETS only, not types, not NOT NULL, not
+//     CHECK -- and it deliberately does not extend the write checking here.
 //
 //  3. SQL NOT PRESENT AS A CONTIGUOUS GO STRING LITERAL. Statements assembled
 //     from fmt.Sprintf, a query builder, or a string variable contribute only
@@ -106,6 +113,25 @@ import (
 //     cutover configurations documented in docs/identity-schema.md are not
 //     modelled, on the ground that a broken default is what ships to everyone
 //     who does not read the guide.
+//
+//     THAT GROUND DID NOT HOLD FOR #883, and the exception is worth stating
+//     rather than leaving as a known-wrong generalisation. The topology that
+//     broke was reached by FOLLOWING the guide -- enable identity migrations,
+//     copy the data, cut over later -- which parks a deployment in it for as
+//     long as the copy takes. It was a documented rollout step, not an exotic
+//     configuration reached by ignoring the docs.
+//
+//     schema_constraint_test.go answers that without modelling a second
+//     configuration at all: it asks whether a constraint's target is DECIDED BY
+//     the configuration, which is a property of the migration alone. A second
+//     universe was considered and declined -- replaying app+identity with
+//     search_path=[public] grows the model but yields no new violations,
+//     because a presence-only model cannot see a constraint defect in any
+//     universe. Making one informative would require tracking which *sql.DB
+//     handle each query executes against, since the app and identity pools
+//     carry different search_paths. That is a different program, and the
+//     trigger for writing it is identitySchemaEnabled() in cmd/server/main.go
+//     flipping to default-on.
 //
 //  6. OTHER CONSUMERS OF THE SHARED LIBRARY. terraform-state-manager-backend
 //     runs identity.RunMigrations unconditionally while this repository gates
@@ -857,7 +883,9 @@ func creditRuntimeDDL(t *testing.T, m *schemaModel, roots []string) []string {
 			for _, stmt := range splitStatements(stripComments(sql)) {
 				s := normalize(stmt)
 				if reCreateTable.MatchString(s) {
-					m.applyCreateTable(s, "public")
+					// origin is empty: this is creditRuntimeDDL, which models
+					// tables the APPLICATION creates at runtime, not migrations.
+					m.applyCreateTable(s, "public", "")
 				}
 			}
 		}


### PR DESCRIPTION
Closes #898. Takes **axis 1 reformulated**, declines **axis 2**, and keeps the text lint as a complement rather than a fallback.

## The formulation

Record each foreign key's target as the **set** of values the migration stream could have given it, and **never evaluate the branch predicate**. A constraint whose possible targets span more than one schema is chosen by the deployment's topology rather than by the migration — reportable **without modelling any topology at all**.

That is what makes it cheap, and it is blind to spelling by construction. It never reads the condition, so `to_regclass`, `'identity'::regnamespace`, `has_schema_privilege`, an `EXCEPTION` handler and a `CASE` all land in the same place. The text lint in `migrations_test.go` catches one spelling of the mistake; this catches the mistake.

## Falsified against the tree where #883 was live

Replaying **without 000056** — the state in which the defect existed:

```
PRE-000056 ledger entries: 71
PRE-000056 multi-schema constraints: 24
   public.namespace_claims(organization_id) -> identity | public
   public.modules(organization_id)          -> identity | public
   ... 22 more
```

**24 of 24**, matching the count I re-derived independently. On the current tree it reports **0**, because 000056 converged them.

## Phase 0 paid for itself three times

The plan's own figures did not survive contact:

- **The obvious DO-block regex does not compile.** `(\$[A-Za-z_]*\$)(.*)\1` — Go's regexp is RE2 and has **no backreferences**; `MustCompile` panics. The closing tag is found by string search instead, which is what a dollar-quote is anyway.
- **Six files contain DO blocks, not nine.** The count was inflated by `DO $` appearing inside a `COMMENT ON … IS '…'` body.
- **The constraint count is 24**, re-derived three ways rather than transcribed. A naive scan said 25; the twenty-fifth was prose in a comment.

## The defect that mattered most was in my own parser

`splitStatements` splits on `;`, and PL/pgSQL control flow carries no semicolon — so the first statement after `THEN` and after `ELSE` arrives glued to its prefix:

```
"BEGIN IF EXISTS (...) THEN ALTER TABLE public.claims ADD CONSTRAINT ..."
"ELSE ALTER TABLE public.claims ADD CONSTRAINT ..."
```

Neither matches `^ALTER TABLE`. Against the real stream that lost exactly **`namespace_claims(organization_id)`** — *the constraint this issue is about* — while still reporting 23 others.

**A guard that looks like it works is worse than one that obviously does not.** There is now a re-anchoring step and a hermetic test named for this case specifically.

## Axis 2 declined, with a written trigger

Replaying app+identity with `search_path=[public]` grows the model but yields **no new violations** — a presence-only model cannot see a constraint defect in *any* universe. Making one informative would need tracking which `*sql.DB` handle each query executes against, since the app and identity pools carry different `search_path`s. That is a different program.

Boundary 5 now records the trigger: `identitySchemaEnabled()` flipping to default-on.

## Containment

The existence model is **untouched** — a conditional statement contributes to the FK ledger and to nothing else, because crediting a conditional `CREATE TABLE` could only ever *hide* a write violation. Verified by the baseline being byte-identical before and after:

```
schema universe: 56 tables (56 from migrations, 0 created by application code)
checked 234 writes against the default schema universe
checked 149 read demands against the default schema universe
```

## Mutations

Ten, each confirmed to apply and compile:

| Mutation | Caught |
|---|---|
| **revert 000056 (the #883 tree)** | ✓ |
| a new schema-branching FK is added | ✓ |
| a runtime-computed FK target | ✓ |
| possible `DROP` treated as certain | ✓ |
| DO blocks stop being descended into | ✓ |
| the PL/pgSQL re-anchor is removed | ✓ |
| certain `ADD` appends instead of replacing | ✓ |
| inline `REFERENCES` no longer recorded | ✓ |
| the floor is lowered to zero | ✓ |
| the floor check always passes | ✓ |

**Four were inert at first, all for one reason:** on a clean tree, breaking the extractor makes the ledger find nothing — and finding nothing is the correct answer there. Hermetic tests that feed the analyzer SQL *containing* the defect fixed that, including one for the floor, which cannot be falsified by lowering it and has to be handed an empty ledger directly (the same treatment `checkNotVacuous` already gets).

**One hermetic fixture was wrong in a way worth recording:** it used `REFERENCES quote_ident(sch).organizations(id)`, which is not valid SQL and which the parser cheerfully resolved to `public.quote_ident`. A hermetic fixture has to be something the database would actually accept, or it tests the parser against a language nobody writes.

## Boundaries rewritten, not left as known-wrong

Boundary 2 no longer claims constraints are entirely outside the model. Boundary 5 keeps its rule but records the exception: its justification — *"a broken default is what ships to everyone who does not read the guide"* — did not hold for #883, which was reached by **following** the guide.

## What this does not cover, stated in the file

`.down.sql` files (the replay is forward-only); DML that branches on schema existence (reported as a fact, never failed on — a data move is not a constraint); and anything about which topology is *correct* — the claim is only that no single arm can be right in every topology.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on `./internal/schemaguard/...` — 0 issues
