### PR TITLE
feat(auth): report the remaining session lifetime, not only its expiry instant

### DIFF
--- a/backend/docs/openapi3.json
+++ b/backend/docs/openapi3.json
@@ -17757,6 +17757,10 @@
                     "session_expires_at": {
                         "type": "string"
                     },
+                    "session_expires_in": {
+                        "description": "SessionExpiresIn is the remaining session lifetime in SECONDS, measured as\nthis response is built. Omitted on exactly the same conditions as\nSessionExpiresAt, plus one more: never emitted non-positive.\n\nIt exists because SessionExpiresAt alone is unusable when the browser's\nclock disagrees with ours -- the client would compare our instant against\nits own Date.now(), which is wrong by exactly the skew. A duration we\nmeasure and it applies shares no clock at all, so skew cannot enter\n(4cloudguru/cloud-suite-ui#181). The client prefers this when present.",
+                        "type": "integer"
+                    },
                     "user": {
                         "$ref": "#/components/schemas/User"
                     }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -14439,6 +14439,10 @@
                 "session_expires_at": {
                     "type": "string"
                 },
+                "session_expires_in": {
+                    "description": "SessionExpiresIn is the remaining session lifetime in SECONDS, measured as\nthis response is built. Omitted on exactly the same conditions as\nSessionExpiresAt, plus one more: never emitted non-positive.\n\nIt exists because SessionExpiresAt alone is unusable when the browser's\nclock disagrees with ours -- the client would compare our instant against\nits own Date.now(), which is wrong by exactly the skew. A duration we\nmeasure and it applies shares no clock at all, so skew cannot enter\n(4cloudguru/cloud-suite-ui#181). The client prefers this when present.",
+                    "type": "integer"
+                },
                 "user": {
                     "$ref": "#/definitions/User"
                 }

--- a/backend/internal/api/admin/me_response.go
+++ b/backend/internal/api/admin/me_response.go
@@ -40,6 +40,26 @@ func buildMeResponse(
 		SessionExpiresAt: sessionExpiresAt,
 	}
 
