### PR TITLE
feat(scm): pin a manual sync to a ref, and refuse one that has moved

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -2494,7 +2494,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Manually trigger an asynchronous repository scan that imports matching tag-based versions from the\nlinked SCM repository. The endpoint returns 202 immediately; the sync runs in the background.\nTags are matched against the configured pattern (default: v*) and the semantic version is extracted.\nVersions that already exist in the registry are silently skipped. The caller's OAuth token is used\nfor SCM API access and is proactively refreshed if it is expired or within 5 minutes of expiry.",
+                "description": "Manually trigger an asynchronous repository scan that imports matching tag-based versions from the\nlinked SCM repository. The endpoint returns 202 immediately; the sync runs in the background.\nTags are matched against the configured pattern (default: v*) and the semantic version is extracted.\nVersions that already exist in the registry are silently skipped. The caller's OAuth token is used\nfor SCM API access and is proactively refreshed if it is expired or within 5 minutes of expiry.\n\nOptionally pinned to one ref. `tag` narrows the sync to that tag alone; `commit_sha`\nadditionally asserts the tag still points at that commit, and the request is refused\nwith 409 if it has moved. Both are validated before the sync is dispatched, so a bad\nref is reported to the caller rather than discovered inside the background job.",
                 "tags": [
                     "SCM Linking"
                 ],
@@ -2505,6 +2505,22 @@
                         "name": "id",
                         "in": "path",
                         "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sync only this tag (default: every tag matching the configured pattern)",
+                        "name": "tag",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Assert the tag points at this commit; requires tag. Abbreviations of 7+ characters are accepted",
+                        "name": "commit_sha",
+                        "in": "query",
                         "schema": {
                             "type": "string"
                         }
@@ -2522,7 +2538,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid module ID",
+                        "description": "Invalid module ID, or commit_sha given without tag",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2544,7 +2560,18 @@
                         }
                     },
                     "404": {
-                        "description": "Module is not linked to a repository",
+                        "description": "Module is not linked to a repository, or the named tag does not exist",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "The named tag no longer points at the asserted commit",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2556,6 +2583,17 @@
                     },
                     "500": {
                         "description": "Internal server error (connector build, token decryption, etc.)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Could not reach the SCM provider to resolve the ref",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1969,7 +1969,7 @@
                         "Bearer": []
                     }
                 ],
-                "description": "Manually trigger an asynchronous repository scan that imports matching tag-based versions from the\nlinked SCM repository. The endpoint returns 202 immediately; the sync runs in the background.\nTags are matched against the configured pattern (default: v*) and the semantic version is extracted.\nVersions that already exist in the registry are silently skipped. The caller's OAuth token is used\nfor SCM API access and is proactively refreshed if it is expired or within 5 minutes of expiry.",
+                "description": "Manually trigger an asynchronous repository scan that imports matching tag-based versions from the\nlinked SCM repository. The endpoint returns 202 immediately; the sync runs in the background.\nTags are matched against the configured pattern (default: v*) and the semantic version is extracted.\nVersions that already exist in the registry are silently skipped. The caller's OAuth token is used\nfor SCM API access and is proactively refreshed if it is expired or within 5 minutes of expiry.\n\nOptionally pinned to one ref. `tag` narrows the sync to that tag alone; `commit_sha`\nadditionally asserts the tag still points at that commit, and the request is refused\nwith 409 if it has moved. Both are validated before the sync is dispatched, so a bad\nref is reported to the caller rather than discovered inside the background job.",
                 "produces": [
                     "application/json"
                 ],
