### PR TITLE
fix(ci): grep -m 5 instead of piping into head, so the skip diagnostic survives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,12 @@ jobs:
           # skip citing the DSN, and at least one must actually have run.
           if grep -q 'TFR_TEST_DATABASE_URL not set' /tmp/pg-tests.log; then
             echo "::error::Postgres tests SKIPPED on an unset DSN -- this job proved nothing."
-            grep -n 'TFR_TEST_DATABASE_URL not set' /tmp/pg-tests.log | head -5
+            # grep -m 5, not `| head -5`: under the `set -o pipefail` above, head closing
+            # the pipe SIGPIPEs grep once its output exceeds the pipe buffer, and the 141
+            # aborts this step BEFORE the sample prints -- losing exactly the diagnostic
+            # naming which tests skipped, in the run where they did. -m 5 stops grep, so
+            # there is no pipe at all.
+            grep -n -m 5 'TFR_TEST_DATABASE_URL not set' /tmp/pg-tests.log
             exit 1
           fi
           if grep -qE 'TFR_TEST_DATABASE_URL is not reachable|not reachable' /tmp/pg-tests.log; then


### PR DESCRIPTION
Found by an estate-wide scan for the class that left `setup-terraform-hardened`'s `main` red for three days ([#49 there](https://github.com/sethbacon/setup-terraform-hardened/pull/49)).

## The mechanism, measured

Under `set -o pipefail`, an early-exiting **reader** closes the pipe and the **writer** takes SIGPIPE on its next write; the pipeline then reports **141** and `set -e` aborts the step. It only bites once the writer's output exceeds the pipe buffer — which is why it reads as flake rather than breakage.

Deterministic on a 200k-line log, 3/3 runs:

```
grep -n "not set" big.log | head -5      -> exit 141   (every time)
grep -n "not set" small.log | head -5    -> exit 0
grep -n -m 5 "not set" big.log           -> exit 0, same five lines
```

`grep -m N` stops grep itself, so there is no pipe at all.

## Scope of the sweep

**13 sites across 5 repositories** on `origin/main`. Only **three** can actually fail something, and they are not equally serious:

| repo | site | consequence |
|---|---|---|
| `azure-pipelines-release-docs` | `gh api --paginate … \| head -n1` | **load-bearing** — the release is never undrafted |
| `terraform-registry-backend` | skip-diagnostic `\| head -5` | loses the lines naming which tests skipped |
| `terraform-state-manager-backend` | same guard, same shape | same |

The other ten are `grep` over small, bounded inputs (nginx conf, HTTP headers, a generated script) or already neutralised with `|| true`. They are provably safe today — a small writer completes in one buffered write before any reader can exit — so I have not churned them.

`tail -N` is deliberately **not** in scope: it must consume to EOF to know which lines are last, so it never closes early. Flagging it would be a false positive.