+	// Derived here rather than passed in, so the duration and the instant cannot
+	// disagree: one argument, one source, computed at the moment the body is
+	// assembled.
+	//
+	// Truncated toward zero rather than rounded -- erring a fraction of a second
+	// short only makes the client schedule marginally early, where rounding up
+	// would let it hold a session past the instant we start rejecting it.
+	//
+	// Omitted rather than emitted non-positive: the client reads a non-positive
+	// duration as a real expiry and fails closed, so asserting that about a
+	// request we are answering 200 would be a lie. Auth rejects an expired token
+	// long before this, making it unreachable in practice; the guard is here so
+	// the response cannot contradict itself if that ever stops being true.
+	if sessionExpiresAt != nil {
+		if remaining := time.Until(*sessionExpiresAt); remaining > 0 {
+			secs := int64(remaining.Seconds())
+			resp.SessionExpiresIn = &secs
+		}
+	}
+
 	for i := range memberships {
 		m := memberships[i]
 		entry := MeMembershipEntry{

--- a/backend/internal/api/admin/me_response_test.go
+++ b/backend/internal/api/admin/me_response_test.go
@@ -83,6 +83,12 @@ func TestBuildMeResponse_WireFormat(t *testing.T) {
 		{
 			// session_expires_at is the one field that IS omitted when absent —
 			// contrast every role_template above.
+			//
+			// session_expires_in is absent here for a REASON worth stating, because
+			// this is an exact-wire-format assertion: meFixedTime is in the past, so
+			// the remaining lifetime is non-positive and the builder omits it. Move
+			// this fixture into the future and this case must gain the field —
+			// TestBuildMeResponse_SessionExpiresIn below covers that direction.
 			name:        "with a session expiry",
 			memberships: nil,
 			expires:     &meFixedTime,
@@ -123,4 +129,57 @@ func TestMeResponse_RoundTripsIntoItsOwnStruct(t *testing.T) {
 	if *back.Memberships[0].RoleTemplate.Name != "owner" {
 		t.Errorf("role_template.name = %q, want \"owner\"", *back.Memberships[0].RoleTemplate.Name)
 	}
+}
+
+// The remaining-lifetime field, which exists because session_expires_at alone is
+// unusable against a browser clock that disagrees with ours: the client would be
+// comparing our instant to its own Date.now(), wrong by exactly the skew. A
+// duration we measure and it applies shares no clock (4cloudguru/cloud-suite-ui#181).
+func TestBuildMeResponse_SessionExpiresIn(t *testing.T) {
+	t.Run("a live expiry carries both the instant and the remaining seconds", func(t *testing.T) {
+		exp := time.Now().Add(90 * time.Minute)
+		got := buildMeResponse(meUser(), nil, []string{"admin"}, &exp)
+		if got.SessionExpiresAt == nil {
+			t.Fatal("SessionExpiresAt nil for a live expiry")
+		}
+		if got.SessionExpiresIn == nil {
+			t.Fatal("SessionExpiresIn nil for a live expiry")
+		}
+		// Truncation toward zero costs at most a second; the builder does no I/O.
+		if *got.SessionExpiresIn < 5390 || *got.SessionExpiresIn > 5400 {
+			t.Errorf("SessionExpiresIn = %d, want ~5400 (90m)", *got.SessionExpiresIn)
+		}
+	})
+
+	t.Run("a lapsed expiry omits the duration but keeps the instant", func(t *testing.T) {
+		// A non-positive duration reads to the client as a real expiry and fails the
+		// session closed, so it must never appear on a response we are answering 200.
+		exp := time.Now().Add(-time.Minute)
+		got := buildMeResponse(meUser(), nil, []string{"admin"}, &exp)
+		if got.SessionExpiresAt == nil {
+			t.Error("SessionExpiresAt dropped for a lapsed expiry; only the duration should be")
+		}
+		if got.SessionExpiresIn != nil {
+			t.Errorf("SessionExpiresIn = %d for a lapsed expiry, want omitted", *got.SessionExpiresIn)
+		}
+	})
+
+	t.Run("no expiry means neither field", func(t *testing.T) {
+		got := buildMeResponse(meUser(), nil, []string{"admin"}, nil)
+		if got.SessionExpiresAt != nil || got.SessionExpiresIn != nil {
+			t.Errorf("expiry fields set without a claim: at=%v in=%v", got.SessionExpiresAt, got.SessionExpiresIn)
+		}
+	})
+
+	t.Run("the emitted body still round-trips into MeResponse", func(t *testing.T) {
+		exp := time.Now().Add(time.Hour)
+		built := buildMeResponse(meUser(), nil, []string{"admin"}, &exp)
+		var back MeResponse
+		if err := json.Unmarshal([]byte(mustJSON(t, built)), &back); err != nil {
+			t.Fatalf("emitted body does not unmarshal into MeResponse: %v", err)
+		}
+		if back.SessionExpiresIn == nil || *back.SessionExpiresIn != *built.SessionExpiresIn {
+			t.Errorf("SessionExpiresIn lost in round-trip: %v", back.SessionExpiresIn)
+		}
+	})
 }

--- a/backend/internal/api/admin/responses.go
+++ b/backend/internal/api/admin/responses.go
@@ -69,6 +69,16 @@ type MeResponse struct {
 	// sets it only when JWT claims carry an expiry, and never for API-key auth.
 	RoleTemplate     *MeRoleTemplateSummary `json:"role_template"`
 	SessionExpiresAt *time.Time             `json:"session_expires_at,omitempty"`
+	// SessionExpiresIn is the remaining session lifetime in SECONDS, measured as
+	// this response is built. Omitted on exactly the same conditions as
+	// SessionExpiresAt, plus one more: never emitted non-positive.
+	//
+	// It exists because SessionExpiresAt alone is unusable when the browser's
+	// clock disagrees with ours -- the client would compare our instant against
+	// its own Date.now(), which is wrong by exactly the skew. A duration we
+	// measure and it applies shares no clock at all, so skew cannot enter
+	// (4cloudguru/cloud-suite-ui#181). The client prefers this when present.
+	SessionExpiresIn *int64 `json:"session_expires_in,omitempty"`
 }
 
 // APIKeyItem represents a single API key in list/get responses.


### PR DESCRIPTION
Adds `session_expires_in` to `/auth/me` — the seconds of session remaining, measured as the body is
built — alongside the existing `session_expires_at`. Backend half of 4cloudguru/cloud-suite-ui#181;
sibling to sethbacon/terraform-state-manager-backend#545.

## Why a duration

The absolute instant is only usable if the browser’s clock agrees with ours. A client comparing our
instant against its own `Date.now()` is wrong by exactly the skew between the two clocks, so a
browser running ahead expires a live session early — and one ahead by more than the remaining
lifetime used to end it on *every* `/me`, a hard lockout (fixed client-side in
4cloudguru/cloud-suite-ui#180).

A duration **removes the shared-clock assumption** rather than correcting for it. We measure it
wholly against our clock, the client applies it wholly against its own, and neither half of the
subtraction crosses the boundary between them.

## Where it is computed

Inside `buildMeResponse`, not passed in as a second argument. One argument, one source — the
duration and the instant cannot drift apart — and it stays testable without a database, which is
the property that function was extracted for in #892.

## Two choices worth reviewing

**Truncated toward zero, not rounded.** Erring a fraction of a second short only makes the client
schedule marginally early; rounding up would let it hold a session past the instant we start
rejecting it.

**Omitted, never emitted non-positive.** The client reads a non-positive duration as a real expiry
and fails closed, so asserting that about a request we are answering `200` would be a lie. Auth
rejects an expired token long before this, so it is unreachable in practice — the guard is there so
the response cannot contradict itself if that ever stops being true.

## A latent trap in the existing test, now written down

`TestBuildMeResponse`’s "with a session expiry" case is an **exact wire-format** assertion, and it
still passes only because `meFixedTime` (2026-08-24) is in the past — so the duration is correctly
omitted. Move that fixture into the future and the case must gain the field. That was a coincidence;
it is now a comment, with `TestBuildMeResponse_SessionExpiresIn` covering the live direction
explicitly.

Mutation-verified **4/4**: dropping the derivation; dropping the `> 0` guard; emitting milliseconds
instead of seconds; emitting elapsed instead of remaining time.

## Generated docs

`MeResponse` gains a field, so `docs/swagger.json` and `docs/openapi3.json` are now stale. I have
**deliberately not regenerated them locally** — the `swagger-docs-sync` job holds the pinned `swag`
and commits the regenerated pair straight to this branch, and generating with a different local
version would only introduce drift of its own. Expect an extra commit from CI.

`go build`, `go vet`, `gofmt` clean; `go test ./internal/api/admin/` passes (6.9s).

## Rollout

Additive and backwards compatible, so safe to land in any order relative to
4cloudguru/cloud-suite-ui#183, sethbacon/terraform-state-manager-backend#545, and the two frontend
type widenings.