@@ -1984,6 +1984,18 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sync only this tag (default: every tag matching the configured pattern)",
+                        "name": "tag",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Assert the tag points at this commit; requires tag. Abbreviations of 7+ characters are accepted",
+                        "name": "commit_sha",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1994,7 +2006,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid module ID",
+                        "description": "Invalid module ID, or commit_sha given without tag",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -2008,7 +2020,14 @@
                         }
                     },
                     "404": {
-                        "description": "Module is not linked to a repository",
+                        "description": "Module is not linked to a repository, or the named tag does not exist",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "409": {
+                        "description": "The named tag no longer points at the asserted commit",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -2016,6 +2035,13 @@
                     },
                     "500": {
                         "description": "Internal server error (connector build, token decryption, etc.)",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "502": {
+                        "description": "Could not reach the SCM provider to resolve the ref",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true

--- a/backend/internal/api/modules/scm_linking.go
+++ b/backend/internal/api/modules/scm_linking.go
@@ -3,9 +3,11 @@ package modules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -496,12 +498,21 @@ func (h *SCMLinkingHandler) GetModuleSCMInfo(c *gin.Context) {
 // @Tags         SCM Linking
 // @Security     Bearer
 // @Produce      json
-// @Param        id  path  string  true  "Module ID (UUID)"
+// @Description
+// @Description  Optionally pinned to one ref. `tag` narrows the sync to that tag alone; `commit_sha`
+// @Description  additionally asserts the tag still points at that commit, and the request is refused
+// @Description  with 409 if it has moved. Both are validated before the sync is dispatched, so a bad
+// @Description  ref is reported to the caller rather than discovered inside the background job.
+// @Param        id          path   string  true   "Module ID (UUID)"
+// @Param        tag         query  string  false  "Sync only this tag (default: every tag matching the configured pattern)"
+// @Param        commit_sha  query  string  false  "Assert the tag points at this commit; requires tag. Abbreviations of 7+ characters are accepted"
 // @Success      202  {object}  admin.MessageResponse
-// @Failure      400  {object}  map[string]interface{}  "Invalid module ID"
+// @Failure      400  {object}  map[string]interface{}  "Invalid module ID, or commit_sha given without tag"
 // @Failure      401  {object}  map[string]interface{}  "Unauthorized or no OAuth token for this SCM provider"
-// @Failure      404  {object}  map[string]interface{}  "Module is not linked to a repository"
+// @Failure      404  {object}  map[string]interface{}  "Module is not linked to a repository, or the named tag does not exist"
+// @Failure      409  {object}  map[string]interface{}  "The named tag no longer points at the asserted commit"
 // @Failure      500  {object}  map[string]interface{}  "Internal server error (connector build, token decryption, etc.)"
+// @Failure      502  {object}  map[string]interface{}  "Could not reach the SCM provider to resolve the ref"
 // @Router       /api/v1/admin/modules/{id}/scm/sync [post]
 // TriggerManualSync manually triggers a repository sync
 // POST /api/v1/admin/modules/:id/scm/sync
@@ -535,18 +546,21 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 
 	// App-mode providers use the shared, admin-managed credential — no per-user
 	// connection is required to trigger a sync.
+	ref, ok := parseSyncRef(c)
+	if !ok {
+		return
+	}
+
 	if provider.AuthMode == scm.AuthModeEntraApp || provider.AuthMode == scm.AuthModeGitHubApp {
 		connector, token, connErr := h.connectorAndToken(c.Request.Context(), provider, uuid.Nil)
 		if connErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": connErr.Error()})
 			return
 		}
-		safego.Go(func() {
-			if syncErr := h.publisher.TriggerManualSync(context.Background(), link, connector, token); syncErr != nil {
-				slog.Warn("manual sync failed", "module_id", moduleID, "error", syncErr)
-			}
-		})
-		c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
+		if !h.resolveSyncRef(c, link, connector, token, ref) {
+			return
+		}
+		h.dispatchSync(c, moduleID, link, connector, token, ref)
 		return
 	}
 
@@ -646,20 +660,114 @@ func (h *SCMLinkingHandler) TriggerManualSync(c *gin.Context) {
 		}
 	}
 
-	// Trigger async sync in background using a new context
-	// (c.Request.Context() would be canceled when the HTTP response is sent)
-	slog.Debug("starting async sync", "module_id", moduleID, "owner", link.RepositoryOwner, "repo", link.RepositoryName)
+	if !h.resolveSyncRef(c, link, connector, token, ref) {
+		return
+	}
+	h.dispatchSync(c, moduleID, link, connector, token, ref)
+}
+
+// parseSyncRef reads the optional ref from the request (#879).
+//
+// Query parameters, not a body: this is a POST with no body today and every
+// existing caller sends none, so a required body would break them and an
+// optional one is two ways to say the same thing. Callers are CI workflows
+// building a URL.
+//
+// Returns false when it has already answered the request.
+func parseSyncRef(c *gin.Context) (services.SyncRef, bool) {
+	ref := services.SyncRef{
+		TagName:   strings.TrimSpace(c.Query("tag")),
+		CommitSHA: strings.TrimSpace(c.Query("commit_sha")),
+	}
+	// A commit without a tag cannot be resolved: the sync walks tags, and a
+	// bare SHA names no tag to import. Refusing is better than ignoring it,
+	// which would let a caller believe it had pinned something.
+	if ref.CommitSHA != "" && ref.TagName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "commit_sha requires tag: a sync imports tags, so a commit alone names nothing to publish",
+		})
+		return services.SyncRef{}, false
+	}
+	return ref, true
+}
+
+// resolveSyncRef checks the named ref BEFORE dispatching, and answers the
+// request itself when it does not hold.
+//
+// SYNCHRONOUS ON PURPOSE. The sync runs detached and the handler answers 202,
+// so a failure discovered inside it reaches nobody -- which would make "fail if
+// the ref no longer resolves" a promise this API could not keep. Resolving
+// first turns a moved or missing tag into a status code the caller sees.
+//
+// Returns false when it has already answered.
+func (h *SCMLinkingHandler) resolveSyncRef(c *gin.Context, link *scm.ModuleSourceRepoRecord, connector scm.Connector, token *scm.OAuthToken, ref services.SyncRef) bool {
+	if ref.TagName == "" {
+		return true
+	}
+	tag, err := h.publisher.ResolveRef(c.Request.Context(), link, connector, token, ref)
+	if err != nil {
+		status, msg := statusForRefError(err)
+		c.JSON(status, gin.H{"error": msg})
+		return false
+	}
+	if tag != nil {
+		slog.Debug("resolved sync ref", "tag", tag.TagName, "commit", tag.TargetCommit)
+	}
+	return true
+}
+
+// statusForRefError maps a ref-resolution failure to a status.
+//
+// A pure function so the mapping is testable without a live SCM connector --
+// and it is the part a publisher actually depends on. The distinctions matter:
+//
+//   - 404: the tag does not exist. The caller named something wrong, or the
+//     push has not landed yet.
+//   - 409: the tag exists and points somewhere else. THE REQUEST WAS FINE and
+//     the repository changed underneath it -- which is the force-moved-tag case
+//     this whole feature exists to refuse. Reporting it as 400 would tell a
+//     publisher it had sent nonsense.
+//   - 502: the registry could not reach the SCM provider. Nothing about the
+//     caller's request is wrong, and it is worth retrying; the other two are
+//     not.
+//
+// The upstream message is passed through for the first two because it names the
+// tag and both commits, which is what a human debugging a failed publish needs.
+// The 502 message is generic: an SCM client error can carry an instance URL or
+// a token fragment.
+func statusForRefError(err error) (int, string) {
+	switch {
+	case errors.Is(err, services.ErrRefNotFound):
+		return http.StatusNotFound, err.Error()
+	case errors.Is(err, services.ErrRefMoved):
+		return http.StatusConflict, err.Error()
+	default:
+		return http.StatusBadGateway, "failed to resolve ref against the repository"
+	}
+}
+
+// dispatchSync starts the sync in the background and answers 202.
+func (h *SCMLinkingHandler) dispatchSync(c *gin.Context, moduleID uuid.UUID, link *scm.ModuleSourceRepoRecord, connector scm.Connector, token *scm.OAuthToken, ref services.SyncRef) {
+	// A new context: c.Request.Context() is canceled when the response is sent.
+	slog.Debug("starting async sync", "module_id", moduleID, "owner", link.RepositoryOwner, "repo", link.RepositoryName, "tag", ref.TagName)
 	safego.Go(func() {
-		slog.Debug("running sync in goroutine", "module_id", moduleID)
-		if err := h.publisher.TriggerManualSync(context.Background(), link, connector, token); err != nil {
-			// Log error but don't fail the request
-			slog.Warn("manual sync failed", "module_id", moduleID, "error", err)
+		if err := h.publisher.TriggerManualSyncRef(context.Background(), link, connector, token, ref); err != nil {
+			slog.Warn("manual sync failed", "module_id", moduleID, "tag", ref.TagName, "error", err)
 		} else {
 			slog.Debug("manual sync completed successfully", "module_id", moduleID)
 		}
 	})
 
-	c.JSON(http.StatusAccepted, gin.H{"message": "sync triggered"})
+	body := gin.H{"message": "sync triggered"}
+	if ref.TagName != "" {
+		// Echo what was pinned, so a caller can confirm the server understood
+		// the ref rather than having silently ignored an unknown parameter.
+		body["tag"] = ref.TagName
+		if ref.CommitSHA != "" {
+			body["commit_sha"] = ref.CommitSHA
+		}
+	}
+	c.JSON(http.StatusAccepted, body)
 }
 
 // @Summary      Get webhook event history

--- a/backend/internal/api/modules/scm_sync_ref_handler_test.go
+++ b/backend/internal/api/modules/scm_sync_ref_handler_test.go
@@ -1,0 +1,139 @@
+package modules
+
+// scm_sync_ref_handler_test.go covers the request half of #879: reading an
+// optional ref, and mapping a resolution failure to a status a publisher can
+// act on.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/terraform-registry/terraform-registry/internal/services"
+)
+
+func ctxWithQuery(t *testing.T, q string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/modules/x/scm/sync?"+q, nil)
+	return c, w
+}
+
+func TestParseSyncRef(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		query      string
+		wantOK     bool
+		wantTag    string
+		wantCommit string
+		wantStatus int
+	}{
+		{
+			name:   "no ref at all is the existing behaviour",
+			query:  "",
+			wantOK: true,
+		},
+		{
+			name:    "tag alone",
+			query:   "tag=v1.2.3",
+			wantOK:  true,
+			wantTag: "v1.2.3",
+		},
+		{
+			name:       "tag and commit",
+			query:      "tag=v1.2.3&commit_sha=1a2b3c4d5e6f",
+			wantOK:     true,
+			wantTag:    "v1.2.3",
+			wantCommit: "1a2b3c4d5e6f",
+		},
+		{
+			name:    "whitespace is trimmed",
+			query:   "tag=%20v1.2.3%20",
+			wantOK:  true,
+			wantTag: "v1.2.3",
+		},
+		{
+			// A bare SHA names no tag to import, and the sync walks tags. If
+			// this were ignored rather than refused, a caller would believe it
+			// had pinned something and get an unpinned sync.
+			name:       "commit without a tag is refused",
+			query:      "commit_sha=1a2b3c4d5e6f",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, w := ctxWithQuery(t, tc.query)
+			ref, ok := parseSyncRef(c)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (body %s)", ok, tc.wantOK, w.Body.String())
+			}
+			if !ok {
+				if w.Code != tc.wantStatus {
+					t.Errorf("status = %d, want %d", w.Code, tc.wantStatus)
+				}
+				return
+			}
+			if ref.TagName != tc.wantTag {
+				t.Errorf("TagName = %q, want %q", ref.TagName, tc.wantTag)
+			}
+			if ref.CommitSHA != tc.wantCommit {
+				t.Errorf("CommitSHA = %q, want %q", ref.CommitSHA, tc.wantCommit)
+			}
+		})
+	}
+}
+
+// TestStatusForRefError pins the distinctions a publisher acts on.
+func TestStatusForRefError(t *testing.T) {
+	moved := fmt.Errorf("%w: v1.2.3 points at aaa, not bbb", services.ErrRefMoved)
+	missing := fmt.Errorf("%w: v9.9.9", services.ErrRefNotFound)
+
+	if got, msg := statusForRefError(missing); got != http.StatusNotFound {
+		t.Errorf("missing ref -> %d (%s), want 404", got, msg)
+	}
+	if got, _ := statusForRefError(moved); got != http.StatusConflict {
+		t.Errorf("moved ref -> %d, want 409. A force-moved tag is not a malformed request: the "+
+			"caller sent something valid and the repository changed underneath it.", got)
+	}
+	if got, _ := statusForRefError(errors.New("dial tcp: connection refused")); got != http.StatusBadGateway {
+		t.Errorf("transport failure -> %d, want 502. Nothing about the request is wrong and it is "+
+			"worth retrying, unlike the other two.", got)
+	}
+}
+
+// TestStatusForRefErrorDoesNotLeakTransportDetail.
+//
+// An SCM client error can carry an instance URL or a token fragment. The two
+// ref errors are this service's own text and name only the tag and commits, so
+// they pass through; anything else is generalised.
+func TestStatusForRefErrorDoesNotLeakTransportDetail(t *testing.T) {
+	_, msg := statusForRefError(errors.New("Get \"https://ghe.internal.example.com/api/v3/repos?token=ghp_secret\": dial tcp"))
+	for _, leak := range []string{"ghe.internal", "ghp_secret", "token="} {
+		if contains(msg, leak) {
+			t.Errorf("the 502 message leaks %q: %s", leak, msg)
+		}
+	}
+	// And the two that DO pass through must still say which tag, or a publisher
+	// cannot tell which of several syncs failed.
+	_, movedMsg := statusForRefError(fmt.Errorf("%w: v1.2.3 points at aaa, not bbb", services.ErrRefMoved))
+	if !contains(movedMsg, "v1.2.3") {
+		t.Errorf("the 409 message does not name the tag: %s", movedMsg)
+	}
+}
+
+func contains(hay, needle string) bool {
+	return len(needle) > 0 && len(hay) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(hay); i++ {
+			if hay[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/backend/internal/services/scm_publisher.go
+++ b/backend/internal/services/scm_publisher.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -413,11 +414,116 @@ func (p *SCMPublisher) extractVersionFromTag(tag, glob string) string {
 	return version
 }
 
+// SyncRef narrows a manual sync to one ref, and optionally asserts which commit
+// that ref must point at (#879).
+//
+// WHY THIS EXISTS. Without it a sync imports whatever the configured tag
+// pattern resolves to AT SYNC TIME, so between a workflow's checkout and the
+// registry's fetch there is a window in which a force-moved tag changes what
+// gets published while the publisher still reports success. A caller had no way
+// to say which ref it meant.
+//
+// The zero value means "every matching tag", which is what a sync triggered
+// from the UI wants and what every existing caller gets.
+type SyncRef struct {
+	// TagName narrows the sync to this tag. Empty means all matching tags.
+	TagName string
+	// CommitSHA, when set alongside TagName, asserts the tag still points at
+	// this commit. A mismatch is a FORCE-MOVED TAG and is refused rather than
+	// published, because publishing it would silently substitute different
+	// content for what the caller asked for.
+	CommitSHA string
+}
+
+// admits decides whether a fetched tag is the one this ref names.
+//
+// A method rather than an inline condition so the narrowing is testable without
+// a live SCM connector -- TriggerManualSyncRef is integration-only, and a
+// mutation that deleted the filter entirely went undetected until this existed.
+//
+// Returns an error rather than false for a MOVED tag, because the two mean
+// opposite things: a non-matching tag is simply not the one asked for and the
+// loop should carry on, while a matching tag pointing at the wrong commit is
+// the force-moved case the whole feature exists to refuse. Publishing it would
+// silently substitute different content for what the caller asked for.
+func (ref SyncRef) admits(tag *scm.GitTag) (bool, error) {
+	if ref.TagName == "" {
+		return true, nil // unpinned: every tag the pattern matches
+	}
+	if tag == nil || tag.TagName != ref.TagName {
+		return false, nil
+	}
+	if ref.CommitSHA != "" && !sameCommit(tag.TargetCommit, ref.CommitSHA) {
+		return false, fmt.Errorf("%w: %s points at %s, not %s",
+			ErrRefMoved, ref.TagName, tag.TargetCommit, ref.CommitSHA)
+	}
+	return true, nil
+}
+
+// ErrRefNotFound means the named tag does not exist in the repository.
+var ErrRefNotFound = errors.New("scm: named ref not found in repository")
+
+// ErrRefMoved means the tag exists but points at a different commit than the
+// caller asserted.
+var ErrRefMoved = errors.New("scm: named ref no longer points at the asserted commit")
+
+// ResolveRef checks that a ref exists and still points where the caller says.
+//
+// SEPARATE FROM THE SYNC, and called synchronously by the handler before it
+// dispatches. The sync itself runs detached and answers 202, so a failure
+// discovered inside it reaches nobody -- which would make "fail if it no longer
+// resolves" a promise the API could not keep. Resolving first turns a moved tag
+// into a status code the caller actually sees.
+func (p *SCMPublisher) ResolveRef(ctx context.Context, moduleSourceRepo *scm.ModuleSourceRepoRecord, connector scm.Connector, token *scm.OAuthToken, ref SyncRef) (*scm.GitTag, error) {
+	if ref.TagName == "" {
+		return nil, nil
+	}
+	tags, err := connector.FetchTags(ctx, token, moduleSourceRepo.RepositoryOwner, moduleSourceRepo.RepositoryName, scm.DefaultPagination())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+	for _, tag := range tags {
+		if tag.TagName != ref.TagName {
+			continue
+		}
+		if ref.CommitSHA != "" && !sameCommit(tag.TargetCommit, ref.CommitSHA) {
+			return nil, fmt.Errorf("%w: %s points at %s, not %s",
+				ErrRefMoved, ref.TagName, tag.TargetCommit, ref.CommitSHA)
+		}
+		return tag, nil
+	}
+	return nil, fmt.Errorf("%w: %s", ErrRefNotFound, ref.TagName)
+}
+
+// sameCommit compares two commit ids, tolerating an abbreviated one.
+//
+// A caller frequently has a short SHA (a workflow that ran `git rev-parse
+// --short HEAD`), and refusing it would push everyone toward omitting the
+// assertion entirely -- which defeats the point. Comparison is on the shorter
+// length, case-insensitively, and an abbreviation shorter than 7 is refused as
+// too weak to identify a commit.
+func sameCommit(actual, asserted string) bool {
+	a := strings.ToLower(strings.TrimSpace(actual))
+	b := strings.ToLower(strings.TrimSpace(asserted))
+	if len(b) < 7 || len(a) < 7 {
+		return false
+	}
+	if len(b) < len(a) {
+		return strings.HasPrefix(a, b)
+	}
+	return strings.HasPrefix(b, a)
+}
+
 // TriggerManualSync scans a repository for tags and publishes any matching versions
 // TriggerManualSync manually syncs all tags for a module source repo.
 // coverage:skip:integration-only — requires live SCM connector and DB
 // This is called when a user manually triggers a sync from the UI
 func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *scm.ModuleSourceRepoRecord, connector scm.Connector, token *scm.OAuthToken) error {
+	return p.TriggerManualSyncRef(ctx, moduleSourceRepo, connector, token, SyncRef{})
+}
+
+// TriggerManualSyncRef is TriggerManualSync narrowed to one ref.
+func (p *SCMPublisher) TriggerManualSyncRef(ctx context.Context, moduleSourceRepo *scm.ModuleSourceRepoRecord, connector scm.Connector, token *scm.OAuthToken, ref SyncRef) error {
 	slog.Debug("starting manual sync", "module_id", moduleSourceRepo.ModuleID, "owner", moduleSourceRepo.RepositoryOwner, "repo", moduleSourceRepo.RepositoryName)
 
 	// List all tags from the repository
@@ -437,6 +543,18 @@ func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *
 
 	matchingTags := 0
 	for _, tag := range tags {
+		// A named ref narrows the sync to exactly that tag, and asserts the
+		// commit if one was given. Checked here as well as in ResolveRef
+		// because the two run at different times: the handler resolves before
+		// dispatching, and the tag could move in between. Publishing the wrong
+		// commit is worse than publishing nothing.
+		include, refErr := ref.admits(tag)
+		if refErr != nil {
+			return refErr
+		}
+		if !include {
+			continue
+		}
 		slog.Debug("checking tag", "tag", tag.TagName)
 
 		// Check if tag matches pattern
@@ -478,6 +596,13 @@ func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *
 
 	slog.Debug("manual sync tag matching complete", "matching_tags", matchingTags, "total_tags", len(tags))
 
+	// A named ref that matched nothing is an error, never a quiet success. The
+	// caller asked for one specific thing; reporting 202 for a tag that does
+	// not exist is the failure mode this whole change exists to remove.
+	if ref.TagName != "" && !sawNamedRef(tags, ref.TagName) {
+		return fmt.Errorf("%w: %s", ErrRefNotFound, ref.TagName)
+	}
+
 	// Update last sync time
 	now := time.Now()
 	moduleSourceRepo.LastSyncAt = &now
@@ -486,6 +611,16 @@ func (p *SCMPublisher) TriggerManualSync(ctx context.Context, moduleSourceRepo *
 	}
 
 	return nil
+}
+
+// sawNamedRef reports whether the fetched tag list contains name.
+func sawNamedRef(tags []*scm.GitTag, name string) bool {
+	for _, t := range tags {
+		if t != nil && t.TagName == name {
+			return true
+		}
+	}
+	return false
 }
 
 // processTagForManualSync processes a single tag during manual sync (no webhook logging)

--- a/backend/internal/services/scm_sync_ref_test.go
+++ b/backend/internal/services/scm_sync_ref_test.go
@@ -1,0 +1,197 @@
+package services
+
+// scm_sync_ref_test.go covers pinning a manual sync to a ref (#879).
+//
+// WHAT THIS FIXES. A sync imported whatever the configured tag pattern resolved
+// to AT SYNC TIME, so between a workflow's checkout and the registry's fetch
+// there was a window in which a force-moved tag changed what got published
+// while the publisher still reported success. The caller could not close that
+// window, because it had no way to say which ref it meant.
+//
+// The interesting cases are all about a tag that moved, so that is what most of
+// these are.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/terraform-registry/terraform-registry/internal/scm"
+)
+
+func TestSameCommitAcceptsAnAbbreviation(t *testing.T) {
+	const full = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+	for _, tc := range []struct {
+		name     string
+		actual   string
+		asserted string
+		want     bool
+	}{
+		{"identical", full, full, true},
+		{"short asserted", full, full[:7], true},
+		{"short asserted, longer", full, full[:12], true},
+		{"case differs", full, strings.ToUpper(full), true},
+		{"whitespace", full, "  " + full + "\n", true},
+		{"different commit", full, "0000000000000000000000000000000000000000", false},
+		{"different at the 8th char", full, full[:7] + "f", false},
+		// Shorter than 7 is refused: it identifies too many commits to be an
+		// assertion about one, and accepting it would make the pin look
+		// stronger than it is.
+		{"too short to mean anything", full, full[:6], false},
+		{"empty asserted", full, "", false},
+		{"empty actual", "", full, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameCommit(tc.actual, tc.asserted); got != tc.want {
+				t.Errorf("sameCommit(%q, %q) = %v, want %v", tc.actual, tc.asserted, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSameCommitIsNotSubstringMatching is the trap this comparison invites.
+//
+// A prefix test is correct; a `strings.Contains` is not. An asserted SHA that
+// appears in the MIDDLE of the actual one identifies nothing, and accepting it
+// would let a wrong commit pass the pin.
+func TestSameCommitIsNotSubstringMatching(t *testing.T) {
+	const actual = "aaaaaaa1234567bbbbbbb"
+	if sameCommit(actual, "1234567") {
+		t.Error("a SHA matched in the middle of another. The comparison must be a prefix test: " +
+			"an abbreviation identifies a commit by its leading characters, and matching anywhere " +
+			"lets an unrelated commit satisfy the pin.")
+	}
+}
+
+// TestErrRefMovedIsDistinctFromNotFound. The handler maps one to 409 and the
+// other to 404, and a publisher needs to tell "your tag moved" from "your tag
+// does not exist" -- they call for different actions.
+func TestErrRefMovedIsDistinctFromNotFound(t *testing.T) {
+	if errors.Is(ErrRefMoved, ErrRefNotFound) || errors.Is(ErrRefNotFound, ErrRefMoved) {
+		t.Fatal("the two ref errors are not distinguishable, so the handler cannot map them to " +
+			"different status codes")
+	}
+}
+
+// TestZeroSyncRefMeansEveryTag pins backwards compatibility: every existing
+// caller passes no ref and must keep getting a full sync.
+func TestZeroSyncRefMeansEveryTag(t *testing.T) {
+	var ref SyncRef
+	if ref.TagName != "" || ref.CommitSHA != "" {
+		t.Fatal("the zero SyncRef is not empty, so an unpinned sync would be narrowed by accident")
+	}
+}
+
+// TestSyncRefAdmits covers the narrowing itself.
+//
+// Extracted from TriggerManualSyncRef, which is integration-only: a mutation
+// that deleted the tag filter entirely went undetected until this test existed,
+// because nothing could reach the loop without a live SCM connector.
+func TestSyncRefAdmits(t *testing.T) {
+	const sha = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+	tag := func(name, commit string) *scm.GitTag { return &scm.GitTag{TagName: name, TargetCommit: commit} }
+
+	for _, tc := range []struct {
+		name        string
+		ref         SyncRef
+		tag         *scm.GitTag
+		wantInclude bool
+		wantMoved   bool
+	}{
+		{
+			name:        "unpinned admits everything",
+			ref:         SyncRef{},
+			tag:         tag("v9.9.9", sha),
+			wantInclude: true,
+		},
+		{
+			name:        "the named tag",
+			ref:         SyncRef{TagName: "v1.2.3"},
+			tag:         tag("v1.2.3", sha),
+			wantInclude: true,
+		},
+		{
+			// Skipped, not an error: it is simply not the tag asked for, and
+			// the loop must carry on to find the one that is.
+			name:        "a different tag is skipped",
+			ref:         SyncRef{TagName: "v1.2.3"},
+			tag:         tag("v1.2.4", sha),
+			wantInclude: false,
+		},
+		{
+			name:        "the named tag at the asserted commit",
+			ref:         SyncRef{TagName: "v1.2.3", CommitSHA: sha},
+			tag:         tag("v1.2.3", sha),
+			wantInclude: true,
+		},
+		{
+			name:        "abbreviated assertion still matches",
+			ref:         SyncRef{TagName: "v1.2.3", CommitSHA: sha[:8]},
+			tag:         tag("v1.2.3", sha),
+			wantInclude: true,
+		},
+		{
+			// THE CASE THIS FEATURE EXISTS FOR. An error, not a skip: skipping
+			// would leave the sync reporting success having published nothing,
+			// which is indistinguishable from the tag not matching the pattern.
+			name:      "the named tag has moved",
+			ref:       SyncRef{TagName: "v1.2.3", CommitSHA: sha},
+			tag:       tag("v1.2.3", "0000000000000000000000000000000000000000"),
+			wantMoved: true,
+		},
+		{
+			name:        "a nil tag is skipped, not a panic",
+			ref:         SyncRef{TagName: "v1.2.3"},
+			tag:         nil,
+			wantInclude: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			include, err := tc.ref.admits(tc.tag)
+			if tc.wantMoved {
+				if !errors.Is(err, ErrRefMoved) {
+					t.Fatalf("err = %v, want ErrRefMoved. A tag that moved must stop the sync, not "+
+						"be silently skipped -- a skip reports success having published nothing.", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if include != tc.wantInclude {
+				t.Errorf("include = %v, want %v", include, tc.wantInclude)
+			}
+		})
+	}
+}
+
+// TestSawNamedRef covers the helper behind "you named a tag that does not
+// exist".
+//
+// A KNOWN GAP, stated rather than left implicit: this covers the helper, not
+// its CALL SITE. The call lives inside TriggerManualSyncRef, which is
+// coverage:skip:integration-only -- it needs a live SCM connector -- so a
+// mutation that deletes the call itself is not caught by anything here. That
+// was verified, not assumed: `if ref.TagName != "" && !sawNamedRef(...)`
+// replaced with `if false` passes this whole package.
+//
+// The consequence if it regressed: a sync pinned to a tag that does not exist
+// would report 202 and publish nothing, silently. Closing it properly needs a
+// connector fake, which is a larger change than this feature.
+func TestSawNamedRef(t *testing.T) {
+	tags := []*scm.GitTag{
+		{TagName: "v1.0.0", TargetCommit: "aaa"},
+		nil, // a connector may yield a nil entry; this must not panic
+		{TagName: "v1.2.3", TargetCommit: "bbb"},
+	}
+	if !sawNamedRef(tags, "v1.2.3") {
+		t.Error("an existing tag was not found")
+	}
+	if sawNamedRef(tags, "v9.9.9") {
+		t.Error("a tag that is not present was reported as found, so a sync pinned to a " +
+			"nonexistent ref would report success having published nothing")
+	}
+	if sawNamedRef(nil, "v1.0.0") {
+		t.Error("an empty tag list reported a match")
+	}
+}


### PR DESCRIPTION
Closes #879.

## Part 2 was already done

The issue asks for two things. **Part 2 — emitting `commit_sha` / `tag_name` from `GetModule` — landed in #948.** The issue's evidence was against `c583d7f` and `main` has moved. Verified before starting rather than reimplemented.

So this is part 1 only.

## What changed

`POST /api/v1/admin/modules/{id}/scm/sync` read nothing but the module id. It imported whatever the configured tag pattern resolved to **at sync time**, so between a workflow's `checkout` and the registry's fetch there was a window in which a force-moved tag changed what got published while the publisher still reported success.

It now accepts an optional `tag`, and an optional `commit_sha` alongside it asserting the tag still points there:

```
POST /api/v1/admin/modules/{id}/scm/sync?tag=v1.2.3&commit_sha=1a2b3c4
```

Query parameters rather than a body: this is a POST with no body today, every existing caller sends none, and the callers are CI workflows building a URL. **Fully backwards compatible** — no ref means today's behaviour exactly.

## Validated synchronously, before dispatch

This is the part that makes the promise keepable. The sync runs detached and the handler answers `202`, so a failure discovered *inside* it reaches nobody — *"fail if the ref no longer resolves"* would have been a promise the API could not deliver.

Resolving first turns a moved or missing tag into a status code the caller actually sees:

| Status | Meaning | Retryable? |
|---|---|---|
| `404` | the tag does not exist — wrong name, or the push hasn't landed | no |
| `409` | the tag exists and points **elsewhere** — the force-moved case | no; the caller must decide |
| `502` | couldn't reach the SCM provider | **yes** |
| `400` | `commit_sha` without `tag` | no |

`409` rather than `400` for a moved tag is deliberate: **the request was fine** and the repository changed underneath it. Reporting that as `400` would tell a publisher it had sent nonsense.

The `502` message is generalised, because an SCM client error can carry an instance URL or a token fragment. The other two are this service's own text and name the tag and both commits — what a human debugging a failed publish needs.

## Details worth flagging

**`commit_sha` without `tag` is refused, not ignored.** A sync walks tags, so a bare SHA names nothing to publish — and ignoring it would let a caller believe it had pinned something.

**Abbreviated SHAs are accepted from 7 characters.** A caller usually has one from `git rev-parse --short HEAD`, and refusing it would push people toward omitting the assertion entirely, which defeats the point. The comparison is a **prefix** test, not a substring one — an abbreviation identifies a commit by its *leading* characters, and matching anywhere would let an unrelated commit satisfy the pin. Both directions mutation-verified.

**The ref is re-checked inside the sync as well as at the handler**, because the two run at different times and the tag can move in between. Publishing the wrong commit is worse than publishing nothing.

## Mutations

Twelve, each confirmed to apply and compile — including SHA compare becoming substring matching, short abbreviations accepted, case-sensitivity, the two ref errors collapsing into one, a moved tag reported as 400, transport detail passed through verbatim, an unpinned sync narrowed by accident, and a moved tag skipped instead of refused.

**The narrowing itself was inert** until `SyncRef.admits` was extracted. It lived inside `TriggerManualSyncRef`, which is `coverage:skip:integration-only`, so a mutation deleting the tag filter entirely went undetected.

## One known gap, stated rather than left implicit

The *"named ref matched nothing"* check also lives inside that integration-only function, so a mutation deleting **its call** is not caught either. **Verified, not assumed** — replacing it with `if false` passes the whole package.

If that regressed, a sync pinned to a nonexistent tag would answer `202` and publish nothing, silently. Closing it needs a connector fake, which is a larger change than this feature. It's documented in the test file next to the helper it covers.

## For the consumer

`terraform-module-publish` (its issue #23) can now pass the tag and commit it checked out, and get a `409` instead of a silently-different publish. Its README's *"Version provenance"* section documents the old limitation and can be updated.

## Verification

- `go test ./... -count=1` — full backend suite green
- `go vet ./...` — clean
- `golangci-lint v2.12.2` (the CI pin) on the touched packages — 0 issues
- Swagger/OpenAPI regenerated with CI's own invocation; the diff is confined to this endpoint
